### PR TITLE
fix: preserve fixed amount for LNURL-pay with intraledger destination

### DIFF
--- a/__tests__/payment-destination/lnurl.spec.ts
+++ b/__tests__/payment-destination/lnurl.spec.ts
@@ -39,11 +39,12 @@ const throwError = () => {
 // Manual mocks for LnUrlPayServiceResponse and LNURLResponse
 const manualMockLnUrlPayServiceResponse = (
   identifier: string,
+  amounts?: { min: Satoshis; max: Satoshis },
 ): LnUrlPayServiceResponse => ({
   callback: "mocked_callback",
-  fixed: true,
-  min: 0 as Satoshis,
-  max: 2000 as Satoshis,
+  fixed: amounts ? amounts.min === amounts.max : true,
+  min: amounts ? amounts.min : (0 as Satoshis),
+  max: amounts ? amounts.max : (2000 as Satoshis),
   domain: "example.com",
   metadata: [
     ["text/plain", "description"],
@@ -289,6 +290,178 @@ describe("resolve lnurl destination", () => {
           }),
         )
       }
+    })
+  })
+
+  describe("with fixed-amount lnurl for username on our domain", () => {
+    const lnurlPaymentDestinationParams = {
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "alice@ourdomain.com",
+        isMerchant: false,
+      } as const,
+      lnurlDomains: ["ourdomain.com"],
+      accountDefaultWalletQuery: jest.fn().mockResolvedValue({
+        data: {
+          accountDefaultWallet: {
+            __typename: "BtcWallet",
+            id: "recipientwalletid",
+            walletCurrency: "BTC",
+          },
+        },
+      }),
+      myWalletIds: ["testwalletid"],
+    }
+
+    it("creates lnurl pay destination to preserve the fixed amount", async () => {
+      const lnurlPayParams = manualMockLnUrlPayServiceResponse("alice@ourdomain.com", {
+        min: 100 as Satoshis,
+        max: 100 as Satoshis,
+      })
+      mockRequestPayServiceParams.mockResolvedValue(lnurlPayParams)
+      mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+
+      const destination = await resolveLnurlDestination(lnurlPaymentDestinationParams)
+
+      expect(destination).toEqual(
+        expect.objectContaining({
+          valid: true,
+          destinationDirection: DestinationDirection.Send,
+          validDestination: expect.objectContaining({
+            paymentType: PaymentType.Lnurl,
+            lnurlParams: lnurlPayParams,
+          }),
+        }),
+      )
+      expect(
+        lnurlPaymentDestinationParams.accountDefaultWalletQuery,
+      ).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("with zero-amount lnurl for username on our domain", () => {
+    const lnurlPaymentDestinationParams = {
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "alice@ourdomain.com",
+        isMerchant: false,
+      } as const,
+      lnurlDomains: ["ourdomain.com"],
+      accountDefaultWalletQuery: jest.fn().mockResolvedValue({
+        data: {
+          accountDefaultWallet: {
+            __typename: "BtcWallet",
+            id: "recipientwalletid",
+            walletCurrency: "BTC",
+          },
+        },
+      }),
+      myWalletIds: ["testwalletid"],
+    }
+
+    it("resolves as intraledger destination instead of unpayable fixed zero amount", async () => {
+      const lnurlPayParams = manualMockLnUrlPayServiceResponse("alice@ourdomain.com", {
+        min: 0 as Satoshis,
+        max: 0 as Satoshis,
+      })
+      mockRequestPayServiceParams.mockResolvedValue(lnurlPayParams)
+      mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+
+      const destination = await resolveLnurlDestination(lnurlPaymentDestinationParams)
+
+      expect(destination).toEqual(
+        expect.objectContaining({
+          valid: true,
+          destinationDirection: DestinationDirection.Send,
+        }),
+      )
+      if (destination.valid) {
+        expect(destination.validDestination).toEqual(
+          expect.objectContaining({
+            paymentType: PaymentType.Intraledger,
+            handle: "alice",
+          }),
+        )
+      }
+    })
+  })
+
+  describe("with variable-amount lnurl resolving to own wallet", () => {
+    const lnurlPaymentDestinationParams = {
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "myself@ourdomain.com",
+        isMerchant: false,
+      } as const,
+      lnurlDomains: ["ourdomain.com"],
+      accountDefaultWalletQuery: jest.fn().mockResolvedValue({
+        data: {
+          accountDefaultWallet: {
+            __typename: "BtcWallet",
+            id: "testwalletid",
+            walletCurrency: "BTC",
+          },
+        },
+      }),
+      myWalletIds: ["testwalletid"],
+    }
+
+    it("falls back to lnurl pay destination when intraledger resolution is invalid", async () => {
+      const lnurlPayParams = manualMockLnUrlPayServiceResponse("myself@ourdomain.com")
+      mockRequestPayServiceParams.mockResolvedValue(lnurlPayParams)
+      mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+
+      const destination = await resolveLnurlDestination(lnurlPaymentDestinationParams)
+
+      expect(destination).toEqual(
+        expect.objectContaining({
+          valid: true,
+          destinationDirection: DestinationDirection.Send,
+          validDestination: expect.objectContaining({
+            paymentType: PaymentType.Lnurl,
+            lnurlParams: lnurlPayParams,
+          }),
+        }),
+      )
+    })
+  })
+
+  describe("with fixed-amount lnurl on external domain", () => {
+    const lnurlPaymentDestinationParams = {
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "bob@external.com",
+        isMerchant: false,
+      } as const,
+      lnurlDomains: ["ourdomain.com"],
+      accountDefaultWalletQuery: jest.fn(),
+      myWalletIds: ["testwalletid"],
+    }
+
+    it("creates lnurl pay destination with the fixed-amount params", async () => {
+      const lnurlPayParams = manualMockLnUrlPayServiceResponse("bob@external.com", {
+        min: 65 as Satoshis,
+        max: 65 as Satoshis,
+      })
+      mockRequestPayServiceParams.mockResolvedValue(lnurlPayParams)
+      mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+
+      const destination = await resolveLnurlDestination(lnurlPaymentDestinationParams)
+
+      expect(destination).toEqual(
+        expect.objectContaining({
+          valid: true,
+          destinationDirection: DestinationDirection.Send,
+          validDestination: expect.objectContaining({
+            paymentType: PaymentType.Lnurl,
+            lnurlParams: lnurlPayParams,
+          }),
+        }),
+      )
     })
   })
 

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -885,13 +885,25 @@ export type CurrencyConversionEstimation = {
   readonly usdCentAmount: Scalars['CentAmount']['output'];
 };
 
+export type DepositFeeTier = {
+  readonly __typename: 'DepositFeeTier';
+  readonly amount: Scalars['String']['output'];
+  /** highest amount this tier applies to, null when unbounded */
+  readonly maxAmount?: Maybe<Scalars['String']['output']>;
+};
+
 export type DepositFeesInformation = {
   readonly __typename: 'DepositFeesInformation';
   readonly minBankFee: Scalars['String']['output'];
   /** below this amount minBankFee will be charged */
   readonly minBankFeeThreshold: Scalars['String']['output'];
-  /** ratio to charge as basis points above minBankFeeThreshold amount */
+  /**
+   * ratio to charge as basis points above minBankFeeThreshold amount
+   * @deprecated fees are a flat amount per tier, use tiers
+   */
   readonly ratio: Scalars['String']['output'];
+  /** amount charged per tier, in ascending order of maxAmount */
+  readonly tiers: ReadonlyArray<DepositFeeTier>;
 };
 
 export type DeviceNotificationTokenCreateInput = {
@@ -10076,6 +10088,7 @@ export type ResolversTypes = {
   Currency: ResolverTypeWrapper<Currency>;
   CurrencyConversionEstimation: ResolverTypeWrapper<CurrencyConversionEstimation>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  DepositFeeTier: ResolverTypeWrapper<DepositFeeTier>;
   DepositFeesInformation: ResolverTypeWrapper<DepositFeesInformation>;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: ResolverTypeWrapper<Scalars['DisplayCurrency']['output']>;
@@ -10379,6 +10392,7 @@ export type ResolversParentTypes = {
   Currency: Currency;
   CurrencyConversionEstimation: CurrencyConversionEstimation;
   DateTime: Scalars['DateTime']['output'];
+  DepositFeeTier: DepositFeeTier;
   DepositFeesInformation: DepositFeesInformation;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: Scalars['DisplayCurrency']['output'];
@@ -11017,10 +11031,17 @@ export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversT
   name: 'DateTime';
 }
 
+export type DepositFeeTierResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeeTier'] = ResolversParentTypes['DepositFeeTier']> = {
+  amount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  maxAmount?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type DepositFeesInformationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeesInformation'] = ResolversParentTypes['DepositFeesInformation']> = {
   minBankFee?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   minBankFeeThreshold?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ratio?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tiers?: Resolver<ReadonlyArray<ResolversTypes['DepositFeeTier']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -12073,6 +12094,7 @@ export type Resolvers<ContextType = any> = {
   Currency?: CurrencyResolvers<ContextType>;
   CurrencyConversionEstimation?: CurrencyConversionEstimationResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
+  DepositFeeTier?: DepositFeeTierResolvers<ContextType>;
   DepositFeesInformation?: DepositFeesInformationResolvers<ContextType>;
   DisplayCurrency?: GraphQLScalarType;
   Email?: EmailResolvers<ContextType>;

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -59,14 +59,20 @@ export const resolveLnurlDestination = async ({
       })
 
       if (lnurlPayParams) {
-        const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl({
-          lnurlDomains,
-          lnurlPayParams,
-          myWalletIds,
-          accountDefaultWalletQuery,
-        })
-        if (maybeIntraledgerDestination && maybeIntraledgerDestination.valid) {
-          return maybeIntraledgerDestination
+        // Skip intraledger optimization for fixed-amount LNURLs to preserve the
+        // min === max constraint (fixes #3583)
+        const isFixedAmount = lnurlPayParams.min === lnurlPayParams.max
+
+        if (!isFixedAmount) {
+          const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl({
+            lnurlDomains,
+            lnurlPayParams,
+            myWalletIds,
+            accountDefaultWalletQuery,
+          })
+          if (maybeIntraledgerDestination && maybeIntraledgerDestination.valid) {
+            return maybeIntraledgerDestination
+          }
         }
 
         return createLnurlPaymentDestination({

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -64,12 +64,14 @@ export const resolveLnurlDestination = async ({
         const isFixedAmount = lnurlPayParams.min === lnurlPayParams.max
 
         if (!isFixedAmount) {
-          const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl({
-            lnurlDomains,
-            lnurlPayParams,
-            myWalletIds,
-            accountDefaultWalletQuery,
-          })
+          const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl(
+            {
+              lnurlDomains,
+              lnurlPayParams,
+              myWalletIds,
+              accountDefaultWalletQuery,
+            },
+          )
           if (maybeIntraledgerDestination && maybeIntraledgerDestination.valid) {
             return maybeIntraledgerDestination
           }

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -59,9 +59,12 @@ export const resolveLnurlDestination = async ({
       })
 
       if (lnurlPayParams) {
-        // Skip intraledger optimization for fixed-amount LNURLs to preserve the
-        // min === max constraint (fixes #3583)
-        const isFixedAmount = lnurlPayParams.min === lnurlPayParams.max
+        // Skip intraledger conversion for fixed-amount LNURLs so the
+        // min === max amount constraint is preserved. A 0/0 response from a
+        // broken service is not treated as fixed since it would lock the
+        // amount at an unpayable 0 sats.
+        const isFixedAmount =
+          lnurlPayParams.min === lnurlPayParams.max && lnurlPayParams.max > 0
 
         if (!isFixedAmount) {
           const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl(


### PR DESCRIPTION
## Summary

Fix LNURL-pay fixed amount handling by skipping the intraledger optimization when `minSendable === maxSendable`. This preserves the fixed amount constraint instead of prompting the user to enter an amount.

## Changes

- Skip `tryGetIntraLedgerDestinationFromLnurl()` when the LNURL-pay response indicates a fixed amount (`min === max`)
- Added comment explaining the rationale

## Testing

- All 14 lnurl-related unit tests pass
- Manual testing recommended: Scan a fixed-amount LNURL-pay QR code (like the [test paycode](https://github.com/blinkbitcoin/blink-mobile/issues/3583#issuecomment-3768070214)) and verify the amount is pre-filled

## Related

Fixes #3583

---
Implementation plan: https://github.com/blinkbitcoin/blink-mobile/issues/3583#issuecomment-3771858362