### PR TITLE
fix: add bitcoin: and lightning: as compatible link

### DIFF
--- a/__tests__/send-bitcoin-screen/compatible-link.spec.ts
+++ b/__tests__/send-bitcoin-screen/compatible-link.spec.ts
@@ -1,0 +1,23 @@
+import { isCompatibleLink } from "../../app/screens/send-bitcoin-screen/compatible-link"
+
+describe("isCompatibleLink", () => {
+  it("accepts lowercase bitcoin and lightning schemes", () => {
+    expect(isCompatibleLink("bitcoin:bc1qexampleaddress")).toBe(true)
+    expect(isCompatibleLink("lightning:lnbc1exampleinvoice")).toBe(true)
+  })
+
+  it("accepts uppercase bitcoin and lightning schemes", () => {
+    expect(isCompatibleLink("BITCOIN:bc1qexampleaddress")).toBe(true)
+    expect(isCompatibleLink("LIGHTNING:lnbc1exampleinvoice")).toBe(true)
+  })
+
+  it("accepts http and https", () => {
+    expect(isCompatibleLink("http://example.com")).toBe(true)
+    expect(isCompatibleLink("https://example.com")).toBe(true)
+  })
+
+  it("rejects unsupported schemes and malformed input", () => {
+    expect(isCompatibleLink("ftp://example.com")).toBe(false)
+    expect(isCompatibleLink("not-a-url")).toBe(false)
+  })
+})

--- a/app/screens/send-bitcoin-screen/compatible-link.ts
+++ b/app/screens/send-bitcoin-screen/compatible-link.ts
@@ -1,0 +1,16 @@
+export const isCompatibleLink = (input: string): boolean => {
+  let url: URL
+
+  try {
+    url = new URL(input)
+  } catch {
+    return false
+  }
+
+  return (
+    url.protocol === "http:" ||
+    url.protocol === "https:" ||
+    url.protocol === "bitcoin:" ||
+    url.protocol === "lightning:"
+  )
+}

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -36,6 +36,7 @@ import { Text, makeStyles, useTheme } from "@rn-vui/themed"
 
 import { Screen } from "../../components/screen"
 import { RootStackParamList } from "../../navigation/stack-param-lists"
+import { isCompatibleLink } from "./compatible-link"
 import { parseDestination } from "./payment-destination"
 import { DestinationDirection } from "./payment-destination/index.types"
 
@@ -120,23 +121,6 @@ export const ScanningQRCodeScreen: React.FC = () => {
     Linking.openURL(url).catch((err) => Alert.alert(err.toString()))
   }
 
-  function isValidHttpUrl(input: string) {
-    let url
-
-    try {
-      url = new URL(input)
-    } catch (_) {
-      return false
-    }
-
-    return (
-      url.protocol === "http:" ||
-      url.protocol === "https:" ||
-      url.protocol === "bitcoin:" ||
-      url.protocol === "lightning:"
-    )
-  }
-
   const processInvoice = React.useMemo(() => {
     return async (data: string | undefined) => {
       if (pending || !wallets || !bitcoinNetwork || !data) {
@@ -195,7 +179,7 @@ export const ScanningQRCodeScreen: React.FC = () => {
             )
             break
           case "UnknownDestination":
-            if (isValidHttpUrl(data.toString())) {
+            if (isCompatibleLink(data.toString())) {
               Alert.alert(
                 LL.ScanningQRCodeScreen.openLinkTitle(),
                 `${data.toString()}\n\n${LL.ScanningQRCodeScreen.confirmOpenLink()}`,

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -129,7 +129,12 @@ export const ScanningQRCodeScreen: React.FC = () => {
       return false
     }
 
-    return url.protocol === "http:" || url.protocol === "https:"
+    return (
+      url.protocol === "http:" ||
+      url.protocol === "https:" ||
+      url.protocol === "bitcoin:" ||
+      url.protocol === "lightning:"
+    )
   }
 
   const processInvoice = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- Added support for bitcoin: and lightning: URI schemes in QR code scanner
- These URIs are now recognized as valid links that can be opened in browser
- Fixes issue #8