### PR TITLE
feat(self-custodial): spark wire codec, identity, and exit-bundle exporter

### DIFF
--- a/__tests__/self-custodial/recovery-bundle/exporter.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/exporter.spec.ts
@@ -30,6 +30,8 @@ import {
 import { RECOVERY_BUNDLE_SCHEMA } from "@app/self-custodial/recovery-bundle/types"
 import type { DecodedTreeNode } from "@app/self-custodial/recovery-bundle/protocol/messages"
 
+import packageJson from "../../../package.json"
+
 const TEST_MNEMONIC =
   "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 
@@ -96,18 +98,22 @@ const encodeQueryNodesResponse = (nodes: TestNode[], offset = 0): Uint8Array => 
   return writer.varint(2, offset).finish()
 }
 
+/** The exact ProtectedChallenge bytes the mock serves; verify_challenge must echo them. */
+const PROTECTED_CHALLENGE_BYTES = new ProtoWriter()
+  .varint(1, 1)
+  .bytes(
+    2,
+    new ProtoWriter()
+      .varint(1, 1)
+      .varint(2, 1752300000)
+      .bytes(3, Uint8Array.from(Buffer.alloc(32, 0x11)))
+      .finish(),
+  )
+  .bytes(3, Uint8Array.from(Buffer.alloc(32, 0xaa)))
+  .finish()
+
 const encodeChallengeResponse = (): Uint8Array => {
-  const challenge = new ProtoWriter()
-    .varint(1, 1)
-    .varint(2, 1752300000)
-    .bytes(3, Uint8Array.from(Buffer.alloc(32, 0x11)))
-    .finish()
-  const protectedChallenge = new ProtoWriter()
-    .varint(1, 1)
-    .bytes(2, challenge)
-    .bytes(3, Uint8Array.from(Buffer.alloc(32, 0xaa)))
-    .finish()
-  return new ProtoWriter().bytes(1, protectedChallenge).finish()
+  return new ProtoWriter().bytes(1, PROTECTED_CHALLENGE_BYTES).finish()
 }
 
 const encodeVerifyResponse = (): Uint8Array =>
@@ -128,6 +134,11 @@ const mockOperator = ({
 }) => {
   const byIdRequests: string[][] = []
   const ownerQueryOffsets: number[] = []
+  const verifyRequests: {
+    protectedChallenge: Uint8Array
+    signature: Uint8Array
+    publicKey: Uint8Array
+  }[] = []
 
   global.fetch = jest.fn(async (url: string, init: { body: Uint8Array }) => {
     const respond = (message: Uint8Array) => ({
@@ -144,6 +155,15 @@ const mockOperator = ({
       return respond(encodeChallengeResponse())
     }
     if (url.endsWith("/spark_authn.SparkAuthnService/verify_challenge")) {
+      // Record what the exporter actually sent: field numbers here mirror
+      // spark_authn.proto, so an encoder regression fails these assertions
+      // instead of only failing against the real coordinator.
+      const request = decodeFields(Uint8Array.from(init.body).subarray(5))
+      verifyRequests.push({
+        protectedChallenge: lastField(request, 1)?.bytes ?? new Uint8Array(0),
+        signature: lastField(request, 2)?.bytes ?? new Uint8Array(0),
+        publicKey: lastField(request, 3)?.bytes ?? new Uint8Array(0),
+      })
       return respond(encodeVerifyResponse())
     }
     if (url.endsWith("/spark.SparkService/query_nodes")) {
@@ -169,7 +189,7 @@ const mockOperator = ({
     throw new Error(`unexpected url: ${url}`)
   }) as unknown as typeof fetch
 
-  return { byIdRequests, ownerQueryOffsets }
+  return { byIdRequests, ownerQueryOffsets, verifyRequests }
 }
 
 describe("findMissingAncestors", () => {
@@ -233,7 +253,7 @@ describe("fetchRecoveryBundle", () => {
     }
 
     // Owner query omits the tree root (the legacy-tree operator bug)
-    const { byIdRequests } = mockOperator({
+    const { byIdRequests, verifyRequests } = mockOperator({
       ownerQueryNodes: [leaf, mid],
       byIdNodes: { "root-1": root },
     })
@@ -259,6 +279,19 @@ describe("fetchRecoveryBundle", () => {
     )
     expect(bundle.nodes.map((n) => n.id)).toEqual(["leaf-1", "mid-1", "root-1"])
     expect(bundle.balances.btcSats).toBe("32768")
+    // Name + pinned version of the SDK, from the same package.json source
+    expect(bundle.sparkSdkVersion).toBe(
+      `breez-sdk-spark-react-native@${packageJson.dependencies["@breeztech/breez-sdk-spark-react-native"]}`,
+    )
+
+    // verify_challenge carried the served ProtectedChallenge bytes, a
+    // signature, and the wallet identity key in the proto's fields 1-3
+    expect(verifyRequests).toHaveLength(1)
+    expect(Buffer.from(verifyRequests[0].protectedChallenge)).toEqual(
+      Buffer.from(PROTECTED_CHALLENGE_BYTES),
+    )
+    expect(Buffer.from(verifyRequests[0].publicKey)).toEqual(Buffer.from(identity))
+    expect(verifyRequests[0].signature.length).toBeGreaterThan(0)
   })
 
   it("refuses to build a bundle with an open exit chain", async () => {
@@ -641,6 +674,46 @@ describe("fetchRecoveryBundle", () => {
     expect(byIdRequests).toEqual([["mid-1"], ["root-1"]])
     expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-1"])
     expect(bundle.nodes.map((n) => n.id)).toEqual(["leaf-1", "mid-1", "root-1"])
+  })
+
+  it("chunks a by-id refetch round larger than one page", async () => {
+    // 101 leaves, each missing its own root: one refetch round with 101
+    // missing ancestors must split into by-id requests of 100 + 1, and two
+    // calls within the same round must not trip the progress check.
+    const chunkLeaves: TestNode[] = Array.from({ length: 101 }, (_, i) => ({
+      id: `leaf-${String(i).padStart(3, "0")}`,
+      valueSats: 10,
+      parentNodeId: `root-${String(i).padStart(3, "0")}`,
+      owner: identity,
+      available: true,
+    }))
+    const byIdNodes = Object.fromEntries(
+      chunkLeaves.map((leaf) => [
+        leaf.parentNodeId,
+        {
+          id: leaf.parentNodeId as string,
+          valueSats: 20,
+          owner: otherOwner,
+          available: false,
+        },
+      ]),
+    )
+    const { byIdRequests } = mockOperator({ ownerQueryNodes: chunkLeaves, byIdNodes })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    // Missing ids surface in leaf order, so the slices are deterministic
+    expect(byIdRequests).toEqual([
+      chunkLeaves.slice(0, 100).map((leaf) => leaf.parentNodeId),
+      [chunkLeaves[100].parentNodeId],
+    ])
+    expect(bundle.leaves).toHaveLength(101)
+    expect(bundle.nodes).toHaveLength(202)
+    expect(bundle.balances.btcSats).toBe("1010")
   })
 
   it("tolerates a truncated by-id round and completes on the next one", async () => {

--- a/__tests__/self-custodial/recovery-bundle/exporter.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/exporter.spec.ts
@@ -1,0 +1,703 @@
+jest.mock("react-native-quick-crypto", () => {
+  const crypto = jest.requireActual("crypto") as typeof import("crypto")
+
+  return {
+    __esModule: true,
+    default: {
+      randomBytes: crypto.randomBytes,
+      createCipheriv: crypto.createCipheriv,
+      createDecipheriv: crypto.createDecipheriv,
+      createHmac: crypto.createHmac,
+      createHash: crypto.createHash,
+    },
+    Buffer,
+  }
+})
+
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+
+import {
+  fetchRecoveryBundle,
+  findMissingAncestors,
+  RecoveryBundleExportError,
+} from "@app/self-custodial/recovery-bundle/exporter"
+import { deriveIdentityKeyPair } from "@app/self-custodial/recovery-bundle/identity"
+import {
+  decodeFields,
+  lastField,
+  ProtoWriter,
+} from "@app/self-custodial/recovery-bundle/protocol/wire"
+import { RECOVERY_BUNDLE_SCHEMA } from "@app/self-custodial/recovery-bundle/types"
+import type { DecodedTreeNode } from "@app/self-custodial/recovery-bundle/protocol/messages"
+
+const TEST_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+// --- test-side encoders for operator responses ---
+
+const frame = (flag: number, payload: Uint8Array): Uint8Array => {
+  const framed = new Uint8Array(5 + payload.length)
+  framed[0] = flag
+  new DataView(framed.buffer).setUint32(1, payload.length, false)
+  framed.set(payload, 5)
+  return framed
+}
+
+const grpcBody = (message: Uint8Array): Uint8Array => {
+  const trailer = frame(0x80, Uint8Array.from(Buffer.from("grpc-status: 0", "utf8")))
+  const out = new Uint8Array(frame(0, message).length + trailer.length)
+  out.set(frame(0, message), 0)
+  out.set(trailer, frame(0, message).length)
+  return out
+}
+
+type TestNode = {
+  id: string
+  valueSats: number
+  parentNodeId?: string
+  owner: Uint8Array
+  available: boolean
+  /**
+   * Which availability field(s) the encoded node carries. Default: both.
+   * "string-only" omits field 19 (a missing varint decodes to 0, not
+   * AVAILABLE=1); "enum-only" omits field 11 (a missing string decodes to ""),
+   * so each variant is a genuinely single-signal fixture.
+   */
+  statusSignal?: "string-only" | "enum-only"
+}
+
+const encodeTreeNode = (node: TestNode): Uint8Array => {
+  const writer = new ProtoWriter()
+    .string(1, node.id)
+    .string(2, "tree-1")
+    .varint(3, node.valueSats)
+  if (node.parentNodeId) writer.string(4, node.parentNodeId)
+  writer.bytes(9, node.owner)
+  if (node.statusSignal !== "enum-only") {
+    writer.string(11, node.available ? "AVAILABLE" : "SPLITTED")
+  }
+  if (node.statusSignal !== "string-only") {
+    writer.varint(19, node.available ? 1 : 5)
+  }
+  return writer.finish()
+}
+
+const encodeQueryNodesResponse = (nodes: TestNode[], offset = 0): Uint8Array => {
+  const writer = new ProtoWriter()
+  for (const node of nodes) {
+    writer.bytes(
+      1,
+      new ProtoWriter().string(1, node.id).bytes(2, encodeTreeNode(node)).finish(),
+    )
+  }
+  // offset omitted (0) terminates the exporter's paging loop; a positive
+  // offset (field 2 varint, mirroring decodeQueryNodesResponse) signals
+  // another page
+  return writer.varint(2, offset).finish()
+}
+
+const encodeChallengeResponse = (): Uint8Array => {
+  const challenge = new ProtoWriter()
+    .varint(1, 1)
+    .varint(2, 1752300000)
+    .bytes(3, Uint8Array.from(Buffer.alloc(32, 0x11)))
+    .finish()
+  const protectedChallenge = new ProtoWriter()
+    .varint(1, 1)
+    .bytes(2, challenge)
+    .bytes(3, Uint8Array.from(Buffer.alloc(32, 0xaa)))
+    .finish()
+  return new ProtoWriter().bytes(1, protectedChallenge).finish()
+}
+
+const encodeVerifyResponse = (): Uint8Array =>
+  new ProtoWriter().string(1, "session-token").varint(2, 9999999999).finish()
+
+type OwnerQueryPage = { nodes: TestNode[]; offset: number }
+
+/** Mounts a fake operator behind global.fetch. */
+const mockOperator = ({
+  ownerQueryNodes,
+  ownerQueryPage,
+  byIdNodes,
+}: {
+  ownerQueryNodes?: TestNode[]
+  /** Per-request owner-query pages, keyed by the offset the request carried. */
+  ownerQueryPage?: (requestOffset: number) => OwnerQueryPage
+  byIdNodes: Record<string, TestNode>
+}) => {
+  const byIdRequests: string[][] = []
+  const ownerQueryOffsets: number[] = []
+
+  global.fetch = jest.fn(async (url: string, init: { body: Uint8Array }) => {
+    const respond = (message: Uint8Array) => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      arrayBuffer: async () => {
+        const body = grpcBody(message)
+        return body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength)
+      },
+    })
+
+    if (url.endsWith("/spark_authn.SparkAuthnService/get_challenge")) {
+      return respond(encodeChallengeResponse())
+    }
+    if (url.endsWith("/spark_authn.SparkAuthnService/verify_challenge")) {
+      return respond(encodeVerifyResponse())
+    }
+    if (url.endsWith("/spark.SparkService/query_nodes")) {
+      const request = decodeFields(Uint8Array.from(init.body).subarray(5))
+      const nodeIdsField = lastField(request, 2)
+      if (!nodeIdsField?.bytes) {
+        const requestOffset = Number(lastField(request, 5)?.varint ?? 0n)
+        ownerQueryOffsets.push(requestOffset)
+        const page = ownerQueryPage
+          ? ownerQueryPage(requestOffset)
+          : { nodes: ownerQueryNodes ?? [], offset: 0 }
+        return respond(encodeQueryNodesResponse(page.nodes, page.offset))
+      }
+      const requestedIds = decodeFields(nodeIdsField.bytes).map((f) =>
+        Buffer.from(f.bytes ?? []).toString("utf8"),
+      )
+      byIdRequests.push(requestedIds)
+      const found = requestedIds
+        .map((id) => byIdNodes[id])
+        .filter((n): n is TestNode => Boolean(n))
+      return respond(encodeQueryNodesResponse(found))
+    }
+    throw new Error(`unexpected url: ${url}`)
+  }) as unknown as typeof fetch
+
+  return { byIdRequests, ownerQueryOffsets }
+}
+
+describe("findMissingAncestors", () => {
+  const node = (id: string, parentNodeId?: string): DecodedTreeNode => ({
+    id,
+    valueSats: 1n,
+    parentNodeId,
+    ownerIdentityPublicKey: new Uint8Array(0),
+    status: "AVAILABLE",
+    treenodeStatus: 1,
+    raw: new Uint8Array(0),
+  })
+
+  it("returns ids of referenced-but-absent parents", () => {
+    const leaf = node("leaf", "mid")
+    const nodes = new Map([
+      ["leaf", leaf],
+      ["mid", node("mid", "root")],
+    ])
+    expect(findMissingAncestors([leaf], nodes)).toEqual(["root"])
+  })
+
+  it("returns empty when every chain reaches a root", () => {
+    const leaf = node("leaf", "root")
+    const nodes = new Map([
+      ["leaf", leaf],
+      ["root", node("root")],
+    ])
+    expect(findMissingAncestors([leaf], nodes)).toEqual([])
+  })
+})
+
+describe("fetchRecoveryBundle", () => {
+  let identity: Uint8Array
+  beforeAll(async () => {
+    const keyPair = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Mainnet)
+    identity = Uint8Array.from(keyPair.publicKey)
+  })
+  const otherOwner = Uint8Array.from(Buffer.alloc(33, 0x03))
+
+  it("assembles a bundle, re-fetching the root omitted by the owner query", async () => {
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 32768,
+      parentNodeId: "mid-1",
+      owner: identity,
+      available: true,
+    }
+    const mid: TestNode = {
+      id: "mid-1",
+      valueSats: 65536,
+      parentNodeId: "root-1",
+      owner: otherOwner,
+      available: false,
+    }
+    const root: TestNode = {
+      id: "root-1",
+      valueSats: 100000,
+      owner: otherOwner,
+      available: false,
+    }
+
+    // Owner query omits the tree root (the legacy-tree operator bug)
+    const { byIdRequests } = mockOperator({
+      ownerQueryNodes: [leaf, mid],
+      byIdNodes: { "root-1": root },
+    })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    expect(byIdRequests).toEqual([["root-1"]])
+    expect(bundle.schema).toBe(RECOVERY_BUNDLE_SCHEMA)
+    expect(bundle.network).toBe("MAINNET")
+    expect(bundle.walletIdentityPublicKey).toBe(Buffer.from(identity).toString("hex"))
+    expect(bundle.leaves).toHaveLength(1)
+    expect(bundle.leaves[0]).toMatchObject({
+      id: "leaf-1",
+      status: "AVAILABLE",
+      valueSats: 32768,
+    })
+    expect(bundle.leaves[0].treeNodeHex).toBe(
+      Buffer.from(encodeTreeNode(leaf)).toString("hex"),
+    )
+    expect(bundle.nodes.map((n) => n.id)).toEqual(["leaf-1", "mid-1", "root-1"])
+    expect(bundle.balances.btcSats).toBe("32768")
+  })
+
+  it("refuses to build a bundle with an open exit chain", async () => {
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 1000,
+      parentNodeId: "root-1",
+      owner: identity,
+      available: true,
+    }
+    mockOperator({ ownerQueryNodes: [leaf], byIdNodes: {} })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toMatchObject({ reason: "incomplete-chain" })
+  })
+
+  it("errors when the wallet has no available leaves", async () => {
+    mockOperator({ ownerQueryNodes: [], byIdNodes: {} })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toBeInstanceOf(RecoveryBundleExportError)
+  })
+
+  it("excludes leaves owned by other identities", async () => {
+    const mine: TestNode = {
+      id: "leaf-mine",
+      valueSats: 100,
+      owner: identity,
+      available: true,
+    }
+    const theirs: TestNode = {
+      id: "leaf-theirs",
+      valueSats: 999,
+      owner: otherOwner,
+      available: true,
+    }
+    mockOperator({ ownerQueryNodes: [mine, theirs], byIdNodes: {} })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+    expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-mine"])
+    expect(bundle.balances.btcSats).toBe("100")
+  })
+
+  it("excludes own leaves that are not AVAILABLE", async () => {
+    const available: TestNode = {
+      id: "leaf-available",
+      valueSats: 700,
+      owner: identity,
+      available: true,
+    }
+    const splitted: TestNode = {
+      id: "leaf-splitted",
+      valueSats: 999,
+      owner: identity,
+      available: false,
+    }
+    mockOperator({ ownerQueryNodes: [available, splitted], byIdNodes: {} })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+    expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-available"])
+    expect(bundle.balances.btcSats).toBe("700")
+  })
+
+  it("accepts leaves signalled by only the legacy status string or only the status enum", async () => {
+    // Carries "AVAILABLE" in field 11 only; field 19 is absent and decodes
+    // to 0, which is NOT TREE_NODE_STATUS_AVAILABLE.
+    const stringOnly: TestNode = {
+      id: "leaf-string-only",
+      valueSats: 100,
+      owner: identity,
+      available: true,
+      statusSignal: "string-only",
+    }
+    // Carries treenodeStatus 1 in field 19 only; field 11 is absent and
+    // decodes to "", which is not "AVAILABLE".
+    const enumOnly: TestNode = {
+      id: "leaf-enum-only",
+      valueSats: 200,
+      owner: identity,
+      available: true,
+      statusSignal: "enum-only",
+    }
+    mockOperator({ ownerQueryNodes: [stringOnly, enumOnly], byIdNodes: {} })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    // Both halves of the availability OR must admit a leaf on their own.
+    expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-enum-only", "leaf-string-only"])
+    expect(bundle.balances.btcSats).toBe("300")
+    // The enum-only leaf has an empty status string; the bundle backfills the
+    // human-readable status from the enum.
+    expect(bundle.leaves.map((l) => l.status)).toEqual(["AVAILABLE", "AVAILABLE"])
+  })
+
+  it("pages through the owner query until the operator returns offset 0", async () => {
+    const pageOneLeaf: TestNode = {
+      id: "leaf-page-1",
+      valueSats: 100,
+      owner: identity,
+      available: true,
+    }
+    const pageTwoLeaf: TestNode = {
+      id: "leaf-page-2",
+      valueSats: 200,
+      owner: identity,
+      available: true,
+    }
+
+    // Positive response offset means more pages; 0 means this page is the last
+    const { ownerQueryOffsets } = mockOperator({
+      ownerQueryPage: (requestOffset) =>
+        requestOffset === 0
+          ? { nodes: [pageOneLeaf], offset: 100 }
+          : { nodes: [pageTwoLeaf], offset: 0 },
+      byIdNodes: {},
+    })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    // The next request skips exactly the nodes already returned (1), not the
+    // requested limit: a short page must re-request its unreturned tail.
+    expect(ownerQueryOffsets).toEqual([0, 1])
+    expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-page-1", "leaf-page-2"])
+    expect(bundle.balances.btcSats).toBe("300")
+  })
+
+  it("does not skip nodes when a page is shorter than the requested limit", async () => {
+    // 60 leaves on the first page with a positive offset ("more pages"), the
+    // remaining 40 only reachable at request offset 60. Advancing by the
+    // limit (100) would skip them and persist an incomplete bundle.
+    const makeLeaf = (index: number): TestNode => ({
+      id: `leaf-${String(index).padStart(3, "0")}`,
+      valueSats: 10,
+      owner: identity,
+      available: true,
+    })
+    const firstBatch = Array.from({ length: 60 }, (_, i) => makeLeaf(i))
+    const secondBatch = Array.from({ length: 40 }, (_, i) => makeLeaf(60 + i))
+
+    const { ownerQueryOffsets } = mockOperator({
+      ownerQueryPage: (requestOffset) => {
+        if (requestOffset === 0) return { nodes: firstBatch, offset: 60 }
+        if (requestOffset === 60) return { nodes: secondBatch, offset: 0 }
+        return { nodes: [], offset: 0 }
+      },
+      byIdNodes: {},
+    })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    expect(ownerQueryOffsets).toEqual([0, 60])
+    expect(bundle.leaves).toHaveLength(100)
+    expect(bundle.balances.btcSats).toBe("1000")
+  })
+
+  it("refuses a bundle whose ancestor chain contains a parent cycle", async () => {
+    // A misbehaving coordinator returns a chain that loops instead of
+    // reaching a root: leaf -> a, a.parent = b, b.parent = a. The walk must
+    // refuse the bundle, not classify the loop as a closed chain.
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 500,
+      parentNodeId: "node-a",
+      owner: identity,
+      available: true,
+    }
+    const nodeA: TestNode = {
+      id: "node-a",
+      valueSats: 600,
+      parentNodeId: "node-b",
+      owner: otherOwner,
+      available: false,
+    }
+    const nodeB: TestNode = {
+      id: "node-b",
+      valueSats: 700,
+      parentNodeId: "node-a",
+      owner: otherOwner,
+      available: false,
+    }
+    mockOperator({ ownerQueryNodes: [leaf, nodeA, nodeB], byIdNodes: {} })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toMatchObject({ reason: "incomplete-chain" })
+  })
+
+  it("gives up when refetch rounds keep progressing without closing the chain", async () => {
+    // Each by-id round reveals exactly one new ancestor whose parent is again
+    // missing; after MAX_ANCESTOR_REFETCH_ROUNDS (10) the chain is still open
+    // and the exporter must refuse rather than loop forever.
+    const chainLength = 13
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 100,
+      parentNodeId: "anc-01",
+      owner: identity,
+      available: true,
+    }
+    const byIdNodes: Record<string, TestNode> = {}
+    for (let i = 1; i <= chainLength; i += 1) {
+      const id = `anc-${String(i).padStart(2, "0")}`
+      byIdNodes[id] = {
+        id,
+        valueSats: 100 + i,
+        parentNodeId: `anc-${String(i + 1).padStart(2, "0")}`,
+        owner: otherOwner,
+        available: false,
+      }
+    }
+    mockOperator({ ownerQueryNodes: [leaf], byIdNodes })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toMatchObject({
+      reason: "incomplete-chain",
+      message: expect.stringContaining("after refetch"),
+    })
+  })
+
+  it("refuses a leaf carrying a negative value", async () => {
+    // int64 on the wire: a hostile operator can encode a negative value, and
+    // Number(bigint) would silently propagate it into displayed amounts.
+    const hostile: TestNode = {
+      id: "leaf-negative",
+      valueSats: -5,
+      owner: identity,
+      available: true,
+    }
+    mockOperator({ ownerQueryNodes: [hostile], byIdNodes: {} })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toMatchObject({ reason: "invalid-node" })
+  })
+
+  it("gives up when the total fetch budget is exhausted", async () => {
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 100,
+      owner: identity,
+      available: true,
+    }
+    mockOperator({ ownerQueryNodes: [leaf], byIdNodes: {} })
+
+    // A zero budget makes the very first operator call exceed the deadline:
+    // the mechanism that caps a degraded-network fetch, pinned without timers.
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+        totalBudgetMs: 0,
+      }),
+    ).rejects.toMatchObject({ reason: "budget-exceeded" })
+  })
+
+  it("keeps the wallet identity out of the NoLeaves error message", async () => {
+    mockOperator({ ownerQueryNodes: [], byIdNodes: {} })
+
+    const error: RecoveryBundleExportError = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    }).then(
+      () => {
+        throw new Error("expected fetchRecoveryBundle to reject")
+      },
+      (err) => err,
+    )
+
+    const identityHex = Buffer.from(identity).toString("hex")
+    // The message may be logged (Crashlytics); the persistent identity
+    // pubkey travels only as a structured field for the UI.
+    expect(error).toBeInstanceOf(RecoveryBundleExportError)
+    expect(error.reason).toBe("no-leaves")
+    expect(error.message).not.toContain(identityHex)
+    expect(error.details?.walletIdentityPublicKey).toBe(identityHex)
+  })
+
+  it("rejects when a hostile operator never terminates the owner query", async () => {
+    const leaf: TestNode = {
+      id: "leaf-endless",
+      valueSats: 1,
+      owner: identity,
+      available: true,
+    }
+    // Every page is non-empty with a positive offset, promising more forever
+    mockOperator({
+      ownerQueryPage: () => ({ nodes: [leaf], offset: 100 }),
+      byIdNodes: {},
+    })
+
+    await expect(
+      fetchRecoveryBundle({
+        mnemonic: TEST_MNEMONIC,
+        network: Network.Mainnet,
+        appVersion: "1.0.1-test",
+      }),
+    ).rejects.toMatchObject({ reason: "paging-limit-exceeded" })
+  })
+
+  it("resolves ancestors that themselves need a second by-id round", async () => {
+    const leaf: TestNode = {
+      id: "leaf-1",
+      valueSats: 4096,
+      parentNodeId: "mid-1",
+      owner: identity,
+      available: true,
+    }
+    const mid: TestNode = {
+      id: "mid-1",
+      valueSats: 8192,
+      parentNodeId: "root-1",
+      owner: otherOwner,
+      available: false,
+    }
+    const root: TestNode = {
+      id: "root-1",
+      valueSats: 16384,
+      owner: otherOwner,
+      available: false,
+    }
+
+    // Owner query omits both ancestors; the refetched mid reveals a missing
+    // root, so closing the chain takes a second by-id round
+    const { byIdRequests } = mockOperator({
+      ownerQueryNodes: [leaf],
+      byIdNodes: { "mid-1": mid, "root-1": root },
+    })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    expect(byIdRequests).toEqual([["mid-1"], ["root-1"]])
+    expect(bundle.leaves.map((l) => l.id)).toEqual(["leaf-1"])
+    expect(bundle.nodes.map((n) => n.id)).toEqual(["leaf-1", "mid-1", "root-1"])
+  })
+
+  it("tolerates a truncated by-id round and completes on the next one", async () => {
+    const leafA: TestNode = {
+      id: "leaf-a",
+      valueSats: 100,
+      parentNodeId: "mid-a",
+      owner: identity,
+      available: true,
+    }
+    const leafB: TestNode = {
+      id: "leaf-b",
+      valueSats: 200,
+      parentNodeId: "mid-b",
+      owner: identity,
+      available: true,
+    }
+    const midA: TestNode = {
+      id: "mid-a",
+      valueSats: 300,
+      owner: otherOwner,
+      available: false,
+    }
+    const midB: TestNode = {
+      id: "mid-b",
+      valueSats: 400,
+      owner: otherOwner,
+      available: false,
+    }
+
+    // The first by-id round returns a strict subset of what was requested
+    // (mid-a but not mid-b), as if the response were truncated by the
+    // operator's limit; the round made progress, so the exporter must retry
+    // instead of refusing the bundle.
+    let midBLookups = 0
+    const byIdNodes = new Proxy<Record<string, TestNode>>(
+      { "mid-a": midA },
+      {
+        get: (target, id) => {
+          if (id === "mid-b") {
+            midBLookups += 1
+            return midBLookups > 1 ? midB : undefined
+          }
+          return target[id as string]
+        },
+      },
+    )
+    const { byIdRequests } = mockOperator({ ownerQueryNodes: [leafA, leafB], byIdNodes })
+
+    const bundle = await fetchRecoveryBundle({
+      mnemonic: TEST_MNEMONIC,
+      network: Network.Mainnet,
+      appVersion: "1.0.1-test",
+    })
+
+    expect(byIdRequests).toEqual([["mid-a", "mid-b"], ["mid-b"]])
+    expect(bundle.nodes.map((n) => n.id)).toEqual(["leaf-a", "leaf-b", "mid-a", "mid-b"])
+    expect(bundle.balances.btcSats).toBe("300")
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/grpc-web.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/grpc-web.spec.ts
@@ -1,0 +1,169 @@
+import {
+  GrpcWebError,
+  grpcWebUnaryCall,
+} from "@app/self-custodial/recovery-bundle/protocol/grpc-web"
+
+const frame = (flag: number, payload: Uint8Array): Uint8Array => {
+  const framed = new Uint8Array(5 + payload.length)
+  framed[0] = flag
+  new DataView(framed.buffer).setUint32(1, payload.length, false)
+  framed.set(payload, 5)
+  return framed
+}
+
+const concat = (...parts: Uint8Array[]): Uint8Array => {
+  const total = parts.reduce((sum, p) => sum + p.length, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const part of parts) {
+    out.set(part, offset)
+    offset += part.length
+  }
+  return out
+}
+
+const textBytes = (text: string): Uint8Array => Uint8Array.from(Buffer.from(text, "utf8"))
+
+type MockResponse = {
+  ok?: boolean
+  status?: number
+  headers?: Record<string, string>
+  body?: Uint8Array
+}
+
+const mockFetchOnce = ({ ok = true, status = 200, headers = {}, body }: MockResponse) => {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok,
+    status,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    arrayBuffer: async () =>
+      (body ?? new Uint8Array(0)).buffer.slice(
+        (body ?? new Uint8Array(0)).byteOffset,
+        (body ?? new Uint8Array(0)).byteOffset + (body ?? new Uint8Array(0)).byteLength,
+      ),
+  })
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+describe("grpcWebUnaryCall", () => {
+  const params = {
+    baseUrl: "https://operator.example",
+    methodPath: "/spark.SparkService/query_nodes",
+    request: Uint8Array.from([1, 2, 3]),
+  }
+
+  it("frames the request and returns the message frame", async () => {
+    const message = Uint8Array.from([9, 8, 7])
+    const fetchMock = mockFetchOnce({
+      body: concat(frame(0, message), frame(0x80, textBytes("grpc-status: 0"))),
+    })
+
+    const result = await grpcWebUnaryCall({ ...params, authorization: "Bearer tok" })
+    expect(Buffer.from(result)).toEqual(Buffer.from(message))
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://operator.example/spark.SparkService/query_nodes")
+    expect(init.headers["Content-Type"]).toBe("application/grpc-web+proto")
+    expect(init.headers.Authorization).toBe("Bearer tok")
+    // 5-byte prefix: flag 0 + big-endian length 3
+    expect(Buffer.from(init.body)).toEqual(Buffer.from([0, 0, 0, 0, 3, 1, 2, 3]))
+  })
+
+  it("throws on non-zero grpc-status in trailers", async () => {
+    mockFetchOnce({
+      body: concat(
+        frame(0, Uint8Array.from([1])),
+        frame(0x80, textBytes("grpc-status: 16\r\ngrpc-message: unauthenticated")),
+      ),
+    })
+    await expect(grpcWebUnaryCall(params)).rejects.toThrow(/status 16.*unauthenticated/)
+  })
+
+  it("throws on trailers-only responses with grpc-status in HTTP headers", async () => {
+    mockFetchOnce({ headers: { "grpc-status": "5", "grpc-message": "not found" } })
+    await expect(grpcWebUnaryCall(params)).rejects.toMatchObject({ grpcStatus: 5 })
+  })
+
+  it("throws on HTTP errors", async () => {
+    mockFetchOnce({ ok: false, status: 503 })
+    await expect(grpcWebUnaryCall(params)).rejects.toMatchObject({ httpStatus: 503 })
+  })
+
+  it("throws when no message frame is present", async () => {
+    mockFetchOnce({ body: frame(0x80, textBytes("grpc-status: 0")) })
+    await expect(grpcWebUnaryCall(params)).rejects.toThrow(/no message frame/)
+  })
+
+  it("wraps network failures in GrpcWebError", async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error("boom")) as unknown as typeof fetch
+    await expect(grpcWebUnaryCall(params)).rejects.toBeInstanceOf(GrpcWebError)
+  })
+
+  it("rejects a compressed message frame instead of feeding it to the decoder", async () => {
+    // Flag bit 0x01 = compressed. Compression is never negotiated, so this
+    // must fail as a protocol violation, not as a cryptic protobuf error.
+    mockFetchOnce({
+      body: concat(
+        frame(0x01, Uint8Array.from([1, 2, 3])),
+        frame(0x80, textBytes("grpc-status: 0")),
+      ),
+    })
+    await expect(grpcWebUnaryCall(params)).rejects.toThrow(/compressed/)
+  })
+
+  it("rejects a response with a message frame but no trailers frame", async () => {
+    // A stream cut after the message frame may have swallowed a non-OK
+    // grpc-status; missing trailers must not be treated as success.
+    mockFetchOnce({ body: frame(0, Uint8Array.from([1, 2, 3])) })
+    await expect(grpcWebUnaryCall(params)).rejects.toThrow(/without a trailers frame/)
+  })
+
+  it("accepts a message frame without trailers when grpc-status: 0 came in the HTTP headers", async () => {
+    const message = Uint8Array.from([4, 5, 6])
+    mockFetchOnce({ headers: { "grpc-status": "0" }, body: frame(0, message) })
+    const result = await grpcWebUnaryCall(params)
+    expect(Buffer.from(result)).toEqual(Buffer.from(message))
+  })
+
+  it("aborts a hung call after the 30s timeout and reports it as a network error", async () => {
+    jest.useFakeTimers()
+    try {
+      global.fetch = jest.fn(
+        (_url: string, init: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener("abort", () => reject(new Error("Aborted")))
+          }),
+      ) as unknown as typeof fetch
+
+      const pending = grpcWebUnaryCall(params).then(
+        () => {
+          throw new Error("expected the call to reject on timeout")
+        },
+        (err) => err,
+      )
+      jest.advanceTimersByTime(30_000)
+      const error = await pending
+      expect(error).toMatchObject({
+        name: "GrpcWebError",
+        message: expect.stringContaining("network error"),
+      })
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("rejects a trailing remainder shorter than a frame header", async () => {
+    // 2 stray bytes after the trailers frame: the stream was cut mid-frame.
+    mockFetchOnce({
+      body: concat(
+        frame(0, Uint8Array.from([1])),
+        frame(0x80, textBytes("grpc-status: 0")),
+        Uint8Array.from([0x80, 0x00]),
+      ),
+    })
+    await expect(grpcWebUnaryCall(params)).rejects.toThrow(/truncated/)
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/identity.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/identity.spec.ts
@@ -1,0 +1,170 @@
+import nodeCrypto from "crypto"
+
+jest.mock("react-native-quick-crypto", () => {
+  const crypto = jest.requireActual("crypto") as typeof import("crypto")
+
+  return {
+    __esModule: true,
+    default: {
+      randomBytes: crypto.randomBytes,
+      pbkdf2Sync: crypto.pbkdf2Sync,
+      createCipheriv: crypto.createCipheriv,
+      createDecipheriv: crypto.createDecipheriv,
+      createHmac: crypto.createHmac,
+      createHash: crypto.createHash,
+      constants: crypto.constants,
+    },
+    Buffer,
+  }
+})
+
+import * as secp256k1 from "@bitcoinerlab/secp256k1"
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+
+import {
+  defaultAccountNumber,
+  deriveBundleEncryptionKeyHex,
+  deriveIdentityKeyPair,
+  sha256,
+  signChallenge,
+} from "@app/self-custodial/recovery-bundle/identity"
+
+/**
+ * Golden vectors computed with an independent pure-Python BIP32/BIP39
+ * implementation (hashlib/hmac + textbook secp256k1 math) for the path
+ * m/8797555'/{account}'/0'. The path itself is confirmed against both the
+ * official JS spark-sdk (`hdkey.derive("m/8797555'/{account}'/0'")`) and the
+ * vendored Rust SDK's default_signer.rs.
+ */
+const TEST_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+const MAINNET_IDENTITY_PUB =
+  "0281363910b0dc0015a4a25e758da30f0e28388ea5252c0e3713936f2d4ef7d3d5"
+const MAINNET_IDENTITY_PRIV =
+  "07ede284a8976f380b6922de4b14f3a30d1c09b4e57e12cebad5d37ee2e2e6c1"
+const REGTEST_IDENTITY_PUB =
+  "02698b27ac308b275671b3ca25436346469d04a5bba578ae39feba1d65897a6abc"
+
+describe("spark identity derivation", () => {
+  it("uses the network-dependent default account number (mainnet=1, regtest=0)", () => {
+    expect(defaultAccountNumber(Network.Mainnet)).toBe(1)
+    expect(defaultAccountNumber(Network.Regtest)).toBe(0)
+  })
+
+  it("derives the mainnet identity key at m/8797555'/1'/0'", async () => {
+    const keyPair = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Mainnet)
+    expect(Buffer.from(keyPair.privateKey).toString("hex")).toBe(MAINNET_IDENTITY_PRIV)
+    expect(Buffer.from(keyPair.publicKey).toString("hex")).toBe(MAINNET_IDENTITY_PUB)
+  })
+
+  it("derives the regtest identity key at m/8797555'/0'/0'", async () => {
+    const keyPair = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Regtest)
+    expect(Buffer.from(keyPair.publicKey).toString("hex")).toBe(REGTEST_IDENTITY_PUB)
+  })
+
+  it("respects an explicit account number override", async () => {
+    const withOverride = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Regtest, 1)
+    expect(Buffer.from(withOverride.publicKey).toString("hex")).toBe(MAINNET_IDENTITY_PUB)
+  })
+})
+
+describe("challenge signing", () => {
+  it("produces a DER-encoded ECDSA signature over sha256(message) that verifies", async () => {
+    const keyPair = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Mainnet)
+    const message = Uint8Array.from(Buffer.from("challenge-bytes", "utf8"))
+
+    const der = signChallenge(message, keyPair.privateKey)
+
+    // DER structure: 0x30 len 0x02 lenR R 0x02 lenS S
+    expect(der[0]).toBe(0x30)
+    expect(der[1]).toBe(der.length - 2)
+    expect(der[2]).toBe(0x02)
+    const rLength = der[3]
+    const r = der.subarray(4, 4 + rLength)
+    expect(der[4 + rLength]).toBe(0x02)
+    const s = der.subarray(4 + rLength + 2)
+
+    const pad32 = (bytes: Uint8Array): Buffer => {
+      const stripped = Buffer.from(bytes).subarray(
+        Math.max(0, bytes.length - 32),
+        bytes.length,
+      )
+      return Buffer.concat([Buffer.alloc(32 - stripped.length, 0), stripped])
+    }
+    const compact = Uint8Array.from(Buffer.concat([pad32(r), pad32(s)]))
+
+    expect(secp256k1.verify(sha256(message), keyPair.publicKey, compact)).toBe(true)
+    // node's crypto agrees the DER signature is valid for this key
+    const spki = nodeCrypto.createPublicKey({
+      key: Buffer.concat([
+        Buffer.from("3036301006072a8648ce3d020106052b8104000a032200", "hex"),
+        Buffer.from(keyPair.publicKey),
+      ]),
+      format: "der",
+      type: "spki",
+    })
+    expect(
+      nodeCrypto.verify(
+        "sha256",
+        Buffer.from(message),
+        { key: spki, dsaEncoding: "der" },
+        Buffer.from(der),
+      ),
+    ).toBe(true)
+  })
+})
+
+describe("challenge signature canonicalization", () => {
+  const SECP256K1_N = BigInt(
+    "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+  )
+
+  const extractS = (der: Uint8Array): bigint => {
+    const rLength = der[3]
+    const s = der.subarray(4 + rLength + 2)
+    return BigInt(`0x${Buffer.from(s).toString("hex")}`)
+  }
+
+  it("is deterministic and low-S", async () => {
+    // Low-S is inherited from the secp256k1 dependency's default; nothing in
+    // our code enforces it. The operators (like Bitcoin consensus tooling)
+    // may reject high-S signatures, so pin the property against a dependency
+    // bump silently changing it. Determinism (RFC 6979) makes the pin stable.
+    const keyPair = await deriveIdentityKeyPair(TEST_MNEMONIC, Network.Mainnet)
+    const message = Uint8Array.from(Buffer.from("challenge-bytes", "utf8"))
+
+    const first = signChallenge(message, keyPair.privateKey)
+    const second = signChallenge(message, keyPair.privateKey)
+
+    expect(Buffer.from(first).toString("hex")).toBe(Buffer.from(second).toString("hex"))
+    const s = extractS(first)
+    expect(s > 0n).toBe(true)
+    expect(s <= SECP256K1_N / 2n).toBe(true)
+  })
+})
+
+describe("bundle encryption key derivation", () => {
+  it("is deterministic and produces a 16-byte hex key", async () => {
+    const key1 = await deriveBundleEncryptionKeyHex(TEST_MNEMONIC)
+    const key2 = await deriveBundleEncryptionKeyHex(TEST_MNEMONIC)
+    expect(key1).toBe(key2)
+    expect(key1).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it("matches the documented derivation: HMAC-SHA256(seed, context) first 16 bytes", async () => {
+    const seed = nodeCrypto.pbkdf2Sync(
+      TEST_MNEMONIC.normalize("NFKD"),
+      "mnemonic",
+      2048,
+      64,
+      "sha512",
+    )
+    const expected = nodeCrypto
+      .createHmac("sha256", seed)
+      .update("blink:recovery-bundle:aes-128-gcm:v1")
+      .digest()
+      .subarray(0, 16)
+      .toString("hex")
+    expect(await deriveBundleEncryptionKeyHex(TEST_MNEMONIC)).toBe(expected)
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/messages.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/messages.spec.ts
@@ -1,0 +1,127 @@
+import {
+  decodeGetChallengeResponse,
+  decodeQueryNodesResponse,
+  decodeVerifyChallengeResponse,
+  encodeChallenge,
+  encodeGetChallengeRequest,
+  encodeQueryNodesRequest,
+  SparkProtoNetwork,
+} from "@app/self-custodial/recovery-bundle/protocol/messages"
+import {
+  decodeFields,
+  lastField,
+  ProtoWriter,
+  utf8Decode,
+} from "@app/self-custodial/recovery-bundle/protocol/wire"
+
+const encodeTestChallenge = () =>
+  new ProtoWriter()
+    .varint(1, 1)
+    .varint(2, 1752300000)
+    .bytes(3, Uint8Array.from(Buffer.alloc(32, 0x11)))
+    .bytes(4, Uint8Array.from(Buffer.alloc(33, 0x02)))
+    .finish()
+
+describe("spark auth messages", () => {
+  it("encodes get_challenge request with the public key", () => {
+    const publicKey = Uint8Array.from(Buffer.alloc(33, 0x03))
+    const fields = decodeFields(encodeGetChallengeRequest(publicKey))
+    expect(Buffer.from(lastField(fields, 1)?.bytes ?? [])).toEqual(Buffer.from(publicKey))
+  })
+
+  it("decodes the protected challenge and re-encodes the inner challenge canonically", () => {
+    const challengeBytes = encodeTestChallenge()
+    const protectedChallenge = new ProtoWriter()
+      .varint(1, 1)
+      .bytes(2, challengeBytes)
+      .bytes(3, Uint8Array.from(Buffer.alloc(32, 0xaa)))
+      .finish()
+    const response = new ProtoWriter().bytes(1, protectedChallenge).finish()
+
+    const decoded = decodeGetChallengeResponse(response)
+    expect(Buffer.from(decoded.raw)).toEqual(Buffer.from(protectedChallenge))
+    // Canonical re-encode of the decoded challenge must be byte-identical to
+    // the canonical server encoding - this is what gets signed.
+    expect(Buffer.from(encodeChallenge(decoded.challenge))).toEqual(
+      Buffer.from(challengeBytes),
+    )
+  })
+
+  it("decodes verify_challenge response", () => {
+    const response = new ProtoWriter().string(1, "session-token").varint(2, 99).finish()
+    expect(decodeVerifyChallengeResponse(response)).toEqual({
+      sessionToken: "session-token",
+      expirationTimestamp: 99n,
+    })
+  })
+
+  it("throws when verify_challenge returns no token", () => {
+    expect(() => decodeVerifyChallengeResponse(new Uint8Array(0))).toThrow(
+      /no session token/,
+    )
+  })
+})
+
+describe("query_nodes messages", () => {
+  it("encodes an owner query", () => {
+    const owner = Uint8Array.from(Buffer.alloc(33, 0x02))
+    const fields = decodeFields(
+      encodeQueryNodesRequest({
+        ownerIdentityPublicKey: owner,
+        includeParents: true,
+        limit: 100,
+        offset: 200,
+        network: SparkProtoNetwork.Mainnet,
+      }),
+    )
+    expect(Buffer.from(lastField(fields, 1)?.bytes ?? [])).toEqual(Buffer.from(owner))
+    expect(lastField(fields, 3)?.varint).toBe(1n)
+    expect(lastField(fields, 4)?.varint).toBe(100n)
+    expect(lastField(fields, 5)?.varint).toBe(200n)
+    expect(lastField(fields, 6)?.varint).toBe(1n)
+  })
+
+  it("encodes a by-node-ids query", () => {
+    const fields = decodeFields(
+      encodeQueryNodesRequest({
+        nodeIds: ["a", "b"],
+        includeParents: true,
+        limit: 100,
+        offset: 0,
+        network: SparkProtoNetwork.Regtest,
+      }),
+    )
+    const nodeIdFields = decodeFields(lastField(fields, 2)?.bytes ?? new Uint8Array(0))
+    expect(nodeIdFields.map((f) => utf8Decode(f.bytes ?? new Uint8Array(0)))).toEqual([
+      "a",
+      "b",
+    ])
+    expect(lastField(fields, 1)).toBeUndefined()
+  })
+
+  it("decodes a nodes map and preserves raw TreeNode bytes", () => {
+    const treeNode = new ProtoWriter()
+      .string(1, "leaf-1")
+      .string(2, "tree-1")
+      .varint(3, 32768)
+      .string(4, "parent-1")
+      .bytes(9, Uint8Array.from(Buffer.alloc(33, 0x02)))
+      .string(11, "AVAILABLE")
+      .varint(19, 1)
+      .finish()
+    const entry = new ProtoWriter().string(1, "leaf-1").bytes(2, treeNode).finish()
+    const response = new ProtoWriter().bytes(1, entry).varint(2, -1n).finish()
+
+    const decoded = decodeQueryNodesResponse(response)
+    expect(decoded.offset).toBe(-1n)
+    const node = decoded.nodes.get("leaf-1")
+    expect(node).toBeDefined()
+    expect(node?.id).toBe("leaf-1")
+    expect(node?.valueSats).toBe(32768n)
+    expect(node?.parentNodeId).toBe("parent-1")
+    expect(node?.status).toBe("AVAILABLE")
+    expect(node?.treenodeStatus).toBe(1)
+    // raw bytes preserved exactly - this is what lands in treeNodeHex
+    expect(Buffer.from(node?.raw ?? [])).toEqual(Buffer.from(treeNode))
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/messages.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/messages.spec.ts
@@ -5,6 +5,7 @@ import {
   encodeChallenge,
   encodeGetChallengeRequest,
   encodeQueryNodesRequest,
+  encodeVerifyChallengeRequest,
   SparkProtoNetwork,
 } from "@app/self-custodial/recovery-bundle/protocol/messages"
 import {
@@ -45,6 +46,27 @@ describe("spark auth messages", () => {
     expect(Buffer.from(encodeChallenge(decoded.challenge))).toEqual(
       Buffer.from(challengeBytes),
     )
+  })
+
+  it("encodes verify_challenge request with challenge, signature and key in fields 1-3", () => {
+    // Field numbers mirror spark_authn.proto; nothing else in the suite pins
+    // them, so a swapped field would otherwise only fail against the real
+    // coordinator.
+    const protectedChallengeRaw = Uint8Array.from(Buffer.alloc(16, 0x0a))
+    const signatureDer = Uint8Array.from(Buffer.alloc(70, 0x0b))
+    const publicKey = Uint8Array.from(Buffer.alloc(33, 0x02))
+
+    const fields = decodeFields(
+      encodeVerifyChallengeRequest({ protectedChallengeRaw, signatureDer, publicKey }),
+    )
+
+    expect(Buffer.from(lastField(fields, 1)?.bytes ?? [])).toEqual(
+      Buffer.from(protectedChallengeRaw),
+    )
+    expect(Buffer.from(lastField(fields, 2)?.bytes ?? [])).toEqual(
+      Buffer.from(signatureDer),
+    )
+    expect(Buffer.from(lastField(fields, 3)?.bytes ?? [])).toEqual(Buffer.from(publicKey))
   })
 
   it("decodes verify_challenge response", () => {

--- a/__tests__/self-custodial/recovery-bundle/wire.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/wire.spec.ts
@@ -1,0 +1,95 @@
+import {
+  decodeFields,
+  lastField,
+  ProtoWriter,
+  utf8Decode,
+  WireType,
+} from "@app/self-custodial/recovery-bundle/protocol/wire"
+
+describe("protobuf wire codec", () => {
+  it("roundtrips varint fields including multi-byte values", () => {
+    const encoded = new ProtoWriter()
+      .varint(1, 1)
+      .varint(2, 300)
+      .varint(3, 0x7fffffffffffffffn)
+      .finish()
+
+    const fields = decodeFields(encoded)
+    expect(lastField(fields, 1)?.varint).toBe(1n)
+    expect(lastField(fields, 2)?.varint).toBe(300n)
+    expect(lastField(fields, 3)?.varint).toBe(0x7fffffffffffffffn)
+  })
+
+  it("omits zero varints and empty bytes, matching proto3 default elision", () => {
+    const encoded = new ProtoWriter()
+      .varint(1, 0)
+      .bytes(2, new Uint8Array(0))
+      .bool(3, false)
+      .finish()
+    expect(encoded).toHaveLength(0)
+  })
+
+  it("encodes negative int64 as 10-byte two's-complement varint", () => {
+    const encoded = new ProtoWriter().varint(1, -1n).finish()
+    // tag byte + 10 varint bytes
+    expect(encoded).toHaveLength(11)
+    const fields = decodeFields(encoded)
+    expect(BigInt.asIntN(64, lastField(fields, 1)?.varint ?? 0n)).toBe(-1n)
+  })
+
+  it("roundtrips strings and nested messages", () => {
+    const inner = new ProtoWriter().string(1, "node-id").varint(2, 42).finish()
+    const outer = new ProtoWriter().bytes(1, inner).string(2, "outer ✓").finish()
+
+    const fields = decodeFields(outer)
+    const innerFields = decodeFields(lastField(fields, 1)?.bytes ?? new Uint8Array(0))
+    expect(utf8Decode(lastField(innerFields, 1)?.bytes ?? new Uint8Array(0))).toBe(
+      "node-id",
+    )
+    expect(lastField(innerFields, 2)?.varint).toBe(42n)
+    expect(utf8Decode(lastField(fields, 2)?.bytes ?? new Uint8Array(0))).toBe("outer ✓")
+  })
+
+  it("preserves raw bytes for length-delimited fields", () => {
+    const payload = Uint8Array.from([0xde, 0xad, 0xbe, 0xef])
+    const encoded = new ProtoWriter().bytes(5, payload).finish()
+    const field = lastField(decodeFields(encoded), 5)
+    expect(field?.wireType).toBe(WireType.LengthDelimited)
+    expect(Buffer.from(field?.bytes ?? []).toString("hex")).toBe("deadbeef")
+  })
+
+  it("skips fixed32/fixed64 fields without corrupting subsequent fields", () => {
+    // Craft: field 1 fixed64 (tag 0x09), field 2 varint (tag 0x10)
+    const raw = Uint8Array.from([0x09, 1, 2, 3, 4, 5, 6, 7, 8, 0x10, 7])
+    const fields = decodeFields(raw)
+    expect(lastField(fields, 2)?.varint).toBe(7n)
+  })
+
+  it("throws on truncated input", () => {
+    const encoded = new ProtoWriter().bytes(1, Uint8Array.from([1, 2, 3])).finish()
+    expect(() => decodeFields(encoded.subarray(0, encoded.length - 1))).toThrow(
+      /truncated/,
+    )
+  })
+
+  it("throws on a varint longer than 10 bytes", () => {
+    // Tag for field 1 varint, then 11 continuation bytes.
+    const raw = Uint8Array.from([0x08, ...Array(10).fill(0xff), 0x01])
+    expect(() => decodeFields(raw)).toThrow(/varint too long/)
+  })
+
+  it("masks a 10-byte varint with overflow bits to 64 bits", () => {
+    // Nine 0xff continuation bytes set bits 0-62; a final 0x7f at shift 63
+    // carries bits 63-69. Canonical parsers keep only the low 64 bits, so the
+    // decoded value must be 2^64 - 1, not a 70-bit number.
+    const raw = Uint8Array.from([0x08, ...Array(9).fill(0xff), 0x7f])
+    const value = lastField(decodeFields(raw), 1)?.varint
+    expect(value).toBe(0xffffffffffffffffn)
+    expect(BigInt.asIntN(64, value ?? 0n)).toBe(-1n)
+  })
+
+  it("takes the last occurrence of a repeated scalar field (proto3 last-wins)", () => {
+    const encoded = new ProtoWriter().varint(1, 7).varint(1, 9).finish()
+    expect(lastField(decodeFields(encoded), 1)?.varint).toBe(9n)
+  })
+})

--- a/app/self-custodial/recovery-bundle/exporter.ts
+++ b/app/self-custodial/recovery-bundle/exporter.ts
@@ -12,6 +12,8 @@
 
 import { Network } from "@breeztech/breez-sdk-spark-react-native"
 
+import packageJson from "../../../package.json"
+
 import { deriveIdentityKeyPair, signChallenge, type IdentityKeyPair } from "./identity"
 import { grpcWebUnaryCall } from "./protocol/grpc-web"
 import {
@@ -41,6 +43,13 @@ import {
  */
 export const SPARK_COORDINATOR_URL = "https://0.spark.lightspark.com"
 const OPERATOR_SET = "breez-sdk"
+
+/**
+ * Name and exact version of the SDK whose wallet state this bundle snapshots,
+ * read from the pinned dependency so it tracks upgrades automatically. The
+ * exit tooling can key version-specific workarounds off it.
+ */
+const SPARK_SDK_VERSION = `breez-sdk-spark-react-native@${packageJson.dependencies["@breeztech/breez-sdk-spark-react-native"]}`
 
 const GET_CHALLENGE_PATH = "/spark_authn.SparkAuthnService/get_challenge"
 const VERIFY_CHALLENGE_PATH = "/spark_authn.SparkAuthnService/verify_challenge"
@@ -367,7 +376,7 @@ export const fetchRecoveryBundle = async ({
     network: bundleNetworkLabelFor(network),
     operatorSet: OPERATOR_SET,
     walletIdentityPublicKey: hexEncode(keyPair.publicKey),
-    sparkSdkVersion: "breez-sdk-spark-react-native",
+    sparkSdkVersion: SPARK_SDK_VERSION,
     appVersion,
     leaves: sortedByIdAsc(leaves).map((leaf) => ({
       id: leaf.id,

--- a/app/self-custodial/recovery-bundle/exporter.ts
+++ b/app/self-custodial/recovery-bundle/exporter.ts
@@ -1,0 +1,393 @@
+/**
+ * Fetches a fresh unilateral-exit recovery bundle from the Spark operators.
+ *
+ * Mirrors the spark-unilateral-exit reference exporter (src/operator/):
+ * authenticate to the coordinator with the seed-derived identity key, page
+ * through query_nodes(owner, include_parents=true), then verify every leaf's
+ * ancestor chain is closed - re-fetching missing ancestors by node id, which
+ * bypasses the operators' root-skip bug on legacy mainnet trees. A bundle
+ * with an open chain is unusable for exit, so incompleteness is an error,
+ * not a warning.
+ */
+
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+
+import { deriveIdentityKeyPair, signChallenge, type IdentityKeyPair } from "./identity"
+import { grpcWebUnaryCall } from "./protocol/grpc-web"
+import {
+  decodeGetChallengeResponse,
+  decodeQueryNodesResponse,
+  decodeVerifyChallengeResponse,
+  encodeChallenge,
+  encodeGetChallengeRequest,
+  encodeQueryNodesRequest,
+  encodeVerifyChallengeRequest,
+  SparkProtoNetwork,
+  TREE_NODE_STATUS_AVAILABLE,
+  type DecodedTreeNode,
+} from "./protocol/messages"
+import {
+  RECOVERY_BUNDLE_SCHEMA,
+  USDB_NOT_COVERED_STATUS,
+  type RecoveryBundle,
+} from "./types"
+
+/**
+ * Operator id 0 is the pool coordinator in the Spark SDK's default config.
+ * The public pool coordinator serves every non-local network - the target
+ * network travels in each request (see protoNetworkFor) - so mainnet and
+ * regtest share this URL, same as the spark-unilateral-exit reference
+ * exporter, whose --coordinator override exists only for LOCAL stacks.
+ */
+export const SPARK_COORDINATOR_URL = "https://0.spark.lightspark.com"
+const OPERATOR_SET = "breez-sdk"
+
+const GET_CHALLENGE_PATH = "/spark_authn.SparkAuthnService/get_challenge"
+const VERIFY_CHALLENGE_PATH = "/spark_authn.SparkAuthnService/verify_challenge"
+const QUERY_NODES_PATH = "/spark.SparkService/query_nodes"
+
+const PAGE_SIZE = 100
+/**
+ * Overall wall-clock budget for one bundle fetch. Each gRPC call has its own
+ * 30s timeout, but auth + up to MAX_OWNER_QUERY_PAGES pages + refetch rounds
+ * would otherwise let a degraded network hold a background refresh for over
+ * an hour; the budget caps the whole fetch instead.
+ */
+const TOTAL_FETCH_BUDGET_MS = 2 * 60_000
+/** Chain walks converge in one refetch round; the cap only guards operator misbehavior. */
+const MAX_ANCESTOR_REFETCH_ROUNDS = 10
+/**
+ * Upper bound on owner-query pages (200 pages x 100 nodes = 20k nodes, far
+ * beyond any real wallet). Guards the same threat as the ancestor-round cap:
+ * a misbehaving coordinator that keeps returning data must not keep a
+ * background refresh looping forever on a phone.
+ */
+const MAX_OWNER_QUERY_PAGES = 200
+
+export const RecoveryBundleExportErrorReason = {
+  NoLeaves: "no-leaves",
+  IncompleteChain: "incomplete-chain",
+  PagingLimitExceeded: "paging-limit-exceeded",
+  BudgetExceeded: "budget-exceeded",
+  InvalidNode: "invalid-node",
+} as const
+
+export type RecoveryBundleExportErrorReason =
+  (typeof RecoveryBundleExportErrorReason)[keyof typeof RecoveryBundleExportErrorReason]
+
+export class RecoveryBundleExportError extends Error {
+  constructor(
+    readonly reason: RecoveryBundleExportErrorReason,
+    message: string,
+    /** Diagnostic identifiers kept out of `message` so error messages can be
+     * logged (e.g. Crashlytics) without leaking the wallet identity. */
+    readonly details?: { walletIdentityPublicKey?: string },
+  ) {
+    super(message)
+    this.name = "RecoveryBundleExportError"
+  }
+}
+
+const protoNetworkFor = (network: Network): SparkProtoNetwork =>
+  network === Network.Mainnet ? SparkProtoNetwork.Mainnet : SparkProtoNetwork.Regtest
+
+const bundleNetworkLabelFor = (network: Network): string =>
+  network === Network.Mainnet ? "MAINNET" : "REGTEST"
+
+/** Remaining time before `deadline`; throws BudgetExceeded when spent. */
+const remainingBudgetMs = (deadline: number): number => {
+  const remaining = deadline - Date.now()
+  if (remaining <= 0) {
+    throw new RecoveryBundleExportError(
+      RecoveryBundleExportErrorReason.BudgetExceeded,
+      `Recovery bundle fetch exceeded its ${TOTAL_FETCH_BUDGET_MS / 1000}s time budget`,
+    )
+  }
+  return remaining
+}
+
+const authenticate = async (
+  baseUrl: string,
+  keyPair: IdentityKeyPair,
+  deadline: number,
+): Promise<string> => {
+  const challengeResponse = await grpcWebUnaryCall({
+    baseUrl,
+    methodPath: GET_CHALLENGE_PATH,
+    request: encodeGetChallengeRequest(keyPair.publicKey),
+    timeoutMs: remainingBudgetMs(deadline),
+  })
+  const protectedChallenge = decodeGetChallengeResponse(challengeResponse)
+
+  const signatureDer = signChallenge(
+    encodeChallenge(protectedChallenge.challenge),
+    keyPair.privateKey,
+  )
+
+  const verifyResponse = await grpcWebUnaryCall({
+    baseUrl,
+    methodPath: VERIFY_CHALLENGE_PATH,
+    request: encodeVerifyChallengeRequest({
+      protectedChallengeRaw: protectedChallenge.raw,
+      signatureDer,
+      publicKey: keyPair.publicKey,
+    }),
+    timeoutMs: remainingBudgetMs(deadline),
+  })
+  const { sessionToken } = decodeVerifyChallengeResponse(verifyResponse)
+  return `Bearer ${sessionToken}`
+}
+
+type QueryContext = {
+  baseUrl: string
+  authorization: string
+  network: SparkProtoNetwork
+  /** Unix ms after which further operator calls throw BudgetExceeded. */
+  deadline: number
+}
+
+const queryNodesByOwner = async (
+  context: QueryContext,
+  ownerIdentityPublicKey: Uint8Array,
+): Promise<Map<string, DecodedTreeNode>> => {
+  const nodes = new Map<string, DecodedTreeNode>()
+  let offset = 0
+
+  for (let page = 0; ; page += 1) {
+    if (page >= MAX_OWNER_QUERY_PAGES) {
+      throw new RecoveryBundleExportError(
+        RecoveryBundleExportErrorReason.PagingLimitExceeded,
+        `Owner query did not terminate within ${MAX_OWNER_QUERY_PAGES} pages`,
+      )
+    }
+    const response = decodeQueryNodesResponse(
+      await grpcWebUnaryCall({
+        baseUrl: context.baseUrl,
+        methodPath: QUERY_NODES_PATH,
+        authorization: context.authorization,
+        request: encodeQueryNodesRequest({
+          ownerIdentityPublicKey,
+          includeParents: true,
+          limit: PAGE_SIZE,
+          offset,
+          network: context.network,
+        }),
+        timeoutMs: remainingBudgetMs(context.deadline),
+      }),
+    )
+    for (const [id, node] of response.nodes) nodes.set(id, node)
+    // The request offset is a skip count and the response offset only signals
+    // "more pages" (semantics validated against the real operators by the
+    // spark-unilateral-exit reference exporter). Advance by the number of
+    // nodes actually returned, not the requested limit: a short page with a
+    // positive offset would otherwise silently skip the unreturned tail, and
+    // a skipped AVAILABLE leaf means an incomplete bundle saved as complete.
+    if (response.nodes.size === 0 || response.offset <= 0n) break
+    offset += response.nodes.size
+  }
+
+  return nodes
+}
+
+const queryNodesByIds = async (
+  context: QueryContext,
+  nodeIds: string[],
+): Promise<Map<string, DecodedTreeNode>> => {
+  const nodes = new Map<string, DecodedTreeNode>()
+  for (let start = 0; start < nodeIds.length; start += PAGE_SIZE) {
+    const response = decodeQueryNodesResponse(
+      await grpcWebUnaryCall({
+        baseUrl: context.baseUrl,
+        methodPath: QUERY_NODES_PATH,
+        authorization: context.authorization,
+        request: encodeQueryNodesRequest({
+          nodeIds: nodeIds.slice(start, start + PAGE_SIZE),
+          includeParents: true,
+          limit: PAGE_SIZE,
+          offset: 0,
+          network: context.network,
+        }),
+        timeoutMs: remainingBudgetMs(context.deadline),
+      }),
+    )
+    for (const [id, node] of response.nodes) nodes.set(id, node)
+  }
+  return nodes
+}
+
+const bytesEqual = (a: Uint8Array, b: Uint8Array): boolean =>
+  a.length === b.length && a.every((byte, i) => byte === b[i])
+
+const isAvailableOwnerLeaf = (
+  node: DecodedTreeNode,
+  identityPublicKey: Uint8Array,
+): boolean =>
+  (node.treenodeStatus === TREE_NODE_STATUS_AVAILABLE ||
+    node.status.toUpperCase() === "AVAILABLE") &&
+  bytesEqual(node.ownerIdentityPublicKey, identityPublicKey)
+
+/**
+ * Node ids whose parents are referenced but absent from the map. Throws
+ * IncompleteChain on a parent-pointer cycle: a chain that loops never reaches
+ * a root, so the bundle would be unusable for exit even though no node is
+ * "missing" - it must be refused, not classified as closed.
+ */
+export const findMissingAncestors = (
+  leaves: DecodedTreeNode[],
+  nodes: Map<string, DecodedTreeNode>,
+): string[] => {
+  const missing = new Set<string>()
+  for (const leaf of leaves) {
+    let current: DecodedTreeNode | undefined = leaf
+    const visited = new Set<string>()
+    while (current?.parentNodeId) {
+      if (visited.has(current.id)) {
+        throw new RecoveryBundleExportError(
+          RecoveryBundleExportErrorReason.IncompleteChain,
+          `Exit chain contains a parent cycle at node ${current.id}`,
+        )
+      }
+      visited.add(current.id)
+      const parent: DecodedTreeNode | undefined = nodes.get(current.parentNodeId)
+      if (!parent) {
+        missing.add(current.parentNodeId)
+        break
+      }
+      current = parent
+    }
+  }
+  return [...missing]
+}
+
+const hexEncode = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex")
+
+export type FetchRecoveryBundleParams = {
+  mnemonic: string
+  network: Network
+  appVersion: string
+  accountNumber?: number
+  coordinatorUrl?: string
+  /** Overrides the total fetch budget; tests pin the budget mechanism with it. */
+  totalBudgetMs?: number
+}
+
+export const fetchRecoveryBundle = async ({
+  mnemonic,
+  network,
+  appVersion,
+  accountNumber,
+  coordinatorUrl = SPARK_COORDINATOR_URL,
+  totalBudgetMs = TOTAL_FETCH_BUDGET_MS,
+}: FetchRecoveryBundleParams): Promise<RecoveryBundle> => {
+  const keyPair = await deriveIdentityKeyPair(mnemonic, network, accountNumber)
+  const deadline = Date.now() + totalBudgetMs
+
+  const context: QueryContext = {
+    baseUrl: coordinatorUrl,
+    authorization: await authenticate(coordinatorUrl, keyPair, deadline),
+    network: protoNetworkFor(network),
+    deadline,
+  }
+
+  const nodes = await queryNodesByOwner(context, keyPair.publicKey)
+  const leaves = [...nodes.values()].filter((node) =>
+    isAvailableOwnerLeaf(node, keyPair.publicKey),
+  )
+
+  // The value decodes as an unsigned varint, so a hostile encoding of a
+  // negative number arrives as a near-2^64 value; either way Number(bigint)
+  // would silently propagate an absurd figure into the displayed amounts.
+  // 21M BTC bounds any real leaf (and stays below MAX_SAFE_INTEGER).
+  const MAX_LEAF_VALUE_SATS = 2_100_000_000_000_000n
+  for (const leaf of leaves) {
+    if (leaf.valueSats < 0n || leaf.valueSats > MAX_LEAF_VALUE_SATS) {
+      throw new RecoveryBundleExportError(
+        RecoveryBundleExportErrorReason.InvalidNode,
+        `Leaf ${leaf.id} carries an implausible value`,
+      )
+    }
+  }
+
+  if (leaves.length === 0) {
+    // The identity and status histogram distinguish "wrong account derived a
+    // different wallet" from "wallet genuinely empty" - the known footgun
+    // this error usually means.
+    const statusCounts: Record<string, number> = {}
+    for (const node of nodes.values()) {
+      const status = node.status || String(node.treenodeStatus)
+      statusCounts[status] = (statusCounts[status] ?? 0) + 1
+    }
+    throw new RecoveryBundleExportError(
+      RecoveryBundleExportErrorReason.NoLeaves,
+      "Spark operators returned no available leaves for this wallet " +
+        `(queriedNodes=${nodes.size}, statuses=${JSON.stringify(statusCounts)})`,
+      { walletIdentityPublicKey: hexEncode(keyPair.publicKey) },
+    )
+  }
+
+  // The bulk owner query can omit tree roots on legacy mainnet trees; by-id
+  // queries do not, so re-fetch missing ancestors until every chain closes.
+  // A round may itself be truncated by the response limit, so keep looping
+  // while rounds make progress and only fail when one resolves nothing.
+  for (let round = 0; round < MAX_ANCESTOR_REFETCH_ROUNDS; round += 1) {
+    const missing = findMissingAncestors(leaves, nodes)
+    if (missing.length === 0) break
+    const fetched = await queryNodesByIds(context, missing)
+    let progressed = false
+    for (const [id, node] of fetched) {
+      if (!nodes.has(id)) progressed = true
+      nodes.set(id, node)
+    }
+    if (!progressed) {
+      throw new RecoveryBundleExportError(
+        RecoveryBundleExportErrorReason.IncompleteChain,
+        `Exit chain incomplete: ancestors not returned by operators: ${missing.join(", ")}`,
+      )
+    }
+  }
+
+  const unresolved = findMissingAncestors(leaves, nodes)
+  if (unresolved.length > 0) {
+    throw new RecoveryBundleExportError(
+      RecoveryBundleExportErrorReason.IncompleteChain,
+      `Exit chain incomplete after refetch: ${unresolved.join(", ")}`,
+    )
+  }
+
+  // Plain code-unit comparison, not localeCompare: node ordering must not
+  // depend on the device's ICU tables so bundles stay byte-reproducible.
+  const sortedByIdAsc = <T extends { id: string }>(items: T[]): T[] =>
+    [...items].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+
+  const totalSats = leaves.reduce((sum, leaf) => sum + leaf.valueSats, 0n)
+
+  return {
+    schema: RECOVERY_BUNDLE_SCHEMA,
+    createdAt: new Date().toISOString(),
+    network: bundleNetworkLabelFor(network),
+    operatorSet: OPERATOR_SET,
+    walletIdentityPublicKey: hexEncode(keyPair.publicKey),
+    sparkSdkVersion: "breez-sdk-spark-react-native",
+    appVersion,
+    leaves: sortedByIdAsc(leaves).map((leaf) => ({
+      id: leaf.id,
+      status:
+        leaf.status ||
+        (leaf.treenodeStatus === TREE_NODE_STATUS_AVAILABLE
+          ? "AVAILABLE"
+          : String(leaf.treenodeStatus)),
+      // Safe: a single leaf cannot exceed 21M BTC = 2.1e15 sats, well below
+      // Number.MAX_SAFE_INTEGER (~9e15); the total stays a bigint string.
+      valueSats: Number(leaf.valueSats),
+      treeNodeHex: hexEncode(leaf.raw),
+    })),
+    nodes: sortedByIdAsc([...nodes.values()]).map((node) => ({
+      id: node.id,
+      treeNodeHex: hexEncode(node.raw),
+    })),
+    balances: {
+      btcSats: totalSats.toString(),
+      usdb: { amount: "0.00", status: USDB_NOT_COVERED_STATUS },
+    },
+  }
+}

--- a/app/self-custodial/recovery-bundle/identity.ts
+++ b/app/self-custodial/recovery-bundle/identity.ts
@@ -1,0 +1,117 @@
+/**
+ * Spark identity key derivation and challenge signing.
+ *
+ * The identity key lives at m/8797555'/{account}'/0' from the BIP39 seed
+ * (same derivation as the Spark SDK's DefaultSigner). The default account
+ * number is network-dependent: 1 on mainnet, 0 on regtest - hardcoding 0 on
+ * mainnet derives a different wallet identity that owns no leaves.
+ *
+ * The path is hardened at every level, so derivation only needs HMAC-SHA512
+ * and a private-key tweak add - no full BIP32 library.
+ */
+
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+import * as secp256k1 from "@bitcoinerlab/secp256k1"
+import { mnemonicToSeed } from "bip39"
+import Crypto from "react-native-quick-crypto"
+
+const SPARK_PURPOSE = 8797555
+const IDENTITY_KEY_INDEX = 0
+const HARDENED_OFFSET = 0x80000000
+
+export type IdentityKeyPair = {
+  privateKey: Uint8Array
+  /** Compressed (33-byte) secp256k1 public key. */
+  publicKey: Uint8Array
+}
+
+export const defaultAccountNumber = (network: Network): number =>
+  network === Network.Regtest ? 0 : 1
+
+const hmacSha512 = (key: Uint8Array | string, data: Uint8Array): Uint8Array =>
+  Uint8Array.from(Crypto.createHmac("sha512", key).update(data).digest())
+
+export const sha256 = (data: Uint8Array): Uint8Array =>
+  Uint8Array.from(Crypto.createHash("sha256").update(data).digest())
+
+type ExtendedKey = { privateKey: Uint8Array; chainCode: Uint8Array }
+
+const masterKeyFromSeed = (seed: Uint8Array): ExtendedKey => {
+  const digest = hmacSha512("Bitcoin seed", seed)
+  return { privateKey: digest.slice(0, 32), chainCode: digest.slice(32) }
+}
+
+const deriveHardenedChild = (parent: ExtendedKey, index: number): ExtendedKey => {
+  const data = new Uint8Array(37)
+  data.set(parent.privateKey, 1)
+  new DataView(data.buffer).setUint32(33, index + HARDENED_OFFSET, false)
+
+  const digest = hmacSha512(parent.chainCode, data)
+  const tweak = digest.slice(0, 32)
+  const childKey = secp256k1.privateAdd(parent.privateKey, tweak)
+  // Probability ~2^-128; BIP32 says skip to the next index, but treat as fatal
+  if (!childKey) throw new Error("BIP32: derived invalid child key")
+  return { privateKey: Uint8Array.from(childKey), chainCode: digest.slice(32) }
+}
+
+// bip39's PBKDF2 is pure JS (noble); the async variant yields between blocks
+// instead of freezing the JS thread for the 2048 rounds (100-300ms on low-end
+// devices), which matters for the background refresh after every payment.
+export const deriveIdentityKeyPair = async (
+  mnemonic: string,
+  network: Network,
+  accountNumber?: number,
+): Promise<IdentityKeyPair> => {
+  const seed = Uint8Array.from(await mnemonicToSeed(mnemonic))
+  const account = accountNumber ?? defaultAccountNumber(network)
+
+  let key = masterKeyFromSeed(seed)
+  for (const index of [SPARK_PURPOSE, account, IDENTITY_KEY_INDEX]) {
+    key = deriveHardenedChild(key, index)
+  }
+
+  const publicKey = secp256k1.pointFromScalar(key.privateKey, true)
+  if (!publicKey) throw new Error("BIP32: derived invalid identity key")
+  return { privateKey: key.privateKey, publicKey: Uint8Array.from(publicKey) }
+}
+
+/**
+ * Deterministic key for encrypting the recovery bundle at rest, derived from
+ * the same BIP39 seed so the bundle is decryptable with the seed alone.
+ * AES-128-GCM key (matching app/utils/crypto helpers), hex-encoded.
+ */
+export const RECOVERY_BUNDLE_ENCRYPTION_CONTEXT = "blink:recovery-bundle:aes-128-gcm:v1"
+
+export const deriveBundleEncryptionKeyHex = async (mnemonic: string): Promise<string> => {
+  const seed = Uint8Array.from(await mnemonicToSeed(mnemonic))
+  const digest = Uint8Array.from(
+    Crypto.createHmac("sha256", seed)
+      .update(Uint8Array.from(Buffer.from(RECOVERY_BUNDLE_ENCRYPTION_CONTEXT, "utf8")))
+      .digest(),
+  )
+  return Buffer.from(digest.slice(0, 16)).toString("hex")
+}
+
+const derInteger = (value: Uint8Array): Uint8Array => {
+  let start = 0
+  while (start < value.length - 1 && value[start] === 0) start += 1
+  let trimmed = value.slice(start)
+  // eslint-disable-next-line no-bitwise -- DER integers need a pad byte when the high bit is set
+  if (trimmed[0] & 0x80) {
+    const padded = new Uint8Array(trimmed.length + 1)
+    padded.set(trimmed, 1)
+    trimmed = padded
+  }
+  return Uint8Array.from([0x02, trimmed.length, ...trimmed])
+}
+
+/** ECDSA over sha256(message), DER-encoded - the operator auth signature format. */
+export const signChallenge = (
+  message: Uint8Array,
+  privateKey: Uint8Array,
+): Uint8Array => {
+  const compact = secp256k1.sign(sha256(message), privateKey)
+  const r = derInteger(Uint8Array.from(compact.slice(0, 32)))
+  const s = derInteger(Uint8Array.from(compact.slice(32, 64)))
+  return Uint8Array.from([0x30, r.length + s.length, ...r, ...s])
+}

--- a/app/self-custodial/recovery-bundle/protocol/grpc-web.ts
+++ b/app/self-custodial/recovery-bundle/protocol/grpc-web.ts
@@ -1,0 +1,198 @@
+/**
+ * Unary gRPC-web client over fetch, sufficient for the two Spark operator
+ * services the exporter calls. The Spark operators serve gRPC-web on the same
+ * URLs as native gRPC (the Spark SDK's browser/WASM builds use it), and unary
+ * calls need no response streaming, so plain fetch + arrayBuffer works in
+ * React Native.
+ */
+
+const GRPC_WEB_CONTENT_TYPE = "application/grpc-web+proto"
+const TRAILER_FLAG = 0x80
+/** Compression is never negotiated (no grpc-encoding header is sent), so a
+ * compressed frame is a protocol violation - e.g. a proxy that compresses
+ * anyway. Passing it to the protobuf decoder would fail with a misleading
+ * wire-format error. */
+const COMPRESSED_FLAG = 0x01
+const CALL_TIMEOUT_MS = 30_000
+
+export class GrpcWebError extends Error {
+  constructor(
+    readonly grpcStatus: number | undefined,
+    readonly httpStatus: number | undefined,
+    message: string,
+  ) {
+    super(message)
+    this.name = "GrpcWebError"
+  }
+}
+
+const frameRequest = (message: Uint8Array): Uint8Array => {
+  const framed = new Uint8Array(5 + message.length)
+  framed[0] = 0
+  new DataView(framed.buffer).setUint32(1, message.length, false)
+  framed.set(message, 5)
+  return framed
+}
+
+type Frame = { flag: number; payload: Uint8Array }
+
+const parseFrames = (body: Uint8Array): Frame[] => {
+  const frames: Frame[] = []
+  let offset = 0
+  while (offset + 5 <= body.length) {
+    const flag = body[offset]
+    const length = new DataView(body.buffer, body.byteOffset + offset + 1, 4).getUint32(
+      0,
+      false,
+    )
+    offset += 5
+    if (offset + length > body.length) {
+      throw new GrpcWebError(undefined, undefined, "grpc-web: truncated response frame")
+    }
+    frames.push({ flag, payload: body.subarray(offset, offset + length) })
+    offset += length
+  }
+  if (offset !== body.length) {
+    // A remainder shorter than a 5-byte frame header means the stream was cut
+    // mid-frame; dropping it silently could hide a lost trailers frame.
+    throw new GrpcWebError(undefined, undefined, "grpc-web: truncated response frame")
+  }
+  return frames
+}
+
+const parseTrailers = (payload: Uint8Array): Map<string, string> => {
+  const trailers = new Map<string, string>()
+  for (const line of Buffer.from(payload).toString("utf8").split("\r\n")) {
+    const separator = line.indexOf(":")
+    if (separator !== -1) {
+      trailers.set(
+        line.slice(0, separator).trim().toLowerCase(),
+        line.slice(separator + 1).trim(),
+      )
+    }
+  }
+  return trailers
+}
+
+type UnaryCallParams = {
+  baseUrl: string
+  /** Full method path, e.g. "/spark.SparkService/query_nodes". */
+  methodPath: string
+  request: Uint8Array
+  /** Value for the `authorization` header, if the method requires a session. */
+  authorization?: string
+  /** Per-call timeout override; callers with an overall deadline pass their
+   * remaining budget so one call cannot outlive it. Capped by the default. */
+  timeoutMs?: number
+}
+
+export const grpcWebUnaryCall = async ({
+  baseUrl,
+  methodPath,
+  request,
+  authorization,
+  timeoutMs,
+}: UnaryCallParams): Promise<Uint8Array> => {
+  const headers: Record<string, string> = {
+    "Content-Type": GRPC_WEB_CONTENT_TYPE,
+    "Accept": GRPC_WEB_CONTENT_TYPE,
+    "X-Grpc-Web": "1",
+    "X-User-Agent": "blink-mobile-recovery-bundle",
+  }
+  if (authorization) headers.Authorization = authorization
+
+  const controller = new AbortController()
+  const effectiveTimeoutMs = Math.min(timeoutMs ?? CALL_TIMEOUT_MS, CALL_TIMEOUT_MS)
+  const timeout = setTimeout(() => controller.abort(), effectiveTimeoutMs)
+
+  let response: Response
+  let body: Uint8Array
+  try {
+    response = await fetch(`${baseUrl}${methodPath}`, {
+      method: "POST",
+      headers,
+      body: frameRequest(request),
+      signal: controller.signal,
+    })
+    body = new Uint8Array(await response.arrayBuffer())
+  } catch (err) {
+    throw new GrpcWebError(
+      undefined,
+      undefined,
+      `grpc-web: ${methodPath} network error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  if (!response.ok) {
+    throw new GrpcWebError(
+      undefined,
+      response.status,
+      `grpc-web: ${methodPath} failed with HTTP ${response.status}`,
+    )
+  }
+
+  // Trailers-only responses carry grpc-status in the HTTP headers
+  const headerStatus = response.headers.get("grpc-status")
+  if (headerStatus !== null && headerStatus !== "0") {
+    throw new GrpcWebError(
+      Number(headerStatus),
+      response.status,
+      `grpc-web: ${methodPath} failed with status ${headerStatus}: ${
+        response.headers.get("grpc-message") ?? ""
+      }`,
+    )
+  }
+
+  let message: Uint8Array | undefined
+  let sawTrailers = false
+  for (const frame of parseFrames(body)) {
+    // eslint-disable-next-line no-bitwise -- gRPC-web compressed flag is the low bit
+    if (frame.flag & COMPRESSED_FLAG) {
+      throw new GrpcWebError(
+        undefined,
+        response.status,
+        `grpc-web: ${methodPath} returned a compressed frame (not supported)`,
+      )
+    }
+    // eslint-disable-next-line no-bitwise -- gRPC-web trailer flag is the high bit
+    if (frame.flag & TRAILER_FLAG) {
+      sawTrailers = true
+      const trailers = parseTrailers(frame.payload)
+      const status = trailers.get("grpc-status")
+      if (status !== undefined && status !== "0") {
+        throw new GrpcWebError(
+          Number(status),
+          response.status,
+          `grpc-web: ${methodPath} failed with status ${status}: ${
+            trailers.get("grpc-message") ?? ""
+          }`,
+        )
+      }
+    } else if (message === undefined) {
+      message = frame.payload
+    }
+  }
+
+  // The trailers frame is where a unary call's real grpc-status arrives
+  // (unless the server already sent it in the HTTP headers, checked above).
+  // A body without one means the stream was cut after the message frame, so
+  // a non-OK status may simply never have arrived - that is not success.
+  if (!sawTrailers && headerStatus === null) {
+    throw new GrpcWebError(
+      undefined,
+      response.status,
+      `grpc-web: ${methodPath} response ended without a trailers frame`,
+    )
+  }
+
+  if (message === undefined) {
+    throw new GrpcWebError(
+      undefined,
+      response.status,
+      `grpc-web: ${methodPath} returned no message frame`,
+    )
+  }
+  return message
+}

--- a/app/self-custodial/recovery-bundle/protocol/messages.ts
+++ b/app/self-custodial/recovery-bundle/protocol/messages.ts
@@ -1,0 +1,196 @@
+/**
+ * Encoders/decoders for the Spark operator messages used by the recovery
+ * bundle exporter. Field numbers mirror spark.proto / spark_authn.proto in the
+ * Spark SDK. Only the fields the exporter reads are decoded; TreeNodes keep
+ * their raw wire bytes so the bundle stores them exactly as the operator sent
+ * them (including fields this client does not model).
+ */
+
+import { decodeFields, lastField, ProtoWriter, utf8Decode, WireType } from "./wire"
+
+/** spark.proto `Network` enum values (proto, not the Breez SDK enum). */
+export const SparkProtoNetwork = {
+  Mainnet: 1,
+  Regtest: 2,
+  Testnet: 3,
+  Signet: 4,
+} as const
+
+export type SparkProtoNetwork = (typeof SparkProtoNetwork)[keyof typeof SparkProtoNetwork]
+
+/** spark.proto `TreeNodeStatus.TREE_NODE_STATUS_AVAILABLE`. */
+export const TREE_NODE_STATUS_AVAILABLE = 1
+
+// --- spark_authn.SparkAuthnService ---
+
+export const encodeGetChallengeRequest = (publicKey: Uint8Array): Uint8Array =>
+  new ProtoWriter().bytes(1, publicKey).finish()
+
+export type DecodedChallenge = {
+  version: number
+  timestamp: bigint
+  nonce: Uint8Array
+  publicKey: Uint8Array
+}
+
+export type DecodedProtectedChallenge = {
+  /** Raw ProtectedChallenge bytes as received; echoed back in verify_challenge. */
+  raw: Uint8Array
+  challenge: DecodedChallenge
+}
+
+const decodeChallenge = (data: Uint8Array): DecodedChallenge => {
+  const fields = decodeFields(data)
+  return {
+    version: Number(lastField(fields, 1)?.varint ?? 0n),
+    timestamp: lastField(fields, 2)?.varint ?? 0n,
+    nonce: lastField(fields, 3)?.bytes ?? new Uint8Array(0),
+    publicKey: lastField(fields, 4)?.bytes ?? new Uint8Array(0),
+  }
+}
+
+/**
+ * Canonical re-encoding of the challenge, reproducing what the server signs
+ * against: fields in tag order with proto3 default elision. Both the official
+ * TS SDK and the Rust SDK sign a re-encoded challenge rather than raw bytes.
+ */
+export const encodeChallenge = (challenge: DecodedChallenge): Uint8Array =>
+  new ProtoWriter()
+    .varint(1, challenge.version)
+    .varint(2, challenge.timestamp)
+    .bytes(3, challenge.nonce)
+    .bytes(4, challenge.publicKey)
+    .finish()
+
+export const decodeGetChallengeResponse = (
+  data: Uint8Array,
+): DecodedProtectedChallenge => {
+  const protectedField = lastField(decodeFields(data), 1)
+  if (!protectedField?.bytes) {
+    throw new Error("spark auth: response has no protected_challenge")
+  }
+  const challengeField = lastField(decodeFields(protectedField.bytes), 2)
+  if (!challengeField?.bytes) {
+    throw new Error("spark auth: protected_challenge has no challenge")
+  }
+  return {
+    raw: protectedField.bytes,
+    challenge: decodeChallenge(challengeField.bytes),
+  }
+}
+
+type VerifyChallengeParams = {
+  protectedChallengeRaw: Uint8Array
+  signatureDer: Uint8Array
+  publicKey: Uint8Array
+}
+
+export const encodeVerifyChallengeRequest = ({
+  protectedChallengeRaw,
+  signatureDer,
+  publicKey,
+}: VerifyChallengeParams): Uint8Array =>
+  new ProtoWriter()
+    .bytes(1, protectedChallengeRaw)
+    .bytes(2, signatureDer)
+    .bytes(3, publicKey)
+    .finish()
+
+export type VerifyChallengeResponse = {
+  sessionToken: string
+  expirationTimestamp: bigint
+}
+
+export const decodeVerifyChallengeResponse = (
+  data: Uint8Array,
+): VerifyChallengeResponse => {
+  const fields = decodeFields(data)
+  const token = lastField(fields, 1)?.bytes
+  if (!token || token.length === 0) {
+    throw new Error("spark auth: verify_challenge returned no session token")
+  }
+  return {
+    sessionToken: utf8Decode(token),
+    expirationTimestamp: lastField(fields, 2)?.varint ?? 0n,
+  }
+}
+
+// --- spark.SparkService/query_nodes ---
+
+type QueryNodesBase = {
+  includeParents: boolean
+  limit: number
+  offset: number
+  network: SparkProtoNetwork
+}
+
+export type QueryNodesRequest = QueryNodesBase &
+  ({ ownerIdentityPublicKey: Uint8Array } | { nodeIds: string[] })
+
+export const encodeQueryNodesRequest = (request: QueryNodesRequest): Uint8Array => {
+  const writer = new ProtoWriter()
+  if ("ownerIdentityPublicKey" in request) {
+    writer.bytes(1, request.ownerIdentityPublicKey)
+  } else {
+    const nodeIds = new ProtoWriter()
+    for (const id of request.nodeIds) nodeIds.string(1, id)
+    writer.bytes(2, nodeIds.finish())
+  }
+  return writer
+    .bool(3, request.includeParents)
+    .varint(4, request.limit)
+    .varint(5, request.offset)
+    .varint(6, request.network)
+    .finish()
+}
+
+export type DecodedTreeNode = {
+  id: string
+  valueSats: bigint
+  parentNodeId: string | undefined
+  ownerIdentityPublicKey: Uint8Array
+  /** Legacy string status, e.g. "AVAILABLE". */
+  status: string
+  /** Typed TreeNodeStatus enum; 1 = AVAILABLE. */
+  treenodeStatus: number
+  /** Raw TreeNode wire bytes exactly as received. */
+  raw: Uint8Array
+}
+
+const decodeTreeNode = (data: Uint8Array): DecodedTreeNode => {
+  const fields = decodeFields(data)
+  const parent = lastField(fields, 4)?.bytes
+  return {
+    id: utf8Decode(lastField(fields, 1)?.bytes ?? new Uint8Array(0)),
+    valueSats: lastField(fields, 3)?.varint ?? 0n,
+    parentNodeId: parent && parent.length > 0 ? utf8Decode(parent) : undefined,
+    ownerIdentityPublicKey: lastField(fields, 9)?.bytes ?? new Uint8Array(0),
+    status: utf8Decode(lastField(fields, 11)?.bytes ?? new Uint8Array(0)),
+    treenodeStatus: Number(lastField(fields, 19)?.varint ?? 0n),
+    raw: data,
+  }
+}
+
+export type QueryNodesResponse = {
+  nodes: Map<string, DecodedTreeNode>
+  offset: bigint
+}
+
+export const decodeQueryNodesResponse = (data: Uint8Array): QueryNodesResponse => {
+  const nodes = new Map<string, DecodedTreeNode>()
+  let offset = 0n
+
+  for (const field of decodeFields(data)) {
+    if (field.fieldNumber === 2 && field.wireType === WireType.Varint) {
+      offset = BigInt.asIntN(64, field.varint ?? 0n)
+    } else if (field.fieldNumber === 1 && field.bytes) {
+      // map<string, TreeNode> entry: key = 1, value = 2
+      const entryFields = decodeFields(field.bytes)
+      const key = lastField(entryFields, 1)?.bytes
+      const value = lastField(entryFields, 2)?.bytes
+      if (key && value) nodes.set(utf8Decode(key), decodeTreeNode(value))
+    }
+  }
+
+  return { nodes, offset }
+}

--- a/app/self-custodial/recovery-bundle/protocol/wire.ts
+++ b/app/self-custodial/recovery-bundle/protocol/wire.ts
@@ -1,0 +1,153 @@
+/* eslint-disable no-bitwise -- protobuf varint/tag encoding is bit manipulation */
+/**
+ * Minimal protobuf wire-format primitives for the handful of Spark operator
+ * messages the recovery-bundle exporter needs. Hand-rolled instead of pulling
+ * in a protobuf runtime: only varint and length-delimited wire types are used
+ * by those messages, and decoding keeps raw sub-message bytes so TreeNodes can
+ * be stored byte-for-byte as received (preserving fields we don't model).
+ */
+
+export const WireType = {
+  Varint: 0,
+  Fixed64: 1,
+  LengthDelimited: 2,
+  Fixed32: 5,
+} as const
+
+export type WireField = {
+  fieldNumber: number
+  wireType: number
+  /** Varint value (present for wire type 0). Fits Spark's timestamps/values. */
+  varint?: bigint
+  /** Raw payload bytes (present for wire type 2). */
+  bytes?: Uint8Array
+}
+
+export class ProtoWriter {
+  private chunks: number[] = []
+
+  private pushVarint(value: bigint): void {
+    let v = value
+    if (v < 0n) {
+      // Negative int32/int64 values are encoded as 10-byte two's complement varints
+      v &= 0xffffffffffffffffn
+    }
+    while (v > 0x7fn) {
+      this.chunks.push(Number(v & 0x7fn) | 0x80)
+      v >>= 7n
+    }
+    this.chunks.push(Number(v))
+  }
+
+  private pushTag(fieldNumber: number, wireType: number): void {
+    this.pushVarint(BigInt((fieldNumber << 3) | wireType))
+  }
+
+  /** Writes a varint field; omitted when zero, matching proto3 default elision. */
+  varint(fieldNumber: number, value: bigint | number): this {
+    const v = typeof value === "number" ? BigInt(value) : value
+    if (v === 0n) return this
+    this.pushTag(fieldNumber, WireType.Varint)
+    this.pushVarint(v)
+    return this
+  }
+
+  bool(fieldNumber: number, value: boolean): this {
+    return this.varint(fieldNumber, value ? 1n : 0n)
+  }
+
+  /** Writes a length-delimited field; omitted when empty. */
+  bytes(fieldNumber: number, value: Uint8Array): this {
+    if (value.length === 0) return this
+    this.pushTag(fieldNumber, WireType.LengthDelimited)
+    this.pushVarint(BigInt(value.length))
+    for (const byte of value) this.chunks.push(byte)
+    return this
+  }
+
+  string(fieldNumber: number, value: string): this {
+    return this.bytes(fieldNumber, Uint8Array.from(Buffer.from(value, "utf8")))
+  }
+
+  finish(): Uint8Array {
+    return Uint8Array.from(this.chunks)
+  }
+}
+
+export const decodeFields = (data: Uint8Array): WireField[] => {
+  const fields: WireField[] = []
+  let offset = 0
+
+  const readVarint = (): bigint => {
+    let result = 0n
+    let shift = 0n
+    for (;;) {
+      if (offset >= data.length) throw new Error("proto: truncated varint")
+      const byte = data[offset]
+      offset += 1
+      result |= BigInt(byte & 0x7f) << shift
+      // Mask to 64 bits: the tenth byte's high bits (shift 63 carries bits
+      // 63-69) would otherwise yield values beyond 2^64 where canonical
+      // parsers truncate - and downstream decoding (BigInt.asIntN, Number
+      // conversions of sat values) assumes 64-bit range.
+      if ((byte & 0x80) === 0) return result & 0xffffffffffffffffn
+      shift += 7n
+      if (shift > 63n) throw new Error("proto: varint too long")
+    }
+  }
+
+  while (offset < data.length) {
+    const tag = readVarint()
+    const fieldNumber = Number(tag >> 3n)
+    const wireType = Number(tag & 0x7n)
+    if (fieldNumber === 0) throw new Error("proto: invalid field number 0")
+
+    switch (wireType) {
+      case WireType.Varint:
+        fields.push({ fieldNumber, wireType, varint: readVarint() })
+        break
+      case WireType.LengthDelimited: {
+        const length = Number(readVarint())
+        if (offset + length > data.length) throw new Error("proto: truncated bytes")
+        fields.push({
+          fieldNumber,
+          wireType,
+          bytes: data.subarray(offset, offset + length),
+        })
+        offset += length
+        break
+      }
+      case WireType.Fixed64:
+        if (offset + 8 > data.length) throw new Error("proto: truncated fixed64")
+        fields.push({ fieldNumber, wireType, bytes: data.subarray(offset, offset + 8) })
+        offset += 8
+        break
+      case WireType.Fixed32:
+        if (offset + 4 > data.length) throw new Error("proto: truncated fixed32")
+        fields.push({ fieldNumber, wireType, bytes: data.subarray(offset, offset + 4) })
+        offset += 4
+        break
+      default:
+        throw new Error(`proto: unsupported wire type ${wireType}`)
+    }
+  }
+
+  return fields
+}
+
+/** Last occurrence wins, matching proto3 semantics for non-repeated fields.
+ * The canonical challenge re-encode depends on parsing exactly as the server
+ * does, so diverging here could make a valid signature verify against the
+ * wrong bytes. */
+export const lastField = (
+  fields: WireField[],
+  fieldNumber: number,
+): WireField | undefined => {
+  for (let i = fields.length - 1; i >= 0; i -= 1) {
+    if (fields[i].fieldNumber === fieldNumber) return fields[i]
+  }
+  return undefined
+}
+
+export const utf8Decode = (bytes: Uint8Array): string =>
+  Buffer.from(bytes).toString("utf8")

--- a/app/self-custodial/recovery-bundle/types.ts
+++ b/app/self-custodial/recovery-bundle/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Unilateral-exit recovery bundle: a snapshot of the wallet's Spark leaves and
+ * their ancestor transactions, fetched from the Spark operators while they are
+ * online. It is the only data (besides the seed) needed to force-exit funds on
+ * chain if the operators disappear, and it cannot be reconstructed from the
+ * seed alone once they do.
+ *
+ * The JSON shape mirrors the `spark.unilateral-exit-bundle.v1` schema produced
+ * by the blinkbitcoin/spark-unilateral-exit exporter so bundles saved by the
+ * app feed that tooling directly.
+ */
+
+export const RECOVERY_BUNDLE_SCHEMA = "spark.unilateral-exit-bundle.v1"
+
+export type RecoveryBundleLeaf = {
+  id: string
+  status: string
+  valueSats: number
+  treeNodeHex: string
+}
+
+export type RecoveryBundleNode = {
+  id: string
+  treeNodeHex: string
+}
+
+export type RecoveryBundleBalances = {
+  btcSats: string
+  usdb: {
+    amount: string
+    status: string
+  }
+}
+
+export type RecoveryBundle = {
+  schema: typeof RECOVERY_BUNDLE_SCHEMA
+  createdAt: string
+  network: string
+  operatorSet: string
+  walletIdentityPublicKey: string
+  sparkSdkVersion: string
+  appVersion: string
+  leaves: RecoveryBundleLeaf[]
+  nodes: RecoveryBundleNode[]
+  balances: RecoveryBundleBalances
+}
+
+export const USDB_NOT_COVERED_STATUS = "not-covered-by-bitcoin-unilateral-exit"


### PR DESCRIPTION
**Stack 1/3** for the unilateral-exit recovery bundle (split out of #3911 per review). Next: `feat--recovery-bundle-storage` -> #3911.

The cryptographic core, with no app wiring - nothing outside these modules imports them yet:

- `protocol/wire.ts` - minimal protobuf wire primitives (varint/length-delimited only), 64-bit masking, proto3 last-wins field selection. Hand-rolled so TreeNodes can be stored byte-for-byte as received.
- `protocol/messages.ts` - encoders/decoders for the Spark authn and query_nodes messages, mirroring spark.proto field numbers.
- `protocol/grpc-web.ts` - fetch-based gRPC-web unary client: 30s per-call timeout, rejects compressed frames, requires a trailers frame (or header-carried status), errors on truncated remainders.
- `identity.ts` - seed-derived Spark identity at m/8797555'/{account}'/0' (network-dependent default account number) and DER challenge signing; bundle encryption key derivation.
- `exporter.ts` - pages owner leaves (offset advanced by returned page size), re-fetches missing ancestors by id (bypassing the operators' root-skip bug), and refuses any bundle whose exit chain is not closed: cycles, unresolved ancestors, implausible leaf values, exceeded paging caps or the 2-minute total fetch budget are all errors, not warnings.

Tests: golden-vector identity derivation (independent Python implementation), determinism + low-S signature pin, byte-level mocked-operator exporter flows (short pages, cycles, refetch rounds, budget), wire/grpc-web edge cases.

Also carries a `chore(graphql)` commit regenerating `generated.ts` for the backend's new `DepositFeeTier` field - main is currently stale against the live schema, and every PR fails `check:codegen` without it.
