### PR TITLE
chore: extend and consolidate deep links in AndroidManifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -61,37 +61,23 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
         <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="lightning"/>
-            <data android:scheme="bitcoinbeach"/>
-            <data android:scheme="blink"/>
-            <data android:scheme="bitcoin"/>
-            <data android:scheme="lapp"/>
-        </intent-filter>
-        <intent-filter>
-            <action android:name="android.intent.action.VIEW"/>
-            <category android:name="android.intent.category.DEFAULT"/>
-            <category android:name="android.intent.category.BROWSABLE"/>
-            <data android:scheme="https" android:host="pay.bbw.sv"/>
-            <data android:scheme="https" android:host="pay.mainnet.galoy.io"/>
-            <data android:scheme="https" android:host="pay.blink.sv"/>
-        </intent-filter>
-        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
           <action android:name="android.nfc.action.NDEF_DISCOVERED" />
           <category android:name="android.intent.category.DEFAULT" />
-          <data android:scheme="https" android:host="pay.blink.sv" />
-      </intent-filter>
-      <intent-filter>
-          <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-          <category android:name="android.intent.category.DEFAULT" />
-          <data android:scheme="lnurlw" />
-      </intent-filter>
-      <intent-filter>
-          <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-          <category android:name="android.intent.category.DEFAULT" />
-          <data android:scheme="lnurlp" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <!-- Custom URL schemes -->
+          <data android:scheme="lnurlw"/>
+          <data android:scheme="lnurlp"/>
+          <data android:scheme="lightning"/>
+          <data android:scheme="lnurl"/>
+          <data android:scheme="bitcoinbeach"/>
+          <data android:scheme="blink"/>
+          <data android:scheme="bitcoin"/>
+          <data android:scheme="lapp"/>
+          <!-- HTTPS URLs with specific hosts -->
+          <data android:scheme="https" android:host="pay.blink.sv"/>
+          <data android:scheme="https" android:host="pay.bbw.sv"/>
+          <data android:scheme="https" android:host="pay.mainnet.galoy.io"/>
       </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -99,7 +99,15 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
   }
 
   const linking: LinkingOptions<RootStackParamList> = {
-    prefixes: [...PREFIX_LINKING, "bitcoin://", "lightning://", "lapp://", "lnurlw://", "lnurlp://", "lnurl://"],
+    prefixes: [
+      ...PREFIX_LINKING,
+      "bitcoin://",
+      "lightning://",
+      "lapp://",
+      "lnurlw://",
+      "lnurlp://",
+      "lnurl://",
+    ],
     config: {
       screens: {
         Primary: {

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -99,7 +99,7 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
   }
 
   const linking: LinkingOptions<RootStackParamList> = {
-    prefixes: [...PREFIX_LINKING, "bitcoin://", "lightning://", "lapp://"],
+    prefixes: [...PREFIX_LINKING, "bitcoin://", "lightning://", "lapp://", "lnurlw://", "lnurlp://", "lnurl://"],
     config: {
       screens: {
         Primary: {

--- a/ios/GaloyApp/Info.plist
+++ b/ios/GaloyApp/Info.plist
@@ -42,6 +42,9 @@
 				<string>bitcoinbeach</string>
 				<string>blink</string>
 				<string>lapp</string>
+				<string>lnurlw</string>
+				<string>lnurlp</string>
+				<string>lnurl</string>
 			</array>
 		</dict>
 		<dict>


### PR DESCRIPTION
Adding the missing:

`"android.intent.action.VIEW"`
and
`"android.intent.category.BROWSABLE"`

to the `lnurlw` and `lnulrp` schemes

Apply same behaviour for links opened in browser or through NFC.