### PR TITLE
fix(android): Dollar balance and transfer features unavailable for VPN users on Android v3.0.4

### DIFF
--- a/__tests__/components/version/version.spec.tsx
+++ b/__tests__/components/version/version.spec.tsx
@@ -4,11 +4,10 @@ import { render } from "@testing-library/react-native"
 
 import { VersionComponent } from "@app/components/version"
 
-const mockUseDeviceLocation = jest.fn()
+const mockUseRegistrationCountry = jest.fn()
 
-jest.mock("@app/hooks/use-device-location", () => ({
-  __esModule: true,
-  default: () => mockUseDeviceLocation(),
+jest.mock("@app/hooks/use-registration-country", () => ({
+  useRegistrationCountry: () => mockUseRegistrationCountry(),
 }))
 
 jest.mock("@app/i18n/i18n-react", () => ({
@@ -43,11 +42,11 @@ jest.mock("@rn-vui/themed", () => ({
 
 describe("VersionComponent", () => {
   beforeEach(() => {
-    mockUseDeviceLocation.mockReset()
+    mockUseRegistrationCountry.mockReset()
   })
 
-  it("shows the device-detected country below the version", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+  it("shows the registration country below the version", () => {
+    mockUseRegistrationCountry.mockReturnValue({ countryCode: "HK" })
 
     const { getByText } = render(<VersionComponent />)
 
@@ -55,7 +54,7 @@ describe("VersionComponent", () => {
   })
 
   it("falls back to the unknown label when the country is not detected", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+    mockUseRegistrationCountry.mockReturnValue({ countryCode: undefined })
 
     const { getByText } = render(<VersionComponent />)
 

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -1,9 +1,6 @@
 import { renderHook, act } from "@testing-library/react-hooks"
 
-import useDeviceLocation, {
-  isBlockedCountry,
-  useIpCountryCode,
-} from "@app/hooks/use-device-location"
+import useDeviceLocation, { isBlockedCountry } from "@app/hooks/use-device-location"
 
 const mockLogError = jest.fn()
 const mockUpdateCountryCode = jest.fn()
@@ -273,41 +270,6 @@ describe("useDeviceLocation", () => {
     await act(async () => {})
 
     expect(mockUpdateCountryCode).toHaveBeenCalledWith(expect.anything(), "DE")
-  })
-})
-
-describe("useIpCountryCode", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockResolveIpCountryCode.mockResolvedValue(undefined)
-  })
-
-  it("does not call IP lookup while disabled", () => {
-    const { result } = renderHook(() => useIpCountryCode(false))
-
-    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
-    expect(result.current).toBeUndefined()
-  })
-
-  it("resolves the country from the adapter chain when enabled", async () => {
-    mockResolveIpCountryCode.mockResolvedValue("HK")
-
-    const { result } = renderHook(() => useIpCountryCode(true))
-
-    await act(async () => {})
-
-    expect(mockResolveIpCountryCode).toHaveBeenCalled()
-    expect(result.current).toBe("HK")
-  })
-
-  it("stays undefined when all adapters return nothing", async () => {
-    mockResolveIpCountryCode.mockResolvedValue(undefined)
-
-    const { result } = renderHook(() => useIpCountryCode(true))
-
-    await act(async () => {})
-
-    expect(result.current).toBeUndefined()
   })
 })
 

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -1,27 +1,31 @@
 import { renderHook } from "@testing-library/react-native"
 
-import { getStableTokenRestricted } from "@app/store/persistent-state/stable-token-restriction"
-import { getStablesatsRestricted } from "@app/store/persistent-state/stablesats-restriction"
+import {
+  getStableTokenRestricted,
+  withStableTokenRestricted,
+} from "@app/store/persistent-state/stable-token-restriction"
+import {
+  getStablesatsRestricted,
+  withStablesatsRestricted,
+} from "@app/store/persistent-state/stablesats-restriction"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
-const mockUseDeviceLocation = jest.fn()
+const mockUseRegistrationCountry = jest.fn()
 const mockUseRemoteConfig = jest.fn()
+const mockUseFeatureFlags = jest.fn()
 const mockUseActiveWallet = jest.fn()
 const mockUpdateState = jest.fn()
-const mockUseIpCountryCode = jest.fn()
 
 let mockPersistentState: PersistentState
 
-jest.mock("@app/hooks/use-device-location", () => ({
-  __esModule: true,
-  ...jest.requireActual("@app/hooks/use-device-location"),
-  default: () => mockUseDeviceLocation(),
-  useIpCountryCode: (enabled: boolean) => mockUseIpCountryCode(enabled),
+jest.mock("@app/hooks/use-registration-country", () => ({
+  useRegistrationCountry: () => mockUseRegistrationCountry(),
 }))
 
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => mockUseFeatureFlags(),
 }))
 
 jest.mock("@app/hooks/use-active-wallet", () => ({
@@ -33,6 +37,12 @@ jest.mock("@app/store/persistent-state", () => ({
     persistentState: mockPersistentState,
     updateState: mockUpdateState,
   }),
+}))
+
+const mockLogRegionRestrictionCleared = jest.fn()
+jest.mock("@app/utils/analytics", () => ({
+  logRegionRestrictionCleared: (...args: unknown[]) =>
+    mockLogRegionRestrictionCleared(...args),
 }))
 
 import {
@@ -50,14 +60,25 @@ const remoteConfig = {
   custodialDollarBalanceBlockedCountries: ["HK"],
   selfCustodialDollarBalanceBlockedCountries: ["FR"],
   dollarRestrictionCacheEnabled: true,
+  restrictionSelfHealEnabled: true,
 }
+
+const country = (countryCode: string | undefined) => ({
+  countryCode,
+  loading: false,
+  trusted: Boolean(countryCode),
+})
 
 const setup = (accountType: AccountType): void => {
   jest.clearAllMocks()
-  mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
+  mockUseRegistrationCountry.mockReturnValue({
+    countryCode: undefined,
+    loading: true,
+    trusted: false,
+  })
   mockUseRemoteConfig.mockReturnValue(remoteConfig)
+  mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: true })
   mockUseActiveWallet.mockReturnValue({ accountType })
-  mockUseIpCountryCode.mockReturnValue(undefined)
   mockPersistentState = baseState
 }
 
@@ -68,29 +89,29 @@ describe("useDollarBalanceRestricted", () => {
     beforeEach(() => setup(AccountType.Custodial))
 
     it("is restricted in a Stablesats-blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       expect(read()).toBe(true)
     })
 
-    it("is case-insensitive on the device country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "hk" })
+    it("is case-insensitive on the registration country", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("hk"))
       expect(read()).toBe(true)
     })
 
     it("is not restricted in a country that only the stable-token list blocks", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
       expect(read()).toBe(false)
     })
 
     it("stays restricted from the persisted custodial flag without a country", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      mockUseRegistrationCountry.mockReturnValue(country(undefined))
       expect(read()).toBe(true)
     })
 
     it("ignores the self-custodial persisted flag", () => {
       mockPersistentState = { ...baseState, stableTokenRestricted: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
       expect(read()).toBe(false)
     })
   })
@@ -99,24 +120,24 @@ describe("useDollarBalanceRestricted", () => {
     beforeEach(() => setup(AccountType.SelfCustodial))
 
     it("is restricted in a stable-token-blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
       expect(read()).toBe(true)
     })
 
     it("is not restricted in a country that only blocks custodial Stablesats", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       expect(read()).toBe(false)
     })
 
     it("stays restricted from the persisted stable-token flag", () => {
       mockPersistentState = { ...baseState, stableTokenRestricted: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      mockUseRegistrationCountry.mockReturnValue(country(undefined))
       expect(read()).toBe(true)
     })
 
     it("ignores the custodial persisted flag", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       expect(read()).toBe(false)
     })
   })
@@ -132,12 +153,12 @@ describe("useDollarBalanceRestricted", () => {
 
     it("ignores the persisted flag so a stale restriction can be lifted", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      mockUseRegistrationCountry.mockReturnValue(country(undefined))
       expect(read()).toBe(false)
     })
 
-    it("still restricts from the live device country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+    it("still restricts from the live registration country", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       expect(read()).toBe(true)
     })
   })
@@ -147,8 +168,8 @@ describe("useDollarBalanceRestrictionSync", () => {
   describe("custodial", () => {
     beforeEach(() => setup(AccountType.Custodial))
 
-    it("persists the custodial flag when the phone country is blocked", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
+    it("persists the custodial flag when the registration country is blocked", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
 
       renderHook(() => useDollarBalanceRestrictionSync())
 
@@ -158,41 +179,132 @@ describe("useDollarBalanceRestrictionSync", () => {
       expect(updater(undefined)).toBeUndefined()
     })
 
-    it("does not consult IP when the phone country already blocks", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
-      renderHook(() => useDollarBalanceRestrictionSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
-    })
-
-    it("falls back to IP and persists when the phone country does not block", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", source: "phone" })
-      mockUseIpCountryCode.mockReturnValue("HK")
-      renderHook(() => useDollarBalanceRestrictionSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(true)
-      expect(mockUpdateState).toHaveBeenCalledTimes(1)
-    })
-
-    it("does not persist when neither phone nor IP blocks", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", source: "phone" })
-      mockUseIpCountryCode.mockReturnValue("AR")
+    it("does not persist when the registration country is not blocked", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
       renderHook(() => useDollarBalanceRestrictionSync())
       expect(mockUpdateState).not.toHaveBeenCalled()
     })
 
     it("does not persist again once already flagged", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       renderHook(() => useDollarBalanceRestrictionSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
       expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("does not persist while the country is still resolving", () => {
+      mockUseRegistrationCountry.mockReturnValue({
+        countryCode: undefined,
+        loading: true,
+        trusted: false,
+      })
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("clears the custodial flag when the trusted country is allowed", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
+
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+      const updater = mockUpdateState.mock.calls[0][0]
+      expect(getStablesatsRestricted(updater(withStablesatsRestricted(baseState)))).toBe(
+        false,
+      )
+      expect(updater(undefined)).toBeUndefined()
+      expect(mockLogRegionRestrictionCleared).toHaveBeenCalledWith({
+        restriction: "dollar_balance",
+        accountType: AccountType.Custodial,
+        countryCode: "SV",
+      })
+    })
+
+    it("logs 'unknown' defensively if trusted is ever reported without a country", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRegistrationCountry.mockReturnValue({
+        countryCode: undefined,
+        loading: false,
+        trusted: true,
+      })
+
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      expect(mockLogRegionRestrictionCleared).toHaveBeenCalledWith(
+        expect.objectContaining({ countryCode: "unknown" }),
+      )
+    })
+
+    it("does not clear when self-healing is remotely disabled", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        restrictionSelfHealEnabled: false,
+      })
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+      expect(mockLogRegionRestrictionCleared).not.toHaveBeenCalled()
+    })
+
+    it("does not clear while the country is still resolving", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRegistrationCountry.mockReturnValue({
+        countryCode: undefined,
+        loading: true,
+        trusted: false,
+      })
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("does not clear while remote config has not loaded (default lists in use)", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: false })
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("still persists while remote config has not loaded", () => {
+      mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: false })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not clear when country detection failed", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRegistrationCountry.mockReturnValue({
+        countryCode: undefined,
+        loading: false,
+        trusted: false,
+      })
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("does not touch the self-custodial flag when clearing the custodial one", () => {
+      mockPersistentState = {
+        ...baseState,
+        stablesatsRestrictedCustodial: true,
+        stableTokenRestricted: true,
+      }
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
+
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      const updater = mockUpdateState.mock.calls[0][0]
+      expect(getStableTokenRestricted(updater(mockPersistentState))).toBe(true)
     })
   })
 
   describe("self-custodial", () => {
     beforeEach(() => setup(AccountType.SelfCustodial))
 
-    it("persists the stable-token flag when the phone country is blocked", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+    it("persists the stable-token flag when the registration country is blocked", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
 
       renderHook(() => useDollarBalanceRestrictionSync())
 
@@ -202,21 +314,18 @@ describe("useDollarBalanceRestrictionSync", () => {
       expect(updater(undefined)).toBeUndefined()
     })
 
-    it("falls back to IP and persists the stable-token flag", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", source: "phone" })
-      mockUseIpCountryCode.mockReturnValue("FR")
-      renderHook(() => useDollarBalanceRestrictionSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(true)
-      expect(mockUpdateState).toHaveBeenCalledTimes(1)
-    })
-  })
+    it("clears the stable-token flag when the trusted country is allowed", () => {
+      mockPersistentState = { ...baseState, stableTokenRestricted: true }
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
 
-  it("does not consult IP when the source is not the phone", () => {
-    setup(AccountType.Custodial)
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "AR", source: "ip" })
-    renderHook(() => useDollarBalanceRestrictionSync())
-    expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
-    expect(mockUpdateState).not.toHaveBeenCalled()
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+      const updater = mockUpdateState.mock.calls[0][0]
+      expect(
+        getStableTokenRestricted(updater(withStableTokenRestricted(baseState))),
+      ).toBe(false)
+    })
   })
 
   describe("with the restriction cache disabled remotely", () => {
@@ -229,21 +338,28 @@ describe("useDollarBalanceRestrictionSync", () => {
     })
 
     it("does not persist even in a blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
+      mockUseRegistrationCountry.mockReturnValue(country("HK"))
       renderHook(() => useDollarBalanceRestrictionSync())
       expect(mockUpdateState).not.toHaveBeenCalled()
     })
 
-    it("does not consult IP", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", source: "phone" })
+    it("still clears a stale flag so it cannot resurface when the cache is re-enabled", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseRegistrationCountry.mockReturnValue(country("SV"))
+
       renderHook(() => useDollarBalanceRestrictionSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+      const updater = mockUpdateState.mock.calls[0][0]
+      expect(getStablesatsRestricted(updater(withStablesatsRestricted(baseState)))).toBe(
+        false,
+      )
     })
   })
 
   it("writes the self-custodial flag too when a blocked-country user switches from custodial to self-custodial", () => {
     setup(AccountType.Custodial)
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
+    mockUseRegistrationCountry.mockReturnValue(country("HK"))
     mockUseRemoteConfig.mockReturnValue({
       custodialDollarBalanceBlockedCountries: ["HK"],
       selfCustodialDollarBalanceBlockedCountries: ["HK"],
@@ -261,5 +377,29 @@ describe("useDollarBalanceRestrictionSync", () => {
     expect(mockUpdateState).toHaveBeenCalledTimes(2)
     const selfCustodialUpdater = mockUpdateState.mock.calls[1][0]
     expect(getStableTokenRestricted(selfCustodialUpdater(baseState))).toBe(true)
+  })
+
+  it("clears the other flag too when an allowed-country user switches account type", () => {
+    setup(AccountType.Custodial)
+    mockPersistentState = {
+      ...baseState,
+      stablesatsRestrictedCustodial: true,
+      stableTokenRestricted: true,
+    }
+    mockUseRegistrationCountry.mockReturnValue(country("SV"))
+
+    const { rerender } = renderHook(() => useDollarBalanceRestrictionSync())
+
+    const custodialUpdater = mockUpdateState.mock.calls[0][0]
+    expect(getStablesatsRestricted(custodialUpdater(mockPersistentState))).toBe(false)
+
+    mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
+    rerender({})
+
+    expect(mockUpdateState).toHaveBeenCalledTimes(2)
+    const selfCustodialUpdater = mockUpdateState.mock.calls[1][0]
+    expect(getStableTokenRestricted(selfCustodialUpdater(mockPersistentState))).toBe(
+      false,
+    )
   })
 })

--- a/__tests__/hooks/use-registration-country.spec.ts
+++ b/__tests__/hooks/use-registration-country.spec.ts
@@ -1,0 +1,251 @@
+import { renderHook, act } from "@testing-library/react-hooks"
+
+import { getFirstSeenCountryCode } from "@app/store/persistent-state/first-seen-country"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+
+const mockLogError = jest.fn()
+
+const mockParsePhoneNumber = jest.fn()
+jest.mock("libphonenumber-js/mobile", () => ({
+  ...jest.requireActual("libphonenumber-js/mobile"),
+  parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
+}))
+
+const mockResolveIpCountryCode = jest.fn()
+const mockDetectAnonymizingIp = jest.fn()
+jest.mock("@app/utils/ip-country-lookup", () => ({
+  resolveIpCountryCodeCached: (...args: unknown[]) => mockResolveIpCountryCode(...args),
+  detectAnonymizingIpCached: (...args: unknown[]) => mockDetectAnonymizingIp(...args),
+}))
+
+jest.mock("@app/utils/log-error", () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+}))
+
+const mockLogPersisted = jest.fn()
+const mockLogDeferred = jest.fn()
+jest.mock("@app/utils/analytics", () => ({
+  logRegistrationCountryPersisted: (...args: unknown[]) => mockLogPersisted(...args),
+  logRegistrationCountryPersistDeferred: (...args: unknown[]) => mockLogDeferred(...args),
+}))
+
+const mockUseSettingsScreenQuery = jest.fn()
+jest.mock("@app/graphql/generated", () => ({
+  useSettingsScreenQuery: (...args: unknown[]) => mockUseSettingsScreenQuery(...args),
+}))
+
+const mockUpdateState = jest.fn()
+let mockPersistentState: PersistentState
+
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: mockPersistentState,
+    updateState: mockUpdateState,
+  }),
+}))
+
+import { useRegistrationCountry } from "@app/hooks/use-registration-country"
+
+const baseState: PersistentState = {
+  schemaVersion: 14,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+/** Applies the captured updaters so assertions can inspect the persisted result. */
+const persistedResult = (): PersistentState | undefined =>
+  mockUpdateState.mock.calls.reduce(
+    (state, [updater]) => updater(state),
+    mockPersistentState as PersistentState | undefined,
+  )
+
+describe("useRegistrationCountry", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
+    mockDetectAnonymizingIp.mockResolvedValue(false)
+    mockUseSettingsScreenQuery.mockReturnValue({ data: undefined, loading: false })
+    mockParsePhoneNumber.mockImplementation(
+      jest.requireActual("libphonenumber-js/mobile").parsePhoneNumber,
+    )
+    mockPersistentState = baseState
+  })
+
+  it("uses the phone country without any IP lookup", async () => {
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "+4915112345678" } },
+      loading: false,
+    })
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("DE")
+    expect(result.current.loading).toBe(false)
+    expect(result.current.trusted).toBe(true)
+    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
+  })
+
+  it("persists the phone country as the first-seen country", async () => {
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "+4915112345678" } },
+      loading: false,
+    })
+
+    renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(getFirstSeenCountryCode(persistedResult() as PersistentState)).toBe("DE")
+    const updater = mockUpdateState.mock.calls[0][0]
+    expect(updater(undefined)).toBeUndefined()
+    expect(mockLogPersisted).toHaveBeenCalledWith({ countryCode: "DE", source: "phone" })
+  })
+
+  it("ignores an IP resolution that lands after unmount", async () => {
+    let resolveLookup: (code: string | undefined) => void = () => {}
+    mockResolveIpCountryCode.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLookup = resolve
+      }),
+    )
+
+    const { unmount } = renderHook(() => useRegistrationCountry())
+    unmount()
+
+    await act(async () => {
+      resolveLookup("HK")
+    })
+
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("prefers the phone country over a stale persisted first-seen country and refreshes it", async () => {
+    mockPersistentState = { ...baseState, firstSeenCountryCode: "PL" }
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "+4915112345678" } },
+      loading: false,
+    })
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("DE")
+    expect(getFirstSeenCountryCode(persistedResult() as PersistentState)).toBe("DE")
+  })
+
+  it("uses the persisted first-seen country without any IP lookup when there is no phone", async () => {
+    mockPersistentState = { ...baseState, firstSeenCountryCode: "SV" }
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("SV")
+    expect(result.current.loading).toBe(false)
+    expect(result.current.trusted).toBe(true)
+    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("resolves and persists the first-seen country once when neither phone nor persisted value exists", async () => {
+    mockResolveIpCountryCode.mockResolvedValue("SV")
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("SV")
+    expect(result.current.trusted).toBe(true)
+    expect(mockResolveIpCountryCode).toHaveBeenCalledTimes(1)
+    expect(getFirstSeenCountryCode(persistedResult() as PersistentState)).toBe("SV")
+    expect(mockLogPersisted).toHaveBeenCalledWith({ countryCode: "SV", source: "ip" })
+  })
+
+  it("does not overwrite a first-seen country persisted concurrently by another mount", async () => {
+    mockResolveIpCountryCode.mockResolvedValue("DE")
+
+    renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    const updater = mockUpdateState.mock.calls[0][0]
+    expect(
+      getFirstSeenCountryCode(updater({ ...baseState, firstSeenCountryCode: "SV" })),
+    ).toBe("SV")
+    expect(updater(undefined)).toBeUndefined()
+  })
+
+  it("uses a VPN-flagged country for the session without persisting it", async () => {
+    mockResolveIpCountryCode.mockResolvedValue("DE")
+    mockDetectAnonymizingIp.mockResolvedValue(true)
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("DE")
+    expect(result.current.trusted).toBe(true)
+    expect(mockUpdateState).not.toHaveBeenCalled()
+    expect(mockLogDeferred).toHaveBeenCalledWith({ countryCode: "DE" })
+    expect(mockLogPersisted).not.toHaveBeenCalled()
+  })
+
+  it("persists the first-seen country when anonymity detection is unavailable", async () => {
+    mockResolveIpCountryCode.mockResolvedValue("SV")
+    mockDetectAnonymizingIp.mockResolvedValue(undefined)
+
+    renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(getFirstSeenCountryCode(persistedResult() as PersistentState)).toBe("SV")
+  })
+
+  it("persists nothing and reports untrusted when the IP lookup fails", async () => {
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBeUndefined()
+    expect(result.current.loading).toBe(false)
+    expect(result.current.trusted).toBe(false)
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("stays loading and does not resolve IP while the settings query is loading", () => {
+    mockUseSettingsScreenQuery.mockReturnValue({ data: undefined, loading: true })
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    expect(result.current.loading).toBe(true)
+    expect(result.current.countryCode).toBeUndefined()
+    expect(result.current.trusted).toBe(false)
+    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
+  })
+
+  it("falls through to the persisted country when the phone cannot be parsed", async () => {
+    mockPersistentState = { ...baseState, firstSeenCountryCode: "SV" }
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "invalid-phone" } },
+      loading: false,
+    })
+
+    const { result } = renderHook(() => useRegistrationCountry())
+
+    await act(async () => {})
+
+    expect(result.current.countryCode).toBe("SV")
+    expect(result.current.trusted).toBe(true)
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "registration-country",
+        context: expect.objectContaining({ source: "phone" }),
+      }),
+    )
+  })
+})

--- a/__tests__/hooks/use-transfer-blocked.spec.ts
+++ b/__tests__/hooks/use-transfer-blocked.spec.ts
@@ -3,23 +3,21 @@ import { renderHook } from "@testing-library/react-native"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
-const mockUseDeviceLocation = jest.fn()
+const mockUseRegistrationCountry = jest.fn()
 const mockUseRemoteConfig = jest.fn()
+const mockUseFeatureFlags = jest.fn()
 const mockUseActiveWallet = jest.fn()
 const mockUpdateState = jest.fn()
-const mockUseIpCountryCode = jest.fn()
 
 let mockPersistentState: PersistentState
 
-jest.mock("@app/hooks/use-device-location", () => ({
-  __esModule: true,
-  ...jest.requireActual("@app/hooks/use-device-location"),
-  default: () => mockUseDeviceLocation(),
-  useIpCountryCode: (enabled: boolean) => mockUseIpCountryCode(enabled),
+jest.mock("@app/hooks/use-registration-country", () => ({
+  useRegistrationCountry: () => mockUseRegistrationCountry(),
 }))
 
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => mockUseFeatureFlags(),
 }))
 
 jest.mock("@app/hooks/use-active-wallet", () => ({
@@ -33,6 +31,12 @@ jest.mock("@app/store/persistent-state", () => ({
   }),
 }))
 
+const mockLogRegionRestrictionCleared = jest.fn()
+jest.mock("@app/utils/analytics", () => ({
+  logRegionRestrictionCleared: (...args: unknown[]) =>
+    mockLogRegionRestrictionCleared(...args),
+}))
+
 import {
   useTransferBlocked,
   useTransferBlockedSync,
@@ -44,16 +48,27 @@ const baseState: PersistentState = {
   galoyAuthToken: "",
 }
 
+const country = (countryCode: string | undefined) => ({
+  countryCode,
+  loading: false,
+  trusted: Boolean(countryCode),
+})
+
 const setup = (): void => {
   jest.clearAllMocks()
-  mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
+  mockUseRegistrationCountry.mockReturnValue({
+    countryCode: undefined,
+    loading: true,
+    trusted: false,
+  })
   mockUseRemoteConfig.mockReturnValue({
     custodialTransferBlockedCountries: ["DE"],
     selfCustodialTransferBlockedCountries: ["FR"],
     dollarRestrictionCacheEnabled: true,
+    restrictionSelfHealEnabled: true,
   })
+  mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: true })
   mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
-  mockUseIpCountryCode.mockReturnValue(undefined)
   mockPersistentState = baseState
 }
 
@@ -61,18 +76,18 @@ describe("useTransferBlocked", () => {
   beforeEach(setup)
 
   it("blocks a self-custodial transfer when the country is in the self-custodial list", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
   })
 
   it("blocks a custodial transfer when the country is in the custodial list", () => {
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "DE" })
+    mockUseRegistrationCountry.mockReturnValue(country("DE"))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
   })
 
   it("reads each account type from its own list, so the lists can diverge", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
 
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
@@ -82,25 +97,25 @@ describe("useTransferBlocked", () => {
   })
 
   it("returns false when the country is in neither list", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "AR" })
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(false)
   })
 
-  it("is case-insensitive on the device country", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "fr" })
+  it("is case-insensitive on the registration country", () => {
+    mockUseRegistrationCountry.mockReturnValue(country("fr"))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
   })
 
   it("stays blocked from the self-custodial persisted flag without a detected country", () => {
     mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
-    mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+    mockUseRegistrationCountry.mockReturnValue(country(undefined))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
   })
 
   it("stays blocked from the custodial persisted flag without a detected country", () => {
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
     mockPersistentState = { ...baseState, stablesatsTransferBlocked: true }
-    mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+    mockUseRegistrationCountry.mockReturnValue(country(undefined))
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
   })
 
@@ -115,12 +130,12 @@ describe("useTransferBlocked", () => {
 
     it("ignores the persisted flag so a stale block can be lifted", () => {
       mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      mockUseRegistrationCountry.mockReturnValue(country(undefined))
       expect(renderHook(() => useTransferBlocked()).result.current).toBe(false)
     })
 
-    it("still blocks from the live device country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+    it("still blocks from the live registration country", () => {
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
       expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
     })
   })
@@ -129,8 +144,8 @@ describe("useTransferBlocked", () => {
 describe("useTransferBlockedSync", () => {
   beforeEach(setup)
 
-  it("persists the self-custodial flag when the phone country is in the self-custodial list", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+  it("persists the self-custodial flag when the registration country is in the self-custodial list", () => {
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
     const updates: Array<PersistentState | undefined> = []
     mockUpdateState.mockImplementation(
       (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
@@ -144,9 +159,9 @@ describe("useTransferBlockedSync", () => {
     expect(updates[1]).toBeUndefined()
   })
 
-  it("persists the custodial flag when the phone country is in the custodial list", () => {
+  it("persists the custodial flag when the registration country is in the custodial list", () => {
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "DE", source: "phone" })
+    mockUseRegistrationCountry.mockReturnValue(country("DE"))
     const updates: Array<PersistentState | undefined> = []
     mockUpdateState.mockImplementation(
       (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
@@ -159,19 +174,20 @@ describe("useTransferBlockedSync", () => {
     expect(updates[0]?.stablesatsTransferBlocked).toBe(true)
   })
 
-  it("persists the self-custodial flag via the IP country fallback when the phone country is not blocked", () => {
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "AR", source: "phone" })
-    mockUseIpCountryCode.mockReturnValue("FR")
-    const updates: Array<PersistentState | undefined> = []
-    mockUpdateState.mockImplementation(
-      (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
-        updates.push(fn(baseState))
-      },
-    )
-
+  it("does not persist when the registration country is not blocked", () => {
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
     renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
 
-    expect(updates[0]?.stableTokenTransferBlocked).toBe(true)
+  it("does not persist while the country is still resolving", () => {
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: undefined,
+      loading: true,
+      trusted: false,
+    })
+    renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).not.toHaveBeenCalled()
   })
 
   it("re-fires on a custodial-to-self-custodial switch in a blocked country, writing the self-custodial flag too", () => {
@@ -180,7 +196,7 @@ describe("useTransferBlockedSync", () => {
       selfCustodialTransferBlockedCountries: ["FR"],
       dollarRestrictionCacheEnabled: true,
     })
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
     const writes: PersistentState[] = []
     mockUpdateState.mockImplementation(
       (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
@@ -201,10 +217,113 @@ describe("useTransferBlockedSync", () => {
 
   it("does not persist again when it is already blocked", () => {
     mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
 
     renderHook(() => useTransferBlockedSync())
 
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("clears the self-custodial flag when the trusted country is allowed", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
+    const updates: Array<PersistentState | undefined> = []
+    mockUpdateState.mockImplementation(
+      (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
+        updates.push(fn(mockPersistentState), fn(undefined))
+      },
+    )
+
+    renderHook(() => useTransferBlockedSync())
+
+    expect(updates[0]?.stableTokenTransferBlocked).toBe(false)
+    expect(updates[1]).toBeUndefined()
+    expect(mockLogRegionRestrictionCleared).toHaveBeenCalledWith({
+      restriction: "transfer",
+      accountType: AccountType.SelfCustodial,
+      countryCode: "AR",
+    })
+  })
+
+  it("logs 'unknown' defensively if trusted is ever reported without a country", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: undefined,
+      loading: false,
+      trusted: true,
+    })
+
+    renderHook(() => useTransferBlockedSync())
+
+    expect(mockLogRegionRestrictionCleared).toHaveBeenCalledWith(
+      expect.objectContaining({ countryCode: "unknown" }),
+    )
+  })
+
+  it("does not clear when self-healing is remotely disabled", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseRemoteConfig.mockReturnValue({
+      custodialTransferBlockedCountries: ["DE"],
+      selfCustodialTransferBlockedCountries: ["FR"],
+      dollarRestrictionCacheEnabled: true,
+      restrictionSelfHealEnabled: false,
+    })
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
+    renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+    expect(mockLogRegionRestrictionCleared).not.toHaveBeenCalled()
+  })
+
+  it("clears the custodial flag when the trusted country is allowed", () => {
+    mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
+    mockPersistentState = { ...baseState, stablesatsTransferBlocked: true }
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
+    const updates: Array<PersistentState | undefined> = []
+    mockUpdateState.mockImplementation(
+      (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
+        updates.push(fn(mockPersistentState))
+      },
+    )
+
+    renderHook(() => useTransferBlockedSync())
+
+    expect(updates[0]?.stablesatsTransferBlocked).toBe(false)
+  })
+
+  it("does not clear while the country is still resolving", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: undefined,
+      loading: true,
+      trusted: false,
+    })
+    renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("does not clear while remote config has not loaded (default lists in use)", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: false })
+    mockUseRegistrationCountry.mockReturnValue(country("AR"))
+    renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("still persists while remote config has not loaded", () => {
+    mockUseFeatureFlags.mockReturnValue({ remoteConfigLoaded: false })
+    mockUseRegistrationCountry.mockReturnValue(country("FR"))
+    renderHook(() => useTransferBlockedSync())
+    expect(mockUpdateState).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not clear when country detection failed", () => {
+    mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: undefined,
+      loading: false,
+      trusted: false,
+    })
+    renderHook(() => useTransferBlockedSync())
     expect(mockUpdateState).not.toHaveBeenCalled()
   })
 
@@ -214,19 +333,29 @@ describe("useTransferBlockedSync", () => {
         custodialTransferBlockedCountries: ["DE"],
         selfCustodialTransferBlockedCountries: ["FR"],
         dollarRestrictionCacheEnabled: false,
+        restrictionSelfHealEnabled: true,
       })
     })
 
     it("does not persist even in a blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+      mockUseRegistrationCountry.mockReturnValue(country("FR"))
       renderHook(() => useTransferBlockedSync())
       expect(mockUpdateState).not.toHaveBeenCalled()
     })
 
-    it("does not consult IP", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "AR", source: "phone" })
+    it("still clears a stale flag so it cannot resurface when the cache is re-enabled", () => {
+      mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+      mockUseRegistrationCountry.mockReturnValue(country("AR"))
+      const updates: Array<PersistentState | undefined> = []
+      mockUpdateState.mockImplementation(
+        (fn: (state: PersistentState | undefined) => PersistentState | undefined) => {
+          updates.push(fn(mockPersistentState))
+        },
+      )
+
       renderHook(() => useTransferBlockedSync())
-      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
+
+      expect(updates[0]?.stableTokenTransferBlocked).toBe(false)
     })
   })
 })

--- a/__tests__/receive-bitcoin/hooks/use-payment-request.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-payment-request.spec.ts
@@ -56,10 +56,16 @@ jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
   useDollarBalanceRestricted: () => mockUseDollarBalanceRestricted(),
 }))
 
-const mockUseDeviceLocation = jest.fn(() => ({ countryCode: "SV", loading: false }))
-jest.mock("@app/hooks/use-device-location", () => ({
-  __esModule: true,
-  default: () => mockUseDeviceLocation(),
+type MockRegistrationCountry = {
+  countryCode: string | undefined
+  loading: boolean
+  trusted: boolean
+}
+const mockUseRegistrationCountry = jest.fn(
+  (): MockRegistrationCountry => ({ countryCode: "SV", loading: false, trusted: true }),
+)
+jest.mock("@app/hooks/use-registration-country", () => ({
+  useRegistrationCountry: () => mockUseRegistrationCountry(),
 }))
 
 const mockUseCountdown = jest.fn()
@@ -165,7 +171,11 @@ describe("usePaymentRequest", () => {
     mockUseLnUpdateHashPaid.mockReturnValue(null)
     mockUseCountdown.mockReturnValue({ remainingSeconds: null, isExpired: false })
     mockUseDollarBalanceRestricted.mockReturnValue(false)
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", loading: false })
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: "SV",
+      loading: false,
+      trusted: true,
+    })
   })
 
   it("returns null when wallet resolution is null", () => {
@@ -290,7 +300,11 @@ describe("usePaymentRequest", () => {
 
   it("defers invoice creation until country detection settles", async () => {
     setupMocksWithPR()
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", loading: true })
+    mockUseRegistrationCountry.mockReturnValue({
+      countryCode: undefined,
+      loading: true,
+      trusted: false,
+    })
 
     renderHook(() => usePaymentRequest())
 

--- a/__tests__/screens/receive.spec.tsx
+++ b/__tests__/screens/receive.spec.tsx
@@ -165,6 +165,10 @@ jest.mock("@app/hooks/use-device-location", () => ({
   default: () => ({ countryCode: "SV", loading: false }),
 }))
 
+jest.mock("@app/hooks/use-registration-country", () => ({
+  useRegistrationCountry: () => ({ countryCode: "SV", loading: false, trusted: true }),
+}))
+
 jest.mock("@app/hooks/use-display-currency", () => {
   const info = {
     BTC: {

--- a/__tests__/store/persistent-state/first-seen-country.spec.ts
+++ b/__tests__/store/persistent-state/first-seen-country.spec.ts
@@ -1,0 +1,45 @@
+import {
+  getFirstSeenCountryCode,
+  withFirstSeenCountryCode,
+} from "@app/store/persistent-state/first-seen-country"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+
+const baseState: PersistentState = {
+  schemaVersion: 14,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+describe("getFirstSeenCountryCode", () => {
+  it("returns undefined as the default", () => {
+    expect(getFirstSeenCountryCode(baseState)).toBeUndefined()
+  })
+
+  it("returns the persisted country code", () => {
+    expect(getFirstSeenCountryCode({ ...baseState, firstSeenCountryCode: "SV" })).toBe(
+      "SV",
+    )
+  })
+})
+
+describe("withFirstSeenCountryCode", () => {
+  it("sets the country code", () => {
+    expect(withFirstSeenCountryCode(baseState, "SV").firstSeenCountryCode).toBe("SV")
+  })
+
+  it("replaces an existing country code", () => {
+    expect(
+      withFirstSeenCountryCode({ ...baseState, firstSeenCountryCode: "PL" }, "SV")
+        .firstSeenCountryCode,
+    ).toBe("SV")
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = { ...baseState, firstSeenCountryCode: "PL" }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    withFirstSeenCountryCode(original, "SV")
+
+    expect(original).toEqual(snapshot)
+  })
+})

--- a/__tests__/store/persistent-state/stable-token-restriction.spec.ts
+++ b/__tests__/store/persistent-state/stable-token-restriction.spec.ts
@@ -1,6 +1,7 @@
 import {
   getStableTokenRestricted,
   withStableTokenRestricted,
+  withoutStableTokenRestricted,
 } from "@app/store/persistent-state/stable-token-restriction"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 
@@ -39,6 +40,29 @@ describe("withStableTokenRestricted", () => {
     const snapshot = JSON.parse(JSON.stringify(original))
 
     withStableTokenRestricted(original)
+
+    expect(original).toEqual(snapshot)
+  })
+})
+
+describe("withoutStableTokenRestricted", () => {
+  it("clears the flag when set", () => {
+    expect(
+      getStableTokenRestricted(
+        withoutStableTokenRestricted(withStableTokenRestricted(baseState)),
+      ),
+    ).toBe(false)
+  })
+
+  it("keeps the flag cleared when already unset", () => {
+    expect(getStableTokenRestricted(withoutStableTokenRestricted(baseState))).toBe(false)
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = { ...baseState, stableTokenRestricted: true }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    withoutStableTokenRestricted(original)
 
     expect(original).toEqual(snapshot)
   })

--- a/__tests__/store/persistent-state/stable-token-transfer-block.spec.ts
+++ b/__tests__/store/persistent-state/stable-token-transfer-block.spec.ts
@@ -1,6 +1,7 @@
 import {
   getStableTokenTransferBlocked,
   withStableTokenTransferBlocked,
+  withoutStableTokenTransferBlocked,
 } from "@app/store/persistent-state/stable-token-transfer-block"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 
@@ -43,6 +44,31 @@ describe("withStableTokenTransferBlocked", () => {
     const snapshot = JSON.parse(JSON.stringify(original))
 
     withStableTokenTransferBlocked(original)
+
+    expect(original).toEqual(snapshot)
+  })
+})
+
+describe("withoutStableTokenTransferBlocked", () => {
+  it("clears the flag when set", () => {
+    expect(
+      getStableTokenTransferBlocked(
+        withoutStableTokenTransferBlocked(withStableTokenTransferBlocked(baseState)),
+      ),
+    ).toBe(false)
+  })
+
+  it("keeps the flag cleared when already unset", () => {
+    expect(
+      getStableTokenTransferBlocked(withoutStableTokenTransferBlocked(baseState)),
+    ).toBe(false)
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = { ...baseState, stableTokenTransferBlocked: true }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    withoutStableTokenTransferBlocked(original)
 
     expect(original).toEqual(snapshot)
   })

--- a/__tests__/store/persistent-state/stablesats-restriction.spec.ts
+++ b/__tests__/store/persistent-state/stablesats-restriction.spec.ts
@@ -1,6 +1,7 @@
 import {
   getStablesatsRestricted,
   withStablesatsRestricted,
+  withoutStablesatsRestricted,
 } from "@app/store/persistent-state/stablesats-restriction"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 
@@ -43,6 +44,32 @@ describe("withStablesatsRestricted", () => {
     const snapshot = JSON.parse(JSON.stringify(original))
 
     withStablesatsRestricted(original)
+
+    expect(original).toEqual(snapshot)
+  })
+})
+
+describe("withoutStablesatsRestricted", () => {
+  it("clears the flag when set", () => {
+    expect(
+      getStablesatsRestricted(
+        withoutStablesatsRestricted(withStablesatsRestricted(baseState)),
+      ),
+    ).toBe(false)
+  })
+
+  it("keeps the flag cleared when already unset", () => {
+    expect(getStablesatsRestricted(withoutStablesatsRestricted(baseState))).toBe(false)
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = {
+      ...baseState,
+      stablesatsRestrictedCustodial: true,
+    }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    withoutStablesatsRestricted(original)
 
     expect(original).toEqual(snapshot)
   })

--- a/__tests__/store/persistent-state/stablesats-transfer-block.spec.ts
+++ b/__tests__/store/persistent-state/stablesats-transfer-block.spec.ts
@@ -1,6 +1,7 @@
 import {
   getStablesatsTransferBlocked,
   withStablesatsTransferBlocked,
+  withoutStablesatsTransferBlocked,
 } from "@app/store/persistent-state/stablesats-transfer-block"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 
@@ -41,6 +42,31 @@ describe("withStablesatsTransferBlocked", () => {
     const snapshot = JSON.parse(JSON.stringify(original))
 
     withStablesatsTransferBlocked(original)
+
+    expect(original).toEqual(snapshot)
+  })
+})
+
+describe("withoutStablesatsTransferBlocked", () => {
+  it("clears the flag when set", () => {
+    expect(
+      getStablesatsTransferBlocked(
+        withoutStablesatsTransferBlocked(withStablesatsTransferBlocked(baseState)),
+      ),
+    ).toBe(false)
+  })
+
+  it("keeps the flag cleared when already unset", () => {
+    expect(
+      getStablesatsTransferBlocked(withoutStablesatsTransferBlocked(baseState)),
+    ).toBe(false)
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = { ...baseState, stablesatsTransferBlocked: true }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    withoutStablesatsTransferBlocked(original)
 
     expect(original).toEqual(snapshot)
   })

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -5,6 +5,8 @@ import Config from "react-native-config"
 import {
   IpLookupAdapter,
   DEFAULT_ADAPTERS,
+  detectAnonymizingIp,
+  detectAnonymizingIpCached,
   resolveIpCountryCode,
   resolveIpCountryCodeCached,
 } from "@app/utils/ip-country-lookup"
@@ -106,6 +108,121 @@ describe("resolveIpCountryCodeCached", () => {
 
     mockedAxios.get.mockClear()
     await expect(resolveIpCountryCodeCached()).resolves.toBe("DE")
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+})
+
+describe("detectAnonymizingIp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mutableConfig.PROXYCHECK_API_KEY = ""
+  })
+
+  it("returns true when proxycheck flags the IP as a VPN", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        "status": "ok",
+        "1.2.3.4": { detections: { proxy: true, vpn: true } },
+      },
+    })
+
+    await expect(detectAnonymizingIp()).resolves.toBe(true)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("proxycheck.io"),
+      expect.anything(),
+    )
+  })
+
+  it("returns false when proxycheck reports the IP clean", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        "status": "ok",
+        "1.2.3.4": { detections: { proxy: false, vpn: false } },
+      },
+    })
+
+    await expect(detectAnonymizingIp()).resolves.toBe(false)
+  })
+
+  it("parses the v2-style flat proxy flag", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { "status": "ok", "1.2.3.4": { proxy: "yes" } },
+    })
+    await expect(detectAnonymizingIp()).resolves.toBe(true)
+
+    mockedAxios.get.mockResolvedValue({
+      data: { "status": "ok", "1.2.3.4": { proxy: "no" } },
+    })
+    await expect(detectAnonymizingIp()).resolves.toBe(false)
+  })
+
+  it("returns undefined when the response carries no detection fields", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        "status": "ok",
+        // eslint-disable-next-line camelcase
+        "1.2.3.4": { location: { country_code: "SE" } },
+      },
+    })
+
+    await expect(detectAnonymizingIp()).resolves.toBeUndefined()
+  })
+
+  it("returns undefined for an unrecognized flat proxy value", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { "status": "ok", "1.2.3.4": { proxy: "maybe" } },
+    })
+
+    await expect(detectAnonymizingIp()).resolves.toBeUndefined()
+  })
+
+  it("returns undefined and reports when the request fails", async () => {
+    mockedAxios.get.mockRejectedValue(new Error("proxycheck down"))
+
+    await expect(detectAnonymizingIp()).resolves.toBeUndefined()
+  })
+
+  it("appends the api key when PROXYCHECK_API_KEY is set", async () => {
+    mutableConfig.PROXYCHECK_API_KEY = "test-proxycheck-key"
+    mockedAxios.get.mockResolvedValue({
+      data: { "status": "ok", "1.2.3.4": { detections: { proxy: false } } },
+    })
+
+    await detectAnonymizingIp()
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("key=test-proxycheck-key"),
+      expect.anything(),
+    )
+  })
+})
+
+describe("detectAnonymizingIpCached", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mutableConfig.PROXYCHECK_API_KEY = ""
+  })
+
+  /** One sequential test: the cache is module state, so the phases (inconclusive
+   *  retries, conclusive reuse) must run in a known order. */
+  it("retries inconclusive detections and caches conclusive ones", async () => {
+    mockedAxios.get.mockRejectedValue(new Error("offline"))
+    await expect(detectAnonymizingIpCached()).resolves.toBeUndefined()
+
+    mockedAxios.get.mockReset()
+    mockedAxios.get.mockResolvedValue({
+      data: { "status": "ok", "1.2.3.4": { detections: { vpn: true } } },
+    })
+    const [first, second] = await Promise.all([
+      detectAnonymizingIpCached(),
+      detectAnonymizingIpCached(),
+    ])
+    expect(first).toBe(true)
+    expect(second).toBe(true)
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+
+    mockedAxios.get.mockClear()
+    await expect(detectAnonymizingIpCached()).resolves.toBe(true)
     expect(mockedAxios.get).not.toHaveBeenCalled()
   })
 })

--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Pressable } from "react-native"
 import DeviceInfo from "react-native-device-info"
 
-import useDeviceLocation from "@app/hooks/use-device-location"
+import { useRegistrationCountry } from "@app/hooks/use-registration-country"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useNavigation } from "@react-navigation/native"
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -28,7 +28,8 @@ export const VersionComponent = () => {
   const styles = useStyles()
   const { navigate } = useNavigation<VersionComponentNavigationProp>()
   const { LL } = useI18nContext()
-  const { countryCode } = useDeviceLocation()
+  /** Shows the same country the region restrictions gate on, for support triage (#3907). */
+  const { countryCode } = useRegistrationCountry()
   const detectedCountry = countryCode ?? LL.common.unknown()
   const [secretMenuCounter, setSecretMenuCounter] = React.useState(0)
   React.useEffect(() => {

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -31,6 +31,7 @@ const BackupNudgeModalThresholdKey = "backupNudgeModalThreshold"
 const NonCustodialEnabledKey = "nonCustodialEnabled"
 const StableBalanceEnabledKey = "stableBalanceEnabled"
 const DollarRestrictionCacheEnabledKey = "dollarRestrictionCacheEnabled"
+const RestrictionSelfHealEnabledKey = "restrictionSelfHealEnabled"
 const AutoConvertMaxAttemptsKey = "autoConvertMaxAttempts"
 const AutoConvertPollMaxAttemptsKey = "autoConvertPollMaxAttempts"
 const AutoConvertPollIntervalMsKey = "autoConvertPollIntervalMs"
@@ -58,6 +59,13 @@ type FeatureFlags = {
   nonCustodialEnabled: boolean
   stableBalanceEnabled: boolean
   remoteConfigReady: boolean
+  /**
+   * True only after a successful fetchAndActivate. `remoteConfigReady` flips
+   * true even on failure (defaults in use) — anything that must not act on
+   * default values (e.g. clearing a persisted region restriction) gates on
+   * this instead.
+   */
+  remoteConfigLoaded: boolean
 }
 
 type RemoteConfig = {
@@ -80,6 +88,7 @@ type RemoteConfig = {
   [NonCustodialEnabledKey]: boolean
   [StableBalanceEnabledKey]: boolean
   [DollarRestrictionCacheEnabledKey]: boolean
+  [RestrictionSelfHealEnabledKey]: boolean
   [AutoConvertMaxAttemptsKey]: number
   [AutoConvertPollMaxAttemptsKey]: number
   [AutoConvertPollIntervalMsKey]: number
@@ -151,6 +160,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   nonCustodialEnabled: false,
   stableBalanceEnabled: false,
   dollarRestrictionCacheEnabled: true,
+  restrictionSelfHealEnabled: true,
   autoConvertMaxAttempts: 3,
   autoConvertPollMaxAttempts: 30,
   autoConvertPollIntervalMs: 500,
@@ -170,6 +180,7 @@ const defaultFeatureFlags: FeatureFlags = {
   nonCustodialEnabled: false,
   stableBalanceEnabled: false,
   remoteConfigReady: false,
+  remoteConfigLoaded: false,
 }
 
 remoteConfigInstance().setDefaults({
@@ -214,6 +225,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
 
   const { currentLevel } = useLevel()
   const [remoteConfigReady, setRemoteConfigReady] = useState(false)
+  const [remoteConfigLoaded, setRemoteConfigLoaded] = useState(false)
   const rolloutLoggedRef = useRef(false)
 
   const {
@@ -295,6 +307,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
 
         const dollarRestrictionCacheEnabled = remoteConfigInstance()
           .getValue(DollarRestrictionCacheEnabledKey)
+          .asBoolean()
+
+        const restrictionSelfHealEnabled = remoteConfigInstance()
+          .getValue(RestrictionSelfHealEnabledKey)
           .asBoolean()
 
         const autoConvertMaxAttempts = remoteConfigInstance()
@@ -382,6 +398,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           nonCustodialEnabled,
           stableBalanceEnabled,
           dollarRestrictionCacheEnabled,
+          restrictionSelfHealEnabled,
           autoConvertMaxAttempts,
           autoConvertPollMaxAttempts,
           autoConvertPollIntervalMs,
@@ -395,6 +412,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           selfCustodialCreationBlockedCountries,
           selfCustodialDepositClaimLeewayVbyte,
         })
+        setRemoteConfigLoaded(true)
       } catch (err) {
         logError({
           scope: "remote-config",
@@ -414,6 +432,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
     stableBalanceEnabled:
       remoteConfig.nonCustodialEnabled && remoteConfig.stableBalanceEnabled,
     remoteConfigReady,
+    remoteConfigLoaded,
   }
 
   useEffect(() => {

--- a/app/hooks/use-device-location.ts
+++ b/app/hooks/use-device-location.ts
@@ -114,21 +114,4 @@ const useDeviceLocation = (): DeviceLocation => {
   }
 }
 
-export const useIpCountryCode = (enabled: boolean): CountryCode | undefined => {
-  const [ipCountryCode, setIpCountryCode] = useState<CountryCode | undefined>()
-
-  useEffect(() => {
-    if (!enabled) return undefined
-    let active = true
-    resolveIpCountryCodeCached().then((code) => {
-      if (active && code) setIpCountryCode(code)
-    })
-    return () => {
-      active = false
-    }
-  }, [enabled])
-
-  return ipCountryCode
-}
-
 export default useDeviceLocation

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -1,29 +1,31 @@
 import { useEffect } from "react"
 
-import { useRemoteConfig } from "@app/config/feature-flags-context"
+import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import {
   getStableTokenRestricted,
   withStableTokenRestricted,
+  withoutStableTokenRestricted,
 } from "@app/store/persistent-state/stable-token-restriction"
 import {
   getStablesatsRestricted,
   withStablesatsRestricted,
+  withoutStablesatsRestricted,
 } from "@app/store/persistent-state/stablesats-restriction"
 import { AccountType } from "@app/types/wallet"
+import { logRegionRestrictionCleared } from "@app/utils/analytics"
 
-import useDeviceLocation, {
-  isBlockedCountry,
-  LocationSource,
-  useIpCountryCode,
-} from "./use-device-location"
+import { isBlockedCountry } from "./use-device-location"
+import { useRegistrationCountry } from "./use-registration-country"
 import { useActiveWallet } from "./use-active-wallet"
 
 type DollarBalanceRestrictionPolicy = {
+  accountType: AccountType
   blockedCountries: string[]
   isPersisted: boolean
   persist: (state: PersistentState) => PersistentState
+  clear: (state: PersistentState) => PersistentState
 }
 
 /**
@@ -40,53 +42,84 @@ const useDollarBalanceRestrictionPolicy = (): DollarBalanceRestrictionPolicy => 
 
   if (accountType === AccountType.SelfCustodial) {
     return {
+      accountType,
       blockedCountries: selfCustodialDollarBalanceBlockedCountries,
       isPersisted: getStableTokenRestricted(persistentState),
       persist: withStableTokenRestricted,
+      clear: withoutStableTokenRestricted,
     }
   }
   return {
+    accountType,
     blockedCountries: custodialDollarBalanceBlockedCountries,
     isPersisted: getStablesatsRestricted(persistentState),
     persist: withStablesatsRestricted,
+    clear: withoutStablesatsRestricted,
   }
 }
 
 export const useDollarBalanceRestricted = (): boolean => {
   const { blockedCountries, isPersisted } = useDollarBalanceRestrictionPolicy()
   const { dollarRestrictionCacheEnabled } = useRemoteConfig()
-  const { countryCode } = useDeviceLocation()
+  const { countryCode } = useRegistrationCountry()
 
   const isCachedRestriction = dollarRestrictionCacheEnabled && isPersisted
 
   return isCachedRestriction || isBlockedCountry(countryCode, blockedCountries)
 }
 
+/**
+ * The restriction follows the account's registration country
+ * (useRegistrationCountry), never the current IP: a VPN exit country must not
+ * flip or latch the restriction (#3907).
+ */
 export const useDollarBalanceRestrictionSync = (): void => {
-  const { blockedCountries, isPersisted, persist } = useDollarBalanceRestrictionPolicy()
-  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
-  const { countryCode, source } = useDeviceLocation()
+  const { accountType, blockedCountries, isPersisted, persist, clear } =
+    useDollarBalanceRestrictionPolicy()
+  const { dollarRestrictionCacheEnabled, restrictionSelfHealEnabled } = useRemoteConfig()
+  const { remoteConfigLoaded } = useFeatureFlags()
+  const { countryCode, loading, trusted } = useRegistrationCountry()
   const { updateState } = usePersistentStateContext()
 
-  const canPersistRestriction = dollarRestrictionCacheEnabled && !isPersisted
-  const primaryBlocked = isBlockedCountry(countryCode, blockedCountries)
-  const isPhoneSource = source === LocationSource.Phone
+  const blocked = isBlockedCountry(countryCode, blockedCountries)
 
-  const shouldConsultIp = canPersistRestriction && isPhoneSource && !primaryBlocked
-
-  const ipCountryCode = useIpCountryCode(shouldConsultIp)
-
-  const shouldPersist =
-    canPersistRestriction &&
-    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
+  const shouldPersist = dollarRestrictionCacheEnabled && !isPersisted && blocked
 
   /**
-   * `persist` is in the deps on purpose: its identity flips with accountType, so
-   * a custodial-to-self-custodial switch in a blocked country re-fires this effect
-   * and writes the self-custodial flag too (anti-bypass double-write).
+   * Clearing needs trustworthy evidence on BOTH sides of the comparison:
+   * `loading`/`trusted` guard the unknown-country window, and
+   * `remoteConfigLoaded` guards the default blocked lists a failed remote-config
+   * fetch leaves behind — a country missing from the defaults must not clear a
+   * flag set from the real config. `restrictionSelfHealEnabled` is the remote
+   * kill-switch for healing itself (compliance escape hatch). Clearing is
+   * deliberately NOT gated on `dollarRestrictionCacheEnabled`: while that
+   * kill-switch is active, stale flags heal instead of freezing until the
+   * cache is re-enabled.
+   */
+  const shouldClear =
+    isPersisted &&
+    restrictionSelfHealEnabled &&
+    remoteConfigLoaded &&
+    !loading &&
+    trusted &&
+    !blocked
+
+  /**
+   * `persist`/`clear` are in the deps on purpose: their identity flips with
+   * accountType, so a custodial-to-self-custodial switch in a blocked country
+   * re-fires this effect and writes the self-custodial flag too (anti-bypass
+   * double-write on set; symmetric heal on clear).
    */
   useEffect(() => {
-    if (!shouldPersist) return
-    updateState((state) => (state ? persist(state) : state))
-  }, [shouldPersist, persist, updateState])
+    if (shouldPersist) {
+      updateState((state) => (state ? persist(state) : state))
+    } else if (shouldClear) {
+      updateState((state) => (state ? clear(state) : state))
+      logRegionRestrictionCleared({
+        restriction: "dollar_balance",
+        accountType,
+        countryCode: countryCode ?? "unknown",
+      })
+    }
+  }, [shouldPersist, shouldClear, persist, clear, updateState, accountType, countryCode])
 }

--- a/app/hooks/use-registration-country.ts
+++ b/app/hooks/use-registration-country.ts
@@ -1,0 +1,127 @@
+import { CountryCode, parsePhoneNumber } from "libphonenumber-js/mobile"
+import { useEffect, useMemo, useState } from "react"
+
+import { useSettingsScreenQuery } from "@app/graphql/generated"
+import { usePersistentStateContext } from "@app/store/persistent-state"
+import {
+  getFirstSeenCountryCode,
+  withFirstSeenCountryCode,
+} from "@app/store/persistent-state/first-seen-country"
+import {
+  logRegistrationCountryPersistDeferred,
+  logRegistrationCountryPersisted,
+} from "@app/utils/analytics"
+import {
+  detectAnonymizingIpCached,
+  resolveIpCountryCodeCached,
+} from "@app/utils/ip-country-lookup"
+import { logError } from "@app/utils/log-error"
+
+type RegistrationCountry = {
+  countryCode: CountryCode | undefined
+  loading: boolean
+  trusted: boolean
+}
+
+type IpResolution = {
+  countryCode: CountryCode | undefined
+  settled: boolean
+}
+
+/**
+ * The country the region restrictions are gated on (#3907): the account's
+ * registration country, never the current IP. Priority:
+ *
+ * 1. Phone-number country — the registration country of a phone account.
+ * 2. Persisted first-seen country — a no-phone (self-custodial) account has no
+ *    registration, so the country resolved on first use is persisted and
+ *    treated as its registration country from then on.
+ * 3. One IP lookup to establish the first-seen country when neither exists.
+ *    A failed lookup persists nothing, so a later session can retry.
+ *
+ * `trusted` is false only while the country is unknown; consumers must fail
+ * open (no restriction) rather than act on an unknown country.
+ */
+export const useRegistrationCountry = (): RegistrationCountry => {
+  const { persistentState, updateState } = usePersistentStateContext()
+  const { data: settingsData, loading: settingsLoading } = useSettingsScreenQuery({
+    fetchPolicy: "cache-first",
+  })
+
+  const persistedCountryCode = getFirstSeenCountryCode(persistentState) as
+    | CountryCode
+    | undefined
+  const userPhone = settingsData?.me?.phone
+
+  const phoneCountryCode = useMemo(() => {
+    if (!userPhone) return undefined
+    try {
+      return parsePhoneNumber(userPhone)?.country
+    } catch (err) {
+      logError({
+        scope: "registration-country",
+        error: err,
+        context: { source: "phone" },
+      })
+      return undefined
+    }
+  }, [userPhone])
+
+  /**
+   * The phone country is stronger evidence than a first-seen IP, so it also
+   * refreshes the persisted value — the registration country then survives a
+   * later switch to a no-phone (self-custodial) session.
+   */
+  useEffect(() => {
+    if (!phoneCountryCode || phoneCountryCode === persistedCountryCode) return
+    updateState((state) =>
+      state ? withFirstSeenCountryCode(state, phoneCountryCode) : state,
+    )
+    logRegistrationCountryPersisted({ countryCode: phoneCountryCode, source: "phone" })
+  }, [phoneCountryCode, persistedCountryCode, updateState])
+
+  const shouldResolveIp = !settingsLoading && !phoneCountryCode && !persistedCountryCode
+
+  const [ipResolution, setIpResolution] = useState<IpResolution>({
+    countryCode: undefined,
+    settled: false,
+  })
+
+  useEffect(() => {
+    if (!shouldResolveIp) return undefined
+    let active = true
+    Promise.all([resolveIpCountryCodeCached(), detectAnonymizingIpCached()]).then(
+      ([resolved, isAnonymizing]) => {
+        if (!active) return
+        setIpResolution({ countryCode: resolved, settled: true })
+        if (!resolved) return
+        /**
+         * A VPN/proxy exit country must never be pinned as the wallet's
+         * registration country (#3907): behind a flagged anonymizer the
+         * resolved country is used for this session only and persisting is
+         * retried on a later session. Only a confirmed flag defers — an
+         * external detector's availability must not gate registration.
+         */
+        if (isAnonymizing === true) {
+          logRegistrationCountryPersistDeferred({ countryCode: resolved })
+          return
+        }
+        updateState((state) =>
+          state && !getFirstSeenCountryCode(state)
+            ? withFirstSeenCountryCode(state, resolved)
+            : state,
+        )
+        logRegistrationCountryPersisted({ countryCode: resolved, source: "ip" })
+      },
+    )
+    return () => {
+      active = false
+    }
+  }, [shouldResolveIp, updateState])
+
+  const countryCode = phoneCountryCode ?? persistedCountryCode ?? ipResolution.countryCode
+  const loading =
+    !countryCode && (settingsLoading || (shouldResolveIp && !ipResolution.settled))
+
+  return { countryCode, loading, trusted: Boolean(countryCode) }
+}

--- a/app/hooks/use-transfer-blocked.ts
+++ b/app/hooks/use-transfer-blocked.ts
@@ -1,29 +1,31 @@
 import { useEffect } from "react"
 
-import { useRemoteConfig } from "@app/config/feature-flags-context"
+import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import {
   getStablesatsTransferBlocked,
   withStablesatsTransferBlocked,
+  withoutStablesatsTransferBlocked,
 } from "@app/store/persistent-state/stablesats-transfer-block"
 import {
   getStableTokenTransferBlocked,
   withStableTokenTransferBlocked,
+  withoutStableTokenTransferBlocked,
 } from "@app/store/persistent-state/stable-token-transfer-block"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
+import { logRegionRestrictionCleared } from "@app/utils/analytics"
 
-import useDeviceLocation, {
-  isBlockedCountry,
-  LocationSource,
-  useIpCountryCode,
-} from "./use-device-location"
+import { isBlockedCountry } from "./use-device-location"
+import { useRegistrationCountry } from "./use-registration-country"
 import { useActiveWallet } from "./use-active-wallet"
 
 type TransferBlockPolicy = {
+  accountType: AccountType
   blockedCountries: string[]
   isPersisted: boolean
   persist: (state: PersistentState) => PersistentState
+  clear: (state: PersistentState) => PersistentState
 }
 
 /** Gating on accountType (not isSelfCustodial) stays stable through the self-custodial cold-start. */
@@ -35,49 +37,82 @@ const useTransferBlockPolicy = (): TransferBlockPolicy => {
 
   if (accountType === AccountType.SelfCustodial) {
     return {
+      accountType,
       blockedCountries: selfCustodialTransferBlockedCountries,
       isPersisted: getStableTokenTransferBlocked(persistentState),
       persist: withStableTokenTransferBlocked,
+      clear: withoutStableTokenTransferBlocked,
     }
   }
   return {
+    accountType,
     blockedCountries: custodialTransferBlockedCountries,
     isPersisted: getStablesatsTransferBlocked(persistentState),
     persist: withStablesatsTransferBlocked,
+    clear: withoutStablesatsTransferBlocked,
   }
 }
 
 export const useTransferBlocked = (): boolean => {
   const { blockedCountries, isPersisted } = useTransferBlockPolicy()
   const { dollarRestrictionCacheEnabled } = useRemoteConfig()
-  const { countryCode } = useDeviceLocation()
+  const { countryCode } = useRegistrationCountry()
 
   const isCachedRestriction = dollarRestrictionCacheEnabled && isPersisted
 
   return isCachedRestriction || isBlockedCountry(countryCode, blockedCountries)
 }
 
+/**
+ * The block follows the account's registration country (useRegistrationCountry),
+ * never the current IP: a VPN exit country must not flip or latch it (#3907).
+ */
 export const useTransferBlockedSync = (): void => {
-  const { blockedCountries, isPersisted, persist } = useTransferBlockPolicy()
-  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
-  const { countryCode, source } = useDeviceLocation()
+  const { accountType, blockedCountries, isPersisted, persist, clear } =
+    useTransferBlockPolicy()
+  const { dollarRestrictionCacheEnabled, restrictionSelfHealEnabled } = useRemoteConfig()
+  const { remoteConfigLoaded } = useFeatureFlags()
+  const { countryCode, loading, trusted } = useRegistrationCountry()
   const { updateState } = usePersistentStateContext()
 
-  const canPersistRestriction = dollarRestrictionCacheEnabled && !isPersisted
-  const primaryBlocked = isBlockedCountry(countryCode, blockedCountries)
-  const isPhoneSource = source === LocationSource.Phone
+  const blocked = isBlockedCountry(countryCode, blockedCountries)
 
-  const shouldConsultIp = canPersistRestriction && isPhoneSource && !primaryBlocked
+  const shouldPersist = dollarRestrictionCacheEnabled && !isPersisted && blocked
 
-  const ipCountryCode = useIpCountryCode(shouldConsultIp)
+  /**
+   * Clearing needs trustworthy evidence on BOTH sides of the comparison:
+   * `loading`/`trusted` guard the unknown-country window, and
+   * `remoteConfigLoaded` guards the default blocked lists a failed remote-config
+   * fetch leaves behind — a country missing from the defaults must not clear a
+   * flag set from the real config. `restrictionSelfHealEnabled` is the remote
+   * kill-switch for healing itself (compliance escape hatch). Clearing is
+   * deliberately NOT gated on `dollarRestrictionCacheEnabled`: while that
+   * kill-switch is active, stale flags heal instead of freezing until the
+   * cache is re-enabled.
+   */
+  const shouldClear =
+    isPersisted &&
+    restrictionSelfHealEnabled &&
+    remoteConfigLoaded &&
+    !loading &&
+    trusted &&
+    !blocked
 
-  const shouldPersist =
-    canPersistRestriction &&
-    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
-
-  /** `persist` is in the deps so an accountType switch re-fires and writes the other flag too (anti-bypass). */
+  /**
+   * `persist`/`clear` are in the deps so an accountType switch re-fires and
+   * writes the other flag too (anti-bypass double-write on set; symmetric heal
+   * on clear).
+   */
   useEffect(() => {
-    if (!shouldPersist) return
-    updateState((state) => (state ? persist(state) : state))
-  }, [shouldPersist, persist, updateState])
+    if (shouldPersist) {
+      updateState((state) => (state ? persist(state) : state))
+    } else if (shouldClear) {
+      updateState((state) => (state ? clear(state) : state))
+      logRegionRestrictionCleared({
+        restriction: "transfer",
+        accountType,
+        countryCode: countryCode ?? "unknown",
+      })
+    }
+  }, [shouldPersist, shouldClear, persist, clear, updateState, accountType, countryCode])
 }

--- a/app/screens/receive-bitcoin-screen/hooks/use-payment-request.ts
+++ b/app/screens/receive-bitcoin-screen/hooks/use-payment-request.ts
@@ -8,8 +8,8 @@ import {
   useLnUsdInvoiceCreateMutation,
   useOnChainAddressCurrentMutation,
 } from "@app/graphql/generated"
-import useDeviceLocation from "@app/hooks/use-device-location"
 import { useDollarBalanceRestricted } from "@app/hooks/use-dollar-balance-restricted"
+import { useRegistrationCountry } from "@app/hooks/use-registration-country"
 import { MoneyAmount, WalletOrDisplayCurrency } from "@app/types/amounts"
 import { BtcWalletDescriptor } from "@app/types/wallets"
 
@@ -80,7 +80,7 @@ const DEFAULT_EXPIRATION_MINUTES: Record<WalletCurrency, number> = {
 export const usePaymentRequest = () => {
   const wallets = useWalletResolution()
   const isDollarBalanceRestricted = useDollarBalanceRestricted()
-  const { loading: locationLoading } = useDeviceLocation()
+  const { loading: locationLoading } = useRegistrationCountry()
 
   const [lnNoAmountInvoiceCreate] = useLnNoAmountInvoiceCreateMutation()
   const [lnUsdInvoiceCreate] = useLnUsdInvoiceCreateMutation()

--- a/app/store/persistent-state/first-seen-country.ts
+++ b/app/store/persistent-state/first-seen-country.ts
@@ -1,0 +1,12 @@
+import { PersistentState } from "./state-migrations"
+
+export const getFirstSeenCountryCode = (state: PersistentState): string | undefined =>
+  state.firstSeenCountryCode
+
+export const withFirstSeenCountryCode = (
+  state: PersistentState,
+  countryCode: string,
+): PersistentState => ({
+  ...state,
+  firstSeenCountryCode: countryCode,
+})

--- a/app/store/persistent-state/stable-token-restriction.ts
+++ b/app/store/persistent-state/stable-token-restriction.ts
@@ -7,3 +7,10 @@ export const withStableTokenRestricted = (state: PersistentState): PersistentSta
   ...state,
   stableTokenRestricted: true,
 })
+
+export const withoutStableTokenRestricted = (
+  state: PersistentState,
+): PersistentState => ({
+  ...state,
+  stableTokenRestricted: false,
+})

--- a/app/store/persistent-state/stable-token-transfer-block.ts
+++ b/app/store/persistent-state/stable-token-transfer-block.ts
@@ -9,3 +9,10 @@ export const withStableTokenTransferBlocked = (
   ...state,
   stableTokenTransferBlocked: true,
 })
+
+export const withoutStableTokenTransferBlocked = (
+  state: PersistentState,
+): PersistentState => ({
+  ...state,
+  stableTokenTransferBlocked: false,
+})

--- a/app/store/persistent-state/stablesats-restriction.ts
+++ b/app/store/persistent-state/stablesats-restriction.ts
@@ -7,3 +7,8 @@ export const withStablesatsRestricted = (state: PersistentState): PersistentStat
   ...state,
   stablesatsRestrictedCustodial: true,
 })
+
+export const withoutStablesatsRestricted = (state: PersistentState): PersistentState => ({
+  ...state,
+  stablesatsRestrictedCustodial: false,
+})

--- a/app/store/persistent-state/stablesats-transfer-block.ts
+++ b/app/store/persistent-state/stablesats-transfer-block.ts
@@ -9,3 +9,10 @@ export const withStablesatsTransferBlocked = (
   ...state,
   stablesatsTransferBlocked: true,
 })
+
+export const withoutStablesatsTransferBlocked = (
+  state: PersistentState,
+): PersistentState => ({
+  ...state,
+  stablesatsTransferBlocked: false,
+})

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -115,6 +115,7 @@ type PersistentState_14 = {
   stableTokenTransferBlocked?: boolean
   stablesatsTransferBlocked?: boolean
   stableTokenRestricted?: boolean
+  firstSeenCountryCode?: string
 }
 
 const migrate14ToCurrent = (state: PersistentState_14): Promise<PersistentState> =>

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -186,3 +186,48 @@ export const logAppFeedback = (params: LogAppFeedbackParams) => {
     is_enjoying_app: params.isEnjoingApp,
   })
 }
+
+type LogRegistrationCountryPersistedParams = {
+  countryCode: string
+  source: "phone" | "ip"
+}
+
+/** The wallet's registration country was pinned (first-seen or phone-derived). */
+export const logRegistrationCountryPersisted = (
+  params: LogRegistrationCountryPersistedParams,
+) => {
+  analytics().logEvent("registration_country_persisted", {
+    country_code: params.countryCode,
+    source: params.source,
+  })
+}
+
+type LogRegistrationCountryDeferredParams = {
+  countryCode: string
+}
+
+/** Pinning was skipped because the IP is a flagged VPN/proxy exit (#3907). */
+export const logRegistrationCountryPersistDeferred = (
+  params: LogRegistrationCountryDeferredParams,
+) => {
+  analytics().logEvent("registration_country_persist_deferred", {
+    country_code: params.countryCode,
+  })
+}
+
+type LogRegionRestrictionClearedParams = {
+  restriction: "dollar_balance" | "transfer"
+  accountType: string
+  countryCode: string
+}
+
+/** A persisted region-restriction flag self-healed off trusted allowed evidence. */
+export const logRegionRestrictionCleared = (
+  params: LogRegionRestrictionClearedParams,
+) => {
+  analytics().logEvent("region_restriction_cleared", {
+    restriction: params.restriction,
+    account_type: params.accountType,
+    country_code: params.countryCode,
+  })
+}

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -90,6 +90,60 @@ export const resolveIpCountryCode = async (
 }
 
 /**
+ * Whether the current IP is a known anonymizer (VPN/proxy/Tor exit), from
+ * proxycheck.io — the one adapter in the chain whose core product is proxy
+ * detection.
+ *
+ * - `true`  → the IP is a flagged anonymizer
+ * - `false` → proxycheck answered and did not flag it
+ * - `undefined` → detection unavailable (request failed or fields missing)
+ *
+ * Callers must treat `undefined` as "no evidence", not as "clean".
+ */
+export const detectAnonymizingIp = async (
+  timeout: number = DEFAULT_TIMEOUT_MS,
+): Promise<boolean | undefined> => {
+  try {
+    // vpn=1 explicitly requests proxy/VPN detection (v2-documented, harmless on v3)
+    const url = Config.PROXYCHECK_API_KEY
+      ? `https://proxycheck.io/v3/?key=${Config.PROXYCHECK_API_KEY}&vpn=1`
+      : "https://proxycheck.io/v3/?vpn=1"
+    const { data } = await axios.get(url, { timeout })
+    type Detections = { proxy?: boolean; vpn?: boolean; tor?: boolean }
+    type IpEntry = { detections?: Detections; proxy?: string }
+    const ipEntry = Object.values(data as Record<string, IpEntry>).find(
+      (v) => v && typeof v === "object" && ("detections" in v || "proxy" in v),
+    )
+    if (!ipEntry) return undefined
+    if (ipEntry.detections) {
+      return Boolean(
+        ipEntry.detections.proxy || ipEntry.detections.vpn || ipEntry.detections.tor,
+      )
+    }
+    // v2-style flat flag
+    if (ipEntry.proxy === "yes") return true
+    if (ipEntry.proxy === "no") return false
+    return undefined
+  } catch (err) {
+    reportError("ip-country-lookup", err)
+    return undefined
+  }
+}
+
+/** Session cache mirroring resolveIpCountryCodeCached: conclusive answers are cached, `undefined` is retried. */
+let sharedAnonymityLookup: Promise<boolean | undefined> | null = null
+
+export const detectAnonymizingIpCached = (): Promise<boolean | undefined> => {
+  if (!sharedAnonymityLookup) {
+    sharedAnonymityLookup = detectAnonymizingIp().then((result) => {
+      if (result === undefined) sharedAnonymityLookup = null
+      return result
+    })
+  }
+  return sharedAnonymityLookup
+}
+
+/**
  * One shared lookup per app session: the device's country rarely changes
  * mid-session and several screens mount hooks that need it, so the external
  * services are hit once instead of once per mount. A failed lookup is not


### PR DESCRIPTION
Closes #3907

## Problem

Dollar/stable balance and transfer show **"not available in your region"** whenever a VPN is on, and recover when it's off. Reported on Android v3.0.4; affects any VPN whose exit lands in a blocked list (EU exits are the common trigger).

## Root cause

Region gates derived the country from **the current network path**:

- **No-phone (self-custodial) accounts**: country = live IP geolocation per session → follows the VPN exit.
- **Phone accounts**: primary check used the phone country, but the sync hooks did a **second IP lookup** (`useIpCountryCode`) even when the phone country was allowed, and could latch the restriction off a VPN exit.
- **The persisted restriction flags were set-only** — no code path ever cleared them. One bad observation latched forever (currently masked only by the `dollarRestrictionCacheEnabled` remote kill-switch), and via #3910 pushed latched users into force-converting their Dollar balance.

## Solution

Restrictions now follow the **account's registration country**, never the current IP:

1. **New `useRegistrationCountry`** (`app/hooks/use-registration-country.ts`), the single country source for the gates:
   - phone country (registration) — also backfills persistent state so it survives a switch to self-custodial;
   - else persisted **first-seen country** (`firstSeenCountryCode`, new persistent-state module);
   - else **one IP lookup ever**, persisted on success; failure persists nothing (retry next session) and reports `trusted: false` — gates fail open on unknown.
   - **VPN-aware persistence**: alongside the country lookup, proxycheck.io's proxy/VPN detection is consulted (new `detectAnonymizingIp*` in `ip-country-lookup.ts`, session-cached). A country resolved through a **flagged anonymizer is used for the session but never persisted** — persisting retries on a later session, so a VPN-always-on user behaves like today (live) instead of getting a VPN exit country pinned forever. Only a confirmed flag defers; if detection is unavailable, persistence proceeds (an external detector's uptime must not gate registration).
2. **Gates rewired** (`use-dollar-balance-restricted`, `use-transfer-blocked`): read the new hook; the IP double-check is deleted (`useIpCountryCode` removed entirely).
3. **Latch is self-correcting**: sync hooks now *clear* the persisted flag when trusted evidence says the country is allowed (new `without*` setters, all four flags). Clearing requires trustworthy evidence on **both sides of the comparison**: `!loading && trusted` for the country, and the new `remoteConfigLoaded` feature flag for the blocked lists — a failed remote-config fetch leaves hardcoded defaults behind (`remoteConfigReady` flips true even then), and a country missing from the defaults must never clear a flag set from the real config. Clearing intentionally ignores the `dollarRestrictionCacheEnabled` kill-switch so stale flags heal while it's active. Set path unchanged. Account-type-switch double-write preserved; clears mirror it.
4. Settings footer and `usePaymentRequest` read the same source, so the footer can no longer contradict the gate.
5. **Observability + ops brake**: analytics events for every registration-country pin, VPN-deferred pin, and self-heal (`app/utils/analytics.ts`), and a `restrictionSelfHealEnabled` remote-config kill-switch (default on) that freezes the clearing behavior without a release. Details under Risks #2.

**Remediation is automatic**: previously latched users self-heal on next home-screen mount; the forced-conversion prompt stops firing.

## Trade-offs (accepted)

- A wallet **first opened/recovered behind an undetected anonymizer** can bake in that country until app data is reset (first-seen = registration by definition). Detected VPNs/proxies are already deferred (see VPN-aware persistence above); the residual risk is proxycheck misses.
- The #3847 anti-bypass (foreign phone, physically in a blocked region) is removed by design.
- **Custodial with a phone number** (the common case): unaffected by device/reinstall/VPN state — the phone country always wins and is re-fetched from the backend on any device.
- **Email-only custodial accounts** have no phone, so they use the first-seen country like self-custodial wallets: stable against VPN toggling (the fix still applies), but re-derived on reinstall/new device. The API exposes no registration-country field for them; adding one server-side would be the proper long-term fix (follow-up).

## Risks

| # | Risk | Probability | Severity | Mitigation (short) |
|---|------|-------------|----------|--------------------|
| 1 | Upgrade-moment bake-in of a VPN country | ~~High~~ → **Low** (only undetected anonymizers) | **High** | **Mitigated in-PR**: VPN-flagged IPs never persist first-seen |
| 2 | Compliance exposure (bypass by design) | Low | Medium–**High** (regulatory posture dependent) | **Partially mitigated in-PR** (no pinned bypass via detected VPNs; telemetry; self-heal kill-switch); sign-off still required |
| 3 | Device-global registration state crosses accounts | Low | Low–Medium | Accept; per-account state if support cases appear |
| 4 | Creation vs. usage gate divergence | Medium | Low | Support/FAQ note |
| 5 | Operational semantics shifted (footer, kill-switch) | High (will be noticed) | Low | Ops/support changelog note |
| 6 | Version skew (old clients keep live-IP behavior) | Certain | Low–Medium | Organic updates, then `minSupported` bump |

1. **Upgrade-moment bake-in.** Existing self-custodial installs have no persisted country; the first open after updating *is* the first-seen moment. A VPN-always-on user (the #3907 reporter cohort) whose first open has a blocked exit could get the wrong country baked in **with no self-heal**.
   *Mitigated in this PR:* first-seen is never persisted from a proxycheck-flagged VPN/proxy/Tor IP — such sessions use the resolved country live and retry persisting later, so the worst case is "behaves like today until a non-VPN open", not "bricked until data wipe". Residual risk is limited to anonymizers proxycheck misses. *Further options if needed:* seed first-seen from the Apollo-cached `countryCode @client` of previous sessions; support runbook for the data-reset escape hatch.
2. **Compliance exposure.** The #3847 anti-bypass is removed by design. Note the VPN-aware persistence also narrows the bypass: a country resolved through a *detected* VPN is never pinned, so a durable bypass requires an anonymizer proxycheck misses — the same exposure the old live-IP model already had.
   *Mitigated in this PR:* (a) **compliance telemetry** — analytics events for every registration-country pin (`registration_country_persisted`, with source), every VPN-deferred pin (`registration_country_persist_deferred`), and every self-heal (`region_restriction_cleared`, with restriction/account type/country), so the field behavior is observable instead of assumed; (b) **`restrictionSelfHealEnabled` remote kill-switch** (default on, mirroring `dollarRestrictionCacheEnabled`) — ops can freeze the new clearing behavior in minutes without a release, degrading to today's set-only semantics while the rest of the fix keeps working.
   *Still required:* explicit compliance sign-off before merge; long-term, a server-side account registration-country field (also fixes email-only custodial); blocked lists remain remote-config so ops can react without a release.
3. **Device-global registration state.** `firstSeenCountryCode` is per-device, not per-account (matching the existing flags' granularity): wallets on one device share it, and a custodial login's phone country overwrites it for all. Multi-account devices spanning countries are rare.
   *Mitigations:* accept for now; if support cases appear, migrate to the existing `…ByAccountId` persistent-state pattern as a follow-up.
4. **Creation vs. usage divergence.** Signup/creation gates intentionally stay on live location while usage gates use registration country — a traveler can be unable to create an account where their existing wallet works. Confusion, not loss.
   *Mitigations:* support/FAQ note; revisit unifying creation gates on registration country only if product wants it (compliance-conservative as is).
5. **Operational semantics shifted.** Settings footer now shows registration country (not current location), and clearing ignores the `dollarRestrictionCacheEnabled` kill-switch, so flags may have healed during a kill-switch period.
   *Mitigations:* brief support/ops changelog note; both changes are intended behavior — this is a communication risk only.
6. **Version skew.** Older clients keep live-IP behavior until updated — certain to occur, bounded impact (it's the pre-existing bug, not a new one).
   *Mitigations:* let organic updates absorb most of the tail, then bump `mobileVersions.minSupported` (AppUpdateModal). With risk 1 mitigated in-PR, a forced fleet-wide upgrade concentrating everyone's first-seen moment is acceptable.

Mitigated in this PR: clearing on remote-config **defaults** after a failed fetch is prevented by the new `remoteConfigLoaded` gate (probability was low but severity high — a config outage could have unlatched legitimate restrictions).

## Tests

- New: `use-registration-country.spec.ts` (tier priority, backfill, persist-once, VPN-deferred persist, unmount, fail-open), `first-seen-country.spec.ts`, `detectAnonymizingIp*` cases in `ip-country-lookup.spec.ts` (v3/v2 shapes, inconclusive handling, session cache).
- Updated: gate specs (persist/clear/no-clear-on-untrusted/no-clear-while-config-unloaded/no-clear-when-self-heal-disabled/kill-switch semantics/account-switch heal/cleared-telemetry), device-location spec, 4 persistent-state specs, 3 consumer specs re-mocked.
- **100% stmt/branch/func/line coverage on every file containing PR logic**; `tsc` + `eslint` clean; all affected suites green. Full suite → CI.

**Pre-merge checklist:**
- [ ] Verify proxycheck v3 detection-field shape against a live response (parser handles v3 `detections` and v2 flat `proxy` defensively; a mismatch degrades to "no evidence" → persist, never a crash or wrong block) — one manual device test with a VPN on covers it.
- [ ] Compliance sign-off on the registration-based model (see Risks #2).

## Appendix A: why the #3847 anti-bypass is removed *by design*

The anti-bypass was the rule "even when the registration country is allowed, a second lookup of the current IP can override it and restrict the account." Keeping it was considered and rejected, for four stacking reasons:

1. **It is logically incompatible with the model this PR adopts.** The decided behavior (the issue's Expected Behavior) is that restrictions are a property of the *account*, not of today's network path — the exact negation of the anti-bypass. Any rule of the form "current IP can restrict an allowed account" re-admits the entire class of VPN false positives this PR exists to eliminate. Removing it isn't a side effect of the refactor; it *is* the refactor.

2. **It inverted the signal hierarchy.** Phone country is a strong, stable, registration-tied signal; IP geolocation is weak and noisy (VPNs, roaming, corporate egress, carrier NAT). The anti-bypass let the weak signal override the strong one — and, combined with the set-only latch, a single noisy reading overrode a clean registration *permanently*, ultimately feeding users into the forced-conversion flow (#3910). The strongest consequence was attached to the weakest evidence.

3. **It failed its own cost-benefit test.** The person it targeted (living in a blocked region, foreign phone, deliberately evading) defeats it trivially — connect through a VPN with an allowed exit; the evasion tool *is* a VPN. The person it actually caught was the honest user in an allowed country whose VPN exit happened to land in a blocked list — someone with nothing to hide who therefore takes no care what their IP looks like. #3907 is the field evidence: real harm to legitimate users, enforcement only against evaders too careless to use the evasion tool.

4. **Its legitimate function was replaced, not just deleted.** The genuine concern behind #3847 — no laundering past the restriction — is addressed without punishing honest users: (a) no *durable* allow-bypass through a VPN, since a country resolved via a detected anonymizer is never pinned as registration (a permanent bypass requires keeping the VPN on forever, the same exposure the old live-IP model had); (b) telemetry makes bypass-shaped events measurable so re-tightening can be decided on data; (c) the `restrictionSelfHealEnabled` kill-switch freezes the new leniency instantly if the data says it's abused; (d) the correct long-term enforcement point is a server-side registration-country field the client can't spoof (follow-up).

A middle-ground variant exists — latch only on **clean, non-VPN-flagged** IPs, which would catch a blocked-region resident on home wifi without ever touching VPN users. It is deliberately *not* included: re-adding any IP-based restriction contradicts the decided direction and is a compliance/product call, not something to fold into a bugfix. That is what "removed by design" means here — explicit, argued, and reversible by the people with the authority to reverse it (hence the compliance sign-off in the checklist).

## Appendix B: user stories — account type × lifecycle

Where the registration country comes from, per account type and lifecycle phase:

| Account type | Registration (signup / wallet creation) | Post-registration (normal use) | Recovery (new device / reinstall) |
|---|---|---|---|
| **Custodial, phone** | Phone country, from the number itself | Phone country, re-parsed from `me.phone` | Phone country, re-fetched from backend — always correct |
| **Custodial, email-only** | First-seen country pinned around first use | Pinned first-seen country | First-seen **re-derived** (no backend country field) |
| **Self-custodial** | First-seen country pinned at creation | Pinned first-seen country | First-seen **re-derived** at seed import |

VPN rule in every cell: a *detected* VPN/proxy never pins a country (session uses it live, pin retries later); an *undetected* one can (residual risk). Format below: **Given** → **when** → **then**, with *Before:* where behavior changed.

### Custodial, phone number

**Registration**
- **C1 — Signup, any network.** Given a new user signing up with an SV phone, when the account is created, then the registration country is SV from the number itself — VPN state during signup is irrelevant to the Dollar/transfer gates. (The *creation* gates — OFAC/first-signup lists — still check live location at signup; unchanged by this PR, see S-X2.)

**Post-registration**
- **C2 — Allowed country, VPN on.** Given an SV-phone user, when they use the app through an EU/HK-exit VPN, then nothing changes: the gate reads the phone country only. *Before:* the IP double-check could latch `stablesatsRestrictedCustodial` permanently.
- **C3 — Previously latched by a VPN session.** Given the stale flag on disk, when they next open the home screen, then it self-heals (`region_restriction_cleared`) and Dollar/transfer return — the #3910 forced-conversion prompt stops. *Before:* restricted forever short of a data wipe.
- **C4 — Genuinely blocked registration (HK phone).** Given an HK-phone user, when they open the app — VPN or not, anywhere — then the restriction applies and persists. A VPN does not clear it: the evidence is the phone country, and it says HK. Unchanged by this PR.

**Recovery**
- **C5 — New device / reinstall / re-login.** Given any phone user on a fresh install, when they log in, then `me.phone` is re-fetched from the backend and the registration country is identical to before — no IP involved, VPN state at login irrelevant. **Recovery is lossless for phone accounts.**

### Custodial, email-only (no phone)

**Registration**
- **E1 — Email signup.** Given a new email-only account, when the app first resolves a country (no phone signal exists), then the first-seen country is pinned — on a clean IP the real country, behind a detected VPN nothing is pinned yet (retries), behind an undetected one possibly the wrong country (residual). Custodial blocked lists and flags apply throughout.

**Post-registration**
- **E2 — Normal use.** Given a pinned first-seen country, when the user toggles a VPN, then the gates don't move — the #3907 fix applies to email accounts too. *Before:* the gate followed the live IP every session.

**Recovery**
- **E3 — New device / reinstall.** Given an email-only user logging in on a fresh install, when the gates need a country, then first-seen is **re-derived at that moment** — the backend has no registration-country field for email accounts. Clean IP → correct; detected VPN → deferred; undetected → wrong bake-in until data reset. This is the cell a server-side registration country would fix (noted follow-up).

### Self-custodial (no phone, no backend account)

**Registration (wallet creation)**
- **N1 — Creation at home.** Given a new wallet created on a clean SV IP, when first-seen resolves, then SV is pinned — later VPN use never moves the gates (the core #3907 fix).
- **N2 — Creation behind a VPN (incl. the upgrade moment).** Given the first open happens with a VPN active — including existing installs whose *first open after updating* is their first-seen moment — when proxycheck flags the anonymizer, then **nothing is pinned**: the session uses the resolved country live (behaves like the old model), and the first non-VPN open pins the real country. *Without this mitigation:* the VPN exit country would be baked in permanently.
- **N3 — Creation in a blocked region.** Given a new wallet created in HK on a clean IP, when first-seen resolves, then HK is pinned and the restriction applies from day one.
- **N4 — Deliberate bypass at creation.** Given someone in HK creating a wallet behind an SV-exit VPN, when first-seen runs, then the detected VPN defers pinning — unrestricted only while the VPN stays on (the old live-IP model's exact exposure), and the first clean open pins HK. An undetected anonymizer makes the bypass stick (residual; observable via `registration_country_persist_deferred` / `registration_country_persisted` telemetry).

**Post-registration**
- **N5 — Allowed pin, any VPN (the #3907 reporter).** Given SV pinned, when any VPN is used, then stable balance and transfer stay available. *Before:* VPN on → "not available in your region", VPN off → works.
- **N6 — Blocked pin, VPN as escape attempt.** Given HK pinned, when the user turns on an SV-exit VPN, then the restriction stays — the pin is the evidence, not the live IP. **No durable bypass post-registration.**
- **N7 — The traveler.** Given SV pinned, when the user travels to a blocked country, then the gates don't move (registration model, deliberate). Creating a *new* wallet there may still be blocked — creation gates stay on live location (accepted divergence, Risks #4).

**Recovery (seed import)**
- **N8 — Recovery at home.** Given a seed import on a fresh install (persistent state is empty — the pin does *not* travel with the seed), when first-seen re-resolves on a clean IP, then the correct country is re-pinned. Recovery is lossy but self-correcting for honest users.
- **N9 — Recovery behind a VPN.** Given the same import behind a detected VPN, then pinning defers (as N2) until a clean open. Behind an *undetected* anonymizer the wrong country is baked until data reset (residual risk — the sharpest remaining edge, Risks #1).

### Cross-cutting

- **X1 — Account-type switch.** Given a custodial phone user switching to self-custodial, when the switch happens, then the phone country was already backfilled into `firstSeenCountryCode`, so the self-custodial session inherits the same registration country; in a blocked country both flags are written (anti-bypass double-write preserved), in an allowed country both heal.
- **X2 — Creation vs. usage gates.** Given any user anywhere, account/wallet *creation* is still gated on live location (`use-creation-block`, `use-custodial-eligibility` — compliance-conservative, unchanged), while Dollar/transfer *usage* follows registration. The two can disagree by design.

### Failure modes and operations

- **F1 — Offline / lookup failure at first open.** Given no phone, no pin, and all geolocation adapters failing, then the country is unknown (`trusted: false`) — **fail open**, nothing persisted, retry next session.
- **F2 — Remote config outage.** Given a failed Firebase fetch (default lists, `remoteConfigLoaded` false), then clearing is blocked — a country missing from the *defaults* must not clear a flag set from the *real* config. Setting still works (over-restriction self-heals later; the safe direction).
- **F3 — Compliance pulls the self-heal brake.** Given ops flips `restrictionSelfHealEnabled` off, then no flags clear (and no cleared-telemetry fires) — set-only semantics restored in minutes without a release; registration-based gating keeps working.
- **F4 — The existing cache kill-switch.** Given `dollarRestrictionCacheEnabled` off, then persisted flags are ignored on read and none are set — but healing still runs, so stale flags are cleaned instead of frozen for resurrection.
- **F5 — Old app version.** Given a pre-fix release, then live-IP behavior persists until the user updates (Risks #6) — bounded: it's the pre-existing bug, not a new one.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
