### PR TITLE
fix(deps): sync shell-quote lockfile entry key with resolutions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17613,7 +17613,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.7.3, shell-quote@^1.8.4:
+shell-quote@^1.10.0, shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.7.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.10.0.tgz#482033e192e4f5c07151521ffa03400ec71b1b0f"
   integrity sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==


### PR DESCRIPTION
Concourse `check-code`/`test-unit` fail on main with **"Extracting deps has created a diff - deps are not in sync"** since #3936 merged: that PR carried Dependabot's lockfile hunk, which kept the stale `shell-quote@^1.8.4` range key while package.json's resolutions moved to `^1.10.0`. A fresh `yarn install` rewrites the key line, so the pipeline's regenerate-and-diff check trips.

One-line fix: the regenerated key (`shell-quote@^1.10.0, ^1.6.1, ^1.7.2, ^1.7.3`). No version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)