### PR TITLE
refactor: redesign transaction history

### DIFF
--- a/__tests__/screens/transaction-history-screen.spec.tsx
+++ b/__tests__/screens/transaction-history-screen.spec.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { act, fireEvent, render, waitFor, cleanup } from "@testing-library/react-native"
+
+import { TransactionHistoryScreen } from "@app/screens/transaction-history"
+
+import { ContextForScreen } from "./helper"
+
+describe("TransactionHistoryScreen", () => {
+  afterEach(cleanup)
+
+  it("shows all transactions by default", async () => {
+    const { findByTestId } = render(
+      <ContextForScreen>
+        <TransactionHistoryScreen />
+      </ContextForScreen>,
+    )
+
+    expect(await findByTestId("transaction-by-index-0")).toBeTruthy()
+  })
+
+  it("filters only BTC transactions", async () => {
+    const screen = render(
+      <ContextForScreen>
+        <TransactionHistoryScreen />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
+    })
+
+    const dropdown = screen.getByTestId("wallet-filter-dropdown")
+    await act(() => fireEvent.press(dropdown))
+
+    const btcOption = await screen.findByText("BTC")
+
+    await act(() => fireEvent.press(btcOption))
+
+    await waitFor(() => {
+      expect(screen.queryByText("user_btc")).toBeTruthy()
+      expect(screen.queryByText("user_usd")).toBeNull()
+    })
+  })
+})

--- a/app/components/wallet-filter-dropdown/index.ts
+++ b/app/components/wallet-filter-dropdown/index.ts
@@ -1,0 +1,1 @@
+export * from "./wallet-filter-dropdown"

--- a/app/components/wallet-filter-dropdown/wallet-filter-dropdown.tsx
+++ b/app/components/wallet-filter-dropdown/wallet-filter-dropdown.tsx
@@ -52,7 +52,10 @@ export const WalletFilterDropdown: React.FC<{
 
   return (
     <>
-      <TouchableWithoutFeedback onPress={loading ? undefined : toggleModal}>
+      <TouchableWithoutFeedback
+        onPress={loading ? undefined : toggleModal}
+        testID="wallet-filter-dropdown"
+      >
         <View style={[styles.fieldBackground, loading && styles.disabled]}>
           <View style={styles.walletSelectorTypeContainer}>
             <View style={current.containerStyle}>

--- a/app/components/wallet-filter-dropdown/wallet-filter-dropdown.tsx
+++ b/app/components/wallet-filter-dropdown/wallet-filter-dropdown.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from "react"
+import { View, Text, TouchableOpacity, TouchableWithoutFeedback } from "react-native"
+import ReactNativeModal from "react-native-modal"
+import Icon from "react-native-vector-icons/Ionicons"
+import { makeStyles, useTheme } from "@rneui/themed"
+
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { WalletCurrency } from "@app/graphql/generated"
+
+export type WalletValues = WalletCurrency | "ALL"
+
+export const WalletFilterDropdown: React.FC<{
+  selected: WalletValues
+  onSelect: (value: WalletValues) => void
+  loading?: boolean
+}> = ({ selected, onSelect, loading = false }) => {
+  const styles = useStyles()
+  const { LL } = useI18nContext()
+  const {
+    theme: { colors },
+  } = useTheme()
+
+  const [isModalVisible, setModalVisible] = useState(false)
+  const toggleModal = () => setModalVisible((visible) => !visible)
+
+  const walletOptions = [
+    {
+      value: "ALL",
+      label: LL.common.all(),
+      description: LL.common.allAccounts(),
+      containerStyle: styles.walletSelectorTypeLabelAll,
+      textStyle: styles.walletSelectorTypeLabelAllText,
+    },
+    {
+      value: "BTC",
+      label: WalletCurrency.Btc,
+      description: LL.common.bitcoin(),
+      containerStyle: styles.walletSelectorTypeLabelBitcoin,
+      textStyle: styles.walletSelectorTypeLabelBtcText,
+    },
+    {
+      value: "USD",
+      label: WalletCurrency.Usd,
+      description: LL.common.dollar(),
+      containerStyle: styles.walletSelectorTypeLabelUsd,
+      textStyle: styles.walletSelectorTypeLabelUsdText,
+    },
+  ] as const
+
+  const current = walletOptions.find((opt) => opt.value === selected)
+  if (!current) return null
+
+  return (
+    <>
+      <TouchableWithoutFeedback onPress={loading ? undefined : toggleModal}>
+        <View style={[styles.fieldBackground, loading && styles.disabled]}>
+          <View style={styles.walletSelectorTypeContainer}>
+            <View style={current.containerStyle}>
+              <Text style={current.textStyle}>{current.label}</Text>
+            </View>
+          </View>
+
+          <View style={styles.walletSelectorInfoContainer}>
+            <View style={styles.walletSelectorTypeTextContainer}>
+              <Text style={styles.walletCurrencyText}>{current.description}</Text>
+            </View>
+          </View>
+
+          <View style={styles.pickWalletIcon}>
+            <Icon name="chevron-down" size={24} color={colors.black} />
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+
+      <ReactNativeModal
+        style={styles.modal}
+        animationIn="fadeInDown"
+        animationOut="fadeOutUp"
+        isVisible={isModalVisible}
+        onBackdropPress={toggleModal}
+        onBackButtonPress={toggleModal}
+      >
+        <View>
+          {walletOptions.map((opt) => (
+            <TouchableOpacity
+              key={opt.value}
+              onPress={() => {
+                onSelect(opt.value)
+                toggleModal()
+              }}
+            >
+              <View style={styles.walletContainer}>
+                <View style={styles.walletSelectorTypeContainer}>
+                  <View style={opt.containerStyle}>
+                    <Text style={opt.textStyle}>{opt.label}</Text>
+                  </View>
+                </View>
+                <View style={styles.walletSelectorInfoContainer}>
+                  <View style={styles.walletSelectorTypeTextContainer}>
+                    <Text style={styles.walletCurrencyText}>{opt.description}</Text>
+                  </View>
+                </View>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      </ReactNativeModal>
+    </>
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  fieldBackground: {
+    flexDirection: "row",
+    backgroundColor: colors.grey5,
+    alignItems: "center",
+    padding: 14,
+    minHeight: 60,
+  },
+  walletContainer: {
+    flexDirection: "row",
+    backgroundColor: colors.grey5,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    alignItems: "center",
+    marginBottom: 10,
+    minHeight: 60,
+  },
+  walletSelectorTypeContainer: {
+    justifyContent: "center",
+    alignItems: "flex-start",
+    width: 50,
+    marginRight: 20,
+  },
+  walletSelectorTypeLabelBitcoin: {
+    height: 30,
+    width: 50,
+    borderRadius: 10,
+    backgroundColor: colors.primary,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  walletSelectorTypeLabelUsd: {
+    height: 30,
+    width: 50,
+    backgroundColor: colors._green,
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  walletSelectorTypeLabelAll: {
+    height: 30,
+    width: 50,
+    backgroundColor: "transparent",
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.primary3,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  walletSelectorTypeLabelUsdText: {
+    fontWeight: "bold",
+    color: colors.black,
+  },
+  walletSelectorTypeLabelBtcText: {
+    fontWeight: "bold",
+    color: colors.white,
+  },
+  walletSelectorTypeLabelAllText: {
+    fontWeight: "bold",
+    color: colors.primary3,
+  },
+  walletSelectorInfoContainer: {
+    flex: 1,
+    flexDirection: "column",
+  },
+  walletCurrencyText: {
+    fontWeight: "bold",
+    fontSize: 18,
+  },
+  walletSelectorTypeTextContainer: {
+    flex: 1,
+    justifyContent: "center",
+  },
+  modal: {
+    marginBottom: "90%",
+  },
+  pickWalletIcon: {
+    marginRight: 12,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+}))

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1657,16 +1657,27 @@ query transactionListForContact($username: Username!, $first: Int, $after: Strin
   }
 }
 
-query transactionListForDefaultAccount($first: Int, $after: String, $last: Int, $before: String) {
+query transactionListForDefaultAccount($first: Int, $after: String, $last: Int, $before: String, $walletIds: [WalletId!]) {
   me {
     id
     defaultAccount {
       id
+      wallets {
+        id
+        walletCurrency
+        __typename
+      }
       pendingIncomingTransactions {
         ...Transaction
         __typename
       }
-      transactions(first: $first, after: $after, last: $last, before: $before) {
+      transactions(
+        first: $first
+        after: $after
+        last: $last
+        before: $before
+        walletIds: $walletIds
+      ) {
         ...TransactionList
         __typename
       }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -3216,10 +3216,11 @@ export type TransactionListForDefaultAccountQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
+  walletIds?: InputMaybe<ReadonlyArray<Scalars['WalletId']['input']> | Scalars['WalletId']['input']>;
 }>;
 
 
-export type TransactionListForDefaultAccountQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly pendingIncomingTransactions: ReadonlyArray<{ readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string, readonly paymentRequest: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null, readonly preImage?: string | null } | { readonly __typename: 'SettlementViaLn', readonly preImage?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null, readonly arrivalInMempoolEstimatedAt?: number | null } }>, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string, readonly paymentRequest: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null, readonly preImage?: string | null } | { readonly __typename: 'SettlementViaLn', readonly preImage?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null, readonly arrivalInMempoolEstimatedAt?: number | null } } }> | null } | null } } | null };
+export type TransactionListForDefaultAccountQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency }>, readonly pendingIncomingTransactions: ReadonlyArray<{ readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string, readonly paymentRequest: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null, readonly preImage?: string | null } | { readonly __typename: 'SettlementViaLn', readonly preImage?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null, readonly arrivalInMempoolEstimatedAt?: number | null } }>, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string, readonly paymentRequest: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null, readonly preImage?: string | null } | { readonly __typename: 'SettlementViaLn', readonly preImage?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null, readonly arrivalInMempoolEstimatedAt?: number | null } } }> | null } | null } } | null };
 
 export type DeviceNotificationTokenCreateMutationVariables = Exact<{
   input: DeviceNotificationTokenCreateInput;
@@ -7992,15 +7993,25 @@ export type UserTotpRegistrationValidateMutationHookResult = ReturnType<typeof u
 export type UserTotpRegistrationValidateMutationResult = Apollo.MutationResult<UserTotpRegistrationValidateMutation>;
 export type UserTotpRegistrationValidateMutationOptions = Apollo.BaseMutationOptions<UserTotpRegistrationValidateMutation, UserTotpRegistrationValidateMutationVariables>;
 export const TransactionListForDefaultAccountDocument = gql`
-    query transactionListForDefaultAccount($first: Int, $after: String, $last: Int, $before: String) {
+    query transactionListForDefaultAccount($first: Int, $after: String, $last: Int, $before: String, $walletIds: [WalletId!]) {
   me {
     id
     defaultAccount {
       id
+      wallets {
+        id
+        walletCurrency
+      }
       pendingIncomingTransactions {
         ...Transaction
       }
-      transactions(first: $first, after: $after, last: $last, before: $before) {
+      transactions(
+        first: $first
+        after: $after
+        last: $last
+        before: $before
+        walletIds: $walletIds
+      ) {
         ...TransactionList
       }
     }
@@ -8025,6 +8036,7 @@ ${TransactionListFragmentDoc}`;
  *      after: // value for 'after'
  *      last: // value for 'last'
  *      before: // value for 'before'
+ *      walletIds: // value for 'walletIds'
  *   },
  * });
  */

--- a/app/graphql/mocks.ts
+++ b/app/graphql/mocks.ts
@@ -14,6 +14,7 @@ import {
   SendBitcoinDetailsScreenDocument,
   UserUpdateUsernameDocument,
   MyUserIdDocument,
+  TransactionListForDefaultAccountDocument,
 } from "./generated"
 
 // TODO: put in __tests__ folder?
@@ -1384,6 +1385,169 @@ const mocks = [
             __typename: "ConsumerAccount",
           },
           __typename: "User",
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: TransactionListForDefaultAccountDocument,
+      variables: {},
+    },
+    result: {
+      data: {
+        me: {
+          __typename: "User",
+          id: "user-id",
+          defaultAccount: {
+            __typename: "ConsumerAccount",
+            id: "account-id",
+            wallets: [
+              {
+                __typename: "BTCWallet",
+                id: "e821e124-1c70-4aab-9416-074ee5be21f6",
+                walletCurrency: "BTC",
+              },
+              {
+                __typename: "UsdWallet",
+                id: "5b54bf9a-46cc-4344-b638-b5e5e157a892",
+                walletCurrency: "USD",
+              },
+            ],
+            pendingIncomingTransactions: [],
+            transactions: {
+              __typename: "TransactionConnection",
+              pageInfo: {
+                __typename: "PageInfo",
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "cursor-1",
+                endCursor: "cursor-1",
+              },
+              edges: [
+                {
+                  __typename: "TransactionEdge",
+                  cursor: "cursor-1",
+                  node: {
+                    __typename: "Transaction",
+                    id: "tx-1",
+                    status: "SUCCESS",
+                    direction: "RECEIVE",
+                    memo: null,
+                    createdAt: 1700000000,
+                    settlementAmount: 1000,
+                    settlementFee: 0,
+                    settlementDisplayFee: "0.00",
+                    settlementCurrency: "BTC",
+                    settlementDisplayAmount: "0.10",
+                    settlementDisplayCurrency: "USD",
+                    settlementPrice: {
+                      __typename: "PriceOfOneSettlementMinorUnitInDisplayMinorUnit",
+                      base: 105000000000,
+                      offset: 12,
+                      currencyUnit: "MINOR",
+                      formattedAmount: "0.105",
+                    },
+                    initiationVia: {
+                      __typename: "InitiationViaLn",
+                      paymentHash: "hash-1",
+                      paymentRequest: "payment-request-1",
+                    },
+                    settlementVia: {
+                      __typename: "SettlementViaIntraLedger",
+                      counterPartyWalletId: null,
+                      counterPartyUsername: "user_btc",
+                      preImage: null,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: TransactionListForDefaultAccountDocument,
+      variables: {
+        walletIds: [
+          "e821e124-1c70-4aab-9416-074ee5be21f6",
+          "5b54bf9a-46cc-4344-b638-b5e5e157a892",
+        ],
+      },
+    },
+    result: {
+      data: {
+        me: {
+          __typename: "User",
+          id: "user-id-mock",
+          defaultAccount: {
+            __typename: "ConsumerAccount",
+            id: "account-id-mock",
+            wallets: [
+              {
+                __typename: "BTCWallet",
+                id: "e821e124-1c70-4aab-9416-074ee5be21f6",
+                walletCurrency: "BTC",
+              },
+              {
+                __typename: "UsdWallet",
+                id: "5b54bf9a-46cc-4344-b638-b5e5e157a892",
+                walletCurrency: "USD",
+              },
+            ],
+            pendingIncomingTransactions: [],
+            transactions: {
+              __typename: "TransactionConnection",
+              pageInfo: {
+                __typename: "PageInfo",
+                hasNextPage: false,
+                hasPreviousPage: false,
+                startCursor: "mock-cursor-start",
+                endCursor: "mock-cursor-end",
+              },
+              edges: [
+                {
+                  __typename: "TransactionEdge",
+                  cursor: "mock-cursor-start",
+                  node: {
+                    __typename: "Transaction",
+                    id: "mock-tx-1",
+                    status: "SUCCESS",
+                    direction: "RECEIVE",
+                    memo: null,
+                    createdAt: 1700000000,
+                    settlementAmount: 1000,
+                    settlementFee: 0,
+                    settlementDisplayFee: "0.00",
+                    settlementCurrency: "BTC",
+                    settlementDisplayAmount: "0.10",
+                    settlementDisplayCurrency: "USD",
+                    settlementPrice: {
+                      __typename: "PriceOfOneSettlementMinorUnitInDisplayMinorUnit",
+                      base: 105000000000,
+                      offset: 12,
+                      currencyUnit: "MINOR",
+                      formattedAmount: "0.105",
+                    },
+                    initiationVia: {
+                      __typename: "InitiationViaLn",
+                      paymentHash: "mock-hash-1",
+                      paymentRequest: "mock-payment-request-1",
+                    },
+                    settlementVia: {
+                      __typename: "SettlementViaIntraLedger",
+                      counterPartyWalletId: null,
+                      counterPartyUsername: "user_btc",
+                      preImage: null,
+                    },
+                  },
+                },
+              ],
+            },
+          },
         },
       },
     },

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2802,6 +2802,9 @@ const en: BaseTranslation = {
       one: "Day",
       other: "Days"
     },
+    dollar: "Dollar",
+    all: "ALL",
+    allAccounts: "All accounts",
   },
   errors: {
     generic: "There was an error.\nPlease try again later.",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -8831,6 +8831,18 @@ type RootTranslation = {
 			 */
 			other: string
 		}
+		/**
+		 * D​o​l​l​a​r
+		 */
+		dollar: string
+		/**
+		 * A​L​L
+		 */
+		all: string
+		/**
+		 * A​l​l​ ​a​c​c​o​u​n​t​s
+		 */
+		allAccounts: string
 	}
 	errors: {
 		/**
@@ -18119,6 +18131,18 @@ export type TranslationFunctions = {
 			 */
 			other: () => LocalizedString
 		}
+		/**
+		 * Dollar
+		 */
+		dollar: () => LocalizedString
+		/**
+		 * ALL
+		 */
+		all: () => LocalizedString
+		/**
+		 * All accounts
+		 */
+		allAccounts: () => LocalizedString
 	}
 	errors: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2698,7 +2698,10 @@
         "day": {
             "one": "Day",
             "other": "Days"
-        }
+        },
+        "dollar": "Dollar",
+        "all": "ALL",
+        "allAccounts": "All accounts"
     },
     "errors": {
         "generic": "There was an error.\nPlease try again later.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2699,7 +2699,10 @@
         "day": {
             "one": "Día",
             "other": "Días"
-        }
+        },
+        "dollar": "Dólar",
+        "all": "TODAS",
+        "allAccounts": "Todas las cuentas"
     },
     "errors": {
         "generic": "Hubo un error inesperado.\nPor favor intente más tarde",


### PR DESCRIPTION
# Transaction History Filter Feature

## Description

This Pull Request introduces a new **transaction filter** feature to the **Transaction History** screen. Users can now filter their transactions by wallet type:

- **ALL** (default): Shows all transactions, regardless of whether they are BTC or USD. This maintains the original behavior of the screen.
- **BTC**: Displays only transactions associated with the BTC wallet.
- **USD**: Displays only transactions associated with the USD wallet.

This improvement enhances the user experience by allowing more precise transaction browsing based on wallet type.


![imagen](https://github.com/user-attachments/assets/9d2172c3-5889-4131-9611-04ddf8958d32)
