### PR TITLE
fix(i18n): restore missing countdown placeholder in French txNotBroad…

### DIFF
--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2526,7 +2526,7 @@
         "sending": "Envoi en cours",
         "receivingAccount": "Solde destinataire",
         "sendingAccount": "Solde expéditeur",
-        "txNotBroadcast": "Votre transaction est actuellement en attente et sera transmise au réseau Bitcoin dans un moment.",
+        "txNotBroadcast": "Votre transaction est en attente. Elle devrait apparaître dans le mempool {countdown: string}.",
         "momentarily": "dans un instant",
         "findingAccount": "Recherche du compte associé à ce paiement...",
         "txNotFoundInAccounts": "Ce paiement est introuvable dans les comptes de cet appareil. Il appartient peut-être à un compte déconnecté.",


### PR DESCRIPTION
…cast

The French translation dropped the {countdown} interpolation, so French users never saw the mempool arrival estimate shown in English (same class of bug as #3326 for Portuguese).