### PR TITLE
feat(self-custodial): recovery-bundle storage, encryption, and refresh orchestration

### DIFF
--- a/__tests__/self-custodial/providers/backup-state.spec.tsx
+++ b/__tests__/self-custodial/providers/backup-state.spec.tsx
@@ -7,7 +7,10 @@ import {
   BackupMethod,
   BackupStatus,
   completedMethodsOf,
+  isCloudSeedBackupCompleted,
+  isPasswordProtectedCloudSeedBackup,
   markBackupCompletedFor,
+  readBackupStateFor,
   removeBackupStateFor,
 } from "@app/self-custodial/providers/backup-state"
 import { AccountType, AccountStatus } from "@app/types/wallet"
@@ -562,6 +565,61 @@ describe("BackupStateProvider", () => {
         method: "manual",
         completedMethods: ["manual"],
       })
+    })
+  })
+
+  describe("cloudPasswordProtected persistence (D9 gate)", () => {
+    it("persists the flag when setBackupCompleted records a password-protected cloud backup", async () => {
+      const { result } = renderHook(() => useBackupState(), { wrapper })
+
+      await act(async () => {})
+
+      await act(async () => {
+        result.current.setBackupCompleted("cloud", { cloudPasswordProtected: true })
+      })
+
+      // Exact JSON: dropping the flag on write would silently close the D9
+      // gate for every future bundle cloud sync, and nothing else covers it.
+      expect(mockSetItem).toHaveBeenCalledWith(
+        BACKUP_KEY,
+        JSON.stringify({
+          status: "completed",
+          method: "cloud",
+          cloudPasswordProtected: true,
+        }),
+      )
+    })
+
+    it("round-trips the flag through markBackupCompletedFor into the D9 gate", async () => {
+      let persisted: string | null = null
+      mockSetItem.mockImplementation(async (_key: string, value: string) => {
+        persisted = value
+      })
+      mockGetItem.mockImplementation(async () => persisted)
+
+      await markBackupCompletedFor(TEST_SC_ACCOUNT_ID, BackupMethod.Cloud, {
+        cloudPasswordProtected: true,
+      })
+
+      const state = await readBackupStateFor(TEST_SC_ACCOUNT_ID)
+      expect(isCloudSeedBackupCompleted(state)).toBe(true)
+      expect(isPasswordProtectedCloudSeedBackup(state)).toBe(true)
+    })
+
+    it("defaults closed: a cloud backup completed without the flag never opens the gate", async () => {
+      let persisted: string | null = null
+      mockSetItem.mockImplementation(async (_key: string, value: string) => {
+        persisted = value
+      })
+      mockGetItem.mockImplementation(async () => persisted)
+
+      await markBackupCompletedFor(TEST_SC_ACCOUNT_ID, BackupMethod.Cloud)
+
+      const state = await readBackupStateFor(TEST_SC_ACCOUNT_ID)
+      // Pre-existing states and passwordless cloud backups look identical:
+      // the seed is in the cloud, but the bundle must not be (PRD rule D9).
+      expect(isCloudSeedBackupCompleted(state)).toBe(true)
+      expect(isPasswordProtectedCloudSeedBackup(state)).toBe(false)
     })
   })
 

--- a/__tests__/self-custodial/providers/backup-state.spec.tsx
+++ b/__tests__/self-custodial/providers/backup-state.spec.tsx
@@ -5,6 +5,11 @@ import {
   BackupStateProvider,
   useBackupState,
   BackupStatus,
+  BackupMethod,
+  isCloudSeedBackupCompleted,
+  isPasswordProtectedCloudSeedBackup,
+  markBackupCompletedFor,
+  readBackupStateFor,
   removeBackupStateFor,
 } from "@app/self-custodial/providers/backup-state"
 import { AccountType, AccountStatus } from "@app/types/wallet"
@@ -246,6 +251,61 @@ describe("BackupStateProvider", () => {
         JSON.stringify({ status: "completed", method: "cloud" }),
       )
       expect(mockSetItem).not.toHaveBeenCalledWith(BACKUP_KEY, expect.any(String))
+    })
+  })
+
+  describe("cloudPasswordProtected persistence (D9 gate)", () => {
+    it("persists the flag when setBackupCompleted records a password-protected cloud backup", async () => {
+      const { result } = renderHook(() => useBackupState(), { wrapper })
+
+      await act(async () => {})
+
+      await act(async () => {
+        result.current.setBackupCompleted("cloud", { cloudPasswordProtected: true })
+      })
+
+      // Exact JSON: dropping the flag on write would silently close the D9
+      // gate for every future bundle cloud sync, and nothing else covers it.
+      expect(mockSetItem).toHaveBeenCalledWith(
+        BACKUP_KEY,
+        JSON.stringify({
+          status: "completed",
+          method: "cloud",
+          cloudPasswordProtected: true,
+        }),
+      )
+    })
+
+    it("round-trips the flag through markBackupCompletedFor into the D9 gate", async () => {
+      let persisted: string | null = null
+      mockSetItem.mockImplementation(async (_key: string, value: string) => {
+        persisted = value
+      })
+      mockGetItem.mockImplementation(async () => persisted)
+
+      await markBackupCompletedFor(TEST_SC_ACCOUNT_ID, BackupMethod.Cloud, {
+        cloudPasswordProtected: true,
+      })
+
+      const state = await readBackupStateFor(TEST_SC_ACCOUNT_ID)
+      expect(isCloudSeedBackupCompleted(state)).toBe(true)
+      expect(isPasswordProtectedCloudSeedBackup(state)).toBe(true)
+    })
+
+    it("defaults closed: a cloud backup completed without the flag never opens the gate", async () => {
+      let persisted: string | null = null
+      mockSetItem.mockImplementation(async (_key: string, value: string) => {
+        persisted = value
+      })
+      mockGetItem.mockImplementation(async () => persisted)
+
+      await markBackupCompletedFor(TEST_SC_ACCOUNT_ID, BackupMethod.Cloud)
+
+      const state = await readBackupStateFor(TEST_SC_ACCOUNT_ID)
+      // Pre-existing states and passwordless cloud backups look identical:
+      // the seed is in the cloud, but the bundle must not be (PRD rule D9).
+      expect(isCloudSeedBackupCompleted(state)).toBe(true)
+      expect(isPasswordProtectedCloudSeedBackup(state)).toBe(false)
     })
   })
 

--- a/__tests__/self-custodial/providers/backup-state.spec.tsx
+++ b/__tests__/self-custodial/providers/backup-state.spec.tsx
@@ -585,6 +585,7 @@ describe("BackupStateProvider", () => {
         JSON.stringify({
           status: "completed",
           method: "cloud",
+          completedMethods: ["cloud"],
           cloudPasswordProtected: true,
         }),
       )

--- a/__tests__/self-custodial/recovery-bundle/cloud.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/cloud.spec.ts
@@ -1,0 +1,154 @@
+let mockPlatformOS: "ios" | "android" = "ios"
+
+const mockGetCurrentUser = jest.fn()
+const mockSignInSilently = jest.fn()
+const mockGetTokens = jest.fn()
+const mockConfigure = jest.fn()
+const mockDriveFindAppDataFile = jest.fn()
+const mockDriveUploadAppDataFile = jest.fn()
+const mockAssertICloudAvailable = jest.fn()
+const mockICloudUploadAppDataFile = jest.fn()
+
+jest.mock("react-native", () => ({
+  Platform: {
+    get OS() {
+      return mockPlatformOS
+    },
+  },
+}))
+
+jest.mock("@react-native-google-signin/google-signin", () => ({
+  GoogleSignin: {
+    configure: (...args: unknown[]) => mockConfigure(...args),
+    getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
+    signInSilently: (...args: unknown[]) => mockSignInSilently(...args),
+    getTokens: (...args: unknown[]) => mockGetTokens(...args),
+  },
+}))
+
+jest.mock("@app/utils/google-drive-client", () => ({
+  findAppDataFile: (...args: unknown[]) => mockDriveFindAppDataFile(...args),
+  uploadAppDataFile: (...args: unknown[]) => mockDriveUploadAppDataFile(...args),
+}))
+
+jest.mock("@app/utils/icloud-client", () => ({
+  assertICloudAvailable: (...args: unknown[]) => mockAssertICloudAvailable(...args),
+  uploadAppDataFile: (...args: unknown[]) => mockICloudUploadAppDataFile(...args),
+}))
+
+import {
+  attemptSilentCloudUpload,
+  getRecoveryBundleFilename,
+  getRecoveryBundleFilenamePrefix,
+} from "@app/self-custodial/recovery-bundle/cloud"
+
+const CONTENT = '{"encrypted":true}'
+const FILE_NAME = "blink-spark-recovery-bundle-mainnet-02ab.json"
+
+describe("recovery bundle filenames", () => {
+  it("builds a lowercase, network-scoped filename around the wallet identifier", () => {
+    expect(getRecoveryBundleFilenamePrefix("MAINNET")).toBe(
+      "blink-spark-recovery-bundle-mainnet-",
+    )
+    expect(getRecoveryBundleFilename("MAINNET", "02ab")).toBe(FILE_NAME)
+  })
+})
+
+describe("attemptSilentCloudUpload on iOS", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPlatformOS = "ios"
+    mockAssertICloudAvailable.mockResolvedValue(undefined)
+    mockICloudUploadAppDataFile.mockResolvedValue(undefined)
+  })
+
+  it("uploads to iCloud without any interactive session", async () => {
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: true })
+    expect(mockICloudUploadAppDataFile).toHaveBeenCalledWith({
+      content: CONTENT,
+      fileName: FILE_NAME,
+    })
+    expect(mockConfigure).not.toHaveBeenCalled()
+  })
+
+  it("maps a reason-carrying error and preserves the original", async () => {
+    const err = Object.assign(new Error("iCloud unavailable"), { reason: "auth" })
+    mockAssertICloudAvailable.mockRejectedValue(err)
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: false, reason: "auth", error: err })
+    expect(mockICloudUploadAppDataFile).not.toHaveBeenCalled()
+  })
+
+  it("maps an error without a reason to unknown, carrying the original", async () => {
+    const err = new Error("NSFileManager write failed")
+    mockICloudUploadAppDataFile.mockRejectedValue(err)
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: false, reason: "unknown", error: err })
+  })
+})
+
+describe("attemptSilentCloudUpload on Android", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPlatformOS = "android"
+    mockGetCurrentUser.mockReturnValue({ user: { email: "u@example.com" } })
+    mockGetTokens.mockResolvedValue({ accessToken: "token-1" })
+    mockDriveFindAppDataFile.mockResolvedValue(undefined)
+    mockDriveUploadAppDataFile.mockResolvedValue(undefined)
+  })
+
+  it("uploads with the current session's token, replacing an existing file", async () => {
+    mockDriveFindAppDataFile.mockResolvedValue("existing-file-id")
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: true })
+    expect(mockSignInSilently).not.toHaveBeenCalled()
+    expect(mockDriveFindAppDataFile).toHaveBeenCalledWith(FILE_NAME, "token-1")
+    expect(mockDriveUploadAppDataFile).toHaveBeenCalledWith({
+      content: CONTENT,
+      fileName: FILE_NAME,
+      accessToken: "token-1",
+      existingId: "existing-file-id",
+    })
+  })
+
+  it("tries a silent sign-in when no user session exists", async () => {
+    mockGetCurrentUser.mockReturnValue(null)
+    mockSignInSilently.mockResolvedValue({ type: "success" })
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: true })
+    expect(mockSignInSilently).toHaveBeenCalledTimes(1)
+    expect(mockDriveUploadAppDataFile).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports an auth failure without popping UI when the silent sign-in fails", async () => {
+    // The event-driven refresh path must never prompt; a user who never
+    // linked Drive is an expected auth miss, not an error.
+    mockGetCurrentUser.mockReturnValue(null)
+    mockSignInSilently.mockResolvedValue({ type: "noSavedCredentialFound" })
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: false, reason: "auth" })
+    expect(mockGetTokens).not.toHaveBeenCalled()
+    expect(mockDriveUploadAppDataFile).not.toHaveBeenCalled()
+  })
+
+  it("maps a Drive upload failure to its reason, carrying the original error", async () => {
+    const err = Object.assign(new Error("quota exceeded"), { reason: "transient" })
+    mockDriveUploadAppDataFile.mockRejectedValue(err)
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: false, reason: "transient", error: err })
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/cloud.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/cloud.spec.ts
@@ -4,6 +4,7 @@ const mockGetCurrentUser = jest.fn()
 const mockSignInSilently = jest.fn()
 const mockGetTokens = jest.fn()
 const mockConfigure = jest.fn()
+const mockClearCachedAccessToken = jest.fn()
 const mockDriveFindAppDataFile = jest.fn()
 const mockDriveUploadAppDataFile = jest.fn()
 const mockAssertICloudAvailable = jest.fn()
@@ -23,10 +24,14 @@ jest.mock("@react-native-google-signin/google-signin", () => ({
     getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
     signInSilently: (...args: unknown[]) => mockSignInSilently(...args),
     getTokens: (...args: unknown[]) => mockGetTokens(...args),
+    clearCachedAccessToken: (...args: unknown[]) => mockClearCachedAccessToken(...args),
   },
 }))
 
+// The real DriveError stays: the dead-token retry decides on `instanceof
+// DriveError && status === 401`, which a stub class would never satisfy.
 jest.mock("@app/utils/google-drive-client", () => ({
+  DriveError: jest.requireActual("@app/utils/google-drive-client").DriveError,
   findAppDataFile: (...args: unknown[]) => mockDriveFindAppDataFile(...args),
   uploadAppDataFile: (...args: unknown[]) => mockDriveUploadAppDataFile(...args),
 }))
@@ -41,6 +46,8 @@ import {
   getRecoveryBundleFilename,
   getRecoveryBundleFilenamePrefix,
 } from "@app/self-custodial/recovery-bundle/cloud"
+import { CloudBackupErrorReason } from "@app/types/cloud-backup"
+import { DriveError } from "@app/utils/google-drive-client"
 
 const CONTENT = '{"encrypted":true}'
 const FILE_NAME = "blink-spark-recovery-bundle-mainnet-02ab.json"
@@ -150,5 +157,45 @@ describe("attemptSilentCloudUpload on Android", () => {
     const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
 
     expect(result).toEqual({ success: false, reason: "transient", error: err })
+  })
+
+  it("clears a dead cached token on a 401 and retries once with a fresh one", async () => {
+    // A token revoked out-of-band stays in the sign-in cache; without the
+    // clear-and-retry, every silent sync would fail with it forever.
+    mockGetTokens
+      .mockResolvedValueOnce({ accessToken: "dead-token" })
+      .mockResolvedValueOnce({ accessToken: "fresh-token" })
+    mockDriveFindAppDataFile
+      .mockRejectedValueOnce(
+        new DriveError(CloudBackupErrorReason.Auth, "Drive query failed (401)", 401),
+      )
+      .mockResolvedValueOnce("existing-file-id")
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: true })
+    expect(mockClearCachedAccessToken).toHaveBeenCalledWith("dead-token")
+    expect(mockDriveFindAppDataFile).toHaveBeenLastCalledWith(FILE_NAME, "fresh-token")
+    expect(mockDriveUploadAppDataFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "fresh-token",
+        existingId: "existing-file-id",
+      }),
+    )
+  })
+
+  it("does not retry a 403: a new token cannot fix a withheld permission", async () => {
+    const forbidden = new DriveError(
+      CloudBackupErrorReason.Auth,
+      "Drive query failed (403)",
+      403,
+    )
+    mockDriveFindAppDataFile.mockRejectedValue(forbidden)
+
+    const result = await attemptSilentCloudUpload(CONTENT, FILE_NAME)
+
+    expect(result).toEqual({ success: false, reason: "auth", error: forbidden })
+    expect(mockClearCachedAccessToken).not.toHaveBeenCalled()
+    expect(mockDriveFindAppDataFile).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/self-custodial/recovery-bundle/encryption.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/encryption.spec.ts
@@ -1,0 +1,124 @@
+jest.mock("react-native-quick-crypto", () => {
+  const crypto = jest.requireActual("crypto") as typeof import("crypto")
+
+  return {
+    __esModule: true,
+    default: {
+      randomBytes: crypto.randomBytes,
+      createCipheriv: crypto.createCipheriv,
+      createDecipheriv: crypto.createDecipheriv,
+      createHmac: crypto.createHmac,
+      createHash: crypto.createHash,
+    },
+    Buffer,
+  }
+})
+
+import {
+  buildEncryptedBundlePayload,
+  decryptBundleBackupPayload,
+  parseBundleBackupMetadata,
+  RecoveryBundlePayloadError,
+} from "@app/self-custodial/recovery-bundle/encryption"
+import {
+  RECOVERY_BUNDLE_SCHEMA,
+  type RecoveryBundle,
+} from "@app/self-custodial/recovery-bundle/types"
+
+const TEST_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+
+const bundle: RecoveryBundle = {
+  schema: RECOVERY_BUNDLE_SCHEMA,
+  createdAt: "2026-07-12T00:00:00.000Z",
+  network: "MAINNET",
+  operatorSet: "breez-sdk",
+  walletIdentityPublicKey: "02".padEnd(66, "ab"),
+  sparkSdkVersion: "breez-sdk-spark-react-native",
+  appVersion: "1.0.1",
+  leaves: [
+    { id: "leaf-1", status: "AVAILABLE", valueSats: 32768, treeNodeHex: "deadbeef" },
+  ],
+  nodes: [
+    { id: "leaf-1", treeNodeHex: "deadbeef" },
+    { id: "root-1", treeNodeHex: "cafebabe" },
+  ],
+  balances: {
+    btcSats: "32768",
+    usdb: { amount: "0.00", status: "not-covered-by-bitcoin-unilateral-exit" },
+  },
+}
+
+describe("recovery bundle encrypted payload", () => {
+  it("roundtrips encrypt/decrypt with the seed-derived key", async () => {
+    const payload = await buildEncryptedBundlePayload(bundle, TEST_MNEMONIC)
+    await expect(decryptBundleBackupPayload(payload, TEST_MNEMONIC)).resolves.toEqual(
+      bundle,
+    )
+  })
+
+  it("keeps only non-sensitive metadata in plaintext", async () => {
+    const payload = await buildEncryptedBundlePayload(bundle, TEST_MNEMONIC)
+    expect(payload).not.toContain("deadbeef")
+    expect(payload).not.toContain("32768")
+
+    const metadata = parseBundleBackupMetadata(payload)
+    expect(metadata).toEqual({
+      network: "MAINNET",
+      walletIdentityPublicKey: bundle.walletIdentityPublicKey,
+      bundleCreatedAt: bundle.createdAt,
+    })
+  })
+
+  it("fails to decrypt with a different seed", async () => {
+    const payload = await buildEncryptedBundlePayload(bundle, TEST_MNEMONIC)
+    const otherMnemonic =
+      "youth indicate void nation bundle execute ritual artwork harvest genuine plunge captain"
+    await expect(decryptBundleBackupPayload(payload, otherMnemonic)).rejects.toThrow(
+      RecoveryBundlePayloadError,
+    )
+  })
+
+  it("rejects a payload whose ciphertext was tampered with (GCM auth)", async () => {
+    const payload = await buildEncryptedBundlePayload(bundle, TEST_MNEMONIC)
+    const parsed = JSON.parse(payload)
+    // Flip one byte of the ciphertext; GCM authentication must reject it
+    // even though the correct seed-derived key is used.
+    const data = Buffer.from(parsed.data, "base64")
+    // eslint-disable-next-line no-bitwise -- flipping one ciphertext bit
+    data[0] ^= 0x01
+    parsed.data = data.toString("base64")
+
+    await expect(
+      decryptBundleBackupPayload(JSON.stringify(parsed), TEST_MNEMONIC),
+    ).rejects.toMatchObject({
+      name: "RecoveryBundlePayloadError",
+      reason: "decrypt-failed",
+    })
+  })
+
+  it("rejects payloads with an unknown schema", async () => {
+    await expect(
+      decryptBundleBackupPayload(JSON.stringify({ schema: "other" }), TEST_MNEMONIC),
+    ).rejects.toThrow(/Unsupported/)
+  })
+
+  it("rejects a payload whose plaintext envelope disagrees with the encrypted bundle", async () => {
+    const payload = await buildEncryptedBundlePayload(bundle, TEST_MNEMONIC)
+    const tampered = JSON.parse(payload)
+    // The encrypted bundle still says MAINNET; only the plaintext envelope lies.
+    tampered.network = "REGTEST"
+
+    await expect(
+      decryptBundleBackupPayload(JSON.stringify(tampered), TEST_MNEMONIC),
+    ).rejects.toMatchObject({
+      name: "RecoveryBundlePayloadError",
+      reason: "envelope-mismatch",
+    })
+  })
+
+  it("returns null metadata for non-bundle JSON", () => {
+    expect(parseBundleBackupMetadata("{}")).toBeNull()
+    expect(parseBundleBackupMetadata("not json")).toBeNull()
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/refresh.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/refresh.spec.ts
@@ -1,0 +1,542 @@
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+
+const mockFetchRecoveryBundle = jest.fn()
+const mockAttemptSilentCloudUpload = jest.fn()
+const mockReadBackupStateFor = jest.fn()
+const mockReadRecoveryBundleSettings = jest.fn()
+const mockSaveEncryptedBundleFile = jest.fn()
+const mockLoadEncryptedBundleFile = jest.fn()
+const mockReadRecoveryBundleState = jest.fn()
+const mockWriteRecoveryBundleState = jest.fn()
+const mockParseBundleBackupMetadata = jest.fn()
+const mockCrashlyticsLog = jest.fn()
+const mockCrashlyticsRecordError = jest.fn()
+
+jest.mock("@react-native-firebase/crashlytics", () => () => ({
+  log: (...args: string[]) => mockCrashlyticsLog(...args),
+  recordError: (...args: Error[]) => mockCrashlyticsRecordError(...args),
+}))
+
+jest.mock("@app/self-custodial/recovery-bundle/exporter", () => ({
+  fetchRecoveryBundle: (...args: unknown[]) => mockFetchRecoveryBundle(...args),
+}))
+
+// Keep the real filename helpers so the filename assertions pin the actual
+// production format; only the upload side effect is stubbed.
+jest.mock("@app/self-custodial/recovery-bundle/cloud", () => ({
+  ...jest.requireActual("@app/self-custodial/recovery-bundle/cloud"),
+  attemptSilentCloudUpload: (...args: unknown[]) => mockAttemptSilentCloudUpload(...args),
+}))
+
+jest.mock("@app/self-custodial/recovery-bundle/encryption", () => ({
+  buildEncryptedBundlePayload: async (bundle: { walletIdentityPublicKey: string }) =>
+    JSON.stringify({
+      network: "MAINNET",
+      walletIdentityPublicKey: bundle.walletIdentityPublicKey,
+      bundleCreatedAt: "2026-07-12T00:00:00.000Z",
+      encrypted: true,
+    }),
+  parseBundleBackupMetadata: (...args: unknown[]) =>
+    mockParseBundleBackupMetadata(...args),
+}))
+
+jest.mock("@app/self-custodial/recovery-bundle/storage", () => ({
+  saveEncryptedBundleFile: (...args: unknown[]) => mockSaveEncryptedBundleFile(...args),
+  loadEncryptedBundleFile: (...args: unknown[]) => mockLoadEncryptedBundleFile(...args),
+  readRecoveryBundleState: (...args: unknown[]) => mockReadRecoveryBundleState(...args),
+  writeRecoveryBundleState: (...args: unknown[]) => mockWriteRecoveryBundleState(...args),
+}))
+
+// Keep the real gates (and the real status/method constants) so the cloud
+// gating under test is production code, not a spec-side re-implementation.
+// Only the storage read is stubbed.
+jest.mock("@app/self-custodial/providers/backup-state", () => {
+  const actual = jest.requireActual("@app/self-custodial/providers/backup-state")
+  return {
+    BackupStatus: actual.BackupStatus,
+    BackupMethod: actual.BackupMethod,
+    isCloudSeedBackupCompleted: actual.isCloudSeedBackupCompleted,
+    isPasswordProtectedCloudSeedBackup: actual.isPasswordProtectedCloudSeedBackup,
+    readBackupStateFor: (...args: unknown[]) => mockReadBackupStateFor(...args),
+  }
+})
+
+jest.mock("@app/self-custodial/recovery-bundle/settings", () => ({
+  ...jest.requireActual("@app/self-custodial/recovery-bundle/settings"),
+  readRecoveryBundleSettings: (...args: unknown[]) =>
+    mockReadRecoveryBundleSettings(...args),
+}))
+
+import { BackupMethod, BackupStatus } from "@app/self-custodial/providers/backup-state"
+import {
+  isBundleFresh,
+  markAccountDeletedForRefresh,
+  markCloudSynced,
+  refreshRecoveryBundle,
+  syncExistingBundleToCloud,
+  unmarkAccountDeletedForRefresh,
+  waitForRefreshesToSettle,
+} from "@app/self-custodial/recovery-bundle/refresh"
+
+const ACCOUNT_ID = "acct-1"
+
+const testBundle = {
+  createdAt: "2026-07-12T00:00:00.000Z",
+  walletIdentityPublicKey: "02abcdef",
+  leaves: [{ id: "leaf-1" }],
+  balances: { btcSats: "32768" },
+}
+
+const savedPayload = JSON.stringify({
+  network: "MAINNET",
+  walletIdentityPublicKey: testBundle.walletIdentityPublicKey,
+  bundleCreatedAt: testBundle.createdAt,
+  encrypted: true,
+})
+
+const testState = {
+  savedAt: 1,
+  bundleCreatedAt: testBundle.createdAt,
+  leafCount: 1,
+  totalSats: "32768",
+  cloudSyncedAt: null,
+}
+
+const cloudBackupState = {
+  status: BackupStatus.Completed,
+  method: BackupMethod.Cloud,
+  cloudPasswordProtected: true,
+}
+// A cloud seed backup saved WITHOUT an extra password: the seed-encrypted
+// bundle must never be uploaded next to it (PRD rule D9).
+const passwordlessCloudBackupState = {
+  status: BackupStatus.Completed,
+  method: BackupMethod.Cloud,
+}
+const manualBackupState = { status: BackupStatus.Completed, method: BackupMethod.Manual }
+
+const refreshParams = {
+  accountId: ACCOUNT_ID,
+  network: Network.Mainnet,
+  mnemonic: "mnemonic",
+  appVersion: "1.0.1",
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFetchRecoveryBundle.mockResolvedValue(testBundle)
+  mockReadRecoveryBundleState.mockResolvedValue(null)
+  mockAttemptSilentCloudUpload.mockResolvedValue({ success: true })
+  // Cloud sync opted in by default here; the opt-out cases flip it per test.
+  mockReadRecoveryBundleSettings.mockResolvedValue({
+    autoRefresh: true,
+    cloudSync: true,
+  })
+  mockParseBundleBackupMetadata.mockImplementation((raw: string) => {
+    const parsed = JSON.parse(raw)
+    return {
+      network: parsed.network,
+      walletIdentityPublicKey: parsed.walletIdentityPublicKey,
+      bundleCreatedAt: parsed.bundleCreatedAt,
+    }
+  })
+})
+
+describe("refreshRecoveryBundle cloud gating", () => {
+  it("uploads to the cloud when sync is opted in and the cloud seed backup is password-protected", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(result.success).toBe(true)
+    expect(mockSaveEncryptedBundleFile).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Mainnet,
+      expect.any(String),
+    )
+    expect(mockAttemptSilentCloudUpload).toHaveBeenCalledWith(
+      expect.any(String),
+      "blink-spark-recovery-bundle-mainnet-02abcdef.json",
+    )
+  })
+
+  it("skips the cloud upload when the user has not opted in to cloud sync", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+    mockReadRecoveryBundleSettings.mockResolvedValue({
+      autoRefresh: true,
+      cloudSync: false,
+    })
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(result.success).toBe(true)
+    expect(mockSaveEncryptedBundleFile).toHaveBeenCalledTimes(1)
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("skips the cloud upload when the cloud seed backup has no password (D9)", async () => {
+    mockReadBackupStateFor.mockResolvedValue(passwordlessCloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(result.success).toBe(true)
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("skips the cloud upload when the seed backup is manual", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(result.success).toBe(true)
+    expect(mockSaveEncryptedBundleFile).toHaveBeenCalledTimes(1)
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("skips the cloud upload when no seed backup exists", async () => {
+    mockReadBackupStateFor.mockResolvedValue(null)
+
+    await refreshRecoveryBundle(refreshParams)
+
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("threads the network into every state read and write", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    await refreshRecoveryBundle({ ...refreshParams, network: Network.Regtest })
+
+    expect(mockSaveEncryptedBundleFile).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Regtest,
+      expect.any(String),
+    )
+    expect(mockReadRecoveryBundleState).toHaveBeenCalledWith(ACCOUNT_ID, Network.Regtest)
+    expect(mockWriteRecoveryBundleState).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Regtest,
+      expect.objectContaining({ leafCount: 1, totalSats: "32768" }),
+    )
+  })
+
+  it("shares a single in-flight run between concurrent callers", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    const [first, second] = await Promise.all([
+      refreshRecoveryBundle(refreshParams),
+      refreshRecoveryBundle(refreshParams),
+    ])
+
+    expect(mockFetchRecoveryBundle).toHaveBeenCalledTimes(1)
+    expect(first).toBe(second)
+  })
+
+  it("keys the in-flight run per network: same-network callers share, different networks run separately", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    const mainnetFirst = refreshRecoveryBundle(refreshParams)
+    const mainnetSecond = refreshRecoveryBundle(refreshParams)
+    const regtest = refreshRecoveryBundle({ ...refreshParams, network: Network.Regtest })
+
+    // Same account + same network coalesce; a different network on the same
+    // account must not be handed the other network's in-flight run.
+    expect(mainnetSecond).toBe(mainnetFirst)
+    expect(regtest).not.toBe(mainnetFirst)
+
+    await Promise.all([mainnetFirst, mainnetSecond, regtest])
+
+    expect(mockFetchRecoveryBundle).toHaveBeenCalledTimes(2)
+    expect(mockFetchRecoveryBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ network: Network.Mainnet }),
+    )
+    expect(mockFetchRecoveryBundle).toHaveBeenCalledWith(
+      expect.objectContaining({ network: Network.Regtest }),
+    )
+  })
+
+  it("preserves the previous cloudSyncedAt in the written state and returns the post-sync re-read", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+    const priorCloudSyncedAt = 1_752_000_000_000
+    const previousState = { ...testState, cloudSyncedAt: priorCloudSyncedAt }
+    const postSyncState = {
+      ...testState,
+      savedAt: 1_752_300_999_999,
+      cloudSyncedAt: priorCloudSyncedAt,
+    }
+    mockReadRecoveryBundleState
+      .mockResolvedValueOnce(previousState) // pre-write read of the previous state
+      .mockResolvedValueOnce(postSyncState) // re-read after the cloud sync
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    // Exact written object: cloudSyncedAt must carry over from the previous
+    // state, not be reset to null on every refresh.
+    expect(mockWriteRecoveryBundleState).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Mainnet,
+      {
+        savedAt: expect.any(Number),
+        bundleCreatedAt: testBundle.createdAt,
+        leafCount: 1,
+        totalSats: "32768",
+        cloudSyncedAt: priorCloudSyncedAt,
+      },
+    )
+    // The returned state is the post-sync re-read (identity, not a
+    // structurally similar locally-built object).
+    expect(result).toEqual({ success: true, state: postSyncState })
+    if (result.success) expect(result.state).toBe(postSyncState)
+  })
+
+  it("resolves { success: false, error } instead of throwing when the fetch rejects", async () => {
+    const failure = new Error("operators unreachable")
+    mockFetchRecoveryBundle.mockRejectedValue(failure)
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(result).toEqual({ success: false, error: failure })
+    expect(mockSaveEncryptedBundleFile).not.toHaveBeenCalled()
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+
+  it("still reports success when the post-save cloud sync step throws", async () => {
+    // The bundle and state are already persisted; a failure in the cloud step
+    // (here: the settings read inside isCloudSyncAllowedFor) must be recorded
+    // separately, not flip the refresh result to failed.
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    const syncFailure = new Error("AsyncStorage unavailable")
+    // The only settings read in a refresh happens inside the cloud step
+    // (isCloudSyncAllowedFor); rejecting it makes that step throw after the
+    // bundle and state were already persisted.
+    mockReadRecoveryBundleSettings.mockRejectedValueOnce(syncFailure)
+
+    const result = await refreshRecoveryBundle(refreshParams)
+
+    expect(mockSaveEncryptedBundleFile).toHaveBeenCalledTimes(1)
+    expect(mockWriteRecoveryBundleState).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.state).toMatchObject({ leafCount: 1, totalSats: "32768" })
+    }
+    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
+      syncFailure,
+      "recovery-bundle-cloud-sync",
+    )
+  })
+})
+
+describe("account deletion vs in-flight refresh", () => {
+  // Module-level marker state persists for the process lifetime, so each test
+  // uses its own account id.
+  it("refuses to start a refresh for a deleted account", async () => {
+    const accountId = "acct-deleted-before-start"
+    markAccountDeletedForRefresh(accountId)
+
+    const result = await refreshRecoveryBundle({ ...refreshParams, accountId })
+
+    expect(result.success).toBe(false)
+    expect(mockFetchRecoveryBundle).not.toHaveBeenCalled()
+    expect(mockSaveEncryptedBundleFile).not.toHaveBeenCalled()
+  })
+
+  it("does not persist a refresh whose account was deleted mid-fetch", async () => {
+    const accountId = "acct-deleted-mid-fetch"
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+    let releaseFetch: (bundle: unknown) => void = () => {}
+    mockFetchRecoveryBundle.mockReturnValue(
+      new Promise((resolve) => {
+        releaseFetch = resolve
+      }),
+    )
+
+    const run = refreshRecoveryBundle({ ...refreshParams, accountId })
+    markAccountDeletedForRefresh(accountId)
+    releaseFetch(testBundle)
+    const result = await run
+
+    expect(result.success).toBe(false)
+    expect(mockSaveEncryptedBundleFile).not.toHaveBeenCalled()
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+
+  it("unmarking after the post-deletion re-sweep lets refreshes run again (set stays bounded)", async () => {
+    const accountId = "acct-unmarked"
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    markAccountDeletedForRefresh(accountId)
+    const blocked = await refreshRecoveryBundle({ ...refreshParams, accountId })
+    expect(blocked.success).toBe(false)
+
+    unmarkAccountDeletedForRefresh(accountId)
+    const allowed = await refreshRecoveryBundle({ ...refreshParams, accountId })
+    expect(allowed.success).toBe(true)
+    expect(mockFetchRecoveryBundle).toHaveBeenCalledTimes(1)
+  })
+
+  it("waitForRefreshesToSettle resolves only after the account's in-flight run finishes", async () => {
+    const accountId = "acct-settle"
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+    let releaseFetch: (bundle: unknown) => void = () => {}
+    mockFetchRecoveryBundle.mockReturnValue(
+      new Promise((resolve) => {
+        releaseFetch = resolve
+      }),
+    )
+
+    const run = refreshRecoveryBundle({ ...refreshParams, accountId })
+    let settled = false
+    const settle = waitForRefreshesToSettle(accountId).then(() => {
+      settled = true
+    })
+
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    releaseFetch(testBundle)
+    await run
+    await settle
+    expect(settled).toBe(true)
+  })
+})
+
+describe("syncExistingBundleToCloud", () => {
+  it("does nothing without a cloud seed backup", async () => {
+    mockReadBackupStateFor.mockResolvedValue(manualBackupState)
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockLoadEncryptedBundleFile).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when cloud sync is not opted in", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockReadRecoveryBundleSettings.mockResolvedValue({
+      autoRefresh: true,
+      cloudSync: false,
+    })
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockLoadEncryptedBundleFile).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when the cloud seed backup is not password-protected (D9)", async () => {
+    mockReadBackupStateFor.mockResolvedValue(passwordlessCloudBackupState)
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockLoadEncryptedBundleFile).not.toHaveBeenCalled()
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when no bundle is saved yet", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(null)
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockLoadEncryptedBundleFile).toHaveBeenCalledWith(ACCOUNT_ID, Network.Mainnet)
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+  })
+
+  it("uploads the saved payload and records cloudSyncedAt", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+    mockReadRecoveryBundleState.mockResolvedValue(testState)
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(true)
+    expect(mockWriteRecoveryBundleState).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Mainnet,
+      expect.objectContaining({ cloudSyncedAt: expect.any(Number) }),
+    )
+  })
+
+  it("records a crashlytics error and returns false when the saved payload no longer parses", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue("corrupt-on-disk")
+    mockParseBundleBackupMetadata.mockReturnValue(null)
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(expect.any(Error))
+    expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+
+  it("reports failure without stamping cloudSyncedAt when the upload fails", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+    mockAttemptSilentCloudUpload.mockResolvedValue({ success: false, reason: "auth" })
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+    expect(mockCrashlyticsLog).toHaveBeenCalledWith(expect.stringContaining("auth"))
+    // Auth failures are expected (cloud never linked): breadcrumb only.
+    expect(mockCrashlyticsRecordError).not.toHaveBeenCalled()
+  })
+
+  it("records the original error for a non-auth upload failure", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+    const providerError = new Error("iCloud write rejected")
+    mockAttemptSilentCloudUpload.mockResolvedValue({
+      success: false,
+      reason: "unknown",
+      error: providerError,
+    })
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    // A systemic provider failure must surface as a standalone Crashlytics
+    // event carrying the original error, not just a breadcrumb reason enum.
+    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
+      providerError,
+      "recovery-bundle-cloud-sync",
+    )
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+})
+
+describe("markCloudSynced", () => {
+  it("stamps cloudSyncedAt on the existing state", async () => {
+    mockReadRecoveryBundleState.mockResolvedValue(testState)
+
+    const next = await markCloudSynced(ACCOUNT_ID, Network.Mainnet)
+
+    expect(mockReadRecoveryBundleState).toHaveBeenCalledWith(ACCOUNT_ID, Network.Mainnet)
+    expect(next).toEqual({ ...testState, cloudSyncedAt: expect.any(Number) })
+    expect(mockWriteRecoveryBundleState).toHaveBeenCalledWith(
+      ACCOUNT_ID,
+      Network.Mainnet,
+      next,
+    )
+  })
+
+  it("returns null and writes nothing when no state exists", async () => {
+    mockReadRecoveryBundleState.mockResolvedValue(null)
+
+    expect(await markCloudSynced(ACCOUNT_ID, Network.Mainnet)).toBeNull()
+    expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+})
+
+describe("isBundleFresh", () => {
+  const MAX_AGE_MS = 24 * 60 * 60 * 1000
+  const NOW = 1_752_300_000_000
+
+  const stateSavedAt = (savedAt: number) => ({ ...testState, savedAt })
+
+  it("is false when no state is saved", () => {
+    expect(isBundleFresh(null, NOW, MAX_AGE_MS)).toBe(false)
+  })
+
+  it("is true when the bundle is younger than the max age", () => {
+    expect(isBundleFresh(stateSavedAt(NOW - MAX_AGE_MS + 1), NOW, MAX_AGE_MS)).toBe(true)
+  })
+
+  it("is false exactly at the max age threshold", () => {
+    expect(isBundleFresh(stateSavedAt(NOW - MAX_AGE_MS), NOW, MAX_AGE_MS)).toBe(false)
+  })
+
+  it("is false when the bundle is older than the max age", () => {
+    expect(isBundleFresh(stateSavedAt(NOW - MAX_AGE_MS - 1), NOW, MAX_AGE_MS)).toBe(false)
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/refresh.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/refresh.spec.ts
@@ -9,12 +9,20 @@ const mockLoadEncryptedBundleFile = jest.fn()
 const mockReadRecoveryBundleState = jest.fn()
 const mockWriteRecoveryBundleState = jest.fn()
 const mockParseBundleBackupMetadata = jest.fn()
-const mockCrashlyticsLog = jest.fn()
-const mockCrashlyticsRecordError = jest.fn()
+const mockRecordAppError = jest.fn()
 
+// The reporting boundary is mocked (not crashlytics underneath it) so the
+// expected/dedupKey classification is asserted directly, and because
+// recordAppError's module-level dedup set would swallow repeat asserts
+// across tests. crashlytics stays mocked for the requireActual import below.
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
-  log: (...args: string[]) => mockCrashlyticsLog(...args),
-  recordError: (...args: Error[]) => mockCrashlyticsRecordError(...args),
+  log: jest.fn(),
+  recordError: jest.fn(),
+}))
+
+jest.mock("@app/utils/error-reporting", () => ({
+  ...jest.requireActual("@app/utils/error-reporting"),
+  recordAppError: (...args: unknown[]) => mockRecordAppError(...args),
 }))
 
 jest.mock("@app/self-custodial/recovery-bundle/exporter", () => ({
@@ -321,10 +329,9 @@ describe("refreshRecoveryBundle cloud gating", () => {
     if (result.success) {
       expect(result.state).toMatchObject({ leafCount: 1, totalSats: "32768" })
     }
-    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
-      syncFailure,
-      "recovery-bundle-cloud-sync",
-    )
+    expect(mockRecordAppError).toHaveBeenCalledWith(syncFailure, {
+      dedupKey: "recovery-bundle-cloud-sync-step",
+    })
   })
 })
 
@@ -451,13 +458,15 @@ describe("syncExistingBundleToCloud", () => {
     )
   })
 
-  it("records a crashlytics error and returns false when the saved payload no longer parses", async () => {
+  it("records an app error and returns false when the saved payload no longer parses", async () => {
     mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
     mockLoadEncryptedBundleFile.mockResolvedValue("corrupt-on-disk")
     mockParseBundleBackupMetadata.mockReturnValue(null)
 
     expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
-    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(expect.any(Error))
+    expect(mockRecordAppError).toHaveBeenCalledWith(expect.any(Error), {
+      dedupKey: "recovery-bundle-corrupt-payload",
+    })
     expect(mockAttemptSilentCloudUpload).not.toHaveBeenCalled()
     expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
   })
@@ -469,12 +478,14 @@ describe("syncExistingBundleToCloud", () => {
 
     expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
     expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
-    expect(mockCrashlyticsLog).toHaveBeenCalledWith(expect.stringContaining("auth"))
-    // Auth failures are expected (cloud never linked): breadcrumb only.
-    expect(mockCrashlyticsRecordError).not.toHaveBeenCalled()
+    // No usable cloud session is a user/device state: expected, never a defect.
+    expect(mockRecordAppError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("auth") }),
+      { expected: true, dedupKey: "recovery-bundle-cloud-sync" },
+    )
   })
 
-  it("records the original error for a non-auth upload failure", async () => {
+  it("records the original error as a defect for an unclassified upload failure", async () => {
     mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
     mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
     const providerError = new Error("iCloud write rejected")
@@ -485,13 +496,32 @@ describe("syncExistingBundleToCloud", () => {
     })
 
     expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
-    // A systemic provider failure must surface as a standalone Crashlytics
-    // event carrying the original error, not just a breadcrumb reason enum.
-    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
-      providerError,
-      "recovery-bundle-cloud-sync",
-    )
+    // A systemic provider failure must reach the boundary as the original
+    // error, unexpected, so it records as a standalone non-fatal.
+    expect(mockRecordAppError).toHaveBeenCalledWith(providerError, {
+      expected: false,
+      dedupKey: "recovery-bundle-cloud-sync",
+    })
     expect(mockWriteRecoveryBundleState).not.toHaveBeenCalled()
+  })
+
+  it("treats a transient network failure as expected, not a defect", async () => {
+    mockReadBackupStateFor.mockResolvedValue(cloudBackupState)
+    mockLoadEncryptedBundleFile.mockResolvedValue(savedPayload)
+    const networkError = new Error("Drive network error: request timed out")
+    mockAttemptSilentCloudUpload.mockResolvedValue({
+      success: false,
+      reason: "transient",
+      error: networkError,
+    })
+
+    expect(await syncExistingBundleToCloud(ACCOUNT_ID, Network.Mainnet)).toBe(false)
+    // The opening scenario: a dropped connection during the post-payment
+    // upload must not file a non-fatal defect for every user on a flaky link.
+    expect(mockRecordAppError).toHaveBeenCalledWith(networkError, {
+      expected: true,
+      dedupKey: "recovery-bundle-cloud-sync",
+    })
   })
 })
 

--- a/__tests__/self-custodial/recovery-bundle/settings.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/settings.spec.ts
@@ -1,0 +1,98 @@
+import AsyncStorage from "@react-native-async-storage/async-storage"
+
+import {
+  defaultRecoveryBundleSettings,
+  readRecoveryBundleSettings,
+  removeRecoveryBundleSettings,
+  writeRecoveryBundleSettings,
+} from "@app/self-custodial/recovery-bundle/settings"
+
+// In-memory AsyncStorage so the per-account keys are exercised through real
+// read-after-write behavior instead of per-call stubs (same pattern as
+// storage.spec.ts).
+jest.mock("@react-native-async-storage/async-storage", () => {
+  const store = new Map<string, string>()
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (key: string) => store.get(key) ?? null,
+      setItem: async (key: string, value: string) => {
+        store.set(key, value)
+      },
+      removeItem: async (key: string) => {
+        store.delete(key)
+      },
+      clear: async () => {
+        store.clear()
+      },
+    },
+  }
+})
+
+const ACCOUNT_ID = "acct-1"
+const OTHER_ACCOUNT_ID = "acct-2"
+
+beforeEach(async () => {
+  await AsyncStorage.clear()
+})
+
+describe("recovery bundle settings", () => {
+  it("defaults to automatic refresh on and cloud sync off", async () => {
+    const settings = await readRecoveryBundleSettings(ACCOUNT_ID)
+
+    // These defaults are product rules (PRD 4.1): refresh is opt-out, cloud
+    // sync is opt-in. Flipping either default is a product decision.
+    expect(settings).toEqual({ autoRefresh: true, cloudSync: false })
+    expect(defaultRecoveryBundleSettings).toEqual({
+      autoRefresh: true,
+      cloudSync: false,
+    })
+  })
+
+  it("round-trips written settings per account", async () => {
+    await writeRecoveryBundleSettings(ACCOUNT_ID, {
+      autoRefresh: false,
+      cloudSync: true,
+    })
+
+    expect(await readRecoveryBundleSettings(ACCOUNT_ID)).toEqual({
+      autoRefresh: false,
+      cloudSync: true,
+    })
+    // Another account keeps the defaults.
+    expect(await readRecoveryBundleSettings(OTHER_ACCOUNT_ID)).toEqual(
+      defaultRecoveryBundleSettings,
+    )
+  })
+
+  it("degrades corrupted stored data to the defaults", async () => {
+    await AsyncStorage.setItem(`recoveryBundleSettings:${ACCOUNT_ID}`, "not-json{")
+
+    expect(await readRecoveryBundleSettings(ACCOUNT_ID)).toEqual(
+      defaultRecoveryBundleSettings,
+    )
+  })
+
+  it("fills missing or mistyped fields with the defaults", async () => {
+    await AsyncStorage.setItem(
+      `recoveryBundleSettings:${ACCOUNT_ID}`,
+      JSON.stringify({ cloudSync: "yes" }),
+    )
+
+    expect(await readRecoveryBundleSettings(ACCOUNT_ID)).toEqual(
+      defaultRecoveryBundleSettings,
+    )
+  })
+
+  it("remove resets the account to the defaults", async () => {
+    await writeRecoveryBundleSettings(ACCOUNT_ID, {
+      autoRefresh: false,
+      cloudSync: true,
+    })
+    await removeRecoveryBundleSettings(ACCOUNT_ID)
+
+    expect(await readRecoveryBundleSettings(ACCOUNT_ID)).toEqual(
+      defaultRecoveryBundleSettings,
+    )
+  })
+})

--- a/__tests__/self-custodial/recovery-bundle/storage.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/storage.spec.ts
@@ -155,14 +155,27 @@ describe("recovery-bundle storage", () => {
       )
     })
 
-    it("recovers the payload from a stranded tmp file (crash between unlink and rename)", async () => {
+    it("recovers the payload from a stranded tmp file without renaming it", async () => {
       fsState.files.set(MAINNET_TMP_PATH, "payload-from-tmp")
 
       expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBe(
         "payload-from-tmp",
       )
-      // The interrupted rename was finished, not just read around.
-      expect(fsState.files.get(MAINNET_PATH)).toBe("payload-from-tmp")
+      // Read in place: a rename here could steal a concurrent save's own
+      // rename out of its unlink-to-move window. Repair belongs to save/delete.
+      expect(fsState.files.has(MAINNET_PATH)).toBe(false)
+      expect(fsState.files.get(MAINNET_TMP_PATH)).toBe("payload-from-tmp")
+    })
+
+    it("a save after a stranded-tmp load still lands cleanly and sweeps the tmp", async () => {
+      fsState.files.set(MAINNET_TMP_PATH, "payload-from-tmp")
+      await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)
+
+      await saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-new")
+
+      expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBe(
+        "payload-new",
+      )
       expect(fsState.files.has(MAINNET_TMP_PATH)).toBe(false)
     })
 

--- a/__tests__/self-custodial/recovery-bundle/storage.spec.ts
+++ b/__tests__/self-custodial/recovery-bundle/storage.spec.ts
@@ -1,0 +1,271 @@
+import { it } from "@jest/globals"
+
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { Network } from "@breeztech/breez-sdk-spark-react-native"
+
+import {
+  deleteRecoveryBundleFile,
+  loadEncryptedBundleFile,
+  readRecoveryBundleState,
+  recoveryBundleDirFor,
+  recoveryBundlePathFor,
+  removeRecoveryBundleState,
+  saveEncryptedBundleFile,
+  writeRecoveryBundleState,
+  type RecoveryBundleState,
+} from "@app/self-custodial/recovery-bundle/storage"
+
+// In-memory AsyncStorage so the network-scoped keys are exercised through
+// real read-after-write behavior instead of per-call stubs.
+jest.mock("@react-native-async-storage/async-storage", () => {
+  const store = new Map<string, string>()
+  return {
+    __esModule: true,
+    default: {
+      getItem: async (key: string) => store.get(key) ?? null,
+      setItem: async (key: string, value: string) => {
+        store.set(key, value)
+      },
+      removeItem: async (key: string) => {
+        store.delete(key)
+      },
+      clear: async () => {
+        store.clear()
+      },
+    },
+  }
+})
+
+// In-memory filesystem with iOS moveFile semantics (refuses to overwrite) so
+// the atomic write-then-rename path actually executes instead of being
+// stubbed away.
+type FsMockState = {
+  files: Map<string, string>
+  mkdirCalls: Array<{ path: string; options?: Record<string, unknown> }>
+  failNextWriteFor: string | null
+}
+
+jest.mock("react-native-fs", () => {
+  const state: FsMockState = {
+    files: new Map<string, string>(),
+    mkdirCalls: [],
+    failNextWriteFor: null,
+  }
+  return {
+    __esModule: true,
+    __fsState: state,
+    DocumentDirectoryPath: "/test/documents",
+    default: {
+      mkdir: async (path: string, options?: Record<string, unknown>) => {
+        state.mkdirCalls.push({ path, options })
+      },
+      writeFile: async (path: string, contents: string) => {
+        if (state.failNextWriteFor === path) {
+          state.failNextWriteFor = null
+          throw new Error(`ENOSPC: simulated write failure for ${path}`)
+        }
+        state.files.set(path, contents)
+      },
+      readFile: async (path: string) => {
+        const contents = state.files.get(path)
+        if (contents === undefined) throw new Error(`ENOENT: ${path}`)
+        return contents
+      },
+      exists: async (path: string) => state.files.has(path),
+      unlink: async (path: string) => {
+        if (!state.files.delete(path)) throw new Error(`ENOENT: ${path}`)
+      },
+      moveFile: async (from: string, to: string) => {
+        const contents = state.files.get(from)
+        if (contents === undefined) throw new Error(`ENOENT: ${from}`)
+        if (state.files.has(to)) throw new Error(`EEXIST: ${to}`)
+        state.files.set(to, contents)
+        state.files.delete(from)
+      },
+    },
+  }
+})
+
+const fsState = (jest.requireMock("react-native-fs") as { __fsState: FsMockState })
+  .__fsState
+
+const ACCOUNT_ID = "acct-1"
+const MAINNET_STATE_KEY = `recoveryBundleState:mainnet:${ACCOUNT_ID}`
+const REGTEST_STATE_KEY = `recoveryBundleState:regtest:${ACCOUNT_ID}`
+
+const makeState = (
+  overrides: Partial<Record<keyof RecoveryBundleState, unknown>> = {},
+): RecoveryBundleState =>
+  ({
+    savedAt: 1_752_300_000_000,
+    bundleCreatedAt: "2026-07-12T00:00:00.000Z",
+    leafCount: 3,
+    totalSats: "32768",
+    cloudSyncedAt: null,
+    ...overrides,
+  }) as RecoveryBundleState
+
+describe("recovery-bundle storage", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    await AsyncStorage.clear()
+    fsState.files.clear()
+    fsState.mkdirCalls.length = 0
+    fsState.failNextWriteFor = null
+  })
+
+  describe("encrypted bundle file", () => {
+    const MAINNET_PATH = "/test/documents/recovery-bundle-mainnet/acct-1.json"
+    const MAINNET_TMP_PATH = `${MAINNET_PATH}.tmp`
+
+    it("round-trips save and load", async () => {
+      await saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-1")
+
+      expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBe("payload-1")
+      expect(fsState.files.get(MAINNET_PATH)).toBe("payload-1")
+      // The rename completed: no tmp file left behind.
+      expect(fsState.files.has(MAINNET_TMP_PATH)).toBe(false)
+    })
+
+    it("excludes the bundle directory from iOS device backups", async () => {
+      // D9 adjacency: an iOS device backup would put the seed-decryptable
+      // bundle in the same Apple account as a passwordless iCloud seed backup.
+      await saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-1")
+
+      expect(fsState.mkdirCalls).toEqual([
+        {
+          path: "/test/documents/recovery-bundle-mainnet",
+          options: { NSURLIsExcludedFromBackupKey: true },
+        },
+      ])
+    })
+
+    it("keeps the previous bundle intact when the new write fails", async () => {
+      await saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-old")
+
+      fsState.failNextWriteFor = MAINNET_TMP_PATH
+      await expect(
+        saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-new"),
+      ).rejects.toThrow(/ENOSPC/)
+
+      // The interrupted write hit only the tmp sibling; the last good copy
+      // is exactly what unilateral exit needs when re-fetching is impossible.
+      expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBe(
+        "payload-old",
+      )
+    })
+
+    it("recovers the payload from a stranded tmp file (crash between unlink and rename)", async () => {
+      fsState.files.set(MAINNET_TMP_PATH, "payload-from-tmp")
+
+      expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBe(
+        "payload-from-tmp",
+      )
+      // The interrupted rename was finished, not just read around.
+      expect(fsState.files.get(MAINNET_PATH)).toBe("payload-from-tmp")
+      expect(fsState.files.has(MAINNET_TMP_PATH)).toBe(false)
+    })
+
+    it("returns null when no bundle was ever saved", async () => {
+      expect(await loadEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet)).toBeNull()
+    })
+
+    it("deletes the bundle file and any stranded tmp sibling", async () => {
+      await saveEncryptedBundleFile(ACCOUNT_ID, Network.Mainnet, "payload-1")
+      fsState.files.set(MAINNET_TMP_PATH, "stranded")
+
+      await deleteRecoveryBundleFile(ACCOUNT_ID, Network.Mainnet)
+
+      expect(fsState.files.has(MAINNET_PATH)).toBe(false)
+      expect(fsState.files.has(MAINNET_TMP_PATH)).toBe(false)
+    })
+
+    it("delete is a no-op when nothing exists", async () => {
+      await expect(
+        deleteRecoveryBundleFile(ACCOUNT_ID, Network.Mainnet),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe("refresh/sync state keying", () => {
+    it("keys the state by network so a mainnet write is invisible on regtest", async () => {
+      const state = makeState()
+      await writeRecoveryBundleState(ACCOUNT_ID, Network.Mainnet, state)
+
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Regtest)).toBeNull()
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Mainnet)).toEqual(state)
+    })
+
+    it("persists under the stable per-network key format", async () => {
+      await writeRecoveryBundleState(ACCOUNT_ID, Network.Mainnet, makeState())
+
+      expect(await AsyncStorage.getItem(MAINNET_STATE_KEY)).toBe(
+        JSON.stringify(makeState()),
+      )
+    })
+
+    it("removes only the addressed network's state", async () => {
+      await writeRecoveryBundleState(ACCOUNT_ID, Network.Mainnet, makeState())
+      await writeRecoveryBundleState(ACCOUNT_ID, Network.Regtest, makeState())
+
+      await removeRecoveryBundleState(ACCOUNT_ID, Network.Regtest)
+
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Regtest)).toBeNull()
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Mainnet)).toEqual(
+        makeState(),
+      )
+      expect(await AsyncStorage.getItem(REGTEST_STATE_KEY)).toBeNull()
+    })
+  })
+
+  describe("readRecoveryBundleState validation", () => {
+    it("returns null when nothing is stored", async () => {
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Mainnet)).toBeNull()
+    })
+
+    it("returns null for corrupt JSON", async () => {
+      await AsyncStorage.setItem(MAINNET_STATE_KEY, "{not json")
+
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Mainnet)).toBeNull()
+    })
+
+    it.each([
+      { name: "missing savedAt", overrides: { savedAt: undefined } },
+      { name: "string savedAt", overrides: { savedAt: "1752300000000" } },
+      { name: "missing leafCount", overrides: { leafCount: undefined } },
+      { name: "string leafCount", overrides: { leafCount: "3" } },
+      { name: "missing totalSats", overrides: { totalSats: undefined } },
+      { name: "numeric totalSats", overrides: { totalSats: 32768 } },
+      { name: "missing bundleCreatedAt", overrides: { bundleCreatedAt: undefined } },
+      { name: "numeric bundleCreatedAt", overrides: { bundleCreatedAt: 1752300000000 } },
+      { name: "string cloudSyncedAt", overrides: { cloudSyncedAt: "yesterday" } },
+      { name: "missing cloudSyncedAt", overrides: { cloudSyncedAt: undefined } },
+    ])("returns null for a stored state with $name", async ({ overrides }) => {
+      // JSON.stringify drops undefined values, so "missing" cases persist
+      // without the field at all.
+      await AsyncStorage.setItem(MAINNET_STATE_KEY, JSON.stringify(makeState(overrides)))
+
+      expect(await readRecoveryBundleState(ACCOUNT_ID, Network.Mainnet)).toBeNull()
+    })
+  })
+
+  describe("bundle file paths", () => {
+    it("separates the bundle directories per network", () => {
+      expect(recoveryBundleDirFor(Network.Mainnet)).toBe(
+        "/test/documents/recovery-bundle-mainnet",
+      )
+      expect(recoveryBundleDirFor(Network.Regtest)).toBe(
+        "/test/documents/recovery-bundle-regtest",
+      )
+    })
+
+    it("places the same account's bundle in different files per network", () => {
+      expect(recoveryBundlePathFor(ACCOUNT_ID, Network.Mainnet)).toBe(
+        "/test/documents/recovery-bundle-mainnet/acct-1.json",
+      )
+      expect(recoveryBundlePathFor(ACCOUNT_ID, Network.Regtest)).toBe(
+        "/test/documents/recovery-bundle-regtest/acct-1.json",
+      )
+    })
+  })
+})

--- a/__tests__/utils/google-drive-session.spec.ts
+++ b/__tests__/utils/google-drive-session.spec.ts
@@ -1,0 +1,106 @@
+const mockClearCachedAccessToken = jest.fn()
+const mockGetTokens = jest.fn()
+
+jest.mock("@react-native-google-signin/google-signin", () => ({
+  GoogleSignin: {
+    clearCachedAccessToken: (...args: unknown[]) => mockClearCachedAccessToken(...args),
+    getTokens: (...args: unknown[]) => mockGetTokens(...args),
+  },
+}))
+
+import { CloudBackupErrorReason } from "@app/types/cloud-backup"
+import { DriveError } from "@app/utils/google-drive-client"
+import { callDrive, isDeadAccessToken } from "@app/utils/google-drive-session"
+
+const deadToken = () =>
+  new DriveError(CloudBackupErrorReason.Auth, "Drive query failed (401)", 401)
+
+describe("isDeadAccessToken", () => {
+  it("is true only for a DriveError carrying a 401 status", () => {
+    expect(isDeadAccessToken(deadToken())).toBe(true)
+    // 403 shares the auth reason but means a withheld permission - a new
+    // token cannot fix it, so it must not count as a dead token.
+    expect(
+      isDeadAccessToken(
+        new DriveError(CloudBackupErrorReason.Auth, "Drive query failed (403)", 403),
+      ),
+    ).toBe(false)
+    expect(
+      isDeadAccessToken(new DriveError(CloudBackupErrorReason.Transient, "network")),
+    ).toBe(false)
+    expect(isDeadAccessToken(new Error("Drive query failed (401)"))).toBe(false)
+  })
+})
+
+describe("callDrive", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockClearCachedAccessToken.mockResolvedValue(undefined)
+    mockGetTokens.mockResolvedValue({ accessToken: "fresh-token" })
+  })
+
+  it("passes the token through and returns the call's value on success", async () => {
+    const call = jest.fn().mockResolvedValue("file-id")
+
+    const result = await callDrive("token-1", call)
+
+    expect(result).toEqual({ value: "file-id", token: "token-1" })
+    expect(call).toHaveBeenCalledWith("token-1")
+    expect(mockClearCachedAccessToken).not.toHaveBeenCalled()
+  })
+
+  it("clears a dead cached token on a 401 and retries once with the refreshed one", async () => {
+    const call = jest.fn().mockRejectedValueOnce(deadToken()).mockResolvedValue("file-id")
+
+    const result = await callDrive("dead-token", call)
+
+    // The refreshed token is returned so the caller holds it for the rest of
+    // the session instead of replaying the dead one on the next call.
+    expect(result).toEqual({ value: "file-id", token: "fresh-token" })
+    expect(mockClearCachedAccessToken).toHaveBeenCalledWith("dead-token")
+    expect(call).toHaveBeenNthCalledWith(2, "fresh-token")
+  })
+
+  it("retries only once: a 401 with the refreshed token propagates", async () => {
+    const secondFailure = deadToken()
+    const call = jest
+      .fn()
+      .mockRejectedValueOnce(deadToken())
+      .mockRejectedValueOnce(secondFailure)
+
+    await expect(callDrive("dead-token", call)).rejects.toBe(secondFailure)
+    expect(call).toHaveBeenCalledTimes(2)
+    expect(mockClearCachedAccessToken).toHaveBeenCalledTimes(1)
+  })
+
+  it("rethrows a non-401 DriveError untouched without clearing the cache", async () => {
+    const forbidden = new DriveError(
+      CloudBackupErrorReason.Auth,
+      "Drive query failed (403)",
+      403,
+    )
+    const call = jest.fn().mockRejectedValue(forbidden)
+
+    await expect(callDrive("token-1", call)).rejects.toBe(forbidden)
+    expect(mockClearCachedAccessToken).not.toHaveBeenCalled()
+    expect(call).toHaveBeenCalledTimes(1)
+  })
+
+  it("rethrows a non-Drive error untouched", async () => {
+    const unrelated = new Error("boom")
+    const call = jest.fn().mockRejectedValue(unrelated)
+
+    await expect(callDrive("token-1", call)).rejects.toBe(unrelated)
+    expect(mockClearCachedAccessToken).not.toHaveBeenCalled()
+  })
+
+  it("keeps the original 401 when the token refresh itself fails", async () => {
+    // The 401 is the diagnosis; a failed refresh only says the retry never ran.
+    const original = deadToken()
+    const call = jest.fn().mockRejectedValue(original)
+    mockGetTokens.mockRejectedValue(new Error("refresh failed"))
+
+    await expect(callDrive("dead-token", call)).rejects.toBe(original)
+    expect(call).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/screens/self-custodial/onboarding/hooks/use-google-drive-backup.ts
+++ b/app/screens/self-custodial/onboarding/hooks/use-google-drive-backup.ts
@@ -25,6 +25,7 @@ import {
   downloadAppDataFile,
   DriveError,
 } from "@app/utils/google-drive-client"
+import { callDrive } from "@app/utils/google-drive-session"
 
 const DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
 
@@ -86,37 +87,6 @@ const signIn = async (): Promise<string> => {
   await ensureDriveScope(response)
   const { accessToken } = await GoogleSignin.getTokens()
   return accessToken
-}
-
-/** Not `reason`: 403 shares it but means a withheld permission, which a new token cannot fix. */
-const isDeadAccessToken = (err: unknown): boolean =>
-  err instanceof DriveError && err.status === 401
-
-/**
- * A revoked token stays in the sign-in cache, so the SDK keeps handing back the same dead
- * one. Clearing it forces a refresh, retried once. The working token comes back because the
- * caller holds it for the rest of the session.
- */
-const callDrive = async <T>(
-  token: string,
-  call: (token: string) => Promise<T>,
-): Promise<{ value: T; token: string }> => {
-  try {
-    return { value: await call(token), token }
-  } catch (err) {
-    if (!isDeadAccessToken(err)) throw err
-
-    let refreshed: string
-    try {
-      await GoogleSignin.clearCachedAccessToken(token)
-      refreshed = (await GoogleSignin.getTokens()).accessToken
-    } catch {
-      /** The 401 is the diagnosis; a failure to refresh only says the retry never ran. */
-      throw err
-    }
-
-    return { value: await call(refreshed), token: refreshed }
-  }
 }
 
 const DriveOperation = {

--- a/app/self-custodial/providers/backup-state.tsx
+++ b/app/self-custodial/providers/backup-state.tsx
@@ -62,8 +62,9 @@ export const completedMethodsOf = (state: BackupState | null): BackupMethod[] =>
 /** Spreads prev so fields this module doesn't know about survive the write. Note
  *  the two writers hand it different prevs: markBackupCompletedFor re-reads
  *  storage, while the provider merges against its in-memory state.
- *  cloudPasswordProtected is not carried over from prev — each completion
- *  declares its own, so it resets unless the caller passes it again. */
+ *  cloudPasswordProtected falls back to prev when this completion doesn't carry
+ *  one, so a manual or keychain completion doesn't erase what an earlier cloud
+ *  backup recorded. */
 const withCompletedMethod = (
   prev: BackupState | null,
   method: BackupMethod,
@@ -75,7 +76,7 @@ const withCompletedMethod = (
     status: BackupStatus.Completed,
     method,
     completedMethods: methods.includes(method) ? methods : [...methods, method],
-    cloudPasswordProtected: options?.cloudPasswordProtected,
+    cloudPasswordProtected: options?.cloudPasswordProtected ?? prev?.cloudPasswordProtected,
   }
 }
 

--- a/app/self-custodial/providers/backup-state.tsx
+++ b/app/self-custodial/providers/backup-state.tsx
@@ -37,11 +37,22 @@ type BackupMethod = (typeof BackupMethod)[keyof typeof BackupMethod]
 type BackupState = {
   status: BackupStatus
   method: BackupMethod | null
+  /**
+   * True when the cloud seed backup was encrypted with an extra user password.
+   * Absent for pre-existing states and non-cloud methods; treated as false, so
+   * bundle cloud sync stays unavailable until the user re-runs the cloud
+   * backup with a password.
+   */
+  cloudPasswordProtected?: boolean
+}
+
+export type BackupCompletedOptions = {
+  cloudPasswordProtected?: boolean
 }
 
 type BackupStateContextValue = {
   backupState: BackupState
-  setBackupCompleted: (method: BackupMethod) => void
+  setBackupCompleted: (method: BackupMethod, options?: BackupCompletedOptions) => void
   resetBackupState: () => void
 }
 
@@ -76,11 +87,38 @@ export const removeBackupStateFor = async (accountId: string): Promise<void> => 
   await AsyncStorage.removeItem(backupStateKeyFor(accountId))
 }
 
+/** Non-hook read for code that runs outside the provider (e.g. bundle sync). */
+export const readBackupStateFor = async (
+  accountId: string,
+): Promise<BackupState | null> => readBackupState(backupStateKeyFor(accountId))
+
+/**
+ * Single definition of "the seed is backed up to the cloud" - the gate the
+ * recovery-bundle cloud sync follows. Screen, refresh hook, and refresh core
+ * all use this so they cannot diverge on it.
+ */
+export const isCloudSeedBackupCompleted = (state: BackupState | null): boolean =>
+  state?.status === BackupStatus.Completed && state.method === BackupMethod.Cloud
+
+/**
+ * The gate for storing the seed-encrypted bundle in the cloud: the bundle must
+ * never sit next to an unencrypted seed (the co-located seed would decrypt it
+ * on the spot), so the cloud seed backup must carry an extra password. See the
+ * spark-unilateral-exit PRD in blink-specs (rule D9).
+ */
+export const isPasswordProtectedCloudSeedBackup = (state: BackupState | null): boolean =>
+  isCloudSeedBackupCompleted(state) && state?.cloudPasswordProtected === true
+
 export const markBackupCompletedFor = async (
   accountId: string,
   method: BackupMethod,
+  options?: BackupCompletedOptions,
 ): Promise<void> => {
-  const state: BackupState = { status: BackupStatus.Completed, method }
+  const state: BackupState = {
+    status: BackupStatus.Completed,
+    method,
+    cloudPasswordProtected: options?.cloudPasswordProtected,
+  }
   await AsyncStorage.setItem(backupStateKeyFor(accountId), JSON.stringify(state))
 }
 
@@ -125,8 +163,12 @@ export const BackupStateProvider: React.FC<React.PropsWithChildren> = ({ childre
   )
 
   const setBackupCompleted = useCallback(
-    (method: BackupMethod) => {
-      persist({ status: BackupStatus.Completed, method })
+    (method: BackupMethod, options?: BackupCompletedOptions) => {
+      persist({
+        status: BackupStatus.Completed,
+        method,
+        cloudPasswordProtected: options?.cloudPasswordProtected,
+      })
     },
     [persist],
   )

--- a/app/self-custodial/providers/backup-state.tsx
+++ b/app/self-custodial/providers/backup-state.tsx
@@ -40,6 +40,17 @@ type BackupState = {
    *  everything the user has done. */
   method: BackupMethod | null
   completedMethods?: BackupMethod[]
+  /**
+   * True when the cloud seed backup was encrypted with an extra user password.
+   * Absent for pre-existing states and non-cloud methods; treated as false, so
+   * bundle cloud sync stays unavailable until the user re-runs the cloud
+   * backup with a password.
+   */
+  cloudPasswordProtected?: boolean
+}
+
+export type BackupCompletedOptions = {
+  cloudPasswordProtected?: boolean
 }
 
 /** The fallback branch doubles as the migration for records persisted before
@@ -50,10 +61,13 @@ export const completedMethodsOf = (state: BackupState | null): BackupMethod[] =>
 
 /** Spreads prev so fields this module doesn't know about survive the write. Note
  *  the two writers hand it different prevs: markBackupCompletedFor re-reads
- *  storage, while the provider merges against its in-memory state. */
+ *  storage, while the provider merges against its in-memory state.
+ *  cloudPasswordProtected is not carried over from prev — each completion
+ *  declares its own, so it resets unless the caller passes it again. */
 const withCompletedMethod = (
   prev: BackupState | null,
   method: BackupMethod,
+  options?: BackupCompletedOptions,
 ): BackupState => {
   const methods = completedMethodsOf(prev)
   return {
@@ -61,12 +75,13 @@ const withCompletedMethod = (
     status: BackupStatus.Completed,
     method,
     completedMethods: methods.includes(method) ? methods : [...methods, method],
+    cloudPasswordProtected: options?.cloudPasswordProtected,
   }
 }
 
 type BackupStateContextValue = {
   backupState: BackupState
-  setBackupCompleted: (method: BackupMethod) => void
+  setBackupCompleted: (method: BackupMethod, options?: BackupCompletedOptions) => void
   resetBackupState: () => void
 }
 
@@ -109,13 +124,39 @@ export const removeBackupStateFor = async (accountId: string): Promise<void> => 
   await AsyncStorage.removeItem(backupStateKeyFor(accountId))
 }
 
+/** Non-hook read for code that runs outside the provider (e.g. bundle sync). */
+export const readBackupStateFor = async (
+  accountId: string,
+): Promise<BackupState | null> => readBackupState(backupStateKeyFor(accountId))
+
+/**
+ * Single definition of "the seed is backed up to the cloud" - the gate the
+ * recovery-bundle cloud sync follows. Screen, refresh hook, and refresh core
+ * all use this so they cannot diverge on it.
+ */
+export const isCloudSeedBackupCompleted = (state: BackupState | null): boolean =>
+  state?.status === BackupStatus.Completed && state.method === BackupMethod.Cloud
+
+/**
+ * The gate for storing the seed-encrypted bundle in the cloud: the bundle must
+ * never sit next to an unencrypted seed (the co-located seed would decrypt it
+ * on the spot), so the cloud seed backup must carry an extra password. See the
+ * spark-unilateral-exit PRD in blink-specs (rule D9).
+ */
+export const isPasswordProtectedCloudSeedBackup = (state: BackupState | null): boolean =>
+  isCloudSeedBackupCompleted(state) && state?.cloudPasswordProtected === true
+
 export const markBackupCompletedFor = async (
   accountId: string,
   method: BackupMethod,
+  options?: BackupCompletedOptions,
 ): Promise<void> => {
   const key = backupStateKeyFor(accountId)
   const prev = await readBackupState(key)
-  await AsyncStorage.setItem(key, JSON.stringify(withCompletedMethod(prev, method)))
+  await AsyncStorage.setItem(
+    key,
+    JSON.stringify(withCompletedMethod(prev, method, options)),
+  )
 }
 
 export const BackupStateProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
@@ -164,8 +205,8 @@ export const BackupStateProvider: React.FC<React.PropsWithChildren> = ({ childre
   )
 
   const setBackupCompleted = useCallback(
-    (method: BackupMethod) => {
-      persist(withCompletedMethod(backupState, method))
+    (method: BackupMethod, options?: BackupCompletedOptions) => {
+      persist(withCompletedMethod(backupState, method, options))
     },
     [persist, backupState],
   )

--- a/app/self-custodial/recovery-bundle/cloud.ts
+++ b/app/self-custodial/recovery-bundle/cloud.ts
@@ -15,6 +15,7 @@ import {
   findAppDataFile as driveFindAppDataFile,
   uploadAppDataFile as driveUploadAppDataFile,
 } from "@app/utils/google-drive-client"
+import { callDrive } from "@app/utils/google-drive-session"
 import {
   assertICloudAvailable,
   uploadAppDataFile as iCloudUploadAppDataFile,
@@ -67,8 +68,16 @@ export const attemptSilentCloudUpload = async (
 
     const accessToken = await silentDriveAccessToken()
     if (!accessToken) return { success: false, reason: CloudBackupErrorReason.Auth }
-    const existingId = await driveFindAppDataFile(fileName, accessToken)
-    await driveUploadAppDataFile({ content, fileName, accessToken, existingId })
+    // callDrive: the sign-in cache keeps handing back a token revoked
+    // out-of-band; on a 401 it clears the cache and retries once with a fresh
+    // token, so one revocation cannot permanently kill silent sync.
+    const { value: existingId, token: freshToken } = await callDrive(
+      accessToken,
+      (token) => driveFindAppDataFile(fileName, token),
+    )
+    await callDrive(freshToken, (token) =>
+      driveUploadAppDataFile({ content, fileName, accessToken: token, existingId }),
+    )
     return { success: true }
   } catch (err) {
     const reason =

--- a/app/self-custodial/recovery-bundle/cloud.ts
+++ b/app/self-custodial/recovery-bundle/cloud.ts
@@ -1,0 +1,80 @@
+/**
+ * Cloud sync for the encrypted recovery bundle. The event-driven refresh path
+ * must never pop UI, so Android only uploads when a silent Google sign-in
+ * succeeds (the user linked Drive before, e.g. for the seed backup); iCloud
+ * needs no interaction. The Recovery Backup screen offers the interactive
+ * session via the shared CloudBackupHook for first-time setup.
+ */
+
+import { Platform } from "react-native"
+
+import { GoogleSignin } from "@react-native-google-signin/google-signin"
+
+import { CloudBackupErrorReason } from "@app/types/cloud-backup"
+import {
+  findAppDataFile as driveFindAppDataFile,
+  uploadAppDataFile as driveUploadAppDataFile,
+} from "@app/utils/google-drive-client"
+import {
+  assertICloudAvailable,
+  uploadAppDataFile as iCloudUploadAppDataFile,
+} from "@app/utils/icloud-client"
+
+export const getRecoveryBundleFilenamePrefix = (network: string): string =>
+  `blink-spark-recovery-bundle-${network.toLowerCase()}-`
+
+export const getRecoveryBundleFilename = (
+  network: string,
+  walletIdentifier: string,
+): string => `${getRecoveryBundleFilenamePrefix(network)}${walletIdentifier}.json`
+
+const DRIVE_SCOPE = "https://www.googleapis.com/auth/drive.appdata"
+
+export type SilentCloudUploadResult =
+  | { success: true }
+  | {
+      success: false
+      reason: CloudBackupErrorReason
+      /** The thrown original, so callers can report a systemic failure with
+       * its real message/stack instead of just the mapped reason enum. */
+      error?: unknown
+    }
+
+const silentDriveAccessToken = async (): Promise<string | null> => {
+  GoogleSignin.configure({ scopes: [DRIVE_SCOPE] })
+  if (!GoogleSignin.getCurrentUser()) {
+    const silent = await GoogleSignin.signInSilently()
+    if (silent.type !== "success") return null
+  }
+  const { accessToken } = await GoogleSignin.getTokens()
+  return accessToken
+}
+
+/**
+ * Best-effort, non-interactive upload. Auth failures are expected (user never
+ * linked cloud backup) and reported as a reason, not thrown.
+ */
+export const attemptSilentCloudUpload = async (
+  content: string,
+  fileName: string,
+): Promise<SilentCloudUploadResult> => {
+  try {
+    if (Platform.OS === "ios") {
+      await assertICloudAvailable()
+      await iCloudUploadAppDataFile({ content, fileName })
+      return { success: true }
+    }
+
+    const accessToken = await silentDriveAccessToken()
+    if (!accessToken) return { success: false, reason: CloudBackupErrorReason.Auth }
+    const existingId = await driveFindAppDataFile(fileName, accessToken)
+    await driveUploadAppDataFile({ content, fileName, accessToken, existingId })
+    return { success: true }
+  } catch (err) {
+    const reason =
+      err && typeof err === "object" && "reason" in err
+        ? (err.reason as CloudBackupErrorReason)
+        : CloudBackupErrorReason.Unknown
+    return { success: false, reason, error: err }
+  }
+}

--- a/app/self-custodial/recovery-bundle/encryption.ts
+++ b/app/self-custodial/recovery-bundle/encryption.ts
@@ -1,0 +1,175 @@
+/**
+ * Encrypted wrapper for the recovery bundle at rest (device filesystem and
+ * cloud). The AES key is derived deterministically from the wallet's BIP39
+ * seed (HMAC-SHA256(seed, context), first 16 bytes), so the only secret needed
+ * to decrypt a backup is the seed itself - matching the unilateral-exit trust
+ * model where everything derives from the seed.
+ *
+ * Plaintext envelope fields are limited to what freshness checks and file
+ * matching need without the seed; balances and leaf details stay encrypted.
+ */
+
+import { decryptAesGcm, encryptAesGcm } from "@app/utils/crypto"
+
+import {
+  deriveBundleEncryptionKeyHex,
+  RECOVERY_BUNDLE_ENCRYPTION_CONTEXT,
+} from "./identity"
+import { RECOVERY_BUNDLE_SCHEMA, type RecoveryBundle } from "./types"
+
+export const RECOVERY_BUNDLE_BACKUP_SCHEMA = "blink.recovery-bundle-backup.v1"
+
+const CIPHER = "AES-128-GCM" as const
+const KEY_DERIVATION = "hmac-sha256-seed" as const
+const GCM_IV_LENGTH = 12
+
+export type RecoveryBundleBackupPayload = {
+  schema: typeof RECOVERY_BUNDLE_BACKUP_SCHEMA
+  encrypted: true
+  cipher: typeof CIPHER
+  /** key = first 16 bytes of HMAC-SHA256(bip39 seed, context), hex */
+  keyDerivation: typeof KEY_DERIVATION
+  context: typeof RECOVERY_BUNDLE_ENCRYPTION_CONTEXT
+  network: string
+  walletIdentityPublicKey: string
+  /** The wrapped bundle's createdAt, readable without decrypting. */
+  bundleCreatedAt: string
+  iv: string
+  data: string
+}
+
+export type RecoveryBundleBackupMetadata = {
+  network: string
+  walletIdentityPublicKey: string
+  bundleCreatedAt: string
+}
+
+export const RecoveryBundlePayloadErrorReason = {
+  InvalidPayload: "invalid-payload",
+  UnsupportedSchema: "unsupported-schema",
+  DecryptFailed: "decrypt-failed",
+  EnvelopeMismatch: "envelope-mismatch",
+} as const
+
+export type RecoveryBundlePayloadErrorReason =
+  (typeof RecoveryBundlePayloadErrorReason)[keyof typeof RecoveryBundlePayloadErrorReason]
+
+export class RecoveryBundlePayloadError extends Error {
+  constructor(
+    readonly reason: RecoveryBundlePayloadErrorReason,
+    message: string,
+  ) {
+    super(message)
+    this.name = "RecoveryBundlePayloadError"
+  }
+}
+
+export const buildEncryptedBundlePayload = async (
+  bundle: RecoveryBundle,
+  mnemonic: string,
+): Promise<string> => {
+  const key = await deriveBundleEncryptionKeyHex(mnemonic)
+  const { data, iv } = encryptAesGcm(JSON.stringify(bundle), key, {
+    ivLength: GCM_IV_LENGTH,
+  })
+
+  const payload: RecoveryBundleBackupPayload = {
+    schema: RECOVERY_BUNDLE_BACKUP_SCHEMA,
+    encrypted: true,
+    cipher: CIPHER,
+    keyDerivation: KEY_DERIVATION,
+    context: RECOVERY_BUNDLE_ENCRYPTION_CONTEXT,
+    network: bundle.network,
+    walletIdentityPublicKey: bundle.walletIdentityPublicKey,
+    bundleCreatedAt: bundle.createdAt,
+    iv,
+    data,
+  }
+  return JSON.stringify(payload)
+}
+
+export const parseBundleBackupMetadata = (
+  raw: string,
+): RecoveryBundleBackupMetadata | null => {
+  try {
+    const parsed = JSON.parse(raw) as Partial<RecoveryBundleBackupPayload>
+    if (parsed.schema !== RECOVERY_BUNDLE_BACKUP_SCHEMA) return null
+    if (
+      typeof parsed.walletIdentityPublicKey !== "string" ||
+      typeof parsed.bundleCreatedAt !== "string" ||
+      typeof parsed.network !== "string"
+    ) {
+      return null
+    }
+    return {
+      network: parsed.network,
+      walletIdentityPublicKey: parsed.walletIdentityPublicKey,
+      bundleCreatedAt: parsed.bundleCreatedAt,
+    }
+  } catch {
+    return null
+  }
+}
+
+export const decryptBundleBackupPayload = async (
+  raw: string,
+  mnemonic: string,
+): Promise<RecoveryBundle> => {
+  let parsed: Partial<RecoveryBundleBackupPayload>
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.InvalidPayload,
+      `Recovery bundle payload is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  if (parsed.schema !== RECOVERY_BUNDLE_BACKUP_SCHEMA || parsed.cipher !== CIPHER) {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.UnsupportedSchema,
+      `Unsupported recovery bundle payload schema/cipher: ${String(parsed.schema)}/${String(parsed.cipher)}`,
+    )
+  }
+  if (typeof parsed.iv !== "string" || typeof parsed.data !== "string") {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.InvalidPayload,
+      "Recovery bundle payload is missing iv/data",
+    )
+  }
+
+  const key = await deriveBundleEncryptionKeyHex(mnemonic)
+  let plaintext: string
+  try {
+    plaintext = decryptAesGcm({ data: parsed.data, key, iv: parsed.iv })
+  } catch (err) {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.DecryptFailed,
+      `Recovery bundle decrypt failed: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  const bundle = JSON.parse(plaintext) as RecoveryBundle
+  if (bundle.schema !== RECOVERY_BUNDLE_SCHEMA) {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.UnsupportedSchema,
+      `Decrypted payload has unexpected bundle schema: ${String(bundle.schema)}`,
+    )
+  }
+
+  // The envelope fields are plaintext and not AEAD-bound (the shared AES-GCM
+  // util has no AAD support yet), so cross-check them against the
+  // authenticated bundle contents: a tampered envelope must not go unnoticed
+  // by anything that actually uses the bundle.
+  if (
+    parsed.network !== bundle.network ||
+    parsed.walletIdentityPublicKey !== bundle.walletIdentityPublicKey ||
+    parsed.bundleCreatedAt !== bundle.createdAt
+  ) {
+    throw new RecoveryBundlePayloadError(
+      RecoveryBundlePayloadErrorReason.EnvelopeMismatch,
+      "Envelope metadata does not match the encrypted bundle contents",
+    )
+  }
+  return bundle
+}

--- a/app/self-custodial/recovery-bundle/refresh.ts
+++ b/app/self-custodial/recovery-bundle/refresh.ts
@@ -1,0 +1,250 @@
+/**
+ * Orchestrates one recovery-bundle refresh: fetch from operators, encrypt with
+ * the seed-derived key, persist to the device filesystem, then cloud sync.
+ * Single-flight per account - payment bursts and manual refreshes share the
+ * in-flight run instead of hammering the operators.
+ *
+ * Cloud sync follows the wallet's seed backup and is opt-in: the bundle is
+ * uploaded only when the user enabled cloud sync AND completed a cloud seed
+ * backup (iCloud/Google Drive) protected by an extra password, and it goes to
+ * the same provider. The password gate exists because the uploaded payload is
+ * seed-encrypted - next to an unencrypted seed in the same cloud account it
+ * would be decryptable on the spot (blink-specs PRD rule D9).
+ */
+
+import { type Network } from "@breeztech/breez-sdk-spark-react-native"
+import crashlytics from "@react-native-firebase/crashlytics"
+
+import { CloudBackupErrorReason } from "@app/types/cloud-backup"
+
+import { networkLabelFor } from "../config"
+import {
+  isPasswordProtectedCloudSeedBackup,
+  readBackupStateFor,
+} from "../providers/backup-state"
+
+import { attemptSilentCloudUpload, getRecoveryBundleFilename } from "./cloud"
+import { buildEncryptedBundlePayload, parseBundleBackupMetadata } from "./encryption"
+import { fetchRecoveryBundle } from "./exporter"
+import { readRecoveryBundleSettings } from "./settings"
+import {
+  loadEncryptedBundleFile,
+  readRecoveryBundleState,
+  saveEncryptedBundleFile,
+  writeRecoveryBundleState,
+  type RecoveryBundleState,
+} from "./storage"
+
+export type RefreshBundleParams = {
+  accountId: string
+  network: Network
+  mnemonic: string
+  appVersion: string
+}
+
+export type RefreshBundleResult =
+  | { success: true; state: RecoveryBundleState }
+  | { success: false; error: unknown }
+
+/** True when a saved bundle exists and is younger than maxAgeMs. Pure so the
+ * staleness policy is testable without timers or hooks. */
+export const isBundleFresh = (
+  state: RecoveryBundleState | null,
+  now: number,
+  maxAgeMs: number,
+): boolean => state !== null && now - state.savedAt < maxAgeMs
+
+/**
+ * Stamps the last successful cloud upload. Shared by the silent sync below
+ * and the screen's interactive upload so both paths stamp identically.
+ * (runRefresh also carries the previous stamp forward in its own write, so a
+ * stamp landing between its read and write can be reverted until the next
+ * successful sync - UI-freshness only, self-healing.)
+ */
+export const markCloudSynced = async (
+  accountId: string,
+  network: Network,
+): Promise<RecoveryBundleState | null> => {
+  const state = await readRecoveryBundleState(accountId, network)
+  if (!state) return null
+  const next = { ...state, cloudSyncedAt: Date.now() }
+  await writeRecoveryBundleState(accountId, network, next)
+  return next
+}
+
+/**
+ * Single definition of "the bundle may be stored in the cloud": the user
+ * opted in AND the cloud seed backup is password-protected (D9). Screen and
+ * sync path both use this so they cannot diverge on it.
+ */
+export const isCloudSyncAllowedFor = async (accountId: string): Promise<boolean> => {
+  const [settings, backupState] = await Promise.all([
+    readRecoveryBundleSettings(accountId),
+    readBackupStateFor(accountId),
+  ])
+  return settings.cloudSync && isPasswordProtectedCloudSeedBackup(backupState)
+}
+
+/**
+ * Uploads the already-saved encrypted bundle to the seed backup's cloud
+ * provider. No-op (false) when cloud sync is not allowed (not opted in, or no
+ * password-protected cloud seed backup), no bundle is saved yet, or the
+ * silent upload fails. Used after each refresh and when the user turns cloud
+ * sync on with a bundle already on disk.
+ */
+export const syncExistingBundleToCloud = async (
+  accountId: string,
+  network: Network,
+): Promise<boolean> => {
+  if (!(await isCloudSyncAllowedFor(accountId))) return false
+
+  const payload = await loadEncryptedBundleFile(accountId, network)
+  if (!payload) return false
+  const metadata = parseBundleBackupMetadata(payload)
+  if (!metadata) {
+    // A saved file that no longer parses means on-disk corruption, not an
+    // expected state - record it, the refresh path will rewrite the file.
+    crashlytics().recordError(
+      new Error("[recovery-bundle] saved bundle payload failed to parse"),
+    )
+    return false
+  }
+
+  const upload = await attemptSilentCloudUpload(
+    payload,
+    getRecoveryBundleFilename(metadata.network, metadata.walletIdentityPublicKey),
+  )
+  if (!upload.success) {
+    if (upload.reason === CloudBackupErrorReason.Auth) {
+      // Expected state: the user never linked a cloud account on this device.
+      crashlytics().log(`[recovery-bundle] silent cloud upload skipped: ${upload.reason}`)
+    } else {
+      // recordError, not a breadcrumb: a provider failure that starts hitting
+      // every user (e.g. iCloud writes breaking on a new iOS version) must
+      // show up as standalone Crashlytics events carrying the original error,
+      // not be visible only when attached to some later recorded error.
+      const wrapped =
+        upload.error instanceof Error
+          ? upload.error
+          : new Error(`[recovery-bundle] silent cloud upload failed: ${upload.reason}`)
+      crashlytics().recordError(wrapped, "recovery-bundle-cloud-sync")
+    }
+    return false
+  }
+
+  await markCloudSynced(accountId, network)
+  return true
+}
+
+const inFlight = new Map<string, Promise<RefreshBundleResult>>()
+
+// Account ids are random UUIDs and never reused. Membership lasts from the
+// deletion mark until the post-deletion re-sweep unmarks it (see
+// unmarkAccountDeletedForRefresh), so the set stays bounded by concurrent
+// deletions rather than growing for the process lifetime.
+const deletedAccounts = new Set<string>()
+
+/**
+ * Marks an account as deleted so an in-flight refresh (typically mid-fetch,
+ * which takes seconds) refuses to persist its result - otherwise the bundle
+ * file and state would reappear after the deletion sweep, for an account no
+ * longer in the registry. Call before sweeping the account's files.
+ */
+export const markAccountDeletedForRefresh = (accountId: string): void => {
+  deletedAccounts.add(accountId)
+}
+
+/**
+ * Resolves once every in-flight refresh for the account (any network) has
+ * settled. A refresh already past its deleted-account check can still land
+ * writes after the deletion sweep; re-sweeping after this resolves closes
+ * that window.
+ */
+export const waitForRefreshesToSettle = async (accountId: string): Promise<void> => {
+  const runs = [...inFlight.entries()]
+    .filter(([key]) => key.startsWith(`${accountId}:`))
+    .map(([, run]) => run)
+  await Promise.allSettled(runs)
+}
+
+/**
+ * Drops the deletion mark once the post-deletion re-sweep has run: every
+ * in-flight refresh has settled and its writes were swept, and nothing can
+ * start a new refresh (the mnemonic and registry entry are gone - the hook
+ * bails without a mnemonic, the screen without an active account), so keeping
+ * the id would only grow the set for the process lifetime.
+ */
+export const unmarkAccountDeletedForRefresh = (accountId: string): void => {
+  deletedAccounts.delete(accountId)
+}
+
+const runRefresh = async ({
+  accountId,
+  network,
+  mnemonic,
+  appVersion,
+}: RefreshBundleParams): Promise<RefreshBundleResult> => {
+  let state: RecoveryBundleState
+  try {
+    const bundle = await fetchRecoveryBundle({ mnemonic, network, appVersion })
+    const payload = await buildEncryptedBundlePayload(bundle, mnemonic)
+
+    // Checked after the slow network fetch, immediately before persisting:
+    // the account may have been deleted while the fetch was in flight.
+    if (deletedAccounts.has(accountId)) {
+      return { success: false, error: new Error("account deleted during refresh") }
+    }
+    await saveEncryptedBundleFile(accountId, network, payload)
+
+    const previous = await readRecoveryBundleState(accountId, network)
+    state = {
+      savedAt: Date.now(),
+      bundleCreatedAt: bundle.createdAt,
+      leafCount: bundle.leaves.length,
+      totalSats: bundle.balances.btcSats,
+      cloudSyncedAt: previous?.cloudSyncedAt ?? null,
+    }
+    await writeRecoveryBundleState(accountId, network, state)
+  } catch (error) {
+    return { success: false, error }
+  }
+
+  // Bundle freshness is decided by the save above; a failure in the cloud
+  // step must not report an already-persisted refresh as failed. The sync's
+  // own upload errors are handled inside it - this catch covers its
+  // storage/settings reads throwing.
+  try {
+    await syncExistingBundleToCloud(accountId, network)
+    const finalState = (await readRecoveryBundleState(accountId, network)) ?? state
+    return { success: true, state: finalState }
+  } catch (error) {
+    crashlytics().recordError(
+      error instanceof Error ? error : new Error(String(error)),
+      "recovery-bundle-cloud-sync",
+    )
+    return { success: true, state }
+  }
+}
+
+export const refreshRecoveryBundle = (
+  params: RefreshBundleParams,
+): Promise<RefreshBundleResult> => {
+  if (deletedAccounts.has(params.accountId)) {
+    return Promise.resolve({
+      success: false,
+      error: new Error("account deleted during refresh"),
+    })
+  }
+  // Keyed per (account, network) like the storage: a refresh started on one
+  // network must not be handed to a caller on the other after an instance
+  // switch.
+  const key = `${params.accountId}:${networkLabelFor(params.network)}`
+  const existing = inFlight.get(key)
+  if (existing) return existing
+
+  const run = runRefresh(params).finally(() => {
+    inFlight.delete(key)
+  })
+  inFlight.set(key, run)
+  return run
+}

--- a/app/self-custodial/recovery-bundle/refresh.ts
+++ b/app/self-custodial/recovery-bundle/refresh.ts
@@ -13,9 +13,9 @@
  */
 
 import { type Network } from "@breeztech/breez-sdk-spark-react-native"
-import crashlytics from "@react-native-firebase/crashlytics"
 
 import { CloudBackupErrorReason } from "@app/types/cloud-backup"
+import { recordAppError, toError } from "@app/utils/error-reporting"
 
 import { networkLabelFor } from "../config"
 import {
@@ -85,6 +85,18 @@ export const isCloudSyncAllowedFor = async (accountId: string): Promise<boolean>
   return settings.cloudSync && isPasswordProtectedCloudSeedBackup(backupState)
 }
 
+// Silent-upload failures that are user/device states, not defects - the same
+// set the interactive Drive hook treats as expected (EXPECTED_DRIVE_REASONS in
+// use-google-drive-backup.ts), plus Auth: on the silent path it means no
+// usable cloud session (never linked, signed out, or a token revoked
+// out-of-band), never a code defect.
+const EXPECTED_SILENT_UPLOAD_REASONS: ReadonlySet<CloudBackupErrorReason> = new Set([
+  CloudBackupErrorReason.Auth,
+  CloudBackupErrorReason.PermissionDenied,
+  CloudBackupErrorReason.Cancelled,
+  CloudBackupErrorReason.Transient,
+])
+
 /**
  * Uploads the already-saved encrypted bundle to the seed backup's cloud
  * provider. No-op (false) when cloud sync is not allowed (not opted in, or no
@@ -104,9 +116,9 @@ export const syncExistingBundleToCloud = async (
   if (!metadata) {
     // A saved file that no longer parses means on-disk corruption, not an
     // expected state - record it, the refresh path will rewrite the file.
-    crashlytics().recordError(
-      new Error("[recovery-bundle] saved bundle payload failed to parse"),
-    )
+    recordAppError(new Error("[recovery-bundle] saved bundle payload failed to parse"), {
+      dedupKey: "recovery-bundle-corrupt-payload",
+    })
     return false
   }
 
@@ -115,20 +127,17 @@ export const syncExistingBundleToCloud = async (
     getRecoveryBundleFilename(metadata.network, metadata.walletIdentityPublicKey),
   )
   if (!upload.success) {
-    if (upload.reason === CloudBackupErrorReason.Auth) {
-      // Expected state: the user never linked a cloud account on this device.
-      crashlytics().log(`[recovery-bundle] silent cloud upload skipped: ${upload.reason}`)
-    } else {
-      // recordError, not a breadcrumb: a provider failure that starts hitting
-      // every user (e.g. iCloud writes breaking on a new iOS version) must
-      // show up as standalone Crashlytics events carrying the original error,
-      // not be visible only when attached to some later recorded error.
-      const wrapped =
-        upload.error instanceof Error
-          ? upload.error
-          : new Error(`[recovery-bundle] silent cloud upload failed: ${upload.reason}`)
-      crashlytics().recordError(wrapped, "recovery-bundle-cloud-sync")
-    }
+    // A remaining failure reason (Unknown) is a provider defect that must
+    // surface as a standalone non-fatal carrying the original error - e.g.
+    // iCloud writes breaking on a new iOS version.
+    const error =
+      upload.error instanceof Error
+        ? upload.error
+        : new Error(`[recovery-bundle] silent cloud upload failed: ${upload.reason}`)
+    recordAppError(error, {
+      expected: EXPECTED_SILENT_UPLOAD_REASONS.has(upload.reason),
+      dedupKey: "recovery-bundle-cloud-sync",
+    })
     return false
   }
 
@@ -218,10 +227,7 @@ const runRefresh = async ({
     const finalState = (await readRecoveryBundleState(accountId, network)) ?? state
     return { success: true, state: finalState }
   } catch (error) {
-    crashlytics().recordError(
-      error instanceof Error ? error : new Error(String(error)),
-      "recovery-bundle-cloud-sync",
-    )
+    recordAppError(toError(error), { dedupKey: "recovery-bundle-cloud-sync-step" })
     return { success: true, state }
   }
 }

--- a/app/self-custodial/recovery-bundle/settings.ts
+++ b/app/self-custodial/recovery-bundle/settings.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-account user preferences for the recovery bundle. Kept separate from the
+ * per-(account, network) refresh state in storage.ts: these are choices the
+ * user makes once, not derived sync metadata, and they apply to the account on
+ * every network.
+ *
+ * Defaults follow the product rules in the blink-specs PRD
+ * (spark-unilateral-exit): automatic refresh is on by default with an opt-out
+ * to save mobile data; cloud sync of the (seed-encrypted) bundle is opt-in and
+ * off by default, even when the seed itself is already backed up to the cloud.
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage"
+
+const RECOVERY_BUNDLE_SETTINGS_KEY_PREFIX = "recoveryBundleSettings"
+
+const settingsKeyFor = (accountId: string): string =>
+  `${RECOVERY_BUNDLE_SETTINGS_KEY_PREFIX}:${accountId}`
+
+export type RecoveryBundleSettings = {
+  /** Refresh the bundle automatically after payments and on staleness. */
+  autoRefresh: boolean
+  /** Upload the encrypted bundle to the seed backup's cloud provider. */
+  cloudSync: boolean
+}
+
+export const defaultRecoveryBundleSettings: RecoveryBundleSettings = {
+  autoRefresh: true,
+  cloudSync: false,
+}
+
+/** Missing or corrupted stored settings degrade to the defaults. */
+export const readRecoveryBundleSettings = async (
+  accountId: string,
+): Promise<RecoveryBundleSettings> => {
+  const raw = await AsyncStorage.getItem(settingsKeyFor(accountId))
+  if (!raw) return defaultRecoveryBundleSettings
+  try {
+    const parsed = JSON.parse(raw)
+    return {
+      autoRefresh:
+        typeof parsed?.autoRefresh === "boolean"
+          ? parsed.autoRefresh
+          : defaultRecoveryBundleSettings.autoRefresh,
+      cloudSync:
+        typeof parsed?.cloudSync === "boolean"
+          ? parsed.cloudSync
+          : defaultRecoveryBundleSettings.cloudSync,
+    }
+  } catch {
+    return defaultRecoveryBundleSettings
+  }
+}
+
+export const writeRecoveryBundleSettings = async (
+  accountId: string,
+  settings: RecoveryBundleSettings,
+): Promise<void> => {
+  await AsyncStorage.setItem(settingsKeyFor(accountId), JSON.stringify(settings))
+}
+
+export const removeRecoveryBundleSettings = async (accountId: string): Promise<void> => {
+  await AsyncStorage.removeItem(settingsKeyFor(accountId))
+}

--- a/app/self-custodial/recovery-bundle/storage.ts
+++ b/app/self-custodial/recovery-bundle/storage.ts
@@ -1,0 +1,136 @@
+/**
+ * Local persistence for the encrypted recovery bundle: the payload lives on
+ * the device filesystem (sibling of the Breez SDK storage dir, cleaned up on
+ * account deletion), and lightweight refresh/cloud-sync state lives in
+ * AsyncStorage for the UI.
+ *
+ * Filesystem rather than keychain is deliberate: the payload is already
+ * AES-GCM encrypted with a seed-derived key (the seed itself lives in the
+ * keychain), and a bundle can reach hundreds of KB, beyond practical keychain
+ * item sizes on Android. The AsyncStorage state holds only non-secret
+ * metadata (timestamps, leaf count).
+ */
+
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { type Network } from "@breeztech/breez-sdk-spark-react-native"
+import RNFS, { DocumentDirectoryPath } from "react-native-fs"
+
+import { networkLabelFor } from "../config"
+
+export const recoveryBundleDirFor = (network: Network): string =>
+  `${DocumentDirectoryPath}/recovery-bundle-${networkLabelFor(network)}`
+
+export const recoveryBundlePathFor = (accountId: string, network: Network): string =>
+  `${recoveryBundleDirFor(network)}/${accountId}.json`
+
+export const saveEncryptedBundleFile = async (
+  accountId: string,
+  network: Network,
+  payload: string,
+): Promise<void> => {
+  // NSURLIsExcludedFromBackupKey: the bundle must not ride along in iOS
+  // device backups - a passwordless iCloud seed backup in the same Apple
+  // account would make it decryptable there (PRD rule D9). Android is covered
+  // by allowBackup="false". No-op key on Android; reapplied on every call
+  // since mkdir is idempotent.
+  await RNFS.mkdir(recoveryBundleDirFor(network), {
+    NSURLIsExcludedFromBackupKey: true,
+  })
+  const path = recoveryBundlePathFor(accountId, network)
+  // Write-then-rename so an interrupted write cannot truncate the last good
+  // bundle: writeFile in place truncates before writing, and the previous
+  // copy is exactly what unilateral exit needs when re-fetching is not an
+  // option. The unlink narrows atomicity (iOS moveFile refuses to overwrite),
+  // but a crash in the gap still leaves the complete payload in the tmp file
+  // rather than a truncated target.
+  const tmpPath = `${path}.tmp`
+  await RNFS.writeFile(tmpPath, payload, "utf8")
+  if (await RNFS.exists(path)) await RNFS.unlink(path)
+  await RNFS.moveFile(tmpPath, path)
+}
+
+export const loadEncryptedBundleFile = async (
+  accountId: string,
+  network: Network,
+): Promise<string | null> => {
+  const path = recoveryBundlePathFor(accountId, network)
+  if (!(await RNFS.exists(path))) {
+    // A crash between the atomic-save's unlink and rename leaves the payload
+    // only in the tmp file; finish the rename instead of reporting no bundle.
+    const tmpPath = `${path}.tmp`
+    if (!(await RNFS.exists(tmpPath))) return null
+    await RNFS.moveFile(tmpPath, path)
+  }
+  return RNFS.readFile(path, "utf8")
+}
+
+export const deleteRecoveryBundleFile = async (
+  accountId: string,
+  network: Network,
+): Promise<void> => {
+  const path = recoveryBundlePathFor(accountId, network)
+  if (await RNFS.exists(path)) await RNFS.unlink(path)
+  // A crash between the atomic-save's write and rename can strand a tmp file
+  // holding the full encrypted payload; deletion must sweep it too.
+  const tmpPath = `${path}.tmp`
+  if (await RNFS.exists(tmpPath)) await RNFS.unlink(tmpPath)
+}
+
+// --- refresh/sync state (AsyncStorage) ---
+
+const RECOVERY_BUNDLE_STATE_KEY_PREFIX = "recoveryBundleState"
+
+// Keyed per (account, network) to mirror the bundle file: after a mainnet <->
+// regtest instance switch the UI must not show the other network's freshness
+// or suppress the staleness refresh with the wrong network's timestamp.
+const stateKeyFor = (accountId: string, network: Network): string =>
+  `${RECOVERY_BUNDLE_STATE_KEY_PREFIX}:${networkLabelFor(network)}:${accountId}`
+
+export type RecoveryBundleState = {
+  /** Unix ms of the last successful fetch+save. */
+  savedAt: number
+  /** The bundle's own createdAt (ISO). */
+  bundleCreatedAt: string
+  leafCount: number
+  totalSats: string
+  /** Unix ms of the last successful cloud upload, if any. */
+  cloudSyncedAt: number | null
+}
+
+export const readRecoveryBundleState = async (
+  accountId: string,
+  network: Network,
+): Promise<RecoveryBundleState | null> => {
+  const raw = await AsyncStorage.getItem(stateKeyFor(accountId, network))
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw)
+    if (
+      typeof parsed?.savedAt !== "number" ||
+      typeof parsed?.bundleCreatedAt !== "string" ||
+      typeof parsed?.leafCount !== "number" ||
+      typeof parsed?.totalSats !== "string" ||
+      (parsed?.cloudSyncedAt !== null && typeof parsed?.cloudSyncedAt !== "number")
+    ) {
+      return null
+    }
+    return parsed as RecoveryBundleState
+  } catch {
+    return null
+  }
+}
+
+export const writeRecoveryBundleState = async (
+  accountId: string,
+  network: Network,
+  state: RecoveryBundleState,
+): Promise<void> => {
+  await AsyncStorage.setItem(stateKeyFor(accountId, network), JSON.stringify(state))
+}
+
+export const removeRecoveryBundleState = async (
+  accountId: string,
+  network: Network,
+): Promise<void> => {
+  await AsyncStorage.removeItem(stateKeyFor(accountId, network))
+}

--- a/app/self-custodial/recovery-bundle/storage.ts
+++ b/app/self-custodial/recovery-bundle/storage.ts
@@ -56,10 +56,13 @@ export const loadEncryptedBundleFile = async (
   const path = recoveryBundlePathFor(accountId, network)
   if (!(await RNFS.exists(path))) {
     // A crash between the atomic-save's unlink and rename leaves the payload
-    // only in the tmp file; finish the rename instead of reporting no bundle.
+    // only in the tmp file; read it in place instead of reporting no bundle.
+    // No rename here: repair belongs to the save and delete paths, so a load
+    // racing a concurrent save's unlink-to-rename window cannot steal the
+    // rename out from under it. The next successful save or delete cleans up.
     const tmpPath = `${path}.tmp`
     if (!(await RNFS.exists(tmpPath))) return null
-    await RNFS.moveFile(tmpPath, path)
+    return RNFS.readFile(tmpPath, "utf8")
   }
   return RNFS.readFile(path, "utf8")
 }

--- a/app/utils/google-drive-session.ts
+++ b/app/utils/google-drive-session.ts
@@ -1,0 +1,40 @@
+/**
+ * Dead-token recovery shared by every Drive caller, interactive or silent.
+ * Lives apart from google-drive-client.ts so that module stays pure fetch;
+ * this one needs the sign-in SDK to refresh tokens.
+ */
+
+import { GoogleSignin } from "@react-native-google-signin/google-signin"
+
+import { DriveError } from "@app/utils/google-drive-client"
+
+/** Not `reason`: 403 shares it but means a withheld permission, which a new token cannot fix. */
+export const isDeadAccessToken = (err: unknown): boolean =>
+  err instanceof DriveError && err.status === 401
+
+/**
+ * A revoked token stays in the sign-in cache, so the SDK keeps handing back the same dead
+ * one. Clearing it forces a refresh, retried once. The working token comes back because the
+ * caller holds it for the rest of the session.
+ */
+export const callDrive = async <T>(
+  token: string,
+  call: (token: string) => Promise<T>,
+): Promise<{ value: T; token: string }> => {
+  try {
+    return { value: await call(token), token }
+  } catch (err) {
+    if (!isDeadAccessToken(err)) throw err
+
+    let refreshed: string
+    try {
+      await GoogleSignin.clearCachedAccessToken(token)
+      refreshed = (await GoogleSignin.getTokens()).accessToken
+    } catch {
+      /** The 401 is the diagnosis; a failure to refresh only says the retry never ran. */
+      throw err
+    }
+
+    return { value: await call(refreshed), token: refreshed }
+  }
+}


### PR DESCRIPTION
**Stack 2/3** for the unilateral-exit recovery bundle (split out of #3911 per review). Base: `feat--recovery-bundle-core`. Next: #3911.

Persistence and orchestration on top of the exporter - still no UI or hooks:

- `encryption.ts` - AES-128-GCM payload keyed from HMAC-SHA256(seed, context); plaintext envelope limited to freshness/matching metadata and cross-checked against the authenticated contents after decrypt.
- `storage.ts` - bundle file under a per-network directory excluded from iOS device backups (D9), written tmp-then-rename so an interrupted write keeps the last good copy (stranded tmp recovered on load, swept on delete); validated AsyncStorage freshness state.
- `settings.ts` - per-account auto-refresh opt-out and cloud-sync opt-in.
- `cloud.ts` - best-effort silent upload to the seed backup's provider (iCloud, or Drive only when a silent sign-in succeeds - the background path never pops UI); failures carry the original error.
- `refresh.ts` - single-flight per (account, network) refresh: fetch, encrypt, persist, then cloud sync in its own error scope so a cloud failure cannot fail a persisted refresh. Cloud sync is gated on `isCloudSyncAllowedFor`: opted in AND password-protected cloud seed backup (D9). Account-deletion marks block in-flight refreshes from persisting after a delete, with `waitForRefreshesToSettle` + unmark for the caller's re-sweep.
- `backup-state.tsx` - records `cloudPasswordProtected` with a completed backup (new optional field/param, backward compatible), making the D9 gate decidable.

Tests: encrypted-payload round-trips including a GCM bit-flip tamper case, real-execution storage tests on an in-memory RNFS with iOS moveFile semantics, refresh gating/single-flight/deletion-race coverage, and a cloud spec for both platform branches.
