### PR TITLE
test: eliminate act() warnings and console.warn noise from jest logs

### DIFF
--- a/__tests__/components/push-notification.spec.tsx
+++ b/__tests__/components/push-notification.spec.tsx
@@ -6,6 +6,7 @@ import { PushNotificationComponent } from "@app/components/push-notification/pus
 import { BulletinsDocument } from "@app/graphql/generated"
 
 import { flushEffects } from "../helpers/flush-effects"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const mockRefetchQueries = jest.fn()
 jest.mock("@apollo/client", () => ({
@@ -149,9 +150,7 @@ describe("PushNotificationComponent", () => {
     })
 
     it("logs instead of throwing when opening the link fails", () => {
-      const consoleErrorSpy = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => undefined)
+      const consoleErrorSpy = silenceConsoleError()
       openURLSpy.mockImplementationOnce(() => {
         throw new Error("no handler for scheme")
       })

--- a/__tests__/components/revealed-checkbox-list/revealed-checkbox-list.spec.tsx
+++ b/__tests__/components/revealed-checkbox-list/revealed-checkbox-list.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
 import { RevealedCheckboxList } from "@app/components/revealed-checkbox-list"
+import { silenceConsoleError } from "../../helpers/silence-console-error"
 
 const labels = ["First", "Second", "Third"]
 
@@ -67,7 +68,7 @@ describe("RevealedCheckboxList", () => {
   })
 
   it("gives duplicate labels stable, independent keys (no key collision)", () => {
-    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const errorSpy = silenceConsoleError()
     const onAllCheckedChange = jest.fn()
     render(
       <ThemeProvider>

--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -1,4 +1,5 @@
 import { resolveGaloyInstanceOrDefault, GALOY_INSTANCES } from "@app/config"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 it("get a full object with BBW", () => {
   const res = resolveGaloyInstanceOrDefault({ id: "Main" })
@@ -19,7 +20,7 @@ it("get a full object with Local", () => {
 })
 
 it("falls back to the Main instance for an unknown standard id", () => {
-  const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+  const consoleErrorSpy = silenceConsoleError()
 
   const res = resolveGaloyInstanceOrDefault({ id: "Nonexistent" } as never)
 

--- a/__tests__/graphql/network-error-component.spec.tsx
+++ b/__tests__/graphql/network-error-component.spec.tsx
@@ -11,6 +11,7 @@ import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 import { useNetworkError } from "@app/graphql/network-error-context"
 import { NetworkErrorCode } from "@app/graphql/error-code"
 import { NetworkErrorComponent } from "@app/graphql/network-error-component"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 jest.mock("@app/graphql/network-error-context")
 jest.mock("@app/i18n/i18n-react")
@@ -265,7 +266,7 @@ describe("NetworkErrorComponent", () => {
     // The component logs the simulated storage failure via console.error;
     // capture it so the expected error doesn't pollute CI logs (and assert it
     // actually happened).
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockRejectedValue(
       new Error("Storage error"),
     )

--- a/__tests__/helpers/flush-effects.ts
+++ b/__tests__/helpers/flush-effects.ts
@@ -20,10 +20,18 @@ import { act } from "@testing-library/react-native"
  * Tests that already await `waitFor`/`findBy*` on the resolved state do not need
  * this — the awaited query already settles the effects inside `act()`.
  */
+// Captured at import time, before any spec installs fake timers. Under
+// `jest.useFakeTimers()` the global `setImmediate` is replaced by one that only
+// fires when the spec advances the clock, so a flush scheduled on it would
+// never resolve and the test would time out. The real one yields to the event
+// loop once, which is all this needs: it settles already-pending promises
+// without disturbing the fake clock the spec is driving.
+const realSetImmediate = globalThis.setImmediate
+
 export const flushEffects = async (): Promise<void> => {
   await act(async () => {
     await new Promise<void>((resolve) => {
-      setImmediate(resolve)
+      realSetImmediate(resolve)
     })
   })
 }

--- a/__tests__/helpers/silence-console-error.ts
+++ b/__tests__/helpers/silence-console-error.ts
@@ -1,0 +1,35 @@
+/**
+ * Mute (and capture) `console.error` for the current test without switching off
+ * the act() regression guard.
+ *
+ * `jest.spyOn(console, "error").mockImplementation(...)` replaces the wrapper
+ * that jest.setup-after-env.ts installs, so for the rest of that file React's
+ * "An update to X inside a test was not wrapped in act(...)" warnings are
+ * neither printed nor failed — the guard is off, silently. This helper swaps
+ * only the *sink* underneath the wrapper, so the inspection stays in place.
+ *
+ *   const errors = silenceConsoleError()
+ *   ...
+ *   expect(errors).toHaveBeenCalledWith(expect.stringContaining("boom"))
+ *
+ * The returned mock receives exactly what `console.error` was called with, so
+ * it is a drop-in for the spy in assertions. The sink is restored after every
+ * test by the guard's own `afterEach` — no teardown needed here.
+ */
+export const silenceConsoleError = (): jest.Mock<void, unknown[]> => {
+  const calls = jest.fn<void, unknown[]>()
+  const setSink = (globalThis as Record<string, unknown>).__setConsoleErrorSink as
+    | ((sink: (...args: unknown[]) => void) => void)
+    | undefined
+
+  if (!setSink) {
+    throw new Error(
+      "console.error guard is not installed — jest.setup-after-env.ts did not run.",
+    )
+  }
+
+  setSink((...args: unknown[]) => {
+    calls(...args)
+  })
+  return calls
+}

--- a/__tests__/hooks/use-alternating-spin.spec.ts
+++ b/__tests__/hooks/use-alternating-spin.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { View } from "react-native"
 
 jest.mock("react-native-reanimated", () => ({
@@ -48,7 +48,7 @@ describe("useAlternatingSpin", () => {
   it("triggerSpin is a function after rerender", () => {
     const { result, rerender } = renderHook(() => useAlternatingSpin())
 
-    rerender()
+    rerender(undefined)
 
     expect(typeof result.current.triggerSpin).toBe("function")
   })

--- a/__tests__/hooks/use-clipboard.spec.ts
+++ b/__tests__/hooks/use-clipboard.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useClipboard } from "@app/hooks/use-clipboard"
 

--- a/__tests__/hooks/use-conversion-formatting.spec.ts
+++ b/__tests__/hooks/use-conversion-formatting.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { useConversionFormatting } from "@app/screens/conversion-flow/hooks/use-conversion-formatting"
 import { ConvertInputType } from "@app/components/transfer-amount-input"

--- a/__tests__/hooks/use-conversion-overlay-focus.spec.ts
+++ b/__tests__/hooks/use-conversion-overlay-focus.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useConversionOverlayFocus } from "@app/screens/conversion-flow/hooks/use-conversion-overlay-focus"
 import { ConvertInputType } from "@app/components/transfer-amount-input"

--- a/__tests__/hooks/use-countdown.spec.ts
+++ b/__tests__/hooks/use-countdown.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useCountdown } from "@app/hooks/use-countdown"
 

--- a/__tests__/hooks/use-debounce.spec.ts
+++ b/__tests__/hooks/use-debounce.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 import { useDebouncedEffect } from "@app/hooks/use-debounce"
 
@@ -77,7 +77,7 @@ describe("useDebouncedEffect", () => {
   it("should reset debounce when dependencies change", () => {
     const callback = jest.fn()
     const { rerender } = renderHook(
-      ({ dep }) => useDebouncedEffect(callback, 500, [dep]),
+      ({ dep }: { dep: number }) => useDebouncedEffect(callback, 500, [dep]),
       { initialProps: { dep: 1 } },
     )
 
@@ -179,7 +179,8 @@ describe("useDebouncedEffect", () => {
   it("should clear timeout when enabled changes to false", () => {
     const callback = jest.fn()
     const { rerender } = renderHook(
-      ({ enabled }) => useDebouncedEffect(callback, 500, [], { enabled }),
+      ({ enabled }: { enabled: boolean }) =>
+        useDebouncedEffect(callback, 500, [], { enabled }),
       { initialProps: { enabled: true } },
     )
 
@@ -199,7 +200,8 @@ describe("useDebouncedEffect", () => {
   it("should only call leading once until trailing executes", () => {
     const callback = jest.fn()
     const { rerender } = renderHook(
-      ({ dep }) => useDebouncedEffect(callback, 500, [dep], { leading: true }),
+      ({ dep }: { dep: number }) =>
+        useDebouncedEffect(callback, 500, [dep], { leading: true }),
       { initialProps: { dep: 1 } },
     )
 
@@ -225,9 +227,12 @@ describe("useDebouncedEffect", () => {
     const callback = jest.fn(() => {
       counter += 1
     })
-    const { rerender } = renderHook(({ cb }) => useDebouncedEffect(cb, 500, []), {
-      initialProps: { cb: callback },
-    })
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) => useDebouncedEffect(cb, 500, []),
+      {
+        initialProps: { cb: callback },
+      },
+    )
 
     counter = 10
 

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import useDeviceLocation, {
   isBlockedCountry,

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { WalletCurrency } from "@app/graphql/generated"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -13,7 +13,7 @@ const mockUseIpCountryCode = jest.fn()
 
 let mockPersistentState: PersistentState
 
-/** Mocked wholesale: the real module warns at load time when no API key is configured. */
+/** Mocked wholesale so these specs never reach a real geo lookup. */
 jest.mock("@app/utils/ip-country-lookup", () => ({
   DEFAULT_ADAPTERS: [],
   resolveIpCountryCode: jest.fn(async () => undefined),

--- a/__tests__/hooks/use-email-reverification.spec.ts
+++ b/__tests__/hooks/use-email-reverification.spec.ts
@@ -2,6 +2,7 @@ import { Alert, AlertButton } from "react-native"
 import { renderHook } from "@testing-library/react-native"
 
 import { useEmailReverification } from "@app/hooks/use-email-reverification"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const EMAIL = "someone@example.com"
 
@@ -55,7 +56,7 @@ describe("useEmailReverification", () => {
     jest.spyOn(Alert, "alert").mockImplementation(() => {})
     // The give-up branches log on purpose; the assertions cover them.
     jest.spyOn(console, "warn").mockImplementation(() => {})
-    jest.spyOn(console, "error").mockImplementation(() => {})
+    silenceConsoleError()
     mockEmailDelete.mockResolvedValue({ data: {} })
     mockRegistrationInitiate.mockResolvedValue(
       registrationResult({ errors: [], emailRegistrationId: "registration-id" }),

--- a/__tests__/hooks/use-equal-pill-width.spec.ts
+++ b/__tests__/hooks/use-equal-pill-width.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 import type { LayoutChangeEvent } from "react-native"
 
 import { useEqualPillWidth } from "@app/components/atomic/currency-pill/use-equal-pill-width"

--- a/__tests__/hooks/use-has-transitioned.spec.ts
+++ b/__tests__/hooks/use-has-transitioned.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 import { useHasTransitioned } from "@app/hooks/use-has-transitioned"
 

--- a/__tests__/hooks/use-incoming-badge-auto-seen.spec.ts
+++ b/__tests__/hooks/use-incoming-badge-auto-seen.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { WalletCurrency } from "@app/graphql/generated"
 import { useIncomingBadgeAutoSeen } from "@app/components/unseen-tx-amount-badge/use-incoming-badge-auto-seen"

--- a/__tests__/hooks/use-kyc-flow.spec.ts
+++ b/__tests__/hooks/use-kyc-flow.spec.ts
@@ -3,6 +3,7 @@ import { Alert } from "react-native"
 
 import { useKycFlow } from "@app/hooks/use-kyc-flow"
 import { KycFlowType } from "@app/graphql/generated"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const mockNavigate = jest.fn()
 const mockGoBack = jest.fn()
@@ -189,7 +190,7 @@ describe("useKycFlow", () => {
   it("calls goBack on canceled error", async () => {
     // The hook logs the simulated failure via console.error; capture it so the
     // expected error doesn't pollute CI logs (and assert it actually happened).
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     mockKycFlowStart.mockRejectedValue(new Error("Request canceled by user"))
 
     const { result } = renderHook(() => useKycFlow())
@@ -210,7 +211,7 @@ describe("useKycFlow", () => {
   it("shows Alert on other errors", async () => {
     // The hook logs the simulated failure via console.error; capture it so the
     // expected error doesn't pollute CI logs (and assert it actually happened).
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     mockKycFlowStart.mockRejectedValue(new Error("Network failure"))
 
     const { result } = renderHook(() => useKycFlow())

--- a/__tests__/hooks/use-notification-permission.spec.ts
+++ b/__tests__/hooks/use-notification-permission.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { useNotificationPermission } from "@app/hooks/use-notification-permission"
 

--- a/__tests__/hooks/use-outgoing-badge-visibility.spec.ts
+++ b/__tests__/hooks/use-outgoing-badge-visibility.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useOutgoingBadgeVisibility } from "@app/components/unseen-tx-amount-badge"
 
@@ -132,7 +132,7 @@ describe("useOutgoingBadgeVisibility", () => {
     const ttlMs = 1000
 
     const { rerender } = renderHook(
-      ({ txId }) =>
+      ({ txId }: { txId: string }) =>
         useOutgoingBadgeVisibility({
           txId,
           isOutgoing: true,

--- a/__tests__/hooks/use-press-scale.spec.ts
+++ b/__tests__/hooks/use-press-scale.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { usePressScale } from "@app/components/animations/press-scale"
 
@@ -60,7 +60,7 @@ describe("usePressScale", () => {
     const firstPressIn = result.current.pressIn
     const firstPressOut = result.current.pressOut
 
-    rerender()
+    rerender(undefined)
 
     expect(result.current.pressIn).toBe(firstPressIn)
     expect(result.current.pressOut).toBe(firstPressOut)

--- a/__tests__/hooks/use-price-conversion.spec.ts
+++ b/__tests__/hooks/use-price-conversion.spec.ts
@@ -25,7 +25,7 @@ import {
   toUsdMoneyAmount,
   UsdMoneyAmount,
 } from "@app/types/amounts"
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 jest.mock("@app/graphql/generated", () => {
   return {

--- a/__tests__/hooks/use-save-lnaddress-contact.spec.ts
+++ b/__tests__/hooks/use-save-lnaddress-contact.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 import { PaymentType } from "@blinkbitcoin/blink-client"
 
 import { ContactType } from "@app/graphql/generated"

--- a/__tests__/hooks/use-screenshot.test.ts
+++ b/__tests__/hooks/use-screenshot.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import type { RefObject } from "react"
 import type { View } from "react-native"
 import Share from "react-native-share"

--- a/__tests__/hooks/use-show-warning-secure-account.spec.tsx
+++ b/__tests__/hooks/use-show-warning-secure-account.spec.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { PropsWithChildren } from "react"
-import { act } from "react-test-renderer"
 
 import { MockedProvider } from "@apollo/client/testing"
 import {
@@ -11,7 +10,7 @@ import {
 } from "@app/graphql/generated"
 import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { useShowWarningSecureAccount } from "@app/screens/settings-screen/account/show-warning-secure-account-hook"
-import { renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),

--- a/__tests__/hooks/use-synced-input-values.spec.ts
+++ b/__tests__/hooks/use-synced-input-values.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { WalletCurrency } from "@app/graphql/generated"
 import { useSyncedInputValues } from "@app/screens/conversion-flow/hooks/use-synced-input-values"
@@ -247,7 +247,13 @@ describe("useSyncedInputValues", () => {
 
   it("does not update when wallets are undefined", () => {
     const { result, rerender } = renderHook(
-      ({ fromWallet, toWallet }) =>
+      ({
+        fromWallet,
+        toWallet,
+      }: {
+        fromWallet: typeof mockBtcWallet | undefined
+        toWallet: typeof mockUsdWallet | undefined
+      }) =>
         useSyncedInputValues({
           fromWallet,
           toWallet,
@@ -255,8 +261,8 @@ describe("useSyncedInputValues", () => {
         }),
       {
         initialProps: {
-          fromWallet: undefined as typeof mockBtcWallet | undefined,
-          toWallet: undefined as typeof mockUsdWallet | undefined,
+          fromWallet: undefined,
+          toWallet: undefined,
         },
       },
     )

--- a/__tests__/hooks/use-transaction-seen-state.spec.ts
+++ b/__tests__/hooks/use-transaction-seen-state.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 jest.mock("@apollo/client", () => {
   const actual = jest.requireActual("@apollo/client")

--- a/__tests__/hooks/use-unseen-tx-amount-badge.spec.ts
+++ b/__tests__/hooks/use-unseen-tx-amount-badge.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { TxDirection, type TransactionFragment } from "@app/graphql/generated"
 import { useUnseenTxAmountBadge } from "@app/components/unseen-tx-amount-badge"

--- a/__tests__/receive-bitcoin/hooks/use-display-payment-request.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-display-payment-request.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { useDisplayPaymentRequest } from "@app/screens/receive-bitcoin-screen/hooks/use-display-payment-request"
 import { Invoice } from "@app/screens/receive-bitcoin-screen/payment/index.types"

--- a/__tests__/receive-bitcoin/hooks/use-invoice-lifecycle.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-invoice-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { flushEffects } from "../../helpers/flush-effects"
 import { useInvoiceLifecycle } from "@app/screens/receive-bitcoin-screen/hooks/use-invoice-lifecycle"

--- a/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { Alert } from "react-native"
 
 import { useLnurlWithdraw } from "@app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw"

--- a/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
@@ -3,6 +3,7 @@ import { Alert } from "react-native"
 
 import { useLnurlWithdraw } from "@app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw"
 import { Invoice } from "@app/screens/receive-bitcoin-screen/payment/index.types"
+import { silenceConsoleError } from "../../helpers/silence-console-error"
 
 const mockLL = {
   RedeemBitcoinScreen: {
@@ -161,7 +162,7 @@ describe("useLnurlWithdraw", () => {
   it("shows submission error on non-ok response", async () => {
     // The hook logs the simulated failure via console.error; capture it so the
     // expected error doesn't pollute CI logs (and assert it actually happened).
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     const alertSpy = jest.spyOn(Alert, "alert")
     mockFetch.mockResolvedValue({
       ok: false,
@@ -189,7 +190,7 @@ describe("useLnurlWithdraw", () => {
   it("shows redeeming error when response status is not ok", async () => {
     // The hook logs the simulated failure via console.error; capture it so the
     // expected error doesn't pollute CI logs (and assert it actually happened).
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     const alertSpy = jest.spyOn(Alert, "alert")
     mockFetch.mockResolvedValue({
       ok: true,

--- a/__tests__/receive-bitcoin/hooks/use-payment-actions.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-payment-actions.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { Share, Alert } from "react-native"
 
 import { usePaymentActions } from "@app/screens/receive-bitcoin-screen/hooks/use-payment-actions"

--- a/__tests__/receive-bitcoin/hooks/use-payment-request.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-payment-request.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { flushEffects } from "../../helpers/flush-effects"
 

--- a/__tests__/receive-bitcoin/hooks/use-receive-carousel.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-receive-carousel.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useReceiveCarousel } from "@app/screens/receive-bitcoin-screen/hooks/use-receive-carousel"
 import { WalletCurrency } from "@app/graphql/generated"

--- a/__tests__/receive-bitcoin/hooks/use-receive-flow.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-receive-flow.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useReceiveFlow } from "@app/screens/receive-bitcoin-screen/hooks/use-receive-flow"
 import { Invoice } from "@app/screens/receive-bitcoin-screen/payment/index.types"

--- a/__tests__/receive-bitcoin/hooks/use-wallet-resolution.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-wallet-resolution.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { useWalletResolution } from "@app/screens/receive-bitcoin-screen/hooks/use-wallet-resolution"
 import { WalletCurrency, Network } from "@app/graphql/generated"

--- a/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-balance.spec.ts
+++ b/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-balance.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 import { useCardBalance } from "@app/screens/card-screen/card-dashboard-screen/hooks/use-card-balance"
 
 const mockUseIsAuthed = jest.fn()

--- a/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-freeze.spec.ts
+++ b/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-freeze.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { CardStatus } from "@app/graphql/generated"
 import { useCardFreeze } from "@app/screens/card-screen/card-dashboard-screen/hooks/use-card-freeze"
 

--- a/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-transactions.spec.ts
+++ b/__tests__/screens/card-screen/card-dashboard-screen/hooks/use-card-transactions.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { useCardTransactions } from "@app/screens/card-screen/card-dashboard-screen/hooks/use-card-transactions"
 
 const mockUseIsAuthed = jest.fn()

--- a/__tests__/screens/card-screen/card-limits-screen/hooks/use-card-limits.spec.ts
+++ b/__tests__/screens/card-screen/card-limits-screen/hooks/use-card-limits.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import { useCardLimits } from "@app/screens/card-screen/card-limits-screen/hooks/use-card-limits"
 

--- a/__tests__/screens/card-screen/card-settings-screen/hooks/use-close-card-account.spec.ts
+++ b/__tests__/screens/card-screen/card-settings-screen/hooks/use-close-card-account.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { CardStatus } from "@app/graphql/generated"
 import { useCloseCardAccount } from "@app/screens/card-screen/card-settings-screen/hooks"
 

--- a/__tests__/screens/card-screen/card-settings-screen/hooks/use-notification-toggle.spec.ts
+++ b/__tests__/screens/card-screen/card-settings-screen/hooks/use-notification-toggle.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 import { NotificationChannel } from "@app/graphql/generated"
 import {
   useNotificationToggle,

--- a/__tests__/screens/card-screen/card-shipping-address-screen/hooks/use-shipping-address-data.spec.ts
+++ b/__tests__/screens/card-screen/card-shipping-address-screen/hooks/use-shipping-address-data.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 
 import { useShippingAddressData } from "@app/screens/card-screen/card-shipping-address-screen/hooks/use-shipping-address-data"
 

--- a/__tests__/screens/card-screen/card-statements-screen/hooks/use-statements-data.spec.ts
+++ b/__tests__/screens/card-screen/card-statements-screen/hooks/use-statements-data.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 import { useStatementsData } from "@app/screens/card-screen/card-statements-screen/hooks/use-statements-data"
 
 const mockUseIsAuthed = jest.fn()

--- a/__tests__/screens/card-screen/hooks/use-card-data.spec.ts
+++ b/__tests__/screens/card-screen/hooks/use-card-data.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-hooks"
+import { renderHook } from "@testing-library/react-native"
 import { useCardData } from "@app/screens/card-screen/hooks/use-card-data"
 
 const mockUseIsAuthed = jest.fn()

--- a/__tests__/screens/card-screen/order-card-screens/use-order-card-flow.spec.ts
+++ b/__tests__/screens/card-screen/order-card-screens/use-order-card-flow.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 import {
   useOrderCardFlow,
@@ -130,8 +130,9 @@ describe("useOrderCardFlow", () => {
   describe("late initialAddress sync", () => {
     it("syncs when initialAddress transitions from null to a value", () => {
       const { result, rerender } = renderHook(
-        ({ initialAddress }) => useOrderCardFlow({ initialAddress }),
-        { initialProps: { initialAddress: null as ShippingAddress | null } },
+        ({ initialAddress }: { initialAddress: ShippingAddress | null }) =>
+          useOrderCardFlow({ initialAddress }),
+        { initialProps: { initialAddress: null } },
       )
 
       expect(result.current.state.useRegisteredAddress).toBe(false)
@@ -149,8 +150,9 @@ describe("useOrderCardFlow", () => {
       }
 
       const { result, rerender } = renderHook(
-        ({ initialAddress }) => useOrderCardFlow({ initialAddress }),
-        { initialProps: { initialAddress: mockAddress as ShippingAddress | null } },
+        ({ initialAddress }: { initialAddress: ShippingAddress | null }) =>
+          useOrderCardFlow({ initialAddress }),
+        { initialProps: { initialAddress: mockAddress } },
       )
 
       rerender({ initialAddress: newAddress })

--- a/__tests__/screens/card-screen/pin-screens/hooks/use-pin-flow.spec.ts
+++ b/__tests__/screens/card-screen/pin-screens/hooks/use-pin-flow.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 import { usePinFlow } from "@app/screens/card-screen/pin-screens/hooks/use-pin-flow"
 

--- a/__tests__/screens/card-screen/replace-card-screens/hooks/use-replace-card-flow.spec.ts
+++ b/__tests__/screens/card-screen/replace-card-screens/hooks/use-replace-card-flow.spec.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react-hooks"
+import { act, renderHook } from "@testing-library/react-native"
 
 import { useReplaceCardFlow } from "@app/screens/card-screen/replace-card-screens/hooks/use-replace-card-flow"
 import { ShippingAddress } from "@app/screens/card-screen/types"

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -31,6 +31,8 @@ import TypesafeI18n from "@app/i18n/i18n-react"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import theme from "@app/rne-theme/theme"
 import { createCache } from "@app/graphql/cache"
+
+import { flushEffects } from "../helpers/flush-effects"
 import { DisplayCurrency as DisplayCurrencyType } from "@app/types/amounts"
 import { withDeviceLocale } from "../helpers/device-locale"
 
@@ -67,8 +69,6 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 const mockNavigate = jest.fn()
-const originalConsoleError = console.error
-let consoleErrorSpy: jest.SpyInstance | null = null
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
@@ -619,22 +619,6 @@ const assertConversionValues = async ({
   }
 }
 
-beforeAll(() => {
-  consoleErrorSpy = jest
-    .spyOn(console, "error")
-    .mockImplementation((message, ...args) => {
-      const text = String(message)
-      if (text.includes("not wrapped in act")) return
-      originalConsoleError(message, ...args)
-    })
-})
-
-afterAll(() => {
-  if (!consoleErrorSpy) return
-  consoleErrorSpy.mockRestore()
-  consoleErrorSpy = null
-})
-
 const defaultActiveWallet = {
   isSelfCustodial: false,
   isReady: false,
@@ -681,6 +665,9 @@ describe("Initial render with both wallets having balance", () => {
 
     expect(getByPlaceholderText("0 SAT")).toBeTruthy()
     expect(getByPlaceholderText("$0")).toBeTruthy()
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("toggle button is enabled", async () => {
@@ -698,6 +685,9 @@ describe("Initial render with both wallets having balance", () => {
 
     const toggleButton = getByTestId("wallet-toggle-button")
     expect(toggleButton.props.accessibilityState?.disabled).toBe(false)
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("next button is disabled when no amount entered", async () => {
@@ -715,6 +705,9 @@ describe("Initial render with both wallets having balance", () => {
 
     const nextButton = getByTestId("next-button")
     expect(nextButton.props.accessibilityState?.disabled).toBe(true)
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("percentage buttons are rendered", async () => {
@@ -734,6 +727,9 @@ describe("Initial render with both wallets having balance", () => {
     expect(getByTestId("convert-75%")).toBeTruthy()
     expect(getByTestId("convert-100%")).toBeTruthy()
     expect(getByTestId("convert-25%")).toBeTruthy()
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 })
 
@@ -757,6 +753,9 @@ describe("Initial render based on wallet balance", () => {
     })
 
     expect(getByPlaceholderText("0 SAT")).toBeTruthy()
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("starts with USD as from when only USD has balance", async () => {
@@ -778,6 +777,9 @@ describe("Initial render based on wallet balance", () => {
     })
 
     expect(getByPlaceholderText("$0")).toBeTruthy()
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 })
 
@@ -826,6 +828,9 @@ describe("Toggle without amount - Critical bug test", () => {
       expect(() => getByPlaceholderText("$0")).not.toThrow()
       expect(() => getByPlaceholderText("0 SAT")).not.toThrow()
     })
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("toggle button remains enabled after toggle without amount", async () => {
@@ -1494,6 +1499,9 @@ describe("Empty state handling", () => {
 
     expect(queryByTestId("wallet-toggle-button")).toBeNull()
     expect(queryByTestId("next-button")).toBeNull()
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 })
 
@@ -1988,8 +1996,12 @@ describe("Comprehensive conversion scenarios", () => {
     let primary: PrimaryAmount | null = null
     const expectedFocusedField = computeFocusedField(scenario.actions)
 
-    const advanceTimers = (ms: number) => {
-      act(() => {
+    // Async act: the fired timers hand off to promise chains (Apollo's mocked
+    // link delivers its result that way), and a synchronous act() returns
+    // before those microtasks run — the resulting commit then lands outside
+    // act() and trips the guard.
+    const advanceTimers = async (ms: number) => {
+      await act(async () => {
         jest.advanceTimersByTime(ms)
         jest.runAllTimers()
       })
@@ -2003,7 +2015,7 @@ describe("Comprehensive conversion scenarios", () => {
           Array.from({ length: 10 }, () => "⌫"),
         )
       })
-      advanceTimers(1500)
+      await advanceTimers(1500)
     }
 
     const focusField = async (field: Field) => {
@@ -2023,7 +2035,7 @@ describe("Comprehensive conversion scenarios", () => {
         await act(async () => {
           fireEvent.press(getByTestId("wallet-toggle-button"))
         })
-        advanceTimers(shouldWaitRecalc ? 1500 : 200)
+        await advanceTimers(shouldWaitRecalc ? 1500 : 200)
         ;[fromCurrency, toCurrency] = [toCurrency, fromCurrency]
         if (primary) {
           primary = {
@@ -2039,7 +2051,7 @@ describe("Comprehensive conversion scenarios", () => {
           await act(async () => {
             fireEvent.press(getByTestId("wallet-toggle-button"))
           })
-          advanceTimers(shouldWaitRecalc ? 1500 : 200)
+          await advanceTimers(shouldWaitRecalc ? 1500 : 200)
           ;[fromCurrency, toCurrency] = [toCurrency, fromCurrency]
           if (primary) {
             primary = {
@@ -2071,7 +2083,7 @@ describe("Comprehensive conversion scenarios", () => {
         await act(async () => {
           pressKeys(getByTestId, digits)
         })
-        advanceTimers(1500)
+        await advanceTimers(1500)
         primary = {
           currency: fieldCurrency,
           amount: amountFromDigits(fieldCurrency, digits, displayCurrency),
@@ -2090,7 +2102,7 @@ describe("Comprehensive conversion scenarios", () => {
         await act(async () => {
           pressKeys(getByTestId, action.digits)
         })
-        advanceTimers(1500)
+        await advanceTimers(1500)
         primary = {
           currency: fieldCurrency,
           amount: amountFromDigits(fieldCurrency, action.digits, displayCurrency),
@@ -2106,7 +2118,7 @@ describe("Comprehensive conversion scenarios", () => {
         await act(async () => {
           fireEvent.press(getByTestId(`convert-${action.value}%`))
         })
-        advanceTimers(1500)
+        await advanceTimers(1500)
         const balance =
           fromCurrency === WalletCurrency.Btc
             ? scenario.options.btcBalance
@@ -2241,6 +2253,9 @@ describe("Self-custodial conversion limits gating", () => {
         "Transfers are temporarily unavailable",
       )
     })
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("keeps Next disabled while limits load successfully but amount is below the minimum", async () => {
@@ -2263,6 +2278,9 @@ describe("Self-custodial conversion limits gating", () => {
     })
 
     expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(true)
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("disables Next when the conversion guard reports hasQuoteError", async () => {
@@ -2290,6 +2308,9 @@ describe("Self-custodial conversion limits gating", () => {
     })
 
     expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(true)
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 
   it("disables Next during the self-custodial SDK boot window — accountType=SelfCustodial + isReady=false", async () => {
@@ -2311,6 +2332,9 @@ describe("Self-custodial conversion limits gating", () => {
     })
 
     expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(true)
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 })
 
@@ -2395,6 +2419,9 @@ describe("Self-custodial percentage chip happy-path", () => {
         }),
       }),
     )
+    // The mocked Apollo queries deliver after the body returns; settle them
+    // inside act() so the assertions above are the last word on this tree.
+    await flushEffects()
   })
 })
 

--- a/__tests__/screens/helper-account-registry.spec.tsx
+++ b/__tests__/screens/helper-account-registry.spec.tsx
@@ -1,0 +1,84 @@
+import React from "react"
+
+import { render, screen } from "@testing-library/react-native"
+
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
+import { AccountType, DefaultAccountId } from "@app/types/wallet"
+
+import { Text } from "react-native"
+
+import { ContextForScreen } from "./helper"
+
+// The shared wrapper hands screens a settled registry composed by the same hook
+// the provider uses (`useComposedAccountRegistry`). These cases pin the two
+// things a screen spec relies on: what the default stub contains, and that
+// seeding through `accountRegistry` actually reaches `useAccountRegistry`. If
+// the provider's composition changes shape, they fail here rather than showing
+// up as an unexplained assertion failure in one of the ~110 screen specs.
+const RegistryProbe = () => {
+  const { accounts, activeAccount, loading } = useAccountRegistry()
+  return (
+    <>
+      <Text testID="loading">{String(loading)}</Text>
+      <Text testID="active">{activeAccount?.id ?? "none"}</Text>
+      {accounts.map((account) => (
+        <Text key={account.id} testID={`account-${account.type}`}>
+          {`${account.id}|${account.label}|${account.selected}`}
+        </Text>
+      ))}
+    </>
+  )
+}
+
+describe("ContextForScreen account registry", () => {
+  it("defaults to a settled custodial-only registry", () => {
+    render(
+      <ContextForScreen>
+        <RegistryProbe />
+      </ContextForScreen>,
+    )
+
+    // Settled: no screen spec has to flush effects to trust `accounts`.
+    expect(screen.getByTestId("loading").props.children).toBe("false")
+    expect(screen.getByTestId("active").props.children).toBe(DefaultAccountId.Custodial)
+    expect(screen.getByTestId(`account-${AccountType.Custodial}`)).toBeTruthy()
+    expect(screen.queryByTestId(`account-${AccountType.SelfCustodial}`)).toBeNull()
+  })
+
+  it("exposes seeded self-custodial entries to the screen under test", () => {
+    render(
+      <ContextForScreen
+        accountRegistry={{
+          entries: [{ id: "self-1", lightningAddress: "someone@blink.sv" }],
+        }}
+      >
+        <RegistryProbe />
+      </ContextForScreen>,
+    )
+
+    expect(
+      screen.getByTestId(`account-${AccountType.SelfCustodial}`).props.children,
+    ).toBe("self-1|someone@blink.sv|false")
+    // The custodial account stays selected: the wrapper's persistent state has
+    // no `activeAccountId`, so selection falls through to the first account.
+    expect(screen.getByTestId("active").props.children).toBe(DefaultAccountId.Custodial)
+  })
+
+  it("keeps the custodial account while the wrapper is authed, whatever the seed says", () => {
+    render(
+      <ContextForScreen
+        accountRegistry={{
+          hasStoredCustodialProfile: false,
+          entries: [{ id: "self-1", lightningAddress: null }],
+        }}
+      >
+        <RegistryProbe />
+      </ContextForScreen>,
+    )
+
+    // `IsAuthedContextProvider value={true}` in the wrapper still forces the
+    // custodial descriptor in — the flag alone cannot remove it. This pins that
+    // relationship so a spec seeding `false` is not misled into thinking it can.
+    expect(screen.getByTestId(`account-${AccountType.Custodial}`)).toBeTruthy()
+  })
+})

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -72,7 +72,9 @@ export const ContextForScreen: React.FC<PropsWithChildren<{ headerShown?: boolea
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider>{children}</AccountRegistryProvider>
+                    <AccountRegistryProvider skipHydration>
+                      {children}
+                    </AccountRegistryProvider>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>
@@ -96,7 +98,9 @@ export const ContextForScreenWithTheme: React.FC<
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider>{children}</AccountRegistryProvider>
+                    <AccountRegistryProvider skipHydration>
+                      {children}
+                    </AccountRegistryProvider>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -105,10 +105,20 @@ const createThemeWithMode = (mode: ThemeMode) =>
     mode,
   })
 
-export const ContextForScreen: React.FC<
-  PropsWithChildren<{ headerShown?: boolean; accountRegistry?: AccountRegistrySeed }>
-> = ({ children, headerShown = false, accountRegistry }) => (
-  <ThemeProvider theme={theme}>
+/**
+ * The provider stack every screen spec renders under. Both exported wrappers
+ * differ only in the theme they supply and whether the header is shown, so the
+ * stack itself lives here once — otherwise the two copies drift, and a provider
+ * added to one silently misses half the suite.
+ */
+const ScreenScaffold: React.FC<
+  PropsWithChildren<{
+    themeValue: ReturnType<typeof createThemeWithMode>
+    headerShown: boolean
+    accountRegistry?: AccountRegistrySeed
+  }>
+> = ({ children, themeValue, headerShown, accountRegistry }) => (
+  <ThemeProvider theme={themeValue}>
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown }}>
         <Stack.Screen name="Home">
@@ -131,28 +141,26 @@ export const ContextForScreen: React.FC<
   </ThemeProvider>
 )
 
+export const ContextForScreen: React.FC<
+  PropsWithChildren<{ headerShown?: boolean; accountRegistry?: AccountRegistrySeed }>
+> = ({ children, headerShown = false, accountRegistry }) => (
+  <ScreenScaffold
+    themeValue={theme}
+    headerShown={headerShown}
+    accountRegistry={accountRegistry}
+  >
+    {children}
+  </ScreenScaffold>
+)
+
 export const ContextForScreenWithTheme: React.FC<
   PropsWithChildren<{ mode: ThemeMode; accountRegistry?: AccountRegistrySeed }>
 > = ({ children, mode, accountRegistry }) => (
-  <ThemeProvider theme={createThemeWithMode(mode)}>
-    <NavigationContainer>
-      <Stack.Navigator screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="Home">
-          {() => (
-            <MockedProvider mocks={mocks} cache={createCache()}>
-              <PersistentStateWrapper>
-                <TypesafeI18n locale={detectDefaultLocale()}>
-                  <IsAuthedContextProvider value={true}>
-                    <StubAccountRegistry {...accountRegistry}>
-                      {children}
-                    </StubAccountRegistry>
-                  </IsAuthedContextProvider>
-                </TypesafeI18n>
-              </PersistentStateWrapper>
-            </MockedProvider>
-          )}
-        </Stack.Screen>
-      </Stack.Navigator>
-    </NavigationContainer>
-  </ThemeProvider>
+  <ScreenScaffold
+    themeValue={createThemeWithMode(mode)}
+    headerShown={false}
+    accountRegistry={accountRegistry}
+  >
+    {children}
+  </ScreenScaffold>
 )

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -11,9 +11,14 @@ import { NavigationContainer } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { createTheme, ThemeProvider } from "@rn-vui/themed"
 
+import type { SelfCustodialAccountEntry } from "@app/self-custodial/storage/account-index"
+
 import { createCache } from "../../app/graphql/cache"
 import { IsAuthedContextProvider } from "../../app/graphql/is-authed-context"
-import { AccountRegistryProvider } from "../../app/hooks/use-account-registry"
+import {
+  AccountRegistryContext,
+  useComposedAccountRegistry,
+} from "../../app/hooks/use-account-registry"
 import { PersistentStateContext } from "../../app/store/persistent-state"
 
 const PersistentStateWrapper: React.FC<PropsWithChildren> = ({ children }) => (
@@ -33,6 +38,47 @@ const PersistentStateWrapper: React.FC<PropsWithChildren> = ({ children }) => (
   >
     <>{children}</>
   </PersistentStateContext.Provider>
+)
+
+export type AccountRegistrySeed = {
+  entries?: SelfCustodialAccountEntry[]
+  hasStoredCustodialProfile?: boolean
+}
+
+/**
+ * A *settled* account registry — it never performs the provider's two device
+ * reads, so mocking `listSelfCustodialAccounts` or
+ * `KeyStoreWrapper.getSessionProfiles` does not reach it. Those reads resolve
+ * after a synchronous test body returns, which trips React's "not wrapped in
+ * act(...)" warning in every suite that mounts a screen.
+ *
+ * To render a screen against self-custodial accounts, seed them through the
+ * `accountRegistry` prop on the wrappers below. To exercise hydration itself,
+ * mount `AccountRegistryProvider` directly and `await flushEffects()`.
+ *
+ * `hasStoredCustodialProfile` defaults to `true` to match the provider under
+ * these wrappers, which mount `IsAuthedContextProvider value={true}`.
+ */
+// Stable identities: the composed value is memoised on these, so fresh
+// literals per render would hand every consumer a new registry each time.
+const NO_ENTRIES: SelfCustodialAccountEntry[] = []
+const noopReload = async () => {}
+
+const StubAccountRegistry: React.FC<PropsWithChildren<AccountRegistrySeed>> = ({
+  children,
+  entries = NO_ENTRIES,
+  hasStoredCustodialProfile = true,
+}) => (
+  <AccountRegistryContext.Provider
+    value={useComposedAccountRegistry({
+      selfCustodialEntries: entries,
+      hasStoredCustodialProfile,
+      loading: false,
+      reloadSelfCustodialAccounts: noopReload,
+    })}
+  >
+    {children}
+  </AccountRegistryContext.Provider>
 )
 
 export const findPressableParent = (
@@ -59,10 +105,9 @@ const createThemeWithMode = (mode: ThemeMode) =>
     mode,
   })
 
-export const ContextForScreen: React.FC<PropsWithChildren<{ headerShown?: boolean }>> = ({
-  children,
-  headerShown = false,
-}) => (
+export const ContextForScreen: React.FC<
+  PropsWithChildren<{ headerShown?: boolean; accountRegistry?: AccountRegistrySeed }>
+> = ({ children, headerShown = false, accountRegistry }) => (
   <ThemeProvider theme={theme}>
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown }}>
@@ -72,9 +117,9 @@ export const ContextForScreen: React.FC<PropsWithChildren<{ headerShown?: boolea
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider skipHydration>
+                    <StubAccountRegistry {...accountRegistry}>
                       {children}
-                    </AccountRegistryProvider>
+                    </StubAccountRegistry>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>
@@ -87,8 +132,8 @@ export const ContextForScreen: React.FC<PropsWithChildren<{ headerShown?: boolea
 )
 
 export const ContextForScreenWithTheme: React.FC<
-  PropsWithChildren<{ mode: ThemeMode }>
-> = ({ children, mode }) => (
+  PropsWithChildren<{ mode: ThemeMode; accountRegistry?: AccountRegistrySeed }>
+> = ({ children, mode, accountRegistry }) => (
   <ThemeProvider theme={createThemeWithMode(mode)}>
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ headerShown: false }}>
@@ -98,9 +143,9 @@ export const ContextForScreenWithTheme: React.FC<
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider skipHydration>
+                    <StubAccountRegistry {...accountRegistry}>
                       {children}
-                    </AccountRegistryProvider>
+                    </StubAccountRegistry>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -57,7 +57,9 @@ export const ContextForScreen: React.FC<PropsWithChildren<{ headerShown?: boolea
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider>{children}</AccountRegistryProvider>
+                    <AccountRegistryProvider skipHydration>
+                      {children}
+                    </AccountRegistryProvider>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>
@@ -81,7 +83,9 @@ export const ContextForScreenWithTheme: React.FC<
               <PersistentStateWrapper>
                 <TypesafeI18n locale={detectDefaultLocale()}>
                   <IsAuthedContextProvider value={true}>
-                    <AccountRegistryProvider>{children}</AccountRegistryProvider>
+                    <AccountRegistryProvider skipHydration>
+                      {children}
+                    </AccountRegistryProvider>
                   </IsAuthedContextProvider>
                 </TypesafeI18n>
               </PersistentStateWrapper>

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -14,15 +14,21 @@ import {
   HomeUnauthedDocument,
   Network,
   useBulletinsQuery,
+  WalletCurrency,
 } from "@app/graphql/generated"
 import { HideAmountContextProvider } from "@app/graphql/hide-amount-context"
 import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { mockCurrencyList } from "@app/graphql/mocks"
-import { ConvertDirection } from "@app/types/payment"
+import type { usePendingDeposits } from "@app/self-custodial/hooks"
+import {
+  ConvertDirection,
+  type DepositStatus,
+  type PendingDeposit,
+} from "@app/types/payment"
 
 let currentMocks: MockedResponse[] = []
 
-/** Mocked wholesale: the real module warns at load time when no API key is configured. */
+/** Mocked wholesale so these specs never reach a real geo lookup. */
 jest.mock("@app/utils/ip-country-lookup", () => ({
   DEFAULT_ADAPTERS: [],
   resolveIpCountryCode: jest.fn(async () => undefined),
@@ -234,10 +240,10 @@ jest.mock("@app/components/migration-reminder-bulletin", () => {
 })
 
 const mockUseNonCustodialConversionLimits = jest.fn()
-let mockPendingDepositsOverride: {
-  deposits: unknown[]
-  refetch?: () => Promise<void>
-} | null = null
+// Typed against the hook so a rename or a dropped field on the real return
+// type fails the typecheck here rather than only at runtime in HomeScreen.
+let mockPendingDepositsOverride: Partial<ReturnType<typeof usePendingDeposits>> | null =
+  null
 
 jest.mock("@app/self-custodial/hooks", () => {
   const actual = jest.requireActual("@app/self-custodial/hooks")
@@ -245,16 +251,13 @@ jest.mock("@app/self-custodial/hooks", () => {
     ...actual,
     useNonCustodialConversionLimits: (direction: string | undefined) =>
       mockUseNonCustodialConversionLimits(direction),
-    // Defaults to a settled stub rather than the real hook: its SDK listing
-    // resolves after the test body returns, so it updated HomeScreen outside
-    // act(). Nothing is lost — HomeScreen's pending-deposit rendering is
-    // covered through the override below, and the hook's own behavior in
-    // __tests__/self-custodial/hooks/use-pending-deposits.spec.ts.
-    usePendingDeposits: () => ({
-      deposits: [],
-      refetch: async () => {},
-      ...mockPendingDepositsOverride,
-    }),
+    // The real hook by default — it is what keeps HomeScreen wired to the
+    // hook's actual shape. Only the tests that need seeded deposits replace it,
+    // through the override.
+    usePendingDeposits: () =>
+      mockPendingDepositsOverride
+        ? { refetch: async () => {}, ...mockPendingDepositsOverride }
+        : actual.usePendingDeposits(),
   }
 })
 
@@ -806,6 +809,9 @@ const runRestrictionInvariantCase = async ({
   await flushEffects()
 
   fireEvent.press(getByTestId("transfer"))
+  // The press re-runs the pending-deposit listing; settle it before asserting
+  // so the assertions read a tree that has stopped changing.
+  await flushEffects()
 
   if (expectButton === "disabled") {
     expect(mockDollarBalanceModalVisible).toBe(true)
@@ -1203,6 +1209,7 @@ describe("HomeScreen", () => {
     expect(mockDollarBalanceModalVisible).toBe(false)
 
     fireEvent.press(getByTestId("transfer"))
+    await flushEffects()
 
     expect(mockDollarBalanceModalVisible).toBe(true)
 
@@ -1816,6 +1823,7 @@ describe("HomeScreen wind-down states", () => {
     expect(await findByTestId("migrate-now-modal")).toBeTruthy()
 
     fireEvent.press(getByTestId("transfer"))
+    await flushEffects()
 
     expect(mockDollarBalanceModalVisible).toBe(true)
     expect(queryByTestId("migrate-now-modal")).toBeNull()
@@ -1991,11 +1999,15 @@ describe("HomeScreen pending receive badge", () => {
       isSelfCustodial: true,
       needsBackendAuth: false,
     }
-    const sparkDeposit = (status: string) => ({
+    const sparkDeposit = (status: DepositStatus): PendingDeposit => ({
       id: "abc:0",
       txid: "abc",
       vout: 0,
-      amount: { amount: 50_000, currency: "BTC", currencyCode: "BTC" },
+      amount: {
+        amount: 50_000,
+        currency: WalletCurrency.Btc,
+        currencyCode: "BTC",
+      },
       status,
       errorReason: null,
     })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -245,10 +245,16 @@ jest.mock("@app/self-custodial/hooks", () => {
     ...actual,
     useNonCustodialConversionLimits: (direction: string | undefined) =>
       mockUseNonCustodialConversionLimits(direction),
-    usePendingDeposits: () =>
-      mockPendingDepositsOverride
-        ? { refetch: async () => {}, ...mockPendingDepositsOverride }
-        : actual.usePendingDeposits(),
+    // Defaults to a settled stub rather than the real hook: its SDK listing
+    // resolves after the test body returns, so it updated HomeScreen outside
+    // act(). Nothing is lost — HomeScreen's pending-deposit rendering is
+    // covered through the override below, and the hook's own behavior in
+    // __tests__/self-custodial/hooks/use-pending-deposits.spec.ts.
+    usePendingDeposits: () => ({
+      deposits: [],
+      refetch: async () => {},
+      ...mockPendingDepositsOverride,
+    }),
   }
 })
 

--- a/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
+++ b/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
@@ -5,6 +5,7 @@ import { PaymentResultStatus } from "@app/types/payment"
 import { AccountType } from "@app/types/wallet"
 
 import { flushEffects } from "../../../helpers/flush-effects"
+import { silenceConsoleError } from "../../../helpers/silence-console-error"
 
 const mockUsePayments = jest.fn()
 const mockTranslateSdkError = jest.fn()
@@ -304,7 +305,7 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined)
+    consoleErrorSpy = silenceConsoleError()
     mockUsePayments.mockReturnValue({
       accountType: AccountType.Custodial,
       lnurlWithdraw: undefined,

--- a/__tests__/screens/self-custodial/onboarding/hooks/use-wallet-mnemonic.spec.ts
+++ b/__tests__/screens/self-custodial/onboarding/hooks/use-wallet-mnemonic.spec.ts
@@ -6,6 +6,7 @@ import {
   useWalletMnemonicState,
 } from "@app/screens/self-custodial/onboarding/hooks/use-wallet-mnemonic"
 import { AccountType } from "@app/types/wallet"
+import { silenceConsoleError } from "../../../../helpers/silence-console-error"
 
 const mockGetMnemonicForAccount = jest.fn()
 const mockUseActiveWallet = jest.fn()
@@ -295,7 +296,7 @@ describe("useWalletIdentity", () => {
         resolveDerivation = resolve
       }),
     )
-    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleError = silenceConsoleError()
 
     try {
       const { unmount } = renderHook(() => useWalletIdentity("youth indicate void"))

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -46,7 +46,10 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 jest.mock("@app/hooks/use-account-registry", () => ({
-  AccountRegistryProvider: ({ children }: { children: React.ReactNode }) => children,
+  // Only the consumer hook is stubbed: the shared screen wrapper builds its
+  // settled registry from this module's context and value builder, so replacing
+  // the module wholesale would leave it without either.
+  ...jest.requireActual("@app/hooks/use-account-registry"),
   useAccountRegistry: () => ({
     accounts: [],
     activeAccount: undefined,

--- a/__tests__/screens/send-details-hide-balance.spec.tsx
+++ b/__tests__/screens/send-details-hide-balance.spec.tsx
@@ -41,7 +41,10 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 jest.mock("@app/hooks/use-account-registry", () => ({
-  AccountRegistryProvider: ({ children }: { children: React.ReactNode }) => children,
+  // Only the consumer hook is stubbed: the shared screen wrapper builds its
+  // settled registry from this module's context and value builder, so replacing
+  // the module wholesale would leave it without either.
+  ...jest.requireActual("@app/hooks/use-account-registry"),
   useAccountRegistry: () => ({
     accounts: [],
     activeAccount: undefined,

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -71,7 +71,10 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 jest.mock("@app/hooks/use-account-registry", () => ({
-  AccountRegistryProvider: ({ children }: { children: React.ReactNode }) => children,
+  // Only the consumer hook is stubbed: the shared screen wrapper builds its
+  // settled registry from this module's context and value builder, so replacing
+  // the module wholesale would leave it without either.
+  ...jest.requireActual("@app/hooks/use-account-registry"),
   useAccountRegistry: () => ({
     accounts: [],
     activeAccount: undefined,

--- a/__tests__/screens/settings-screen/account/settings/delete.spec.tsx
+++ b/__tests__/screens/settings-screen/account/settings/delete.spec.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider, createTheme } from "@rn-vui/themed"
 
 import { dark, light } from "@app/rne-theme/colors"
 import { Delete } from "@app/screens/settings-screen/account/settings/delete"
+import { silenceConsoleError } from "../../../../helpers/silence-console-error"
 
 const mockDeleteAccount = jest.fn()
 const mockSetAccountIsBeingDeleted = jest.fn()
@@ -343,7 +344,7 @@ describe("Delete", () => {
 
   describe("when the mutation throws", () => {
     beforeEach(() => {
-      jest.spyOn(console, "error").mockImplementation(() => {})
+      silenceConsoleError()
       mockDeleteAccount.mockRejectedValue(new Error("network down"))
     })
 

--- a/__tests__/screens/settings-screen/multi-account.spec.tsx
+++ b/__tests__/screens/settings-screen/multi-account.spec.tsx
@@ -140,6 +140,10 @@ describe("Settings", () => {
 
   it("saves the active custodial profile when a token is present and none are stored yet", async () => {
     mockAppConfigToken = "mock-token-1"
+    // Both `Once`s are consumed by the component under test: the shared wrapper
+    // supplies a settled registry rather than mounting AccountRegistryProvider,
+    // so nothing else reads the KeyStore here. First call finds no profile and
+    // triggers the save; the second sees it stored.
     ;(KeyStoreWrapper.getSessionProfiles as jest.Mock)
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce(expectedProfiles)

--- a/__tests__/screens/settings-screen/settings-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/settings-screen.spec.tsx
@@ -197,7 +197,7 @@ jest.mock("@apollo/client", () => {
   }
 })
 
-/** Mocked wholesale: the real module warns at load time when no API key is configured. */
+/** Mocked wholesale so these specs never reach a real geo lookup. */
 jest.mock("@app/utils/ip-country-lookup", () => ({
   DEFAULT_ADAPTERS: [],
   resolveIpCountryCode: jest.fn(async () => undefined),

--- a/__tests__/screens/telegram-auth.spec.tsx
+++ b/__tests__/screens/telegram-auth.spec.tsx
@@ -2,7 +2,7 @@
 import React from "react"
 import axios from "axios"
 import { Linking } from "react-native"
-import { renderHook, act } from "@testing-library/react-hooks"
+import { renderHook, act } from "@testing-library/react-native"
 
 import {
   useTelegramLogin,

--- a/__tests__/self-custodial/components/auto-convert-listener-mount.spec.tsx
+++ b/__tests__/self-custodial/components/auto-convert-listener-mount.spec.tsx
@@ -8,6 +8,7 @@ if (typeof window !== "undefined" && !window.dispatchEvent) {
 }
 
 import { AutoConvertListenerMount } from "@app/self-custodial/components/auto-convert-listener-mount"
+import { silenceConsoleError } from "../../helpers/silence-console-error"
 
 const mockListener = jest.fn()
 
@@ -52,7 +53,7 @@ describe("AutoConvertListenerMount", () => {
       }
     }
 
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+    const consoleErrorSpy = silenceConsoleError()
     render(
       <Boundary>
         <AutoConvertListenerMount />

--- a/__tests__/self-custodial/hooks/use-payment-request.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request.spec.ts
@@ -10,6 +10,7 @@ import {
   usdWallet,
 } from "../../helpers/self-custodial-payment-request"
 import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
+import { silenceConsoleError } from "../../helpers/silence-console-error"
 
 const mockReceiveLightning = jest.fn()
 const mockReceiveOnchain = jest.fn()
@@ -418,7 +419,7 @@ describe("usePaymentRequest", () => {
   describe("onchain adapter rejection (regression)", () => {
     it("does not crash the hook when createReceiveOnchain rejects", async () => {
       mockReceiveOnchain.mockRejectedValueOnce(new Error("onchain receive boom"))
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+      const consoleSpy = silenceConsoleError()
 
       const { result } = renderHook(() => usePaymentRequest())
 
@@ -431,14 +432,15 @@ describe("usePaymentRequest", () => {
 
     it("does not surface an unhandled rejection when the SDK adapter throws", async () => {
       const onUnhandled = jest.fn()
-      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+      const consoleSpy = silenceConsoleError()
       process.on("unhandledRejection", onUnhandled)
 
       mockReceiveOnchain.mockRejectedValueOnce(new Error("onchain rejected"))
       renderHook(() => usePaymentRequest())
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 0)
-      })
+      // Settle the rejected adapter call inside act(): the hook commits state
+      // as it recovers, and letting that land after the test body is exactly
+      // the race the act() guard exists to catch.
+      await flushEffects()
       process.off("unhandledRejection", onUnhandled)
       consoleSpy.mockRestore()
 

--- a/__tests__/self-custodial/logging.spec.ts
+++ b/__tests__/self-custodial/logging.spec.ts
@@ -3,6 +3,7 @@ import {
   createSdkLogListener,
   logSdkEvent,
 } from "@app/self-custodial/logging"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const mockLog = jest.fn()
 const mockRecordError = jest.fn()
@@ -23,11 +24,13 @@ const loadFreshLoggingModule = () => {
 }
 
 describe("logSdkEvent", () => {
+  let consoleErrors: ReturnType<typeof silenceConsoleError>
+
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(console, "debug").mockImplementation()
     jest.spyOn(console, "warn").mockImplementation()
-    jest.spyOn(console, "error").mockImplementation()
+    consoleErrors = silenceConsoleError()
   })
 
   afterEach(() => {
@@ -62,7 +65,7 @@ describe("logSdkEvent", () => {
     const fresh = loadFreshLoggingModule()
     fresh.logSdkEvent(SdkLogLevel.Error, "error message")
 
-    expect(console.error).toHaveBeenCalledWith("[SparkSDK] error message")
+    expect(consoleErrors).toHaveBeenCalledWith("[SparkSDK] error message")
     expect(mockRecordError).toHaveBeenCalledWith(
       expect.objectContaining({ message: "[SparkSDK] error message" }),
     )
@@ -102,7 +105,7 @@ describe("createSdkLogListener", () => {
     jest.clearAllMocks()
     jest.spyOn(console, "debug").mockImplementation()
     jest.spyOn(console, "warn").mockImplementation()
-    jest.spyOn(console, "error").mockImplementation()
+    silenceConsoleError()
   })
 
   afterEach(() => {

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -282,28 +282,57 @@ describe("no-key warning", () => {
     jest.resetModules()
   })
 
-  it("warns on module load when no API keys are configured", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const loadWithKeys = (keys: Record<string, string>): any => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let mod: any
     jest.isolateModules(() => {
-      jest.mock("react-native-config", () => ({
-        GEO_IPIFY_API_KEY: "",
-        IPINFO_API_KEY: "",
-        PROXYCHECK_API_KEY: "",
-        IPAPI_API_KEY: "",
-      }))
-      require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires
+      jest.mock("react-native-config", () => keys)
+      mod = require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires
     })
+    return mod
+  }
+
+  const noKeys = {
+    GEO_IPIFY_API_KEY: "",
+    IPINFO_API_KEY: "",
+    PROXYCHECK_API_KEY: "",
+    IPAPI_API_KEY: "",
+  }
+
+  it("stays quiet at module load, so importers that never look up see nothing", () => {
+    loadWithKeys(noKeys)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("warns on the first lookup when no API keys are configured", async () => {
+    const mod = loadWithKeys(noKeys)
+
+    await mod.resolveIpCountryCode([])
+
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No API key configured"))
   })
 
-  it("does not warn when at least one API key is configured", () => {
-    jest.isolateModules(() => {
-      jest.mock("react-native-config", () => ({
-        GEO_IPIFY_API_KEY: "test-key",
-        IPINFO_API_KEY: "",
-        IPAPI_API_KEY: "",
-      }))
-      require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires
+  it("warns only once however many lookups run", async () => {
+    const mod = loadWithKeys(noKeys)
+
+    await mod.resolveIpCountryCode([])
+    await mod.resolveIpCountryCode([])
+    await mod.resolveIpCountryCode([])
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not warn when at least one API key is configured", async () => {
+    const mod = loadWithKeys({
+      GEO_IPIFY_API_KEY: "test-key",
+      IPINFO_API_KEY: "",
+      IPAPI_API_KEY: "",
     })
+
+    await mod.resolveIpCountryCode([])
+
     expect(warnSpy).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/utils/log-error.spec.ts
+++ b/__tests__/utils/log-error.spec.ts
@@ -1,4 +1,5 @@
 import { logError } from "@app/utils/log-error"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const mockLog = jest.fn()
 const mockRecordError = jest.fn()
@@ -21,7 +22,7 @@ describe("logError", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined)
+    consoleErrorSpy = silenceConsoleError()
   })
 
   afterEach(() => {

--- a/__tests__/utils/notifications.spec.ts
+++ b/__tests__/utils/notifications.spec.ts
@@ -1,4 +1,5 @@
 import { addDeviceToken } from "@app/utils/notifications"
+import { silenceConsoleError } from "../helpers/silence-console-error"
 
 const mockGetToken = jest.fn()
 
@@ -28,7 +29,7 @@ describe("addDeviceToken error reporting", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined)
+    consoleErrorSpy = silenceConsoleError()
   })
 
   afterEach(() => {

--- a/app/hooks/use-account-registry.tsx
+++ b/app/hooks/use-account-registry.tsx
@@ -66,8 +66,23 @@ type AccountRegistryResult = {
 
 const AccountRegistryContext = createContext<AccountRegistryResult | null>(null)
 
-/** Owns the registry so its two device reads run once and are shared via context. */
-export const AccountRegistryProvider = ({ children }: { children: ReactNode }) => {
+/**
+ * Owns the registry so its two device reads run once and are shared via context.
+ *
+ * `skipHydration` is a test-only affordance: it skips the two async device
+ * reads so the provider settles synchronously on mount. In the jest
+ * environment those reads resolve to empty data anyway, but their promises
+ * settle after the test body finishes, tripping React's "not wrapped in
+ * act(...)" warning in every suite that mounts a screen. Production callers
+ * must never pass it.
+ */
+export const AccountRegistryProvider = ({
+  children,
+  skipHydration = false,
+}: {
+  children: ReactNode
+  skipHydration?: boolean
+}) => {
   const isAuthed = useIsAuthed()
   const { persistentState, updateState } = usePersistentStateContext()
   const { LL } = useI18nContext()
@@ -86,8 +101,8 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
   const [hasStoredCustodialProfile, setHasStoredCustodialProfile] = useState(isAuthed)
 
   // True until both async reads settle, so callers can wait before trusting `accounts`.
-  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(true)
-  const [profilesHydrating, setProfilesHydrating] = useState(true)
+  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(!skipHydration)
+  const [profilesHydrating, setProfilesHydrating] = useState(!skipHydration)
 
   // Consumers can call the reload below at any time, so a read that is still in
   // flight may resolve after a newer one has already answered. Applying it then
@@ -95,6 +110,8 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
   const reloadRequestRef = useRef(0)
 
   const reloadSelfCustodialAccounts = useCallback(async () => {
+    if (skipHydration) return
+
     const request = reloadRequestRef.current + 1
     reloadRequestRef.current = request
 
@@ -107,13 +124,14 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
       setSelfCustodialEntries(result.entries)
     }
     setSelfCustodialHydrating(false)
-  }, [])
+  }, [skipHydration])
 
   useEffect(() => {
     reloadSelfCustodialAccounts()
   }, [reloadSelfCustodialAccounts, persistentState.activeAccountId])
 
   useEffect(() => {
+    if (skipHydration) return undefined
     let mounted = true
     setProfilesHydrating(true)
     KeyStoreWrapper.getSessionProfiles().then((profiles) => {
@@ -125,7 +143,7 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
     return () => {
       mounted = false
     }
-  }, [persistentState.galoyAuthToken, persistentState.activeAccountId])
+  }, [skipHydration, persistentState.galoyAuthToken, persistentState.activeAccountId])
 
   const accounts = useMemo(() => {
     const list: AccountDescriptor[] = []

--- a/app/hooks/use-account-registry.tsx
+++ b/app/hooks/use-account-registry.tsx
@@ -64,86 +64,34 @@ type AccountRegistryResult = {
   reloadSelfCustodialAccounts: () => Promise<void>
 }
 
-const AccountRegistryContext = createContext<AccountRegistryResult | null>(null)
+/**
+ * Exported so tests can supply a settled registry without mounting the
+ * provider's device reads — see `__tests__/screens/helper.tsx`. Application
+ * code goes through `AccountRegistryProvider` / `useAccountRegistry`.
+ */
+export const AccountRegistryContext = createContext<AccountRegistryResult | null>(null)
 
 /**
- * Owns the registry so its two device reads run once and are shared via context.
+ * Composes the registry value from inputs that have already been resolved.
  *
- * `skipHydration` is a test-only affordance: it skips the two async device
- * reads so the provider settles synchronously on mount. In the jest
- * environment those reads resolve to empty data anyway, but their promises
- * settle after the test body finishes, tripping React's "not wrapped in
- * act(...)" warning in every suite that mounts a screen. Production callers
- * must never pass it.
+ * Split out of the provider so "what the registry looks like" is defined once
+ * and stays independent of "where the data came from": the provider feeds it
+ * the two device reads, while tests feed it seeded entries directly.
  */
-export const AccountRegistryProvider = ({
-  children,
-  skipHydration = false,
+export const useComposedAccountRegistry = ({
+  selfCustodialEntries,
+  hasStoredCustodialProfile,
+  loading,
+  reloadSelfCustodialAccounts,
 }: {
-  children: ReactNode
-  skipHydration?: boolean
-}) => {
+  selfCustodialEntries: SelfCustodialAccountEntry[]
+  hasStoredCustodialProfile: boolean
+  loading: boolean
+  reloadSelfCustodialAccounts: () => Promise<void>
+}): AccountRegistryResult => {
   const isAuthed = useIsAuthed()
   const { persistentState, updateState } = usePersistentStateContext()
   const { LL } = useI18nContext()
-
-  const [selfCustodialEntries, setSelfCustodialEntries] = useState<
-    SelfCustodialAccountEntry[]
-  >(() => {
-    // Surface the active self-custodial id on first render to avoid the unauthed flash.
-    const id = persistentState.activeAccountId
-    if (!id || id === DefaultAccountId.Custodial) return []
-    return [{ id, lightningAddress: null }]
-  })
-
-  // KeyStore-derived so home agrees with switch-account when the live token has
-  // been cleared but a session profile is still saved.
-  const [hasStoredCustodialProfile, setHasStoredCustodialProfile] = useState(isAuthed)
-
-  // True until both async reads settle, so callers can wait before trusting `accounts`.
-  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(!skipHydration)
-  const [profilesHydrating, setProfilesHydrating] = useState(!skipHydration)
-
-  // Consumers can call the reload below at any time, so a read that is still in
-  // flight may resolve after a newer one has already answered. Applying it then
-  // would clobber fresher entries with stale ones, so late answers are dropped.
-  const reloadRequestRef = useRef(0)
-
-  const reloadSelfCustodialAccounts = useCallback(async () => {
-    if (skipHydration) return
-
-    const request = reloadRequestRef.current + 1
-    reloadRequestRef.current = request
-
-    setSelfCustodialHydrating(true)
-    const result = await listSelfCustodialAccounts()
-
-    if (reloadRequestRef.current !== request) return
-
-    if (result.status === StorageReadStatus.Ok) {
-      setSelfCustodialEntries(result.entries)
-    }
-    setSelfCustodialHydrating(false)
-  }, [skipHydration])
-
-  useEffect(() => {
-    reloadSelfCustodialAccounts()
-  }, [reloadSelfCustodialAccounts, persistentState.activeAccountId])
-
-  useEffect(() => {
-    if (skipHydration) return undefined
-    let mounted = true
-    setProfilesHydrating(true)
-    KeyStoreWrapper.getSessionProfiles().then((profiles) => {
-      if (mounted) {
-        setHasStoredCustodialProfile(profiles.length > 0)
-        setProfilesHydrating(false)
-      }
-    })
-    return () => {
-      mounted = false
-    }
-  }, [skipHydration, persistentState.galoyAuthToken, persistentState.activeAccountId])
 
   const accounts = useMemo(() => {
     const list: AccountDescriptor[] = []
@@ -180,12 +128,12 @@ export const AccountRegistryProvider = ({
     [updateState],
   )
 
-  const value = useMemo<AccountRegistryResult>(
+  return useMemo<AccountRegistryResult>(
     () => ({
       accounts,
       activeAccount,
       selfCustodialEntries,
-      loading: selfCustodialHydrating || profilesHydrating,
+      loading,
       setActiveAccountId,
       reloadSelfCustodialAccounts,
     }),
@@ -193,12 +141,79 @@ export const AccountRegistryProvider = ({
       accounts,
       activeAccount,
       selfCustodialEntries,
-      selfCustodialHydrating,
-      profilesHydrating,
+      loading,
       setActiveAccountId,
       reloadSelfCustodialAccounts,
     ],
   )
+}
+
+/** Owns the registry so its two device reads run once and are shared via context. */
+export const AccountRegistryProvider = ({ children }: { children: ReactNode }) => {
+  const isAuthed = useIsAuthed()
+  const { persistentState } = usePersistentStateContext()
+
+  const [selfCustodialEntries, setSelfCustodialEntries] = useState<
+    SelfCustodialAccountEntry[]
+  >(() => {
+    // Surface the active self-custodial id on first render to avoid the unauthed flash.
+    const id = persistentState.activeAccountId
+    if (!id || id === DefaultAccountId.Custodial) return []
+    return [{ id, lightningAddress: null }]
+  })
+
+  // KeyStore-derived so home agrees with switch-account when the live token has
+  // been cleared but a session profile is still saved.
+  const [hasStoredCustodialProfile, setHasStoredCustodialProfile] = useState(isAuthed)
+
+  // True until both async reads settle, so callers can wait before trusting `accounts`.
+  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(true)
+  const [profilesHydrating, setProfilesHydrating] = useState(true)
+
+  // Consumers can call the reload below at any time, so a read that is still in
+  // flight may resolve after a newer one has already answered. Applying it then
+  // would clobber fresher entries with stale ones, so late answers are dropped.
+  const reloadRequestRef = useRef(0)
+
+  const reloadSelfCustodialAccounts = useCallback(async () => {
+    const request = reloadRequestRef.current + 1
+    reloadRequestRef.current = request
+
+    setSelfCustodialHydrating(true)
+    const result = await listSelfCustodialAccounts()
+
+    if (reloadRequestRef.current !== request) return
+
+    if (result.status === StorageReadStatus.Ok) {
+      setSelfCustodialEntries(result.entries)
+    }
+    setSelfCustodialHydrating(false)
+  }, [])
+
+  useEffect(() => {
+    reloadSelfCustodialAccounts()
+  }, [reloadSelfCustodialAccounts, persistentState.activeAccountId])
+
+  useEffect(() => {
+    let mounted = true
+    setProfilesHydrating(true)
+    KeyStoreWrapper.getSessionProfiles().then((profiles) => {
+      if (mounted) {
+        setHasStoredCustodialProfile(profiles.length > 0)
+        setProfilesHydrating(false)
+      }
+    })
+    return () => {
+      mounted = false
+    }
+  }, [persistentState.galoyAuthToken, persistentState.activeAccountId])
+
+  const value = useComposedAccountRegistry({
+    selfCustodialEntries,
+    hasStoredCustodialProfile,
+    loading: selfCustodialHydrating || profilesHydrating,
+    reloadSelfCustodialAccounts,
+  })
 
   return (
     <AccountRegistryContext.Provider value={value}>

--- a/app/hooks/use-account-registry.tsx
+++ b/app/hooks/use-account-registry.tsx
@@ -65,8 +65,23 @@ type AccountRegistryResult = {
 
 const AccountRegistryContext = createContext<AccountRegistryResult | null>(null)
 
-/** Owns the registry so its two device reads run once and are shared via context. */
-export const AccountRegistryProvider = ({ children }: { children: ReactNode }) => {
+/**
+ * Owns the registry so its two device reads run once and are shared via context.
+ *
+ * `skipHydration` is a test-only affordance: it skips the two async device
+ * reads so the provider settles synchronously on mount. In the jest
+ * environment those reads resolve to empty data anyway, but their promises
+ * settle after the test body finishes, tripping React's "not wrapped in
+ * act(...)" warning in every suite that mounts a screen. Production callers
+ * must never pass it.
+ */
+export const AccountRegistryProvider = ({
+  children,
+  skipHydration = false,
+}: {
+  children: ReactNode
+  skipHydration?: boolean
+}) => {
   const isAuthed = useIsAuthed()
   const { persistentState, updateState } = usePersistentStateContext()
   const { LL } = useI18nContext()
@@ -85,23 +100,25 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
   const [hasStoredCustodialProfile, setHasStoredCustodialProfile] = useState(isAuthed)
 
   // True until both async reads settle, so callers can wait before trusting `accounts`.
-  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(true)
-  const [profilesHydrating, setProfilesHydrating] = useState(true)
+  const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(!skipHydration)
+  const [profilesHydrating, setProfilesHydrating] = useState(!skipHydration)
 
   const reloadSelfCustodialAccounts = useCallback(async () => {
+    if (skipHydration) return
     setSelfCustodialHydrating(true)
     const result = await listSelfCustodialAccounts()
     if (result.status === StorageReadStatus.Ok) {
       setSelfCustodialEntries(result.entries)
     }
     setSelfCustodialHydrating(false)
-  }, [])
+  }, [skipHydration])
 
   useEffect(() => {
     reloadSelfCustodialAccounts()
   }, [reloadSelfCustodialAccounts, persistentState.activeAccountId])
 
   useEffect(() => {
+    if (skipHydration) return undefined
     let mounted = true
     setProfilesHydrating(true)
     KeyStoreWrapper.getSessionProfiles().then((profiles) => {
@@ -113,7 +130,7 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
     return () => {
       mounted = false
     }
-  }, [persistentState.galoyAuthToken, persistentState.activeAccountId])
+  }, [skipHydration, persistentState.galoyAuthToken, persistentState.activeAccountId])
 
   const accounts = useMemo(() => {
     const list: AccountDescriptor[] = []

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -65,12 +65,29 @@ export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
   ipapiAdapter,
 ]
 
-if (
-  !Config.GEO_IPIFY_API_KEY &&
-  !Config.IPINFO_API_KEY &&
-  !Config.PROXYCHECK_API_KEY &&
-  !Config.IPAPI_API_KEY
-) {
+/**
+ * Warn once, on the first lookup rather than at module load.
+ *
+ * The keys are unset in every jest environment, so warning at import time meant
+ * every suite that pulled this module in — directly or through a screen — got
+ * the line, which is how it ended up on a global console.warn suppression list.
+ * Deferring it to the first actual lookup keeps the warning where it means
+ * something (a real request is about to run on a rate-limited free tier) and
+ * off the logs of tests that never look a country up.
+ */
+let hasWarnedAboutMissingKey = false
+
+const warnOnceIfNoApiKey = () => {
+  if (hasWarnedAboutMissingKey) return
+  if (
+    Config.GEO_IPIFY_API_KEY ||
+    Config.IPINFO_API_KEY ||
+    Config.PROXYCHECK_API_KEY ||
+    Config.IPAPI_API_KEY
+  ) {
+    return
+  }
+  hasWarnedAboutMissingKey = true
   console.warn(
     "[ip-country-lookup] No API key configured. Running on free tiers only (rate-limited). Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, PROXYCHECK_API_KEY, or IPAPI_API_KEY in .env.local.",
   )
@@ -80,6 +97,8 @@ export const resolveIpCountryCode = async (
   adapters: IpLookupAdapter[] = DEFAULT_ADAPTERS,
   timeout: number = DEFAULT_TIMEOUT_MS,
 ): Promise<CountryCode | undefined> => {
+  warnOnceIfNoApiKey()
+
   for (const adapter of adapters) {
     try {
       const countryCode = await adapter(timeout)

--- a/jest.setup-after-env.ts
+++ b/jest.setup-after-env.ts
@@ -1,5 +1,9 @@
 import { format } from "util"
 
+// The ambient `expect` is typed by @types/jest, which does not declare
+// `getState`; the @jest/globals one does, and is the same object at runtime.
+import { expect } from "@jest/globals"
+
 // Shared per-test setup/teardown (registered via setupFilesAfterEnv in jest.config.js).
 //
 // In CI, retry flaky tests at test granularity instead of re-running the whole
@@ -120,29 +124,99 @@ afterAll(() => {
 // The message is recorded here and thrown from a hook rather than thrown inline:
 // console.error runs inside React's commit phase, where throwing corrupts the
 // render and reports something unrelated.
-const escapedActUpdates: string[] = []
+//
+// Each record carries the test that was running when the warning was emitted.
+// RNTL's cleanup runs after this file's afterEach, so an unmount-time warning
+// from test A is only flushed at test B's afterEach; without the tag, B fails
+// naming a component from A and CI's retry re-runs B — which passes, because
+// the leak was never B's. The tag makes that case readable.
+type EscapedActUpdate = { line: string; testName: string }
+
+const escapedActUpdates: EscapedActUpdate[] = []
 const originalConsoleError = console.error.bind(console)
 
-console.error = (...args: unknown[]) => {
+// Where console.error output actually goes. Specs mute or capture it by
+// swapping this sink (see __tests__/helpers/silence-console-error.ts) rather
+// than replacing console.error, which would take the act() inspection below
+// with it. Reset after every test by the hook further down.
+let consoleErrorSink: (...args: unknown[]) => void = originalConsoleError
+
+const guardedConsoleError = (...args: unknown[]) => {
   const template = typeof args[0] === "string" ? args[0] : ""
   if (template.includes("was not wrapped in act(")) {
     // React names the component through a %s placeholder, so the template has
     // to be formatted before it reads as anything useful. Keep the first line
     // only; the full React stack still goes to stderr below.
     const formatted = format(...(args as [string, ...unknown[]]))
-    escapedActUpdates.push(formatted.split("\n")[0].trim())
+    escapedActUpdates.push({
+      line: formatted.split("\n")[0].trim(),
+      testName: expect.getState().currentTestName ?? "<outside a test>",
+    })
   }
-  originalConsoleError(...(args as Parameters<typeof console.error>))
+  consoleErrorSink(...args)
 }
 
+// Locked rather than assigned. A spec that did
+// `jest.spyOn(console, "error").mockImplementation(...)` used to switch the
+// guard off for its whole file — silently, and an afterEach check cannot catch
+// it, because specs restore the spy before the hook runs. Refusing the write
+// turns that into an immediate failure at the call site.
+//
+// jest.spyOn goes through Object.defineProperty, so what a spec actually sees
+// is `TypeError: Cannot redefine property: error` on the spyOn line. The fix is
+// always the same: use `silenceConsoleError()` from
+// __tests__/helpers/silence-console-error.ts, which mutes (and captures) the
+// output while leaving the guard installed. Direct assignment hits the setter
+// below and gets that message spelled out.
+Object.defineProperty(console, "error", {
+  configurable: false,
+  enumerable: true,
+  get: () => guardedConsoleError,
+  set: () => {
+    throw new Error(
+      `console.error is owned by the act() regression guard and cannot be ` +
+        `replaced — doing so would disable escaped-update detection for this ` +
+        `whole spec file. Use silenceConsoleError() from ` +
+        `__tests__/helpers/silence-console-error.ts, which mutes (and captures) ` +
+        `the output while leaving the guard installed.`,
+    )
+  },
+})
+
+/**
+ * Route console.error somewhere else for the current test, keeping the act()
+ * guard installed underneath. Used by `silenceConsoleError()`; specs should go
+ * through that helper rather than calling this directly.
+ */
+const setConsoleErrorSink = (sink: (...args: unknown[]) => void) => {
+  consoleErrorSink = sink
+}
+
+// The helper lives in __tests__/helpers and cannot import from a setup file, so
+// the seam is handed over on globalThis.
+;(globalThis as Record<string, unknown>).__setConsoleErrorSink = setConsoleErrorSink
+
 const failOnEscapedActUpdates = () => {
+  consoleErrorSink = originalConsoleError
+
   if (escapedActUpdates.length === 0) return
   const total = escapedActUpdates.length
-  const seen = [...new Set(escapedActUpdates)]
+  const currentTestName = expect.getState().currentTestName ?? ""
+  const seen = [...new Map(escapedActUpdates.map((u) => [`${u.testName}|${u.line}`, u]))]
   escapedActUpdates.length = 0
+
+  const elsewhere = seen.some(([, update]) => update.testName !== currentTestName)
+
   throw new Error(
     `${total} state update(s) escaped act():\n` +
-      `${seen.map((line) => `  - ${line}`).join("\n")}\n\n` +
+      `${seen
+        .map(([, update]) => `  - ${update.line}\n      (during: ${update.testName})`)
+        .join("\n")}\n\n` +
+      (elsewhere
+        ? `At least one update was emitted while a *different* test was running — ` +
+          `fix that test, not this one. Unmount-time warnings surface here because ` +
+          `RNTL's cleanup runs after this hook.\n\n`
+        : "") +
       `Await the render instead of letting it settle after the test body — see ` +
       `__tests__/helpers/flush-effects.ts. Full React stacks are above.`,
   )

--- a/jest.setup-after-env.ts
+++ b/jest.setup-after-env.ts
@@ -196,30 +196,51 @@ const setConsoleErrorSink = (sink: (...args: unknown[]) => void) => {
 // the seam is handed over on globalThis.
 ;(globalThis as Record<string, unknown>).__setConsoleErrorSink = setConsoleErrorSink
 
+const dedupe = (updates: EscapedActUpdate[]): EscapedActUpdate[] => [
+  ...new Map(
+    updates.map((update) => [`${update.testName}|${update.line}`, update]),
+  ).values(),
+]
+
+const describeEscapedUpdates = (
+  updates: EscapedActUpdate[],
+  total: number,
+  currentTestName: string,
+): string => {
+  const listed = dedupe(updates)
+    .map((update) => `  - ${update.line}\n      (during: ${update.testName})`)
+    .join("\n")
+
+  const fromAnotherTest = dedupe(updates).some(
+    (update) => update.testName !== currentTestName,
+  )
+
+  const misattribution = fromAnotherTest
+    ? `At least one update was emitted while a *different* test was running — ` +
+      `fix that test, not this one. Unmount-time warnings surface here because ` +
+      `RNTL's cleanup runs after this hook.\n\n`
+    : ""
+
+  return (
+    `${total} state update(s) escaped act():\n${listed}\n\n` +
+    misattribution +
+    `Await the render instead of letting it settle after the test body — see ` +
+    `__tests__/helpers/flush-effects.ts. Full React stacks are above.`
+  )
+}
+
 const failOnEscapedActUpdates = () => {
   consoleErrorSink = originalConsoleError
-
   if (escapedActUpdates.length === 0) return
-  const total = escapedActUpdates.length
-  const currentTestName = expect.getState().currentTestName ?? ""
-  const seen = [...new Map(escapedActUpdates.map((u) => [`${u.testName}|${u.line}`, u]))]
+
+  const message = describeEscapedUpdates(
+    escapedActUpdates,
+    escapedActUpdates.length,
+    expect.getState().currentTestName ?? "",
+  )
   escapedActUpdates.length = 0
 
-  const elsewhere = seen.some(([, update]) => update.testName !== currentTestName)
-
-  throw new Error(
-    `${total} state update(s) escaped act():\n` +
-      `${seen
-        .map(([, update]) => `  - ${update.line}\n      (during: ${update.testName})`)
-        .join("\n")}\n\n` +
-      (elsewhere
-        ? `At least one update was emitted while a *different* test was running — ` +
-          `fix that test, not this one. Unmount-time warnings surface here because ` +
-          `RNTL's cleanup runs after this hook.\n\n`
-        : "") +
-      `Await the render instead of letting it settle after the test body — see ` +
-      `__tests__/helpers/flush-effects.ts. Full React stacks are above.`,
-  )
+  throw new Error(message)
 }
 
 // Registered last so it runs after the microtask drain above (jest-circus runs

--- a/jest.setup-after-env.ts
+++ b/jest.setup-after-env.ts
@@ -1,3 +1,5 @@
+import { format } from "util"
+
 // Shared per-test setup/teardown (registered via setupFilesAfterEnv in jest.config.js).
 //
 // In CI, retry flaky tests at test granularity instead of re-running the whole
@@ -99,3 +101,56 @@ afterAll(() => {
   jest.useRealTimers()
   clearLiveTimers()
 })
+
+// --- act() regression guard ---------------------------------------------
+//
+// React logs "An update to X inside a test was not wrapped in act(...)" through
+// console.error whenever a state update lands after the test body returned.
+// Each one marks a real race: the assertions ran against a tree that was still
+// changing. Left as warnings they scroll past, and the suite drifts back into
+// noise (this happened after #3820), so they fail the test instead.
+//
+// Fixing one: await the render rather than silencing the warning — `await
+// waitFor(...)` / `await findBy*` for state you can assert on, or
+// `await flushEffects()` (__tests__/helpers/flush-effects.ts) for a
+// render-and-assert test whose effects settle on their own. If the update comes
+// from a provider the shared wrapper mounts, fix it at the wrapper — patching
+// spec by spec is whack-a-mole, since which suites trip is timing-dependent.
+//
+// The message is recorded here and thrown from a hook rather than thrown inline:
+// console.error runs inside React's commit phase, where throwing corrupts the
+// render and reports something unrelated.
+const escapedActUpdates: string[] = []
+const originalConsoleError = console.error.bind(console)
+
+console.error = (...args: unknown[]) => {
+  const template = typeof args[0] === "string" ? args[0] : ""
+  if (template.includes("was not wrapped in act(")) {
+    // React names the component through a %s placeholder, so the template has
+    // to be formatted before it reads as anything useful. Keep the first line
+    // only; the full React stack still goes to stderr below.
+    const formatted = format(...(args as [string, ...unknown[]]))
+    escapedActUpdates.push(formatted.split("\n")[0].trim())
+  }
+  originalConsoleError(...(args as Parameters<typeof console.error>))
+}
+
+const failOnEscapedActUpdates = () => {
+  if (escapedActUpdates.length === 0) return
+  const total = escapedActUpdates.length
+  const seen = [...new Set(escapedActUpdates)]
+  escapedActUpdates.length = 0
+  throw new Error(
+    `${total} state update(s) escaped act():\n` +
+      `${seen.map((line) => `  - ${line}`).join("\n")}\n\n` +
+      `Await the render instead of letting it settle after the test body — see ` +
+      `__tests__/helpers/flush-effects.ts. Full React stacks are above.`,
+  )
+}
+
+// Registered last so it runs after the microtask drain above (jest-circus runs
+// afterEach hooks in registration order). RNTL registers its own cleanup when a
+// spec imports it — i.e. after this file — so unmount-time warnings land after
+// this hook has run; afterAll catches those.
+afterEach(failOnEscapedActUpdates)
+afterAll(failOnEscapedActUpdates)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,21 +1,27 @@
-// In CI, suppress noisy, non-actionable deprecation warnings emitted during
-// tests by third-party internals, so Concourse/CI logs stay readable:
+// Suppress known, non-actionable console.warn noise during tests so local and
+// CI logs stay readable (originally CI-only, extended to local runs — the
+// repeated noise drowned out real output; see issue #3813):
 // - "InteractionManager has been deprecated": @react-navigation/* internals and
 //   app/screens/transaction-history/transaction-history-screen.tsx
 // - "SafeAreaView has been deprecated": react-native-country-picker-modal
-// Locally the warnings are left intact so developers still see the deprecations.
-// See https://github.com/blinkbitcoin/blink-mobile/issues/3813
-const isCI = Boolean(process.env.CI) && process.env.CI !== "false"
+// - "[ip-country-lookup] No API key configured": app/utils/ip-country-lookup.ts
+//   warns at module load when no geo API key env vars are set, which is always
+//   the case in the jest environment. The warning behavior itself is asserted
+//   in __tests__/utils/ip-country-lookup.spec.ts via a local console.warn spy
+//   (spies layer on top of this filter, so those assertions are unaffected).
+//
+// Anything not on this list still prints — new warnings stay visible. Before
+// adding a pattern here, make sure the warning is either third-party noise we
+// cannot fix or app behavior pinned by an explicit test assertion.
+const SUPPRESSED_WARNINGS = [
+  /InteractionManager has been deprecated/,
+  /SafeAreaView has been deprecated/,
+  /\[ip-country-lookup\] No API key configured/,
+]
 
-if (isCI) {
-  const SUPPRESSED_WARNINGS = [
-    /InteractionManager has been deprecated/,
-    /SafeAreaView has been deprecated/,
-  ]
-  const originalWarn = console.warn.bind(console)
-  console.warn = (...args) => {
-    const message = typeof args[0] === "string" ? args[0] : ""
-    if (SUPPRESSED_WARNINGS.some((re) => re.test(message))) return
-    originalWarn(...args)
-  }
+const originalWarn = console.warn.bind(console)
+console.warn = (...args) => {
+  const message = typeof args[0] === "string" ? args[0] : ""
+  if (SUPPRESSED_WARNINGS.some((re) => re.test(message))) return
+  originalWarn(...args)
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,19 +4,16 @@
 // - "InteractionManager has been deprecated": @react-navigation/* internals and
 //   app/screens/transaction-history/transaction-history-screen.tsx
 // - "SafeAreaView has been deprecated": react-native-country-picker-modal
-// - "[ip-country-lookup] No API key configured": app/utils/ip-country-lookup.ts
-//   warns at module load when no geo API key env vars are set, which is always
-//   the case in the jest environment. The warning behavior itself is asserted
-//   in __tests__/utils/ip-country-lookup.spec.ts via a local console.warn spy
-//   (spies layer on top of this filter, so those assertions are unaffected).
 //
-// Anything not on this list still prints — new warnings stay visible. Before
-// adding a pattern here, make sure the warning is either third-party noise we
-// cannot fix or app behavior pinned by an explicit test assertion.
+// Both are third-party deprecations we cannot act on. Anything not on this list
+// still prints — new warnings stay visible. This list is for third-party noise
+// only: a warning our own code emits belongs fixed at the source, not hidden
+// here, because hiding it also hides the regression that would make it fire for
+// a real reason (app/utils/ip-country-lookup.ts was on this list until its
+// warning moved off module load and onto the first actual lookup).
 const SUPPRESSED_WARNINGS = [
   /InteractionManager has been deprecated/,
   /SafeAreaView has been deprecated/,
-  /\[ip-country-lookup\] No API key configured/,
 ]
 
 const originalWarn = console.warn.bind(console)

--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
     "@react-native/typescript-config": "0.76.9",
     "@rnx-kit/align-deps": "^3.2.1",
     "@testing-library/jest-native": "^5.4.1",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/react-native": "^13.3.3",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@tsconfig/react-native": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5624,14 +5624,6 @@
     pretty-format "^29.0.3"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react-native@^13.3.3":
   version "13.3.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-13.3.3.tgz#4bf02911c4e18075df40b5de0e029c209fb45bda"
@@ -16212,13 +16204,6 @@ react-dom@^19.2.3:
   integrity sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==
   dependencies:
     scheduler "^0.27.0"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
## Summary

Jest output (local and CI) was bloated by two kinds of repeated noise:

1. **`act()` warnings** — most of them trace to `AccountRegistryProvider`'s two async device reads (`listSelfCustodialAccounts()`, `KeyStoreWrapper.getSessionProfiles()`). Their promises settle after the test body finishes, so the resulting `setState`s fire outside `act()`. The affected set is timing-dependent (16 suites in one run, a different set in the next) across the ~110 specs that mount `ContextForScreen`, so per-spec `act()` patching would be whack-a-mole.
2. **`console.warn` noise** — `[ip-country-lookup] No API key configured` at module load in ~27 suites, plus the `InteractionManager`/`SafeAreaView` deprecations that were already suppressed in CI but still printed locally.

Beyond silencing them, the branch adds a guard that **fails** a test when a state update escapes `act()`, so the suite cannot quietly drift back into noise.

## Changes

- `app/hooks/use-account-registry.tsx`: split into "read the device" and "compose the value". `useComposedAccountRegistry` is exported alongside `AccountRegistryContext`, so tests can supply a settled registry without any test-only branch in shipped code. The provider's own hydration is unchanged from `main`.
- `__tests__/screens/helper.tsx`: both `ContextForScreen` variants mount a settled stub registry built from that same hook, with an `accountRegistry` prop for specs that need seeded self-custodial accounts. Specs that exercise real hydration (`use-account-registry.spec`, `wallet.spec`) mount `AccountRegistryProvider` directly. `__tests__/screens/helper-account-registry.spec.tsx` pins the default and the seeded path, so the stub cannot silently diverge from the provider.
- `jest.setup-after-env.ts`: the act() guard. `console.error` is locked against replacement — a spec that switched the guard off with `jest.spyOn` used to disable escaped-update detection for its whole file, silently. `silenceConsoleError()` (`__tests__/helpers/silence-console-error.ts`) mutes and captures output through a sink underneath the guard instead. Each escaped update records the test that emitted it, so an unmount-time leak from test A no longer fails test B under a component name from A.
- `jest.setup.js`: warn suppression is now unconditional (local noise was just as distracting as CI noise) and is limited to the two third-party deprecations. The file documents the rule: this list is for third-party noise only.
- `app/utils/ip-country-lookup.ts`: the no-API-key warning moved off module load and onto the first actual lookup, so it no longer fires in every suite that transitively imports the module — and no longer needs suppressing.
- `__tests__/helpers/flush-effects.ts`: captures the real `setImmediate` at import time, so the helper does not hang in fake-timer suites.
- ~40 specs migrate from `@testing-library/react-hooks` to `@testing-library/react-native`; the dependency and its orphaned lockfile entry are dropped.

## Test plan

- [x] Full parallel suite locally: 523 suites / 5834 tests passing
- [x] Zero `act()` warnings, zero `console.warn`/`console.error` in the full-suite log
- [x] Real-hydration specs (`use-account-registry`, `wallet`) still pass
- [x] `ip-country-lookup.spec.ts` covers quiet-at-load, warn-on-first-lookup, and warn-only-once
- [x] Guard verified to bite: a deliberate escaped update inside a spec that mutes `console.error` fails, naming the right test
- [x] `eslint` and `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
