### PR TITLE
fix(test): assert settled highlight state in transaction history spec

### DIFF
--- a/__tests__/screens/transaction-history-screen.spec.tsx
+++ b/__tests__/screens/transaction-history-screen.spec.tsx
@@ -397,16 +397,17 @@ describe("TransactionHistoryScreen", () => {
       </ContextForScreen>,
     )
 
+    // The screen transiently highlights the latest tx per currency until the
+    // markTxSeen -> cache -> baseline-backfill roundtrip settles, so wait for
+    // the settled state instead of asserting right after the rows appear.
     await waitFor(() => {
-      expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
+      expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
+        "no-highlight",
+      )
+      expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
+        "no-highlight",
+      )
     })
-
-    expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
-      "no-highlight",
-    )
-    expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
-      "no-highlight",
-    )
   })
 
   it("highlights transactions newer than min lastSeen when ALL", async () => {
@@ -426,25 +427,26 @@ describe("TransactionHistoryScreen", () => {
       </ContextForScreen>,
     )
 
+    // min(lastSeenBtcId,lastSeenUsdId) = ...9015 and both are unseen => highlighted.
+    // Match ":highlight" (not "highlight", which is a substring of "no-highlight")
+    // and wait for the settled state: the first data render briefly shows
+    // no-highlight until the highlight baseline is initialized.
     await waitFor(() => {
-      expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
+      expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
+        ":highlight",
+      )
+      expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
+        ":highlight",
+      )
     })
-
-    // min(lastSeenBtcId,lastSeenUsdId) = ...9015 and both are unseen => highlighted
-    expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
-      "highlight",
-    )
-    expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
-      "highlight",
-    )
 
     // ensure highlight doesn't flip off after `markTxSeen` updates cache
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
-        "highlight",
+        ":highlight",
       )
       expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
-        "highlight",
+        ":highlight",
       )
     })
   })


### PR DESCRIPTION
### Problem

`transaction-history-screen.spec.tsx › highlights none when lastSeen ids are missing` fails on Concourse CI but passes on GitHub CI:

```
Expected substring: "no-highlight"
Received string:    "507f1f77bcf86cd799439012:highlight"
```

### Root cause

With empty `lastSeen` ids the screen renders a transient highlight frame. Sampling the tree per event-loop tick shows:

```
tick 0–1:  <none>
tick 2–3:  507f1f77bcf86cd799439012:highlight   ← what Concourse catches
tick 4+:   507f1f77bcf86cd799439012:no-highlight (settled)
```

The chain: the highlight baseline initializes to `{btcId: "", usdId: ""}`, so `shouldHighlightById` falls back to `txId === latestTxIdForCurrency` and highlights the latest tx per currency; then `markTxSeen` writes the cache and the baseline backfill adopts those ids, turning the highlight off. The test waited only for row *existence* and asserted synchronously, so it raced this window.

Concourse (floating `node:24-alpine`, musl) lands the `waitFor` poll inside the window consistently — all `jest.retryTimes(2)` attempts fail. GitHub CI (Node 24.13.0 pinned via `.nvmrc`) polls after it closes.

### Fix

- Move the `no-highlight` assertions inside `waitFor` so the test asserts the settled state.
- Make the "highlights transactions newer than min lastSeen" assertions strict: `toContain("highlight")` also matches `"no-highlight"` and could never fail. Assert `":highlight"` instead; with strict matching the first assertion pair also needs `waitFor` (the first data render briefly shows `no-highlight` before the baseline initializes).

Verified: spec passes 6/6 across repeated local runs; eslint/tsc clean.

### Follow-ups (not in this PR)

- Pin `ci/image/Dockerfile` to `node:24.13.0-alpine` to match `.nvmrc` and eliminate runtime drift between the two CIs.
- The transient highlight flash is real app behavior for never-seen users, and the mapper unit spec ("highlights only the latest when the currency has never been seen") contradicts this screen spec's settled expectation ("highlights none") — needs a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)