### PR TITLE
fix(contacts): list self-custodial transactions on the contact screen

### DIFF
--- a/__tests__/components/icon-hero.spec.tsx
+++ b/__tests__/components/icon-hero.spec.tsx
@@ -26,6 +26,37 @@ describe("IconHero", () => {
     expect(getByText("Test Title")).toBeTruthy()
   })
 
+  it("lets a title wrap by default, because a heading is a sentence", async () => {
+    const { getByText } = render(
+      <ContextForScreen>
+        <IconHero icon="cloud-arrow-up" iconColor="green" title="Test Title" />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(getByText("Test Title").props.numberOfLines).toBeUndefined()
+  })
+
+  it("cuts a title short when the caller caps its lines", async () => {
+    // A lightning address is one unbreakable thing: wrapping it mid-address reads as two
+    // addresses, so a screen showing one asks for a single line instead.
+    const { getByText } = render(
+      <ContextForScreen>
+        <IconHero
+          icon="cloud-arrow-up"
+          iconColor="green"
+          title="deepbassoon958@walletofsatoshi.com"
+          titleLines={1}
+        />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    const title = getByText("deepbassoon958@walletofsatoshi.com")
+    expect(title.props.numberOfLines).toBe(1)
+    expect(title.props.ellipsizeMode).toBe("middle")
+  })
+
   it("renders subtitle when provided", async () => {
     const { getByText } = render(
       <ContextForScreen>

--- a/__tests__/custodial/contact-adapter.spec.ts
+++ b/__tests__/custodial/contact-adapter.spec.ts
@@ -128,12 +128,12 @@ describe("useCustodialContactAdapter", () => {
     )
   })
 
-  it("returns an empty transactions list (custodial does not back this)", async () => {
+  it("returns an exhausted empty page (the contact query backs this instead)", async () => {
     const { result } = renderHook(() => useCustodialContactAdapter())
 
-    const txs = await result.current.getTransactions("c1")
+    const page = await result.current.getTransactions("c1")
 
-    expect(txs).toEqual([])
+    expect(page).toEqual({ transactions: [], nextCursor: null })
   })
 
   it("propagates the loading flag from the underlying query", () => {

--- a/__tests__/custodial/contact-adapter.spec.ts
+++ b/__tests__/custodial/contact-adapter.spec.ts
@@ -120,6 +120,20 @@ describe("useCustodialContactAdapter", () => {
     expect(mockRefetch).toHaveBeenCalled()
   })
 
+  it("answers with an empty list when the refetch comes back without contacts", async () => {
+    // A rename whose refetch answers with nothing leaves the caller an empty list to
+    // render rather than reading `contacts` off undefined data.
+    mockRefetch.mockResolvedValue({ data: undefined })
+    const { result } = renderHook(() => useCustodialContactAdapter())
+
+    let updated: Awaited<ReturnType<typeof result.current.update>> | undefined
+    await act(async () => {
+      updated = await result.current.update("c1", { displayName: "New Alice" })
+    })
+
+    expect(updated).toEqual({ contacts: [] })
+  })
+
   it("rejects updating an unknown contact id", async () => {
     const { result } = renderHook(() => useCustodialContactAdapter())
 

--- a/__tests__/hooks/use-contact-transactions.spec.ts
+++ b/__tests__/hooks/use-contact-transactions.spec.ts
@@ -80,6 +80,55 @@ describe("useContactTransactions", () => {
     expect(result.current.isLoading).toBe(true)
   })
 
+  describe("a page that holds nothing for this contact", () => {
+    it("keeps reading, because an empty list has no scroll to ask with", async () => {
+      mockGetTransactions
+        .mockResolvedValueOnce(page([], "20"))
+        .mockResolvedValueOnce(page([], "40"))
+        .mockResolvedValueOnce(page(["tx-1"], null))
+
+      const { result } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledTimes(3)
+      expect(mockGetTransactions).toHaveBeenLastCalledWith(IDENTIFIER, "40")
+      expect(result.current.transactions).toEqual([{ id: "tx-1" }])
+    })
+
+    it("reads as loading while it is still searching", async () => {
+      mockGetTransactions.mockResolvedValueOnce(page([], "20"))
+      mockGetTransactions.mockReturnValue(new Promise(() => {}))
+
+      const { result } = renderContactTransactions()
+      await flushEffects()
+
+      expect(result.current.isLoading).toBe(true)
+    })
+
+    it("settles on the empty state once the history runs out", async () => {
+      mockGetTransactions
+        .mockResolvedValueOnce(page([], "20"))
+        .mockResolvedValueOnce(page([], null))
+
+      const { result } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledTimes(2)
+      expect(result.current.transactions).toEqual([])
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it("stops searching, rather than spinning on, when a page fails", async () => {
+      mockGetTransactions.mockResolvedValueOnce(page([], "20"))
+      mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+
+      const { result } = renderContactTransactions()
+      await flushEffects()
+
+      expect(result.current.hasError).toBe(true)
+    })
+  })
+
   it("reports a failed first page through hasError", async () => {
     mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
 
@@ -258,6 +307,31 @@ describe("useContactTransactions", () => {
       })
 
       expect(result.current.isLoading).toBe(true)
+    })
+
+    it("does not fail the contact that replaced it when a later page rejects", async () => {
+      const { result, rerender } = await renderWithFirstPage()
+
+      let rejectStalePage: (reason: Error) => void = () => {}
+      mockGetTransactions.mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectStalePage = reject
+        }),
+      )
+      act(() => {
+        result.current.loadMore()
+      })
+
+      mockGetTransactions.mockResolvedValueOnce(page(["bob-tx"], null))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      await act(async () => {
+        rejectStalePage(new Error("sdk unavailable"))
+      })
+
+      expect(result.current.hasError).toBe(false)
+      expect(result.current.transactions).toEqual([{ id: "bob-tx" }])
     })
 
     it("does not fail the contact that replaced it", async () => {

--- a/__tests__/hooks/use-contact-transactions.spec.ts
+++ b/__tests__/hooks/use-contact-transactions.spec.ts
@@ -7,9 +7,12 @@ import { flushEffects } from "../helpers/flush-effects"
 const mockGetTransactions = jest.fn()
 const mockContactsLoading = jest.fn()
 
+/** Held on an object so a test can swap the reader the way a reconnect does. */
+const mockContactAdapter = { getTransactions: mockGetTransactions }
+
 jest.mock("@app/hooks/use-contacts", () => ({
   useContacts: () => ({
-    getTransactions: mockGetTransactions,
+    getTransactions: mockContactAdapter.getTransactions,
     loading: mockContactsLoading(),
   }),
 }))
@@ -48,6 +51,7 @@ describe("useContactTransactions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockContactsLoading.mockReturnValue(false)
+    mockContactAdapter.getTransactions = mockGetTransactions
     mockGetTransactions.mockResolvedValue(page([], null))
   })
 
@@ -70,14 +74,30 @@ describe("useContactTransactions", () => {
     expect(result.current.isLoading).toBe(false)
   })
 
-  it("waits for the adapter to be ready, and reads as loading meanwhile", async () => {
+  it("reads without waiting on a contact list it never consults", async () => {
     mockContactsLoading.mockReturnValue(true)
+    mockGetTransactions.mockResolvedValue(page(["tx-1"], null))
 
     const { result } = renderContactTransactions()
     await flushEffects()
 
-    expect(mockGetTransactions).not.toHaveBeenCalled()
-    expect(result.current.isLoading).toBe(true)
+    expect(mockGetTransactions).toHaveBeenCalledWith(IDENTIFIER)
+    expect(result.current.transactions).toEqual([{ id: "tx-1" }])
+  })
+
+  it("re-reads when the adapter reconnects and hands over a new reader", async () => {
+    mockGetTransactions.mockResolvedValue(page([], null))
+
+    const { rerender } = renderContactTransactions()
+    await flushEffects()
+    expect(mockGetTransactions).toHaveBeenCalledTimes(1)
+
+    const reconnectedGetTransactions = jest.fn().mockResolvedValue(page(["tx-1"], null))
+    mockContactAdapter.getTransactions = reconnectedGetTransactions
+    rerender({ id: IDENTIFIER, enabled: true })
+    await flushEffects()
+
+    expect(reconnectedGetTransactions).toHaveBeenCalledWith(IDENTIFIER)
   })
 
   describe("a page that holds nothing for this contact", () => {

--- a/__tests__/hooks/use-contact-transactions.spec.ts
+++ b/__tests__/hooks/use-contact-transactions.spec.ts
@@ -1,0 +1,299 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { useContactTransactions } from "@app/hooks/use-contact-transactions"
+
+import { flushEffects } from "../helpers/flush-effects"
+
+const mockGetTransactions = jest.fn()
+const mockContactsLoading = jest.fn()
+
+jest.mock("@app/hooks/use-contacts", () => ({
+  useContacts: () => ({
+    getTransactions: mockGetTransactions,
+    loading: mockContactsLoading(),
+  }),
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useFocusEffect: (callback: () => undefined | (() => void)) => {
+    const { useEffect } = jest.requireActual("react")
+    useEffect(callback, [callback])
+  },
+}))
+
+const page = (ids: string[], nextCursor: string | null) => ({
+  transactions: ids.map((id) => ({ id })),
+  nextCursor,
+})
+
+const IDENTIFIER = "alice@blink.sv"
+
+const renderContactTransactions = (isEnabled = true, identifier = IDENTIFIER) =>
+  renderHook(
+    ({ id, enabled }: { id: string; enabled: boolean }) =>
+      useContactTransactions(id, enabled),
+    { initialProps: { id: identifier, enabled: isEnabled } },
+  )
+
+/** Loads a first page and leaves a cursor pointing at the next one. */
+const renderWithFirstPage = async () => {
+  mockGetTransactions.mockResolvedValueOnce(page(["tx-1"], "20"))
+  const rendered = renderContactTransactions()
+  await flushEffects()
+  return rendered
+}
+
+describe("useContactTransactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockContactsLoading.mockReturnValue(false)
+    mockGetTransactions.mockResolvedValue(page([], null))
+  })
+
+  it("loads the first page for the contact's payment identifier", async () => {
+    mockGetTransactions.mockResolvedValue(page(["tx-1"], null))
+
+    const { result } = renderContactTransactions()
+    await flushEffects()
+
+    expect(mockGetTransactions).toHaveBeenCalledWith(IDENTIFIER)
+    expect(result.current.transactions).toEqual([{ id: "tx-1" }])
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("stays out of the way when it is not the active source", async () => {
+    const { result } = renderContactTransactions(false)
+    await flushEffects()
+
+    expect(mockGetTransactions).not.toHaveBeenCalled()
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("waits for the adapter to be ready, and reads as loading meanwhile", async () => {
+    mockContactsLoading.mockReturnValue(true)
+
+    const { result } = renderContactTransactions()
+    await flushEffects()
+
+    expect(mockGetTransactions).not.toHaveBeenCalled()
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it("reports a failed first page through hasError", async () => {
+    mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+
+    const { result } = renderContactTransactions()
+    await flushEffects()
+
+    expect(result.current.hasError).toBe(true)
+  })
+
+  it("drops the previous contact's payments the moment it is pointed at another", async () => {
+    const { result, rerender } = await renderWithFirstPage()
+    expect(result.current.transactions).toEqual([{ id: "tx-1" }])
+
+    mockGetTransactions.mockReturnValue(new Promise(() => {}))
+    rerender({ id: "bob@blink.sv", enabled: true })
+
+    expect(result.current.transactions).toEqual([])
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  describe("loadMore", () => {
+    it("appends the next page and follows the cursor it was handed", async () => {
+      const { result } = await renderWithFirstPage()
+
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-2"], "40"))
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(mockGetTransactions).toHaveBeenLastCalledWith(IDENTIFIER, "20")
+      expect(result.current.transactions).toEqual([{ id: "tx-1" }, { id: "tx-2" }])
+    })
+
+    it("drops a repeat of a transaction an earlier page already listed", async () => {
+      const { result } = await renderWithFirstPage()
+
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-1", "tx-2"], null))
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(result.current.transactions).toEqual([{ id: "tx-1" }, { id: "tx-2" }])
+    })
+
+    it("does nothing once the history is exhausted", async () => {
+      mockGetTransactions.mockResolvedValue(page(["tx-1"], null))
+      const { result } = renderContactTransactions()
+      await flushEffects()
+      mockGetTransactions.mockClear()
+
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(mockGetTransactions).not.toHaveBeenCalled()
+    })
+
+    it("ignores a second call while the first is still in flight", async () => {
+      const { result } = await renderWithFirstPage()
+
+      mockGetTransactions.mockClear()
+      mockGetTransactions.mockReturnValue(new Promise(() => {}))
+      await act(async () => {
+        result.current.loadMore()
+        result.current.loadMore()
+      })
+
+      expect(mockGetTransactions).toHaveBeenCalledTimes(1)
+    })
+
+    it("keeps the list a failed page did not touch, and lets the next scroll retry", async () => {
+      const { result } = await renderWithFirstPage()
+
+      mockGetTransactions.mockRejectedValueOnce(new Error("sdk unavailable"))
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(result.current.hasError).toBe(false)
+      expect(result.current.transactions).toEqual([{ id: "tx-1" }])
+
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-2"], null))
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(result.current.transactions).toEqual([{ id: "tx-1" }, { id: "tx-2" }])
+    })
+
+    it("discards a page that lands after the first page was re-read", async () => {
+      const { result, rerender } = await renderWithFirstPage()
+
+      let resolveStalePage: (value: unknown) => void = () => {}
+      mockGetTransactions.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStalePage = resolve
+        }),
+      )
+      act(() => {
+        result.current.loadMore()
+      })
+
+      /** Re-reading the first page invalidates the cursor the in-flight call was using. */
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-9"], "20"))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      await act(async () => {
+        resolveStalePage(page(["stale-tx"], "40"))
+      })
+
+      expect(result.current.transactions).toEqual([{ id: "tx-9" }])
+    })
+
+    it("can page again after the first page was re-read", async () => {
+      const { result, rerender } = await renderWithFirstPage()
+
+      mockGetTransactions.mockReturnValueOnce(new Promise(() => {}))
+      act(() => {
+        result.current.loadMore()
+      })
+
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-9"], "20"))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      mockGetTransactions.mockResolvedValueOnce(page(["tx-10"], null))
+      await act(async () => {
+        result.current.loadMore()
+      })
+
+      expect(result.current.transactions).toEqual([{ id: "tx-9" }, { id: "tx-10" }])
+    })
+  })
+
+  describe("a first page that lands after another was asked for", () => {
+    it("does not overwrite the contact that replaced it", async () => {
+      let resolveSlowPage: (value: unknown) => void = () => {}
+      mockGetTransactions.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlowPage = resolve
+        }),
+      )
+
+      const { result, rerender } = renderContactTransactions()
+      await flushEffects()
+
+      mockGetTransactions.mockResolvedValueOnce(page(["bob-tx"], null))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      await act(async () => {
+        resolveSlowPage(page(["alice-tx"], "20"))
+      })
+
+      expect(result.current.transactions).toEqual([{ id: "bob-tx" }])
+    })
+
+    it("does not mark the contact that replaced it as loaded", async () => {
+      let resolveSlowPage: (value: unknown) => void = () => {}
+      mockGetTransactions.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSlowPage = resolve
+        }),
+      )
+
+      const { result, rerender } = renderContactTransactions()
+      await flushEffects()
+
+      mockGetTransactions.mockReturnValueOnce(new Promise(() => {}))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      await act(async () => {
+        resolveSlowPage(page(["alice-tx"], "20"))
+      })
+
+      expect(result.current.isLoading).toBe(true)
+    })
+
+    it("does not fail the contact that replaced it", async () => {
+      let rejectSlowPage: (reason: Error) => void = () => {}
+      mockGetTransactions.mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectSlowPage = reject
+        }),
+      )
+
+      const { result, rerender } = renderContactTransactions()
+      await flushEffects()
+
+      mockGetTransactions.mockResolvedValueOnce(page(["bob-tx"], null))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      await act(async () => {
+        rejectSlowPage(new Error("sdk unavailable"))
+      })
+
+      expect(result.current.hasError).toBe(false)
+    })
+
+    it("does not leave the replacing contact stuck loading", async () => {
+      mockGetTransactions.mockReturnValueOnce(new Promise(() => {}))
+
+      const { result, rerender } = renderContactTransactions()
+      await flushEffects()
+      expect(result.current.isLoading).toBe(true)
+
+      mockGetTransactions.mockResolvedValueOnce(page(["bob-tx"], null))
+      rerender({ id: "bob@blink.sv", enabled: true })
+      await flushEffects()
+
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+})

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -149,6 +149,24 @@ describe("ContactTransactions", () => {
       expect(getByTestId("contact-no-transactions")).toBeTruthy()
     })
 
+    it("spins while the query is still in flight", () => {
+      mockUseQuery.mockReturnValue(custodialQuery({ loading: true }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
+    it("does not claim a contact has no transactions before the query answers", () => {
+      mockUseQuery.mockReturnValue(custodialQuery({ data: undefined }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
     it("reports a failed query through a toast", () => {
       mockUseQuery.mockReturnValue({
         error: new Error("network"),

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -204,6 +204,23 @@ describe("ContactTransactions", () => {
       expect(queryByTestId("contact-transactions-loading")).toBeNull()
     })
 
+    it("still holds its space when the history cannot be read", () => {
+      // The toast carries the failure; the layout must not move under it, or the send
+      // button climbs the screen on exactly the contact whose list is missing.
+      mockUseQuery.mockReturnValue({
+        error: new Error("network"),
+        data: undefined,
+        fetchMore: jest.fn(),
+      })
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(
+        StyleSheet.flatten(getByTestId("contact-transactions-unavailable").props.style),
+      ).toMatchObject({ flex: 1 })
+      expect(queryByTestId("contact-transactions-list")).toBeNull()
+    })
+
     it("reports a failed query through a toast", () => {
       mockUseQuery.mockReturnValue({
         error: new Error("network"),
@@ -385,6 +402,18 @@ describe("ContactTransactions", () => {
       expect(screen.UNSAFE_getByType(SectionList).props.windowSize).toBe(
         TRANSACTION_LIST_WINDOW_SIZE,
       )
+    })
+
+    it("holds the space below it, so what follows keeps its place", () => {
+      // Whatever the contact's history holds, the list fills the room between the header
+      // and the send button: a short one must not pull that button up the screen.
+      const screen = renderContactTransactions()
+      const list = screen.UNSAFE_getByType(SectionList)
+
+      let container = list.parent
+      while (container && typeof container.type !== "string") container = container.parent
+
+      expect(StyleSheet.flatten(container?.props.style)).toMatchObject({ flex: 1 })
     })
 
     it("dates every row, so a payment is placed within its day", () => {

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { SectionList } from "react-native"
+import { SectionList, StyleSheet } from "react-native"
 
 import { fireEvent, render } from "@testing-library/react-native"
 
@@ -66,19 +66,21 @@ jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", 
 }))
 
 /** Records the props each row is handed, so the list's contract with the row is assertable. */
-const mockRowProps: Array<{ txid: string; onPress?: (txid: string) => void }> = []
+type RowProps = {
+  txid: string
+  onPress?: (txid: string) => void
+  subtitle?: boolean
+  isFirst?: boolean
+  isLast?: boolean
+}
+
+const mockRowProps: RowProps[] = []
 
 jest.mock("@app/components/transaction-item", () => ({
   ...jest.requireActual("@app/components/transaction-item"),
-  MemoizedTransactionItem: ({
-    txid,
-    onPress,
-  }: {
-    txid: string
-    onPress?: (txid: string) => void
-  }) => {
+  MemoizedTransactionItem: ({ txid, onPress, subtitle, isFirst, isLast }: RowProps) => {
     const { View } = jest.requireActual("react-native")
-    mockRowProps.push({ txid, onPress })
+    mockRowProps.push({ txid, onPress, subtitle, isFirst, isLast })
     return <View testID={`transaction-${txid}`} />
   },
 }))
@@ -116,6 +118,9 @@ const contact: UserContact = {
   alias: "Alice",
   transactionsCount: 2,
 }
+
+/** The radius the date group's card carries, mirrored from the screen's own token. */
+const GROUP_RADIUS = 8
 
 const makeFragment = (id: string) => ({
   __typename: "Transaction" as const,
@@ -380,6 +385,68 @@ describe("ContactTransactions", () => {
       expect(screen.UNSAFE_getByType(SectionList).props.windowSize).toBe(
         TRANSACTION_LIST_WINDOW_SIZE,
       )
+    })
+
+    it("dates every row, so a payment is placed within its day", () => {
+      renderContactTransactions()
+
+      expect(mockRowProps.length).toBeGreaterThan(0)
+      expect(mockRowProps.every((props) => props.subtitle)).toBe(true)
+    })
+
+    it("marks the ends of a date group, which carry its card edges", () => {
+      mockUseQuery.mockReturnValue(
+        custodialQuery({
+          edges: [
+            { node: makeFragment("first-tx") },
+            { node: makeFragment("middle-tx") },
+            { node: makeFragment("last-tx") },
+          ],
+        }),
+      )
+
+      renderContactTransactions()
+
+      expect(
+        mockRowProps.map(({ txid, isFirst, isLast }) => ({ txid, isFirst, isLast })),
+      ).toEqual([
+        { txid: "first-tx", isFirst: true, isLast: false },
+        { txid: "middle-tx", isFirst: false, isLast: false },
+        { txid: "last-tx", isFirst: false, isLast: true },
+      ])
+    })
+
+    it("rounds the group's outer corners and nothing in between", () => {
+      mockUseQuery.mockReturnValue(
+        custodialQuery({
+          edges: [
+            { node: makeFragment("first-tx") },
+            { node: makeFragment("middle-tx") },
+            { node: makeFragment("last-tx") },
+          ],
+        }),
+      )
+
+      const { getByTestId } = renderContactTransactions()
+
+      /** The row wraps in the view that carries the corners, past the row component. */
+      const cornersOf = (txid: string) => {
+        let node = getByTestId(`transaction-${txid}`).parent
+        while (node && typeof node.type !== "string") node = node.parent
+        return StyleSheet.flatten(node?.props.style)
+      }
+
+      expect(cornersOf("first-tx")).toEqual({
+        borderTopLeftRadius: GROUP_RADIUS,
+        borderTopRightRadius: GROUP_RADIUS,
+        overflow: "hidden",
+      })
+      expect(cornersOf("middle-tx")).toEqual({})
+      expect(cornersOf("last-tx")).toEqual({
+        borderBottomLeftRadius: GROUP_RADIUS,
+        borderBottomRightRadius: GROUP_RADIUS,
+        overflow: "hidden",
+      })
     })
   })
 })

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -3,8 +3,6 @@ import { SectionList } from "react-native"
 
 import { fireEvent, render } from "@testing-library/react-native"
 
-import { flushEffects } from "../../../helpers/flush-effects"
-
 import { ThemeProvider } from "@rn-vui/themed"
 
 import { TRANSACTION_LIST_WINDOW_SIZE } from "@app/components/transaction-item"
@@ -16,11 +14,32 @@ import { ContactTransactions } from "@app/screens/people-screen/contacts/contact
 import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
-const mockGetTransactions = jest.fn()
-const mockContactsLoading = jest.fn()
+const mockUseContactTransactions = jest.fn()
+const mockLoadMore = jest.fn()
 const mockActiveAccountType = jest.fn()
 const mockToastShow = jest.fn()
 const mockFragments = jest.fn()
+
+const contactTransactions = (overrides: Record<string, unknown> = {}) => ({
+  transactions: [],
+  isLoading: false,
+  hasError: false,
+  loadMore: mockLoadMore,
+  ...overrides,
+})
+
+/** An answered query: `data` present means the backend has spoken, empty edges or not. */
+const custodialQuery = ({
+  edges = [] as unknown[],
+  pageInfo = { hasNextPage: false, endCursor: null },
+  ...overrides
+}: Record<string, unknown> = {}) => ({
+  error: undefined,
+  loading: false,
+  fetchMore: jest.fn(),
+  data: { me: { contactByUsername: { transactions: { edges, pageInfo } } } },
+  ...overrides,
+})
 
 jest.mock("@app/graphql/generated", () => ({
   ...jest.requireActual("@app/graphql/generated"),
@@ -35,11 +54,9 @@ jest.mock("@app/hooks/use-account-registry", () => ({
   useAccountRegistry: () => ({ activeAccount: { type: mockActiveAccountType() } }),
 }))
 
-jest.mock("@app/hooks/use-contacts", () => ({
-  useContacts: () => ({
-    getTransactions: mockGetTransactions,
-    loading: mockContactsLoading(),
-  }),
+jest.mock("@app/hooks/use-contact-transactions", () => ({
+  useContactTransactions: (contactId: string, isEnabled: boolean) =>
+    mockUseContactTransactions(contactId, isEnabled),
 }))
 
 jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
@@ -118,32 +135,16 @@ describe("ContactTransactions", () => {
     jest.clearAllMocks()
     mockRowProps.length = 0
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
-    mockContactsLoading.mockReturnValue(false)
-    mockGetTransactions.mockResolvedValue([])
+    mockUseContactTransactions.mockReturnValue(contactTransactions())
     mockFragments.mockReturnValue([])
-    mockUseQuery.mockReturnValue({
-      error: undefined,
-      data: undefined,
-      fetchMore: jest.fn(),
-    })
+    mockUseQuery.mockReturnValue(custodialQuery())
   })
 
   describe("custodial account", () => {
     it("runs the contact query and lists what it returns", async () => {
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore: jest.fn(),
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: false, endCursor: null },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({ edges: [{ node: makeFragment("custodial-tx") }] }),
+      )
 
       const { getByTestId } = renderContactTransactions()
 
@@ -180,20 +181,13 @@ describe("ContactTransactions", () => {
 
     it("asks for the next page when the list reaches its end", async () => {
       const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore,
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({
+          fetchMore,
+          edges: [{ node: makeFragment("custodial-tx") }],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        }),
+      )
 
       const { getByTestId } = renderContactTransactions()
       fireEvent(getByTestId("contact-transactions-list"), "endReached")
@@ -201,24 +195,14 @@ describe("ContactTransactions", () => {
       expect(fetchMore).toHaveBeenCalledWith({
         variables: { username: contact.username, after: "cursor-1" },
       })
+      expect(mockLoadMore).not.toHaveBeenCalled()
     })
 
     it("does not page past the last cursor", () => {
       const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore,
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: false, endCursor: null },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({ fetchMore, edges: [{ node: makeFragment("custodial-tx") }] }),
+      )
 
       const { getByTestId } = renderContactTransactions()
       fireEvent(getByTestId("contact-transactions-list"), "endReached")
@@ -226,10 +210,10 @@ describe("ContactTransactions", () => {
       expect(fetchMore).not.toHaveBeenCalled()
     })
 
-    it("does not ask the contact adapter for transactions", () => {
+    it("leaves the contact adapter switched off", () => {
       renderContactTransactions()
 
-      expect(mockGetTransactions).not.toHaveBeenCalled()
+      expect(mockUseContactTransactions).toHaveBeenCalledWith(contact.handle, false)
     })
   })
 
@@ -238,115 +222,50 @@ describe("ContactTransactions", () => {
       mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
     })
 
-    it("skips the custodial query, which has no session to resolve through", async () => {
+    it("skips the custodial query, which has no session to resolve through", () => {
       renderContactTransactions()
-      await flushEffects()
 
       expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ skip: true }))
     })
 
-    it("lists the transactions the contact adapter returns", async () => {
-      const normalized = [{ id: "sc-tx" }]
-      mockGetTransactions.mockResolvedValue(normalized)
+    it("drives the adapter for this contact", () => {
+      renderContactTransactions()
+
+      expect(mockUseContactTransactions).toHaveBeenCalledWith(contact.handle, true)
+    })
+
+    it("lists the transactions the adapter returns", () => {
+      mockUseContactTransactions.mockReturnValue(
+        contactTransactions({ transactions: [{ id: "sc-tx" }] }),
+      )
       mockFragments.mockImplementation((txs: unknown[]) =>
         txs.length ? [makeFragment("sc-tx")] : [],
       )
 
       const { getByTestId } = renderContactTransactions()
-      await flushEffects()
 
-      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
       expect(getByTestId("transaction-sc-tx")).toBeTruthy()
     })
 
-    it("shows the empty state when the contact has no matching payments", async () => {
+    it("shows the empty state when the contact has no matching payments", () => {
       const { getByTestId } = renderContactTransactions()
-      await flushEffects()
 
-      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
       expect(getByTestId("contact-no-transactions")).toBeTruthy()
     })
 
-    it("ignores a late adapter answer after it unmounts", async () => {
-      let resolveTransactions: (value: unknown[]) => void = () => {}
-      mockGetTransactions.mockReturnValue(
-        new Promise((resolve) => {
-          resolveTransactions = resolve
-        }),
-      )
+    it("spins instead of claiming the contact has no payments", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ isLoading: true }))
 
-      const { unmount } = renderContactTransactions()
-      unmount()
-      resolveTransactions([{ id: "late-tx" }])
-      await flushEffects()
+      const { getByTestId, queryByTestId } = renderContactTransactions()
 
-      expect(mockGetTransactions).toHaveBeenCalled()
-      expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
     })
 
-    it("ignores a late adapter failure after it unmounts", async () => {
-      let rejectTransactions: (reason: Error) => void = () => {}
-      mockGetTransactions.mockReturnValue(
-        new Promise((_resolve, reject) => {
-          rejectTransactions = reject
-        }),
-      )
-
-      const { unmount } = renderContactTransactions()
-      unmount()
-      rejectTransactions(new Error("sdk unavailable"))
-      await flushEffects()
-
-      expect(mockGetTransactions).toHaveBeenCalled()
-      expect(mockToastShow).not.toHaveBeenCalled()
-    })
-
-    it("does not page, because the adapter answers without a cursor", async () => {
-      const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
-
-      const { getByTestId } = renderContactTransactions()
-      await flushEffects()
-      fireEvent(getByTestId("contact-transactions-list"), "endReached")
-
-      expect(fetchMore).not.toHaveBeenCalled()
-    })
-
-    describe("while the adapter is still answering", () => {
-      it("waits for the contact list before asking for transactions", () => {
-        mockContactsLoading.mockReturnValue(true)
-
-        renderContactTransactions()
-
-        expect(mockGetTransactions).not.toHaveBeenCalled()
-      })
-
-      it("spins instead of claiming the contact has no payments", () => {
-        mockContactsLoading.mockReturnValue(true)
-
-        const { getByTestId, queryByTestId } = renderContactTransactions()
-
-        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
-        expect(queryByTestId("contact-no-transactions")).toBeNull()
-      })
-
-      it("keeps spinning until the adapter answers", async () => {
-        mockGetTransactions.mockReturnValue(new Promise(() => {}))
-
-        const { getByTestId, queryByTestId } = renderContactTransactions()
-        await flushEffects()
-
-        expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
-        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
-        expect(queryByTestId("contact-no-transactions")).toBeNull()
-      })
-    })
-
-    it("reports a failed adapter call through a toast", async () => {
-      mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+    it("reports a failed adapter call through a toast", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ hasError: true }))
 
       const { queryByTestId } = renderContactTransactions()
-      await flushEffects()
 
       expect(mockToastShow).toHaveBeenCalledTimes(1)
       expect(queryByTestId("contact-transactions-list")).toBeNull()
@@ -356,24 +275,21 @@ describe("ContactTransactions", () => {
       expect(message(i18nObject("en"))).toBe("Error loading transactions")
     })
 
-    it("clears a previous failure when the contact changes", async () => {
-      mockGetTransactions.mockRejectedValueOnce(new Error("sdk unavailable"))
+    it("asks the adapter for the next page when the list reaches its end", () => {
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
 
-      const { queryByTestId, rerender } = renderContactTransactions()
-      await flushEffects()
+      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+    })
 
-      expect(queryByTestId("contact-transactions-list")).toBeNull()
+    it("never pages the custodial query, which has no session to resolve through", () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
 
-      mockGetTransactions.mockResolvedValue([])
-      rerender(
-        <ThemeProvider theme={theme}>
-          <ContactTransactions contact={{ ...contact, id: "contact-2" }} />
-        </ThemeProvider>,
-      )
-      await flushEffects()
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
 
-      expect(mockGetTransactions).toHaveBeenCalledWith("contact-2")
-      expect(queryByTestId("contact-no-transactions")).toBeTruthy()
+      expect(fetchMore).not.toHaveBeenCalled()
     })
   })
 

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -2,8 +2,6 @@ import * as React from "react"
 
 import { fireEvent, render } from "@testing-library/react-native"
 
-import { flushEffects } from "../../../helpers/flush-effects"
-
 import { ThemeProvider } from "@rn-vui/themed"
 
 import { TxStatus, UserContact } from "@app/graphql/generated"
@@ -14,11 +12,32 @@ import { ContactTransactions } from "@app/screens/people-screen/contacts/contact
 import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
-const mockGetTransactions = jest.fn()
-const mockContactsLoading = jest.fn()
+const mockUseContactTransactions = jest.fn()
+const mockLoadMore = jest.fn()
 const mockActiveAccountType = jest.fn()
 const mockToastShow = jest.fn()
 const mockFragments = jest.fn()
+
+const contactTransactions = (overrides: Record<string, unknown> = {}) => ({
+  transactions: [],
+  isLoading: false,
+  hasError: false,
+  loadMore: mockLoadMore,
+  ...overrides,
+})
+
+/** An answered query: `data` present means the backend has spoken, empty edges or not. */
+const custodialQuery = ({
+  edges = [] as unknown[],
+  pageInfo = { hasNextPage: false, endCursor: null },
+  ...overrides
+}: Record<string, unknown> = {}) => ({
+  error: undefined,
+  loading: false,
+  fetchMore: jest.fn(),
+  data: { me: { contactByUsername: { transactions: { edges, pageInfo } } } },
+  ...overrides,
+})
 
 jest.mock("@app/graphql/generated", () => ({
   ...jest.requireActual("@app/graphql/generated"),
@@ -33,11 +52,9 @@ jest.mock("@app/hooks/use-account-registry", () => ({
   useAccountRegistry: () => ({ activeAccount: { type: mockActiveAccountType() } }),
 }))
 
-jest.mock("@app/hooks/use-contacts", () => ({
-  useContacts: () => ({
-    getTransactions: mockGetTransactions,
-    loading: mockContactsLoading(),
-  }),
+jest.mock("@app/hooks/use-contact-transactions", () => ({
+  useContactTransactions: (contactId: string, isEnabled: boolean) =>
+    mockUseContactTransactions(contactId, isEnabled),
 }))
 
 jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
@@ -104,32 +121,16 @@ describe("ContactTransactions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
-    mockContactsLoading.mockReturnValue(false)
-    mockGetTransactions.mockResolvedValue([])
+    mockUseContactTransactions.mockReturnValue(contactTransactions())
     mockFragments.mockReturnValue([])
-    mockUseQuery.mockReturnValue({
-      error: undefined,
-      data: undefined,
-      fetchMore: jest.fn(),
-    })
+    mockUseQuery.mockReturnValue(custodialQuery())
   })
 
   describe("custodial account", () => {
     it("runs the contact query and lists what it returns", async () => {
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore: jest.fn(),
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: false, endCursor: null },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({ edges: [{ node: makeFragment("custodial-tx") }] }),
+      )
 
       const { getByTestId } = renderContactTransactions()
 
@@ -166,20 +167,13 @@ describe("ContactTransactions", () => {
 
     it("asks for the next page when the list reaches its end", async () => {
       const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore,
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({
+          fetchMore,
+          edges: [{ node: makeFragment("custodial-tx") }],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        }),
+      )
 
       const { getByTestId } = renderContactTransactions()
       fireEvent(getByTestId("contact-transactions-list"), "endReached")
@@ -187,24 +181,14 @@ describe("ContactTransactions", () => {
       expect(fetchMore).toHaveBeenCalledWith({
         variables: { username: contact.username, after: "cursor-1" },
       })
+      expect(mockLoadMore).not.toHaveBeenCalled()
     })
 
     it("does not page past the last cursor", () => {
       const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({
-        error: undefined,
-        fetchMore,
-        data: {
-          me: {
-            contactByUsername: {
-              transactions: {
-                edges: [{ node: makeFragment("custodial-tx") }],
-                pageInfo: { hasNextPage: false, endCursor: null },
-              },
-            },
-          },
-        },
-      })
+      mockUseQuery.mockReturnValue(
+        custodialQuery({ fetchMore, edges: [{ node: makeFragment("custodial-tx") }] }),
+      )
 
       const { getByTestId } = renderContactTransactions()
       fireEvent(getByTestId("contact-transactions-list"), "endReached")
@@ -212,10 +196,10 @@ describe("ContactTransactions", () => {
       expect(fetchMore).not.toHaveBeenCalled()
     })
 
-    it("does not ask the contact adapter for transactions", () => {
+    it("leaves the contact adapter switched off", () => {
       renderContactTransactions()
 
-      expect(mockGetTransactions).not.toHaveBeenCalled()
+      expect(mockUseContactTransactions).toHaveBeenCalledWith(contact.handle, false)
     })
   })
 
@@ -224,115 +208,50 @@ describe("ContactTransactions", () => {
       mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
     })
 
-    it("skips the custodial query, which has no session to resolve through", async () => {
+    it("skips the custodial query, which has no session to resolve through", () => {
       renderContactTransactions()
-      await flushEffects()
 
       expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ skip: true }))
     })
 
-    it("lists the transactions the contact adapter returns", async () => {
-      const normalized = [{ id: "sc-tx" }]
-      mockGetTransactions.mockResolvedValue(normalized)
+    it("drives the adapter for this contact", () => {
+      renderContactTransactions()
+
+      expect(mockUseContactTransactions).toHaveBeenCalledWith(contact.handle, true)
+    })
+
+    it("lists the transactions the adapter returns", () => {
+      mockUseContactTransactions.mockReturnValue(
+        contactTransactions({ transactions: [{ id: "sc-tx" }] }),
+      )
       mockFragments.mockImplementation((txs: unknown[]) =>
         txs.length ? [makeFragment("sc-tx")] : [],
       )
 
       const { getByTestId } = renderContactTransactions()
-      await flushEffects()
 
-      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
       expect(getByTestId("transaction-sc-tx")).toBeTruthy()
     })
 
-    it("shows the empty state when the contact has no matching payments", async () => {
+    it("shows the empty state when the contact has no matching payments", () => {
       const { getByTestId } = renderContactTransactions()
-      await flushEffects()
 
-      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
       expect(getByTestId("contact-no-transactions")).toBeTruthy()
     })
 
-    it("ignores a late adapter answer after it unmounts", async () => {
-      let resolveTransactions: (value: unknown[]) => void = () => {}
-      mockGetTransactions.mockReturnValue(
-        new Promise((resolve) => {
-          resolveTransactions = resolve
-        }),
-      )
+    it("spins instead of claiming the contact has no payments", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ isLoading: true }))
 
-      const { unmount } = renderContactTransactions()
-      unmount()
-      resolveTransactions([{ id: "late-tx" }])
-      await flushEffects()
+      const { getByTestId, queryByTestId } = renderContactTransactions()
 
-      expect(mockGetTransactions).toHaveBeenCalled()
-      expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
     })
 
-    it("ignores a late adapter failure after it unmounts", async () => {
-      let rejectTransactions: (reason: Error) => void = () => {}
-      mockGetTransactions.mockReturnValue(
-        new Promise((_resolve, reject) => {
-          rejectTransactions = reject
-        }),
-      )
-
-      const { unmount } = renderContactTransactions()
-      unmount()
-      rejectTransactions(new Error("sdk unavailable"))
-      await flushEffects()
-
-      expect(mockGetTransactions).toHaveBeenCalled()
-      expect(mockToastShow).not.toHaveBeenCalled()
-    })
-
-    it("does not page, because the adapter answers without a cursor", async () => {
-      const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
-
-      const { getByTestId } = renderContactTransactions()
-      await flushEffects()
-      fireEvent(getByTestId("contact-transactions-list"), "endReached")
-
-      expect(fetchMore).not.toHaveBeenCalled()
-    })
-
-    describe("while the adapter is still answering", () => {
-      it("waits for the contact list before asking for transactions", () => {
-        mockContactsLoading.mockReturnValue(true)
-
-        renderContactTransactions()
-
-        expect(mockGetTransactions).not.toHaveBeenCalled()
-      })
-
-      it("spins instead of claiming the contact has no payments", () => {
-        mockContactsLoading.mockReturnValue(true)
-
-        const { getByTestId, queryByTestId } = renderContactTransactions()
-
-        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
-        expect(queryByTestId("contact-no-transactions")).toBeNull()
-      })
-
-      it("keeps spinning until the adapter answers", async () => {
-        mockGetTransactions.mockReturnValue(new Promise(() => {}))
-
-        const { getByTestId, queryByTestId } = renderContactTransactions()
-        await flushEffects()
-
-        expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
-        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
-        expect(queryByTestId("contact-no-transactions")).toBeNull()
-      })
-    })
-
-    it("reports a failed adapter call through a toast", async () => {
-      mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+    it("reports a failed adapter call through a toast", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ hasError: true }))
 
       const { queryByTestId } = renderContactTransactions()
-      await flushEffects()
 
       expect(mockToastShow).toHaveBeenCalledTimes(1)
       expect(queryByTestId("contact-transactions-list")).toBeNull()
@@ -342,24 +261,21 @@ describe("ContactTransactions", () => {
       expect(message(i18nObject("en"))).toBe("Error loading transactions")
     })
 
-    it("clears a previous failure when the contact changes", async () => {
-      mockGetTransactions.mockRejectedValueOnce(new Error("sdk unavailable"))
+    it("asks the adapter for the next page when the list reaches its end", () => {
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
 
-      const { queryByTestId, rerender } = renderContactTransactions()
-      await flushEffects()
+      expect(mockLoadMore).toHaveBeenCalledTimes(1)
+    })
 
-      expect(queryByTestId("contact-transactions-list")).toBeNull()
+    it("never pages the custodial query, which has no session to resolve through", () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
 
-      mockGetTransactions.mockResolvedValue([])
-      rerender(
-        <ThemeProvider theme={theme}>
-          <ContactTransactions contact={{ ...contact, id: "contact-2" }} />
-        </ThemeProvider>,
-      )
-      await flushEffects()
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
 
-      expect(mockGetTransactions).toHaveBeenCalledWith("contact-2")
-      expect(queryByTestId("contact-no-transactions")).toBeTruthy()
+      expect(fetchMore).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -17,6 +17,7 @@ import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
 const mockGetTransactions = jest.fn()
+const mockContactsLoading = jest.fn()
 const mockActiveAccountType = jest.fn()
 const mockToastShow = jest.fn()
 const mockFragments = jest.fn()
@@ -35,7 +36,10 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 jest.mock("@app/hooks/use-contacts", () => ({
-  useContacts: () => ({ getTransactions: mockGetTransactions }),
+  useContacts: () => ({
+    getTransactions: mockGetTransactions,
+    loading: mockContactsLoading(),
+  }),
 }))
 
 jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
@@ -114,6 +118,7 @@ describe("ContactTransactions", () => {
     jest.clearAllMocks()
     mockRowProps.length = 0
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
+    mockContactsLoading.mockReturnValue(false)
     mockGetTransactions.mockResolvedValue([])
     mockFragments.mockReturnValue([])
     mockUseQuery.mockReturnValue({
@@ -221,18 +226,6 @@ describe("ContactTransactions", () => {
       expect(fetchMore).not.toHaveBeenCalled()
     })
 
-    it("does not page a self-custodial list, which the adapter answers in full", async () => {
-      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
-      const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
-
-      const { getByTestId } = renderContactTransactions()
-      await flushEffects()
-      fireEvent(getByTestId("contact-transactions-list"), "endReached")
-
-      expect(fetchMore).not.toHaveBeenCalled()
-    })
-
     it("does not ask the contact adapter for transactions", () => {
       renderContactTransactions()
 
@@ -289,6 +282,98 @@ describe("ContactTransactions", () => {
 
       expect(mockGetTransactions).toHaveBeenCalled()
       expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+    })
+
+    it("ignores a late adapter failure after it unmounts", async () => {
+      let rejectTransactions: (reason: Error) => void = () => {}
+      mockGetTransactions.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectTransactions = reject
+        }),
+      )
+
+      const { unmount } = renderContactTransactions()
+      unmount()
+      rejectTransactions(new Error("sdk unavailable"))
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalled()
+      expect(mockToastShow).not.toHaveBeenCalled()
+    })
+
+    it("does not page, because the adapter answers without a cursor", async () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    describe("while the adapter is still answering", () => {
+      it("waits for the contact list before asking for transactions", () => {
+        mockContactsLoading.mockReturnValue(true)
+
+        renderContactTransactions()
+
+        expect(mockGetTransactions).not.toHaveBeenCalled()
+      })
+
+      it("spins instead of claiming the contact has no payments", () => {
+        mockContactsLoading.mockReturnValue(true)
+
+        const { getByTestId, queryByTestId } = renderContactTransactions()
+
+        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+        expect(queryByTestId("contact-no-transactions")).toBeNull()
+      })
+
+      it("keeps spinning until the adapter answers", async () => {
+        mockGetTransactions.mockReturnValue(new Promise(() => {}))
+
+        const { getByTestId, queryByTestId } = renderContactTransactions()
+        await flushEffects()
+
+        expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+        expect(queryByTestId("contact-no-transactions")).toBeNull()
+      })
+    })
+
+    it("reports a failed adapter call through a toast", async () => {
+      mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+
+      const { queryByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
+      expect(queryByTestId("contact-transactions-list")).toBeNull()
+
+      loadLocale("en")
+      const [{ message }] = mockToastShow.mock.calls[0]
+      expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("clears a previous failure when the contact changes", async () => {
+      mockGetTransactions.mockRejectedValueOnce(new Error("sdk unavailable"))
+
+      const { queryByTestId, rerender } = renderContactTransactions()
+      await flushEffects()
+
+      expect(queryByTestId("contact-transactions-list")).toBeNull()
+
+      mockGetTransactions.mockResolvedValue([])
+      rerender(
+        <ThemeProvider theme={theme}>
+          <ContactTransactions contact={{ ...contact, id: "contact-2" }} />
+        </ThemeProvider>,
+      )
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith("contact-2")
+      expect(queryByTestId("contact-no-transactions")).toBeTruthy()
     })
   })
 

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -14,6 +14,7 @@ import { ContactTransactions } from "@app/screens/people-screen/contacts/contact
 import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
+const mockUseIsAuthed = jest.fn()
 const mockUseContactTransactions = jest.fn()
 const mockLoadMore = jest.fn()
 const mockActiveAccountType = jest.fn()
@@ -47,7 +48,7 @@ jest.mock("@app/graphql/generated", () => ({
 }))
 
 jest.mock("@app/graphql/is-authed-context", () => ({
-  useIsAuthed: () => true,
+  useIsAuthed: () => mockUseIsAuthed(),
 }))
 
 jest.mock("@app/hooks/use-account-registry", () => ({
@@ -134,6 +135,7 @@ describe("ContactTransactions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockRowProps.length = 0
+    mockUseIsAuthed.mockReturnValue(true)
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
     mockUseContactTransactions.mockReturnValue(contactTransactions())
     mockFragments.mockReturnValue([])
@@ -179,6 +181,16 @@ describe("ContactTransactions", () => {
 
       expect(getByTestId("contact-transactions-loading")).toBeTruthy()
       expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
+    it("does not spin forever on a query it never ran", () => {
+      mockUseIsAuthed.mockReturnValue(false)
+      mockUseQuery.mockReturnValue(custodialQuery({ data: undefined }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+      expect(queryByTestId("contact-transactions-loading")).toBeNull()
     })
 
     it("reports a failed query through a toast", () => {

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -87,13 +87,17 @@ jest.mock("@app/utils/toast", () => ({
   toastShow: (args: unknown) => mockToastShow(args),
 }))
 
-/** Real translations so the section headers and empty state read like production. */
+/**
+ * Real translations so the section headers and empty state read like production, resolved
+ * once so `LL` keeps the stable identity the real context hands out.
+ */
 jest.mock("@app/i18n/i18n-react", () => {
   const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
   const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
   loadLocale("en")
+  const LL = i18nObject("en")
 
-  return { useI18nContext: () => ({ LL: i18nObject("en"), locale: "en" }) }
+  return { useI18nContext: () => ({ LL, locale: "en" }) }
 })
 
 jest.mock("@react-navigation/native", () => ({
@@ -124,12 +128,14 @@ const makeFragment = (id: string) => ({
   settlementCurrency: "BTC",
 })
 
-const renderContactTransactions = () =>
-  render(
-    <ThemeProvider theme={theme}>
-      <ContactTransactions contact={contact} />
-    </ThemeProvider>,
-  )
+/** A fresh element each call: re-rendering the same one lets React bail out entirely. */
+const contactTransactionsScreen = () => (
+  <ThemeProvider theme={theme}>
+    <ContactTransactions contact={contact} />
+  </ThemeProvider>
+)
+
+const renderContactTransactions = () => render(contactTransactionsScreen())
 
 describe("ContactTransactions", () => {
   beforeEach(() => {
@@ -303,6 +309,16 @@ describe("ContactTransactions", () => {
       loadLocale("en")
       const [{ message }] = mockToastShow.mock.calls[0]
       expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("does not toast again when the screen re-renders with the error still up", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ hasError: true }))
+
+      const { rerender } = renderContactTransactions()
+      rerender(contactTransactionsScreen())
+      rerender(contactTransactionsScreen())
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
     })
 
     it("asks the adapter for the next page when the list reaches its end", () => {

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -163,6 +163,24 @@ describe("ContactTransactions", () => {
       expect(getByTestId("contact-no-transactions")).toBeTruthy()
     })
 
+    it("spins while the query is still in flight", () => {
+      mockUseQuery.mockReturnValue(custodialQuery({ loading: true }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
+    it("does not claim a contact has no transactions before the query answers", () => {
+      mockUseQuery.mockReturnValue(custodialQuery({ data: undefined }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+      expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
     it("reports a failed query through a toast", () => {
       mockUseQuery.mockReturnValue({
         error: new Error("network"),

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -12,6 +12,7 @@ import { ContactTransactions } from "@app/screens/people-screen/contacts/contact
 import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
+const mockUseIsAuthed = jest.fn()
 const mockUseContactTransactions = jest.fn()
 const mockLoadMore = jest.fn()
 const mockActiveAccountType = jest.fn()
@@ -45,7 +46,7 @@ jest.mock("@app/graphql/generated", () => ({
 }))
 
 jest.mock("@app/graphql/is-authed-context", () => ({
-  useIsAuthed: () => true,
+  useIsAuthed: () => mockUseIsAuthed(),
 }))
 
 jest.mock("@app/hooks/use-account-registry", () => ({
@@ -120,6 +121,7 @@ const renderContactTransactions = () =>
 describe("ContactTransactions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUseIsAuthed.mockReturnValue(true)
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
     mockUseContactTransactions.mockReturnValue(contactTransactions())
     mockFragments.mockReturnValue([])
@@ -165,6 +167,16 @@ describe("ContactTransactions", () => {
 
       expect(getByTestId("contact-transactions-loading")).toBeTruthy()
       expect(queryByTestId("contact-no-transactions")).toBeNull()
+    })
+
+    it("does not spin forever on a query it never ran", () => {
+      mockUseIsAuthed.mockReturnValue(false)
+      mockUseQuery.mockReturnValue(custodialQuery({ data: undefined }))
+
+      const { getByTestId, queryByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+      expect(queryByTestId("contact-transactions-loading")).toBeNull()
     })
 
     it("reports a failed query through a toast", () => {

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -74,13 +74,17 @@ jest.mock("@app/utils/toast", () => ({
   toastShow: (args: unknown) => mockToastShow(args),
 }))
 
-/** Real translations so the section headers and empty state read like production. */
+/**
+ * Real translations so the section headers and empty state read like production, resolved
+ * once so `LL` keeps the stable identity the real context hands out.
+ */
 jest.mock("@app/i18n/i18n-react", () => {
   const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
   const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
   loadLocale("en")
+  const LL = i18nObject("en")
 
-  return { useI18nContext: () => ({ LL: i18nObject("en"), locale: "en" }) }
+  return { useI18nContext: () => ({ LL, locale: "en" }) }
 })
 
 jest.mock("@react-navigation/native", () => ({
@@ -111,12 +115,14 @@ const makeFragment = (id: string) => ({
   settlementCurrency: "BTC",
 })
 
-const renderContactTransactions = () =>
-  render(
-    <ThemeProvider theme={theme}>
-      <ContactTransactions contact={contact} />
-    </ThemeProvider>,
-  )
+/** A fresh element each call: re-rendering the same one lets React bail out entirely. */
+const contactTransactionsScreen = () => (
+  <ThemeProvider theme={theme}>
+    <ContactTransactions contact={contact} />
+  </ThemeProvider>
+)
+
+const renderContactTransactions = () => render(contactTransactionsScreen())
 
 describe("ContactTransactions", () => {
   beforeEach(() => {
@@ -289,6 +295,16 @@ describe("ContactTransactions", () => {
       loadLocale("en")
       const [{ message }] = mockToastShow.mock.calls[0]
       expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("does not toast again when the screen re-renders with the error still up", () => {
+      mockUseContactTransactions.mockReturnValue(contactTransactions({ hasError: true }))
+
+      const { rerender } = renderContactTransactions()
+      rerender(contactTransactionsScreen())
+      rerender(contactTransactionsScreen())
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
     })
 
     it("asks the adapter for the next page when the list reaches its end", () => {

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -15,6 +15,7 @@ import { AccountType } from "@app/types/wallet"
 
 const mockUseQuery = jest.fn()
 const mockGetTransactions = jest.fn()
+const mockContactsLoading = jest.fn()
 const mockActiveAccountType = jest.fn()
 const mockToastShow = jest.fn()
 const mockFragments = jest.fn()
@@ -33,7 +34,10 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 jest.mock("@app/hooks/use-contacts", () => ({
-  useContacts: () => ({ getTransactions: mockGetTransactions }),
+  useContacts: () => ({
+    getTransactions: mockGetTransactions,
+    loading: mockContactsLoading(),
+  }),
 }))
 
 jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
@@ -100,6 +104,7 @@ describe("ContactTransactions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockActiveAccountType.mockReturnValue(AccountType.Custodial)
+    mockContactsLoading.mockReturnValue(false)
     mockGetTransactions.mockResolvedValue([])
     mockFragments.mockReturnValue([])
     mockUseQuery.mockReturnValue({
@@ -207,18 +212,6 @@ describe("ContactTransactions", () => {
       expect(fetchMore).not.toHaveBeenCalled()
     })
 
-    it("does not page a self-custodial list, which the adapter answers in full", async () => {
-      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
-      const fetchMore = jest.fn()
-      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
-
-      const { getByTestId } = renderContactTransactions()
-      await flushEffects()
-      fireEvent(getByTestId("contact-transactions-list"), "endReached")
-
-      expect(fetchMore).not.toHaveBeenCalled()
-    })
-
     it("does not ask the contact adapter for transactions", () => {
       renderContactTransactions()
 
@@ -275,6 +268,98 @@ describe("ContactTransactions", () => {
 
       expect(mockGetTransactions).toHaveBeenCalled()
       expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+    })
+
+    it("ignores a late adapter failure after it unmounts", async () => {
+      let rejectTransactions: (reason: Error) => void = () => {}
+      mockGetTransactions.mockReturnValue(
+        new Promise((_resolve, reject) => {
+          rejectTransactions = reject
+        }),
+      )
+
+      const { unmount } = renderContactTransactions()
+      unmount()
+      rejectTransactions(new Error("sdk unavailable"))
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalled()
+      expect(mockToastShow).not.toHaveBeenCalled()
+    })
+
+    it("does not page, because the adapter answers without a cursor", async () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    describe("while the adapter is still answering", () => {
+      it("waits for the contact list before asking for transactions", () => {
+        mockContactsLoading.mockReturnValue(true)
+
+        renderContactTransactions()
+
+        expect(mockGetTransactions).not.toHaveBeenCalled()
+      })
+
+      it("spins instead of claiming the contact has no payments", () => {
+        mockContactsLoading.mockReturnValue(true)
+
+        const { getByTestId, queryByTestId } = renderContactTransactions()
+
+        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+        expect(queryByTestId("contact-no-transactions")).toBeNull()
+      })
+
+      it("keeps spinning until the adapter answers", async () => {
+        mockGetTransactions.mockReturnValue(new Promise(() => {}))
+
+        const { getByTestId, queryByTestId } = renderContactTransactions()
+        await flushEffects()
+
+        expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+        expect(getByTestId("contact-transactions-loading")).toBeTruthy()
+        expect(queryByTestId("contact-no-transactions")).toBeNull()
+      })
+    })
+
+    it("reports a failed adapter call through a toast", async () => {
+      mockGetTransactions.mockRejectedValue(new Error("sdk unavailable"))
+
+      const { queryByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
+      expect(queryByTestId("contact-transactions-list")).toBeNull()
+
+      loadLocale("en")
+      const [{ message }] = mockToastShow.mock.calls[0]
+      expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("clears a previous failure when the contact changes", async () => {
+      mockGetTransactions.mockRejectedValueOnce(new Error("sdk unavailable"))
+
+      const { queryByTestId, rerender } = renderContactTransactions()
+      await flushEffects()
+
+      expect(queryByTestId("contact-transactions-list")).toBeNull()
+
+      mockGetTransactions.mockResolvedValue([])
+      rerender(
+        <ThemeProvider theme={theme}>
+          <ContactTransactions contact={{ ...contact, id: "contact-2" }} />
+        </ThemeProvider>,
+      )
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith("contact-2")
+      expect(queryByTestId("contact-no-transactions")).toBeTruthy()
     })
   })
 })

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -1,201 +1,338 @@
-import React from "react"
+import * as React from "react"
 import { SectionList } from "react-native"
-import { MockedResponse } from "@apollo/client/testing"
-import { render, waitFor } from "@testing-library/react-native"
 
-import { ContactTransactions } from "@app/screens/people-screen/contacts/contact-transactions"
-import { TransactionListForContactDocument } from "@app/graphql/generated"
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { flushEffects } from "../../../helpers/flush-effects"
+
+import { ThemeProvider } from "@rn-vui/themed"
+
 import { TRANSACTION_LIST_WINDOW_SIZE } from "@app/components/transaction-item"
+import { TxStatus, UserContact } from "@app/graphql/generated"
+import { i18nObject } from "@app/i18n/i18n-util"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
+import theme from "@app/rne-theme/theme"
+import { ContactTransactions } from "@app/screens/people-screen/contacts/contact-transactions"
+import { AccountType } from "@app/types/wallet"
 
-import { ContextForScreen } from "../../helper"
+const mockUseQuery = jest.fn()
+const mockGetTransactions = jest.fn()
+const mockActiveAccountType = jest.fn()
+const mockToastShow = jest.fn()
+const mockFragments = jest.fn()
 
-const CONTACT_USERNAME = "test_contact"
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useTransactionListForContactQuery: (options: unknown) => mockUseQuery(options),
+}))
 
-let currentMocks: MockedResponse[] = []
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => true,
+}))
 
-jest.mock("@app/graphql/mocks", () => {
-  const actual = jest.requireActual("@app/graphql/mocks")
-  return {
-    __esModule: true,
-    get default() {
-      // Spec-specific mocks first so they take precedence; the shared mocks
-      // backfill every other query fired by mounted components, keeping
-      // Apollo's MockLink warning-free.
-      return [...currentMocks, ...actual.default]
-    },
-  }
-})
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ activeAccount: { type: mockActiveAccountType() } }),
+}))
 
-// Records the props each row is handed, so the list's contract with the row
-// (one shared handler, or none at all) is assertable from here.
+jest.mock("@app/hooks/use-contacts", () => ({
+  useContacts: () => ({ getTransactions: mockGetTransactions }),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
+  useSelfCustodialTransactionFragments: (transactions: unknown) =>
+    mockFragments(transactions),
+}))
+
+/** Records the props each row is handed, so the list's contract with the row is assertable. */
 const mockRowProps: Array<{ txid: string; onPress?: (txid: string) => void }> = []
 
-jest.mock("@app/components/transaction-item", () => {
-  const actual = jest.requireActual("@app/components/transaction-item")
-  const React = jest.requireActual("react")
-  const { Text } = jest.requireActual("react-native")
-
-  type Props = { txid: string; onPress?: (txid: string) => void }
-
-  const MemoizedTransactionItem = ({ txid, onPress }: Props) => {
+jest.mock("@app/components/transaction-item", () => ({
+  ...jest.requireActual("@app/components/transaction-item"),
+  MemoizedTransactionItem: ({
+    txid,
+    onPress,
+  }: {
+    txid: string
+    onPress?: (txid: string) => void
+  }) => {
+    const { View } = jest.requireActual("react-native")
     mockRowProps.push({ txid, onPress })
-    return React.createElement(Text, { testID: `row-${txid}` }, txid)
-  }
-
-  return {
-    __esModule: true,
-    ...actual,
-    MemoizedTransactionItem,
-  }
-})
-
-const makeEdge = (id: string, cursor: string, createdAt: number) => ({
-  __typename: "TransactionEdge",
-  cursor,
-  node: {
-    __typename: "Transaction",
-    id,
-    status: "SUCCESS",
-    direction: "RECEIVE",
-    memo: null,
-    createdAt,
-    settlementAmount: 1000,
-    settlementFee: 0,
-    settlementDisplayFee: "0.00",
-    settlementCurrency: "BTC",
-    settlementDisplayAmount: "0.10",
-    settlementDisplayCurrency: "USD",
-    settlementPrice: {
-      __typename: "PriceOfOneSettlementMinorUnitInDisplayMinorUnit",
-      base: 105000000000,
-      offset: 12,
-      currencyUnit: "MINOR",
-      formattedAmount: "0.105",
-    },
-    initiationVia: {
-      __typename: "InitiationViaLn",
-      paymentHash: `hash-${id}`,
-      paymentRequest: `payment-request-${id}`,
-    },
-    settlementVia: {
-      __typename: "SettlementViaIntraLedger",
-      counterPartyWalletId: null,
-      counterPartyUsername: CONTACT_USERNAME,
-      preImage: null,
-    },
+    return <View testID={`transaction-${txid}`} />
   },
+}))
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (args: unknown) => mockToastShow(args),
+}))
+
+/** Real translations so the section headers and empty state read like production. */
+jest.mock("@app/i18n/i18n-react", () => {
+  const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
+  const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
+  loadLocale("en")
+
+  return { useI18nContext: () => ({ LL: i18nObject("en"), locale: "en" }) }
 })
 
-const buildContactMocks = (): MockedResponse[] => {
-  const result = {
-    data: {
-      me: {
-        __typename: "User",
-        id: "user-id",
-        contactByUsername: {
-          __typename: "UserContact",
-          transactions: {
-            __typename: "TransactionConnection",
-            pageInfo: {
-              __typename: "PageInfo",
-              hasNextPage: false,
-              hasPreviousPage: false,
-              startCursor: "cursor-1",
-              endCursor: "cursor-2",
-            },
-            edges: [
-              makeEdge("507f1f77bcf86cd799439011", "cursor-1", 1700000001),
-              makeEdge("507f1f77bcf86cd799439012", "cursor-2", 1700000000),
-            ],
-          },
-        },
-      },
-    },
-  }
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useFocusEffect: (callback: () => undefined | (() => void)) => {
+    const { useEffect } = jest.requireActual("react")
+    useEffect(callback, [callback])
+  },
+}))
 
-  return [
-    {
-      request: {
-        query: TransactionListForContactDocument,
-        variables: { username: CONTACT_USERNAME },
-      },
-      maxUsageCount: Number.POSITIVE_INFINITY,
-      result,
-    },
-  ]
+const contact: UserContact = {
+  __typename: "UserContact",
+  id: "contact-1",
+  handle: "alice@blink.sv",
+  username: "alice@blink.sv",
+  alias: "Alice",
+  transactionsCount: 2,
 }
+
+const makeFragment = (id: string) => ({
+  __typename: "Transaction" as const,
+  id,
+  status: TxStatus.Success,
+  createdAt: 1747691078,
+  direction: "SEND",
+  memo: null,
+  settlementAmount: 100,
+  settlementCurrency: "BTC",
+})
 
 const renderContactTransactions = () =>
   render(
-    <ContextForScreen>
-      <ContactTransactions contactUsername={CONTACT_USERNAME} />
-    </ContextForScreen>,
+    <ThemeProvider theme={theme}>
+      <ContactTransactions contact={contact} />
+    </ThemeProvider>,
   )
 
 describe("ContactTransactions", () => {
   beforeEach(() => {
-    loadLocale("en")
+    jest.clearAllMocks()
     mockRowProps.length = 0
-    currentMocks = buildContactMocks()
+    mockActiveAccountType.mockReturnValue(AccountType.Custodial)
+    mockGetTransactions.mockResolvedValue([])
+    mockFragments.mockReturnValue([])
+    mockUseQuery.mockReturnValue({
+      error: undefined,
+      data: undefined,
+      fetchMore: jest.fn(),
+    })
   })
 
-  it("renders a row per transaction of the contact", async () => {
-    const screen = renderContactTransactions()
+  describe("custodial account", () => {
+    it("runs the contact query and lists what it returns", async () => {
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore: jest.fn(),
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      })
 
-    await waitFor(() => {
-      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+      const { getByTestId } = renderContactTransactions()
+
+      expect(getByTestId("transaction-custodial-tx")).toBeTruthy()
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: false,
+          variables: { username: contact.username },
+        }),
+      )
     })
-    expect(screen.getByTestId("row-507f1f77bcf86cd799439012")).toBeTruthy()
+
+    it("shows the empty state instead of a blank area when there is nothing", () => {
+      const { getByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+    })
+
+    it("reports a failed query through a toast", () => {
+      mockUseQuery.mockReturnValue({
+        error: new Error("network"),
+        data: undefined,
+        fetchMore: jest.fn(),
+      })
+
+      renderContactTransactions()
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
+
+      loadLocale("en")
+      const [{ message }] = mockToastShow.mock.calls[0]
+      expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("asks for the next page when the list reaches its end", async () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore,
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+              },
+            },
+          },
+        },
+      })
+
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).toHaveBeenCalledWith({
+        variables: { username: contact.username, after: "cursor-1" },
+      })
+    })
+
+    it("does not page past the last cursor", () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore,
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      })
+
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    it("does not page a self-custodial list, which the adapter answers in full", async () => {
+      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    it("does not ask the contact adapter for transactions", () => {
+      renderContactTransactions()
+
+      expect(mockGetTransactions).not.toHaveBeenCalled()
+    })
   })
 
-  it("leaves its rows non-pressable", async () => {
-    // This list only shows the history with one contact; it does not navigate
-    // into a transaction, and a row handed a handler here would look tappable
-    // and go nowhere.
-    const screen = renderContactTransactions()
-
-    await waitFor(() => {
-      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+  describe("self-custodial account", () => {
+    beforeEach(() => {
+      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
     })
 
-    expect(mockRowProps.length).toBeGreaterThan(0)
-    expect(mockRowProps.every((props) => props.onPress === undefined)).toBe(true)
+    it("skips the custodial query, which has no session to resolve through", async () => {
+      renderContactTransactions()
+      await flushEffects()
+
+      expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ skip: true }))
+    })
+
+    it("lists the transactions the contact adapter returns", async () => {
+      const normalized = [{ id: "sc-tx" }]
+      mockGetTransactions.mockResolvedValue(normalized)
+      mockFragments.mockImplementation((txs: unknown[]) =>
+        txs.length ? [makeFragment("sc-tx")] : [],
+      )
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+      expect(getByTestId("transaction-sc-tx")).toBeTruthy()
+    })
+
+    it("shows the empty state when the contact has no matching payments", async () => {
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+    })
+
+    it("ignores a late adapter answer after it unmounts", async () => {
+      let resolveTransactions: (value: unknown[]) => void = () => {}
+      mockGetTransactions.mockReturnValue(
+        new Promise((resolve) => {
+          resolveTransactions = resolve
+        }),
+      )
+
+      const { unmount } = renderContactTransactions()
+      unmount()
+      resolveTransactions([{ id: "late-tx" }])
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalled()
+      expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+    })
   })
 
-  it("hands the list the same render callbacks across re-renders", async () => {
-    // A fresh arrow per render defeats the row's React.memo, which is the whole
-    // point of the memoization: every mounted row would re-render with it.
-    const screen = renderContactTransactions()
-
-    await waitFor(() => {
-      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+  describe("list", () => {
+    beforeEach(() => {
+      mockUseQuery.mockReturnValue(
+        custodialQuery({ edges: [{ node: makeFragment("custodial-tx") }] }),
+      )
     })
 
-    const first = screen.UNSAFE_getByType(SectionList).props
+    it("leaves its rows non-pressable", () => {
+      /**
+       * This list only shows the history with one contact; it does not navigate into a
+       * transaction, and a row handed a handler here would look tappable and go nowhere.
+       */
+      renderContactTransactions()
 
-    screen.rerender(
-      <ContextForScreen>
-        <ContactTransactions contactUsername={CONTACT_USERNAME} />
-      </ContextForScreen>,
-    )
-
-    const second = screen.UNSAFE_getByType(SectionList).props
-
-    expect(second.renderItem).toBe(first.renderItem)
-    expect(second.keyExtractor).toBe(first.keyExtractor)
-    expect(second.renderSectionHeader).toBe(first.renderSectionHeader)
-  })
-
-  it("bounds the mounted row set with the shared window size", async () => {
-    const screen = renderContactTransactions()
-
-    await waitFor(() => {
-      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+      expect(mockRowProps.length).toBeGreaterThan(0)
+      expect(mockRowProps.every((props) => props.onPress === undefined)).toBe(true)
     })
 
-    expect(screen.UNSAFE_getByType(SectionList).props.windowSize).toBe(
-      TRANSACTION_LIST_WINDOW_SIZE,
-    )
+    it("hands the list the same render callbacks across re-renders", () => {
+      /**
+       * A fresh arrow per render defeats the row's React.memo, which is the whole point of
+       * the memoization: every mounted row would re-render with it.
+       */
+      const screen = renderContactTransactions()
+      const first = screen.UNSAFE_getByType(SectionList).props
+
+      screen.rerender(contactTransactionsScreen())
+
+      const second = screen.UNSAFE_getByType(SectionList).props
+
+      expect(second.renderItem).toBe(first.renderItem)
+      expect(second.keyExtractor).toBe(first.keyExtractor)
+      expect(second.renderSectionHeader).toBe(first.renderSectionHeader)
+    })
+
+    it("bounds the mounted row set with the shared window size", () => {
+      const screen = renderContactTransactions()
+
+      expect(screen.UNSAFE_getByType(SectionList).props.windowSize).toBe(
+        TRANSACTION_LIST_WINDOW_SIZE,
+      )
+    })
   })
 })

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -1,0 +1,280 @@
+import * as React from "react"
+
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { flushEffects } from "../../../helpers/flush-effects"
+
+import { ThemeProvider } from "@rn-vui/themed"
+
+import { TxStatus, UserContact } from "@app/graphql/generated"
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import theme from "@app/rne-theme/theme"
+import { ContactTransactions } from "@app/screens/people-screen/contacts/contact-transactions"
+import { AccountType } from "@app/types/wallet"
+
+const mockUseQuery = jest.fn()
+const mockGetTransactions = jest.fn()
+const mockActiveAccountType = jest.fn()
+const mockToastShow = jest.fn()
+const mockFragments = jest.fn()
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useTransactionListForContactQuery: (options: unknown) => mockUseQuery(options),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => true,
+}))
+
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ activeAccount: { type: mockActiveAccountType() } }),
+}))
+
+jest.mock("@app/hooks/use-contacts", () => ({
+  useContacts: () => ({ getTransactions: mockGetTransactions }),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-self-custodial-transaction-fragments", () => ({
+  useSelfCustodialTransactionFragments: (transactions: unknown) =>
+    mockFragments(transactions),
+}))
+
+jest.mock("@app/components/transaction-item", () => ({
+  MemoizedTransactionItem: ({ txid }: { txid: string }) => {
+    const { View } = jest.requireActual("react-native")
+    return <View testID={`transaction-${txid}`} />
+  },
+}))
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (args: unknown) => mockToastShow(args),
+}))
+
+/** Real translations so the section headers and empty state read like production. */
+jest.mock("@app/i18n/i18n-react", () => {
+  const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
+  const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
+  loadLocale("en")
+
+  return { useI18nContext: () => ({ LL: i18nObject("en"), locale: "en" }) }
+})
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useFocusEffect: (callback: () => undefined | (() => void)) => {
+    const { useEffect } = jest.requireActual("react")
+    useEffect(callback, [callback])
+  },
+}))
+
+const contact: UserContact = {
+  __typename: "UserContact",
+  id: "contact-1",
+  handle: "alice@blink.sv",
+  username: "alice@blink.sv",
+  alias: "Alice",
+  transactionsCount: 2,
+}
+
+const makeFragment = (id: string) => ({
+  __typename: "Transaction" as const,
+  id,
+  status: TxStatus.Success,
+  createdAt: 1747691078,
+  direction: "SEND",
+  memo: null,
+  settlementAmount: 100,
+  settlementCurrency: "BTC",
+})
+
+const renderContactTransactions = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <ContactTransactions contact={contact} />
+    </ThemeProvider>,
+  )
+
+describe("ContactTransactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockActiveAccountType.mockReturnValue(AccountType.Custodial)
+    mockGetTransactions.mockResolvedValue([])
+    mockFragments.mockReturnValue([])
+    mockUseQuery.mockReturnValue({
+      error: undefined,
+      data: undefined,
+      fetchMore: jest.fn(),
+    })
+  })
+
+  describe("custodial account", () => {
+    it("runs the contact query and lists what it returns", async () => {
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore: jest.fn(),
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      })
+
+      const { getByTestId } = renderContactTransactions()
+
+      expect(getByTestId("transaction-custodial-tx")).toBeTruthy()
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: false,
+          variables: { username: contact.username },
+        }),
+      )
+    })
+
+    it("shows the empty state instead of a blank area when there is nothing", () => {
+      const { getByTestId } = renderContactTransactions()
+
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+    })
+
+    it("reports a failed query through a toast", () => {
+      mockUseQuery.mockReturnValue({
+        error: new Error("network"),
+        data: undefined,
+        fetchMore: jest.fn(),
+      })
+
+      renderContactTransactions()
+
+      expect(mockToastShow).toHaveBeenCalledTimes(1)
+
+      loadLocale("en")
+      const [{ message }] = mockToastShow.mock.calls[0]
+      expect(message(i18nObject("en"))).toBe("Error loading transactions")
+    })
+
+    it("asks for the next page when the list reaches its end", async () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore,
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+              },
+            },
+          },
+        },
+      })
+
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).toHaveBeenCalledWith({
+        variables: { username: contact.username, after: "cursor-1" },
+      })
+    })
+
+    it("does not page past the last cursor", () => {
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({
+        error: undefined,
+        fetchMore,
+        data: {
+          me: {
+            contactByUsername: {
+              transactions: {
+                edges: [{ node: makeFragment("custodial-tx") }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      })
+
+      const { getByTestId } = renderContactTransactions()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    it("does not page a self-custodial list, which the adapter answers in full", async () => {
+      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
+      const fetchMore = jest.fn()
+      mockUseQuery.mockReturnValue({ error: undefined, data: undefined, fetchMore })
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+      fireEvent(getByTestId("contact-transactions-list"), "endReached")
+
+      expect(fetchMore).not.toHaveBeenCalled()
+    })
+
+    it("does not ask the contact adapter for transactions", () => {
+      renderContactTransactions()
+
+      expect(mockGetTransactions).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("self-custodial account", () => {
+    beforeEach(() => {
+      mockActiveAccountType.mockReturnValue(AccountType.SelfCustodial)
+    })
+
+    it("skips the custodial query, which has no session to resolve through", async () => {
+      renderContactTransactions()
+      await flushEffects()
+
+      expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({ skip: true }))
+    })
+
+    it("lists the transactions the contact adapter returns", async () => {
+      const normalized = [{ id: "sc-tx" }]
+      mockGetTransactions.mockResolvedValue(normalized)
+      mockFragments.mockImplementation((txs: unknown[]) =>
+        txs.length ? [makeFragment("sc-tx")] : [],
+      )
+
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+      expect(getByTestId("transaction-sc-tx")).toBeTruthy()
+    })
+
+    it("shows the empty state when the contact has no matching payments", async () => {
+      const { getByTestId } = renderContactTransactions()
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalledWith(contact.id)
+      expect(getByTestId("contact-no-transactions")).toBeTruthy()
+    })
+
+    it("ignores a late adapter answer after it unmounts", async () => {
+      let resolveTransactions: (value: unknown[]) => void = () => {}
+      mockGetTransactions.mockReturnValue(
+        new Promise((resolve) => {
+          resolveTransactions = resolve
+        }),
+      )
+
+      const { unmount } = renderContactTransactions()
+      unmount()
+      resolveTransactions([{ id: "late-tx" }])
+      await flushEffects()
+
+      expect(mockGetTransactions).toHaveBeenCalled()
+      expect(mockFragments).not.toHaveBeenCalledWith([{ id: "late-tx" }])
+    })
+  })
+})

--- a/__tests__/screens/people-screen/contacts/contacts-detail.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contacts-detail.spec.tsx
@@ -75,6 +75,14 @@ describe("ContactsDetailScreen", () => {
     expect(getByText("alice@blink.sv")).toBeTruthy()
   })
 
+  it("keeps a long address on one line rather than breaking it in two", () => {
+    const { getByText } = renderContactsDetail(
+      makeContact({ handle: "deepbassoon958@walletofsatoshi.com" }),
+    )
+
+    expect(getByText("deepbassoon958@walletofsatoshi.com").props.numberOfLines).toBe(1)
+  })
+
   it("completes a bare handle with the instance hostname", () => {
     const { getByText } = renderContactsDetail(makeContact({ handle: " alice " }))
 

--- a/__tests__/screens/people-screen/contacts/contacts-detail.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contacts-detail.spec.tsx
@@ -1,0 +1,124 @@
+import * as React from "react"
+
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { ThemeProvider } from "@rn-vui/themed"
+
+import { UserContact } from "@app/graphql/generated"
+import theme from "@app/rne-theme/theme"
+import {
+  ContactsDetailScreen,
+  ContactsDetailScreenJSX,
+} from "@app/screens/people-screen/contacts/contacts-detail"
+
+import { findPressableParent } from "../../helper"
+
+const mockNavigate = jest.fn()
+const mockLnAddressHostname = jest.fn()
+
+jest.mock("@app/hooks", () => ({
+  ...jest.requireActual("@app/hooks"),
+  useAppConfig: () => ({
+    appConfig: { galoyInstance: { lnAddressHostname: mockLnAddressHostname() } },
+  }),
+}))
+
+/** The list has its own spec; here it only has to report the contact it was handed. */
+jest.mock("@app/screens/people-screen/contacts/contact-transactions", () => ({
+  ContactTransactions: ({ contact }: { contact: { id: string } }) => {
+    const { View } = jest.requireActual("react-native")
+    return <View testID={`contact-transactions-${contact.id}`} />
+  },
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
+/** Real translations so the send button reads like production. */
+jest.mock("@app/i18n/i18n-react", () => {
+  const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
+  const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
+  loadLocale("en")
+  const LL = i18nObject("en")
+
+  return { useI18nContext: () => ({ LL, locale: "en" }) }
+})
+
+const makeContact = (overrides: Partial<UserContact> = {}): UserContact => ({
+  __typename: "UserContact",
+  id: "contact-1",
+  handle: "alice@blink.sv",
+  username: "alice",
+  alias: "Alice",
+  transactionsCount: 2,
+  ...overrides,
+})
+
+const renderContactsDetail = (contact: UserContact) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <ContactsDetailScreenJSX contact={contact} />
+    </ThemeProvider>,
+  )
+
+describe("ContactsDetailScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLnAddressHostname.mockReturnValue("blink.sv")
+  })
+
+  it("heads the screen with the contact's lightning address", () => {
+    const { getByText } = renderContactsDetail(makeContact())
+
+    expect(getByText("alice@blink.sv")).toBeTruthy()
+  })
+
+  it("completes a bare handle with the instance hostname", () => {
+    const { getByText } = renderContactsDetail(makeContact({ handle: " alice " }))
+
+    expect(getByText("alice@blink.sv")).toBeTruthy()
+  })
+
+  it("heads the screen with nothing rather than a bare domain", () => {
+    // A contact with no handle has no address to show, and "@blink.sv" would read
+    // like one belonging to nobody.
+    const { queryByText } = renderContactsDetail(makeContact({ handle: "  " }))
+
+    expect(queryByText(/@/)).toBeNull()
+  })
+
+  it("hands the contact to the transactions list", () => {
+    const { getByTestId } = renderContactsDetail(makeContact())
+
+    expect(getByTestId("contact-transactions-contact-1")).toBeTruthy()
+  })
+
+  it("opens the send flow for the contact", () => {
+    const contact = makeContact()
+    const { getByText } = renderContactsDetail(contact)
+
+    fireEvent.press(findPressableParent(getByText("Send")))
+
+    expect(mockNavigate).toHaveBeenCalledWith("sendBitcoinDestination", {
+      username: contact.username,
+    })
+  })
+
+  it("reads the contact off the route it was navigated with", () => {
+    const contact = makeContact({ id: "contact-2", handle: "bob@blink.sv" })
+    const route = { params: { contact } } as React.ComponentProps<
+      typeof ContactsDetailScreen
+    >["route"]
+
+    const { getByText, getByTestId } = render(
+      <ThemeProvider theme={theme}>
+        <ContactsDetailScreen route={route} />
+      </ThemeProvider>,
+    )
+
+    expect(getByText("bob@blink.sv")).toBeTruthy()
+    expect(getByTestId("contact-transactions-contact-2")).toBeTruthy()
+  })
+})

--- a/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
+++ b/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
@@ -8,26 +8,20 @@ const mockListContacts = jest.fn()
 const mockFindOrCreateContact = jest.fn()
 const mockUpdateContact = jest.fn()
 const mockDeleteContact = jest.fn()
-const mockListPayments = jest.fn()
-const mockMapTransactions = jest.fn()
+const mockFetchContactPaymentsPage = jest.fn()
 const mockUseSelfCustodialWallet = jest.fn()
 
-jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
-  // eslint-disable-next-line camelcase
-  PaymentDetails_Tags: { Lightning: "Lightning", Spark: "Spark" },
-  PaymentType: { Send: "Send", Receive: "Receive" },
-}))
+jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({}))
 
 jest.mock("@app/self-custodial/bridge", () => ({
   listContacts: (...args: unknown[]) => mockListContacts(...args),
   findOrCreateContact: (...args: unknown[]) => mockFindOrCreateContact(...args),
   updateContact: (...args: unknown[]) => mockUpdateContact(...args),
   deleteContact: (...args: unknown[]) => mockDeleteContact(...args),
-  listPayments: (...args: unknown[]) => mockListPayments(...args),
 }))
 
-jest.mock("@app/self-custodial/mappers/transaction", () => ({
-  mapSelfCustodialTransactions: (...args: unknown[]) => mockMapTransactions(...args),
+jest.mock("@app/self-custodial/providers/contact-payments", () => ({
+  fetchContactPaymentsPage: (...args: unknown[]) => mockFetchContactPaymentsPage(...args),
 }))
 
 jest.mock("@app/self-custodial/providers/wallet", () => ({
@@ -65,8 +59,11 @@ describe("useSelfCustodialContacts", () => {
     mockFindOrCreateContact.mockResolvedValue(undefined)
     mockUpdateContact.mockResolvedValue(undefined)
     mockDeleteContact.mockResolvedValue(undefined)
-    mockListPayments.mockResolvedValue({ payments: [] })
-    mockMapTransactions.mockReturnValue([])
+    mockFetchContactPaymentsPage.mockResolvedValue({
+      transactions: [],
+      rawOffset: 0,
+      hasMore: false,
+    })
     mockUseSelfCustodialWallet.mockReturnValue({ sdk: mockSdk })
   })
 
@@ -166,44 +163,74 @@ describe("useSelfCustodialContacts", () => {
     expect(mockDeleteContact).toHaveBeenCalledWith(mockSdk, "c1")
   })
 
-  it("getTransactions() returns an empty list when the contact id is unknown", async () => {
+  it("getTransactions() returns an exhausted page when the wallet is not connected", async () => {
+    mockUseSelfCustodialWallet.mockReturnValue({ sdk: null })
+
     const { result } = renderHook(() => useSelfCustodialContacts())
     await waitFor(() => expect(result.current.loading).toBe(false))
 
-    const txs = await result.current.getTransactions("missing")
+    const page = await result.current.getTransactions("alice@blink.sv")
 
-    expect(txs).toEqual([])
-    expect(mockListPayments).not.toHaveBeenCalled()
+    expect(page).toEqual({ transactions: [], nextCursor: null })
+    expect(mockFetchContactPaymentsPage).not.toHaveBeenCalled()
   })
 
-  it("getTransactions() filters payments to those matching the contact's lnAddress", async () => {
-    const matchingPayment = {
-      paymentType: "Send",
-      details: {
-        tag: "Lightning",
-        inner: { lnurlPayInfo: { lnAddress: "ALICE@BLINK.SV" } },
-      },
-    }
-    const nonMatchingPayment = {
-      paymentType: "Send",
-      details: {
-        tag: "Lightning",
-        inner: { lnurlPayInfo: { lnAddress: "stranger@blink.sv" } },
-      },
-    }
-    const sparkPayment = {
-      paymentType: "Send",
-      details: { tag: "Spark", inner: {} },
-    }
-    mockListPayments.mockResolvedValue({
-      payments: [matchingPayment, nonMatchingPayment, sparkPayment],
+  it("getTransactions() asks for the payments from the start of the history", async () => {
+    mockFetchContactPaymentsPage.mockResolvedValue({
+      transactions: [{ id: "tx-1" }],
+      rawOffset: 20,
+      hasMore: true,
     })
 
     const { result } = renderHook(() => useSelfCustodialContacts())
     await waitFor(() => expect(result.current.loading).toBe(false))
 
-    await result.current.getTransactions("c1")
+    const page = await result.current.getTransactions("alice@blink.sv")
 
-    expect(mockMapTransactions).toHaveBeenCalledWith([matchingPayment])
+    expect(mockFetchContactPaymentsPage).toHaveBeenCalledWith(
+      mockSdk,
+      "alice@blink.sv",
+      0,
+    )
+    expect(page).toEqual({ transactions: [{ id: "tx-1" }], nextCursor: "20" })
+  })
+
+  it("getTransactions() resumes from the cursor it handed out", async () => {
+    mockFetchContactPaymentsPage.mockResolvedValue({
+      transactions: [],
+      rawOffset: 60,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(() => useSelfCustodialContacts())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const page = await result.current.getTransactions("alice@blink.sv", "40")
+
+    expect(mockFetchContactPaymentsPage).toHaveBeenCalledWith(
+      mockSdk,
+      "alice@blink.sv",
+      40,
+    )
+    expect(page.nextCursor).toBeNull()
+  })
+
+  it("getTransactions() restarts rather than passing a cursor it did not issue", async () => {
+    mockFetchContactPaymentsPage.mockResolvedValue({
+      transactions: [],
+      rawOffset: 0,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(() => useSelfCustodialContacts())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await result.current.getTransactions("alice@blink.sv", "not-a-number")
+
+    expect(mockFetchContactPaymentsPage).toHaveBeenCalledWith(
+      mockSdk,
+      "alice@blink.sv",
+      0,
+    )
   })
 })

--- a/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
+++ b/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
@@ -88,6 +88,20 @@ describe("useSelfCustodialContacts", () => {
     expect(mockListContacts).not.toHaveBeenCalled()
   })
 
+  it("list() answers with nothing while the wallet is not connected", async () => {
+    mockUseSelfCustodialWallet.mockReturnValue({ sdk: null })
+    const { result } = renderHook(() => useSelfCustodialContacts())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    let contacts: Awaited<ReturnType<typeof result.current.list>>["contacts"] = []
+    await act(async () => {
+      ;({ contacts } = await result.current.list())
+    })
+
+    expect(contacts).toEqual([])
+    expect(mockListContacts).not.toHaveBeenCalled()
+  })
+
   it("exposes full write capabilities", async () => {
     const { result } = renderHook(() => useSelfCustodialContacts())
     await waitFor(() => expect(result.current.loading).toBe(false))
@@ -140,6 +154,21 @@ describe("useSelfCustodialContacts", () => {
       id: "c1",
       name: "Alice 2",
       paymentIdentifier: "alice@blink.sv",
+    })
+  })
+
+  it("update() keeps the name when only the payment identifier changes", async () => {
+    const { result } = renderHook(() => useSelfCustodialContacts())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.update("c1", { paymentIdentifier: "alice@other.sv" })
+    })
+
+    expect(mockUpdateContact).toHaveBeenCalledWith(mockSdk, {
+      id: "c1",
+      name: "Alice",
+      paymentIdentifier: "alice@other.sv",
     })
   })
 
@@ -232,5 +261,36 @@ describe("useSelfCustodialContacts", () => {
       "alice@blink.sv",
       0,
     )
+  })
+
+  it("holds no contacts when the first read fails, and stops loading", async () => {
+    // A failed read leaves the screen with nothing to match against rather than a
+    // half-populated list, and must not spin forever.
+    mockListContacts.mockRejectedValue(new Error("sdk unavailable"))
+
+    const { result } = renderHook(() => useSelfCustodialContacts())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    await expect(result.current.update("c1", { displayName: "Alice 2" })).rejects.toThrow(
+      /Contact c1 not found/,
+    )
+  })
+
+  it("ignores a read that answers after it unmounts", async () => {
+    let rejectRead: (error: Error) => void = () => {}
+    mockListContacts.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectRead = reject
+      }),
+    )
+
+    const { unmount } = renderHook(() => useSelfCustodialContacts())
+    unmount()
+
+    await act(async () => {
+      rejectRead(new Error("late"))
+    })
+
+    expect(mockListContacts).toHaveBeenCalledWith(mockSdk)
   })
 })

--- a/__tests__/self-custodial/hooks/use-self-custodial-transaction-fragments.spec.ts
+++ b/__tests__/self-custodial/hooks/use-self-custodial-transaction-fragments.spec.ts
@@ -1,0 +1,164 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { flushEffects } from "../../helpers/flush-effects"
+
+import { TxStatus, WalletCurrency } from "@app/graphql/generated"
+import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
+import {
+  NormalizedTransaction,
+  PaymentType,
+  TransactionDirection,
+  TransactionStatus,
+} from "@app/types/transaction"
+
+const mockWriteFragment = jest.fn()
+const mockBatch = jest.fn(({ update }: { update: (cache: unknown) => void }) =>
+  update({
+    identify: ({ id }: { id: string }) => `Transaction:${id}`,
+    writeFragment: mockWriteFragment,
+  }),
+)
+
+jest.mock("@apollo/client", () => ({
+  ...jest.requireActual("@apollo/client"),
+  useApolloClient: () => ({ cache: { batch: mockBatch } }),
+}))
+
+const mockConvertMoneyAmount = jest.fn()
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({
+    convertMoneyAmount: mockConvertMoneyAmount(),
+    displayCurrency: "USD",
+  }),
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({ fractionDigits: 2 }),
+}))
+
+/** Real translations: the description resolver reaches deep into `LL` and a hand-rolled
+ *  stub would only prove the stub matches itself. */
+jest.mock("@app/i18n/i18n-react", () => {
+  const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
+  const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
+  loadLocale("en")
+
+  return { useI18nContext: () => ({ LL: i18nObject("en") }) }
+})
+
+const makeTransaction = (
+  overrides: Partial<NormalizedTransaction> = {},
+): NormalizedTransaction => ({
+  id: "tx-1",
+  amount: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+  direction: TransactionDirection.Send,
+  status: TransactionStatus.Completed,
+  timestamp: 1747691078,
+  paymentType: PaymentType.Lightning,
+  ...overrides,
+})
+
+describe("useSelfCustodialTransactionFragments", () => {
+  const originalWarn = console.warn
+
+  beforeAll(() => {
+    /** React Native warns once that InteractionManager is deprecated. The hook keeps it
+     *  for parity with the screens this logic was extracted from, so that one message is
+     *  dropped here while every other warning still surfaces. */
+    jest.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      const [first] = args
+      if (
+        typeof first === "string" &&
+        first.includes("InteractionManager has been deprecated")
+      )
+        return
+      originalWarn(...args)
+    })
+  })
+
+  afterAll(() => {
+    jest.mocked(console.warn).mockRestore()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConvertMoneyAmount.mockReturnValue(undefined)
+  })
+
+  it("maps self-custodial transactions to the shared fragment shape", () => {
+    const { result } = renderHook(() =>
+      useSelfCustodialTransactionFragments([makeTransaction()]),
+    )
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0]).toMatchObject({
+      __typename: "Transaction",
+      id: "tx-1",
+      status: TxStatus.Success,
+    })
+  })
+
+  it("drops failed payments so they never reach a history list", () => {
+    const { result } = renderHook(() =>
+      useSelfCustodialTransactionFragments([
+        makeTransaction({ id: "ok" }),
+        makeTransaction({ id: "failed", status: TransactionStatus.Failed }),
+      ]),
+    )
+
+    expect(result.current.map((tx) => tx.id)).toEqual(["ok"])
+  })
+
+  it("primes the cache so the shared transaction item can read each fragment", async () => {
+    renderHook(() => useSelfCustodialTransactionFragments([makeTransaction()]))
+    await flushEffects()
+
+    expect(mockBatch).toHaveBeenCalledTimes(1)
+    expect(mockWriteFragment).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "Transaction:tx-1" }),
+    )
+  })
+
+  it("skips the cache write when there is nothing to prime", async () => {
+    renderHook(() => useSelfCustodialTransactionFragments([]))
+    await flushEffects()
+
+    expect(mockBatch).not.toHaveBeenCalled()
+  })
+
+  it("still maps when no price conversion is available yet", () => {
+    mockConvertMoneyAmount.mockReturnValue(undefined)
+
+    const { result } = renderHook(() =>
+      useSelfCustodialTransactionFragments([makeTransaction()]),
+    )
+
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0].settlementDisplayCurrency).toBe("BTC")
+  })
+
+  it("formats display amounts once the price conversion is ready", () => {
+    mockConvertMoneyAmount.mockReturnValue((amount: { amount: number }) => ({
+      amount: amount.amount,
+      currency: "DisplayCurrency",
+      currencyCode: "USD",
+    }))
+
+    const { result } = renderHook(() =>
+      useSelfCustodialTransactionFragments([makeTransaction()]),
+    )
+
+    expect(result.current[0].settlementDisplayCurrency).toBe("USD")
+  })
+
+  it("never writes to the cache once it has unmounted", async () => {
+    const { unmount } = renderHook(() =>
+      useSelfCustodialTransactionFragments([makeTransaction()]),
+    )
+    unmount()
+    await flushEffects()
+
+    expect(mockBatch).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/self-custodial/providers/contact-payments.spec.ts
+++ b/__tests__/self-custodial/providers/contact-payments.spec.ts
@@ -1,0 +1,129 @@
+import { fetchContactPaymentsPage } from "@app/self-custodial/providers/contact-payments"
+import { NormalizedTransaction, TransactionDirection } from "@app/types/transaction"
+
+const mockFetchAndMapPayments = jest.fn()
+
+jest.mock("@app/self-custodial/providers/payments-page", () => ({
+  ...jest.requireActual("@app/self-custodial/providers/payments-page"),
+  fetchAndMapPayments: (...args: unknown[]) => mockFetchAndMapPayments(...args),
+}))
+
+const sdk = { id: "sdk" } as never
+
+const tx = (
+  id: string,
+  lnAddress?: string,
+  direction: TransactionDirection = TransactionDirection.Send,
+) => ({ id, lnAddress, direction }) as unknown as NormalizedTransaction
+
+/** One raw SDK page: `rawCount` counts what the SDK answered, not what survived mapping. */
+const rawPage = (
+  transactions: NormalizedTransaction[],
+  { rawCount = 20, hasMore = true }: { rawCount?: number; hasMore?: boolean } = {},
+) => ({ transactions, rawCount, hasMore })
+
+describe("fetchContactPaymentsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("keeps only the payments whose lightning address is the contact's", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(
+      rawPage([tx("mine", "alice@blink.sv"), tx("theirs", "bob@blink.sv"), tx("none")], {
+        hasMore: false,
+      }),
+    )
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(page.transactions.map((t) => t.id)).toEqual(["mine"])
+  })
+
+  it("leaves out receives, whose address is the one the payer resolved", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(
+      rawPage(
+        [
+          tx("sent", "alice@blink.sv"),
+          tx("received", "alice@blink.sv", TransactionDirection.Receive),
+        ],
+        { hasMore: false },
+      ),
+    )
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(page.transactions.map((t) => t.id)).toEqual(["sent"])
+  })
+
+  it("matches regardless of case or surrounding whitespace", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(
+      rawPage([tx("mine", "  ALICE@Blink.SV ")], { hasMore: false }),
+    )
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(page.transactions.map((t) => t.id)).toEqual(["mine"])
+  })
+
+  it("resumes from the offset it is given", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(rawPage([], { hasMore: false }))
+
+    await fetchContactPaymentsPage(sdk, "alice@blink.sv", 40)
+
+    expect(mockFetchAndMapPayments).toHaveBeenCalledWith(sdk, 40)
+  })
+
+  it("keeps reading past raw pages that hold nothing for this contact", async () => {
+    mockFetchAndMapPayments
+      .mockResolvedValueOnce(rawPage([tx("stranger", "bob@blink.sv")]))
+      .mockResolvedValueOnce(rawPage([tx("stranger-2", "carol@blink.sv")]))
+      .mockResolvedValueOnce(rawPage([tx("mine", "alice@blink.sv")], { hasMore: false }))
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(mockFetchAndMapPayments).toHaveBeenCalledTimes(3)
+    expect(mockFetchAndMapPayments).toHaveBeenNthCalledWith(2, sdk, 20)
+    expect(mockFetchAndMapPayments).toHaveBeenNthCalledWith(3, sdk, 40)
+    expect(page.transactions.map((t) => t.id)).toEqual(["mine"])
+  })
+
+  it("stops once it has filled a page of matches, leaving a cursor to resume from", async () => {
+    const full = Array.from({ length: 20 }, (_, i) => tx(`tx-${i}`, "alice@blink.sv"))
+    mockFetchAndMapPayments.mockResolvedValue(rawPage(full))
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(mockFetchAndMapPayments).toHaveBeenCalledTimes(1)
+    expect(page.transactions).toHaveLength(20)
+    expect(page).toMatchObject({ rawOffset: 20, hasMore: true })
+  })
+
+  it("reports the history as exhausted when the wallet runs out", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(
+      rawPage([tx("mine", "alice@blink.sv")], { rawCount: 7, hasMore: false }),
+    )
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(page).toMatchObject({ rawOffset: 7, hasMore: false })
+  })
+
+  it("gives up its budget rather than walking the whole wallet for a sparse contact", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(rawPage([tx("stranger", "bob@blink.sv")]))
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(mockFetchAndMapPayments).toHaveBeenCalledTimes(5)
+    expect(page.transactions).toEqual([])
+    expect(page).toMatchObject({ rawOffset: 100, hasMore: true })
+  })
+
+  it("stops on an empty answer without advancing the cursor", async () => {
+    mockFetchAndMapPayments.mockResolvedValue(rawPage([], { rawCount: 0 }))
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 60)
+
+    expect(mockFetchAndMapPayments).toHaveBeenCalledTimes(1)
+    expect(page).toEqual({ transactions: [], rawOffset: 60, hasMore: false })
+  })
+})

--- a/__tests__/self-custodial/providers/contact-payments.spec.ts
+++ b/__tests__/self-custodial/providers/contact-payments.spec.ts
@@ -39,7 +39,7 @@ describe("fetchContactPaymentsPage", () => {
     expect(page.transactions.map((t) => t.id)).toEqual(["mine"])
   })
 
-  it("leaves out receives, whose address is the one the payer resolved", async () => {
+  it("lists what the contact was paid and what they paid back", async () => {
     mockFetchAndMapPayments.mockResolvedValue(
       rawPage(
         [
@@ -52,7 +52,21 @@ describe("fetchContactPaymentsPage", () => {
 
     const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
 
-    expect(page.transactions.map((t) => t.id)).toEqual(["sent"])
+    expect(page.transactions.map((t) => t.id)).toEqual(["sent", "received"])
+  })
+
+  it("leaves out a receive addressed to anyone but the contact", async () => {
+    // A received payment that carries the user's own address rather than the sender's
+    // belongs to no contact, and must not surface on every contact screen.
+    mockFetchAndMapPayments.mockResolvedValue(
+      rawPage([tx("mine", "me@blink.sv", TransactionDirection.Receive)], {
+        hasMore: false,
+      }),
+    )
+
+    const page = await fetchContactPaymentsPage(sdk, "alice@blink.sv", 0)
+
+    expect(page.transactions).toEqual([])
   })
 
   it("matches regardless of case or surrounding whitespace", async () => {

--- a/__tests__/self-custodial/providers/payments-page.spec.ts
+++ b/__tests__/self-custodial/providers/payments-page.spec.ts
@@ -1,0 +1,134 @@
+import {
+  fetchAndMapPayments,
+  TRANSACTIONS_PER_PAGE,
+} from "@app/self-custodial/providers/payments-page"
+
+const mockListPayments = jest.fn()
+const mockMapTransactions = jest.fn()
+const mockRecordErrorOnce = jest.fn()
+const mockRequireSparkTokenIdentifier = jest.fn()
+
+jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
+  PaymentMethod: { Token: "Token", Lightning: "Lightning" },
+  PaymentDetails: {
+    Token: {
+      instanceOf: (details: { tag?: string }) => details?.tag === "Token",
+    },
+  },
+}))
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  listPayments: (...args: unknown[]) => mockListPayments(...args),
+}))
+
+jest.mock("@app/self-custodial/config", () => ({
+  requireSparkTokenIdentifier: () => mockRequireSparkTokenIdentifier(),
+}))
+
+jest.mock("@app/self-custodial/logging", () => ({
+  recordErrorOnce: (...args: unknown[]) => mockRecordErrorOnce(...args),
+}))
+
+jest.mock("@app/self-custodial/mappers/transaction", () => ({
+  mapSelfCustodialTransactions: (...args: unknown[]) => mockMapTransactions(...args),
+}))
+
+const sdk = { id: "sdk" } as never
+
+const lightningPayment = { id: "ln", method: "Lightning" }
+
+const tokenPayment = (identifier: string) => ({
+  id: `token-${identifier}`,
+  method: "Token",
+  details: { tag: "Token", inner: { metadata: { identifier } } },
+})
+
+describe("fetchAndMapPayments", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMapTransactions.mockReturnValue([])
+    mockRequireSparkTokenIdentifier.mockReturnValue("usdb")
+  })
+
+  it("asks the SDK for one page starting at the given offset", async () => {
+    mockListPayments.mockResolvedValue({ payments: [] })
+
+    await fetchAndMapPayments(sdk, 40)
+
+    expect(mockListPayments).toHaveBeenCalledWith(sdk, 40, TRANSACTIONS_PER_PAGE)
+  })
+
+  it("counts what the SDK answered, not what survived mapping", async () => {
+    mockListPayments.mockResolvedValue({ payments: [lightningPayment, lightningPayment] })
+    mockMapTransactions.mockReturnValue([{ id: "only-one" }])
+
+    const page = await fetchAndMapPayments(sdk, 0)
+
+    expect(page.rawCount).toBe(2)
+    expect(page.transactions).toEqual([{ id: "only-one" }])
+  })
+
+  it("reports more pages while the SDK fills the page it was asked for", async () => {
+    mockListPayments.mockResolvedValue({
+      payments: Array.from({ length: TRANSACTIONS_PER_PAGE }, () => lightningPayment),
+    })
+
+    const page = await fetchAndMapPayments(sdk, 0)
+
+    expect(page.hasMore).toBe(true)
+  })
+
+  it("reports the history as exhausted on a short page", async () => {
+    mockListPayments.mockResolvedValue({ payments: [lightningPayment] })
+
+    const page = await fetchAndMapPayments(sdk, 0)
+
+    expect(page.hasMore).toBe(false)
+  })
+
+  it("keeps every payment that is not a token payment", async () => {
+    mockListPayments.mockResolvedValue({ payments: [lightningPayment] })
+
+    await fetchAndMapPayments(sdk, 0)
+
+    expect(mockMapTransactions).toHaveBeenCalledWith([lightningPayment])
+  })
+
+  it("keeps token payments minted by the token this build expects", async () => {
+    const known = tokenPayment("usdb")
+    mockListPayments.mockResolvedValue({ payments: [known] })
+
+    await fetchAndMapPayments(sdk, 0)
+
+    expect(mockMapTransactions).toHaveBeenCalledWith([known])
+    expect(mockRecordErrorOnce).not.toHaveBeenCalled()
+  })
+
+  it("drops a token payment from an unknown token and reports it once", async () => {
+    mockListPayments.mockResolvedValue({ payments: [tokenPayment("counterfeit")] })
+
+    await fetchAndMapPayments(sdk, 0)
+
+    expect(mockMapTransactions).toHaveBeenCalledWith([])
+    expect(mockRecordErrorOnce).toHaveBeenCalledWith(
+      "spark-unknown-token-payment:counterfeit",
+      expect.objectContaining({
+        message: expect.stringContaining("Unknown token payment dropped"),
+      }),
+    )
+  })
+
+  it("drops a token payment whose details are missing or not token details", async () => {
+    mockListPayments.mockResolvedValue({
+      payments: [
+        { id: "no-details", method: "Token" },
+        { id: "wrong-details", method: "Token", details: { tag: "Lightning" } },
+      ],
+    })
+
+    await fetchAndMapPayments(sdk, 0)
+
+    expect(mockMapTransactions).toHaveBeenCalledWith([])
+    expect(mockRecordErrorOnce).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/self-custodial/providers/payments-page.spec.ts
+++ b/__tests__/self-custodial/providers/payments-page.spec.ts
@@ -29,7 +29,10 @@ jest.mock("@app/self-custodial/logging", () => ({
   recordErrorOnce: (...args: unknown[]) => mockRecordErrorOnce(...args),
 }))
 
+/** Only the mapping is stubbed. `isKnownPayment` comes from the module itself so the
+ *  token filtering below exercises the real predicate against the mocked config. */
 jest.mock("@app/self-custodial/mappers/transaction", () => ({
+  ...jest.requireActual("@app/self-custodial/mappers/transaction"),
   mapSelfCustodialTransactions: (...args: unknown[]) => mockMapTransactions(...args),
 }))
 

--- a/__tests__/self-custodial/providers/wallet-snapshot.spec.ts
+++ b/__tests__/self-custodial/providers/wallet-snapshot.spec.ts
@@ -191,7 +191,7 @@ const buildUnknownTokenPayment = (id: string) => ({
 })
 
 describe("hasMore pagination", () => {
-  it("computes hasMore from the raw response, not after isKnownPayment filtering", async () => {
+  it("reports the page's own hasMore, unchanged by payments it dropped", async () => {
     // 20 raw items (page-size) where 5 are unknown tokens that get filtered out.
     const sdk = createMockSdk()
     const payments = [
@@ -445,50 +445,6 @@ describe("appendTransactions", () => {
 
     // Existing wallet is empty so the first "a" is appended; the second is filtered.
     expect(result[0].transactions.map((t) => t.id)).toEqual(["a", "b"])
-  })
-})
-
-describe("isKnownPayment crashlytics reporting", () => {
-  beforeEach(() => {
-    mockRecordError.mockClear()
-  })
-
-  it("records to crashlytics once per unknown token identifier and drops the payment", async () => {
-    const fresh = loadFreshSnapshotModule()
-    const unknownTokenPayment = {
-      id: "unknown-1",
-      method: 2,
-      paymentType: 0,
-      status: 0,
-      amount: 100,
-      fees: 0,
-      timestamp: 0,
-      details: {
-        tag: "Token",
-        inner: {
-          metadata: { identifier: "rogue-token-id", decimals: 6, ticker: "ROGUE" },
-        },
-      },
-    }
-    const sdk = {
-      getInfo: jest.fn().mockResolvedValue({
-        identityPubkey: "pk",
-        balanceSats: 0,
-        tokenBalances: {},
-      }),
-      listPayments: jest.fn().mockResolvedValue({
-        payments: [unknownTokenPayment, unknownTokenPayment],
-      }),
-    } as never
-
-    await fresh.getSelfCustodialWalletSnapshot(sdk)
-
-    const reportedErrors = mockRecordError.mock.calls.filter((args) => {
-      const message = args[0]?.message ?? ""
-      return message.includes("rogue-token-id")
-    })
-    expect(reportedErrors).toHaveLength(1)
-    expect(reportedErrors[0][0].message).toContain("expected=test-token-id")
   })
 })
 

--- a/__tests__/self-custodial/providers/wallet-snapshot.spec.ts
+++ b/__tests__/self-custodial/providers/wallet-snapshot.spec.ts
@@ -190,7 +190,7 @@ const buildUnknownTokenPayment = (id: string) => ({
 })
 
 describe("hasMore pagination", () => {
-  it("computes hasMore from the raw response, not after isKnownPayment filtering", async () => {
+  it("reports the page's own hasMore, unchanged by payments it dropped", async () => {
     // 20 raw items (page-size) where 5 are unknown tokens that get filtered out.
     const sdk = createMockSdk()
     const payments = [
@@ -444,50 +444,6 @@ describe("appendTransactions", () => {
 
     // Existing wallet is empty so the first "a" is appended; the second is filtered.
     expect(result[0].transactions.map((t) => t.id)).toEqual(["a", "b"])
-  })
-})
-
-describe("isKnownPayment crashlytics reporting", () => {
-  beforeEach(() => {
-    mockRecordError.mockClear()
-  })
-
-  it("records to crashlytics once per unknown token identifier and drops the payment", async () => {
-    const fresh = loadFreshSnapshotModule()
-    const unknownTokenPayment = {
-      id: "unknown-1",
-      method: 2,
-      paymentType: 0,
-      status: 0,
-      amount: 100,
-      fees: 0,
-      timestamp: 0,
-      details: {
-        tag: "Token",
-        inner: {
-          metadata: { identifier: "rogue-token-id", decimals: 6, ticker: "ROGUE" },
-        },
-      },
-    }
-    const sdk = {
-      getInfo: jest.fn().mockResolvedValue({
-        identityPubkey: "pk",
-        balanceSats: 0,
-        tokenBalances: {},
-      }),
-      listPayments: jest.fn().mockResolvedValue({
-        payments: [unknownTokenPayment, unknownTokenPayment],
-      }),
-    } as never
-
-    await fresh.getSelfCustodialWalletSnapshot(sdk)
-
-    const reportedErrors = mockRecordError.mock.calls.filter((args) => {
-      const message = args[0]?.message ?? ""
-      return message.includes("rogue-token-id")
-    })
-    expect(reportedErrors).toHaveLength(1)
-    expect(reportedErrors[0][0].message).toContain("expected=test-token-id")
   })
 })
 

--- a/app/components/icon-hero/icon-hero.tsx
+++ b/app/components/icon-hero/icon-hero.tsx
@@ -10,6 +10,11 @@ type IconHeroProps = {
   iconColor: string
   title: string
   subtitle?: React.ReactNode
+  /**
+   * Caps the title, for a screen whose title is one unbreakable thing — a lightning
+   * address — rather than a sentence. Left open otherwise, so a heading still wraps.
+   */
+  titleLines?: number
 }
 
 export const IconHero: React.FC<IconHeroProps> = ({
@@ -17,6 +22,7 @@ export const IconHero: React.FC<IconHeroProps> = ({
   iconColor,
   title,
   subtitle,
+  titleLines,
 }) => {
   const styles = useStyles()
 
@@ -30,7 +36,9 @@ export const IconHero: React.FC<IconHeroProps> = ({
         <GaloyIcon name={icon} size={34} color={iconColor} />
       </View>
       <View style={styles.textContainer}>
-        <Text style={styles.title}>{title}</Text>
+        <Text style={styles.title} numberOfLines={titleLines} ellipsizeMode="middle">
+          {title}
+        </Text>
         {hasVisibleTextSubtitle && <Text style={styles.subtitle}>{subtitle}</Text>}
         {isPlainTextSubtitle ? null : subtitle}
       </View>

--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -316,6 +316,7 @@ const useStyles = makeStyles(({ colors }, props: UseStyleProps) => ({
     fontWeight: "400",
   },
   subtitle: {
+    color: colors.grey2,
     fontSize: 14,
     lineHeight: 20,
     fontWeight: "400",

--- a/app/custodial/contact-adapter.ts
+++ b/app/custodial/contact-adapter.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react"
 
+import { gql } from "@apollo/client"
 import {
   useContactsQuery,
   useUserContactUpdateAliasMutation,
@@ -12,6 +13,20 @@ import {
   type ContactTransactionsPage,
 } from "@app/types/contact"
 import { AccountType } from "@app/types/wallet"
+
+gql`
+  mutation userContactUpdateAlias($input: UserContactUpdateAliasInput!) {
+    userContactUpdateAlias(input: $input) {
+      errors {
+        message
+      }
+      contact {
+        alias
+        id
+      }
+    }
+  }
+`
 
 const unsupported = (operation: string): Error =>
   new Error(`Custodial contacts do not support ${operation}`)

--- a/app/custodial/contact-adapter.ts
+++ b/app/custodial/contact-adapter.ts
@@ -9,8 +9,8 @@ import {
   type Contact,
   type ContactAdapter,
   type ContactListResult,
+  type ContactTransactionsPage,
 } from "@app/types/contact"
-import { type NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
 
 const unsupported = (operation: string): Error =>
@@ -82,8 +82,15 @@ export const useCustodialContactAdapter = (): ContactAdapter & {
     throw unsupported("deleting contacts")
   }, [])
 
+  /**
+   * Custodial contact history is resolved by the `transactionListForContact` query, which
+   * pages through Apollo, so the adapter has nothing to answer here.
+   */
   const getTransactions = useCallback(
-    async (_contactId: string): Promise<NormalizedTransaction[]> => [],
+    async (_contactId: string): Promise<ContactTransactionsPage> => ({
+      transactions: [],
+      nextCursor: null,
+    }),
     [],
   )
 

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -3287,6 +3287,13 @@ export type WalletOverviewScreenQueryVariables = Exact<{ [key: string]: never; }
 
 export type WalletOverviewScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> } } | null };
 
+export type UserContactUpdateAliasMutationVariables = Exact<{
+  input: UserContactUpdateAliasInput;
+}>;
+
+
+export type UserContactUpdateAliasMutation = { readonly __typename: 'Mutation', readonly userContactUpdateAlias: { readonly __typename: 'UserContactUpdateAliasPayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly contact?: { readonly __typename: 'UserContact', readonly alias?: string | null, readonly id: string } | null } };
+
 export type ExportCsvSettingQueryVariables = Exact<{
   walletIds: ReadonlyArray<Scalars['WalletId']['input']> | Scalars['WalletId']['input'];
 }>;
@@ -3671,13 +3678,6 @@ export type ContactsCardQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type ContactsCardQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly contacts: ReadonlyArray<{ readonly __typename: 'UserContact', readonly id: string, readonly handle: string, readonly username: string, readonly alias?: string | null, readonly transactionsCount: number }> } | null };
-
-export type UserContactUpdateAliasMutationVariables = Exact<{
-  input: UserContactUpdateAliasInput;
-}>;
-
-
-export type UserContactUpdateAliasMutation = { readonly __typename: 'Mutation', readonly userContactUpdateAlias: { readonly __typename: 'UserContactUpdateAliasPayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly contact?: { readonly __typename: 'UserContact', readonly alias?: string | null, readonly id: string } | null } };
 
 export type UserLoginMutationVariables = Exact<{
   input: UserLoginInput;
@@ -4505,6 +4505,45 @@ export type WalletOverviewScreenQueryHookResult = ReturnType<typeof useWalletOve
 export type WalletOverviewScreenLazyQueryHookResult = ReturnType<typeof useWalletOverviewScreenLazyQuery>;
 export type WalletOverviewScreenSuspenseQueryHookResult = ReturnType<typeof useWalletOverviewScreenSuspenseQuery>;
 export type WalletOverviewScreenQueryResult = Apollo.QueryResult<WalletOverviewScreenQuery, WalletOverviewScreenQueryVariables>;
+export const UserContactUpdateAliasDocument = gql`
+    mutation userContactUpdateAlias($input: UserContactUpdateAliasInput!) {
+  userContactUpdateAlias(input: $input) {
+    errors {
+      message
+    }
+    contact {
+      alias
+      id
+    }
+  }
+}
+    `;
+export type UserContactUpdateAliasMutationFn = Apollo.MutationFunction<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>;
+
+/**
+ * __useUserContactUpdateAliasMutation__
+ *
+ * To run a mutation, you first call `useUserContactUpdateAliasMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUserContactUpdateAliasMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [userContactUpdateAliasMutation, { data, loading, error }] = useUserContactUpdateAliasMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUserContactUpdateAliasMutation(baseOptions?: Apollo.MutationHookOptions<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>(UserContactUpdateAliasDocument, options);
+      }
+export type UserContactUpdateAliasMutationHookResult = ReturnType<typeof useUserContactUpdateAliasMutation>;
+export type UserContactUpdateAliasMutationResult = Apollo.MutationResult<UserContactUpdateAliasMutation>;
+export type UserContactUpdateAliasMutationOptions = Apollo.BaseMutationOptions<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>;
 export const ExportCsvSettingDocument = gql`
     query ExportCsvSetting($walletIds: [WalletId!]!) {
   me {
@@ -7356,45 +7395,6 @@ export type ContactsCardQueryHookResult = ReturnType<typeof useContactsCardQuery
 export type ContactsCardLazyQueryHookResult = ReturnType<typeof useContactsCardLazyQuery>;
 export type ContactsCardSuspenseQueryHookResult = ReturnType<typeof useContactsCardSuspenseQuery>;
 export type ContactsCardQueryResult = Apollo.QueryResult<ContactsCardQuery, ContactsCardQueryVariables>;
-export const UserContactUpdateAliasDocument = gql`
-    mutation userContactUpdateAlias($input: UserContactUpdateAliasInput!) {
-  userContactUpdateAlias(input: $input) {
-    errors {
-      message
-    }
-    contact {
-      alias
-      id
-    }
-  }
-}
-    `;
-export type UserContactUpdateAliasMutationFn = Apollo.MutationFunction<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>;
-
-/**
- * __useUserContactUpdateAliasMutation__
- *
- * To run a mutation, you first call `useUserContactUpdateAliasMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUserContactUpdateAliasMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [userContactUpdateAliasMutation, { data, loading, error }] = useUserContactUpdateAliasMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useUserContactUpdateAliasMutation(baseOptions?: Apollo.MutationHookOptions<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>(UserContactUpdateAliasDocument, options);
-      }
-export type UserContactUpdateAliasMutationHookResult = ReturnType<typeof useUserContactUpdateAliasMutation>;
-export type UserContactUpdateAliasMutationResult = Apollo.MutationResult<UserContactUpdateAliasMutation>;
-export type UserContactUpdateAliasMutationOptions = Apollo.BaseMutationOptions<UserContactUpdateAliasMutation, UserContactUpdateAliasMutationVariables>;
 export const UserLoginDocument = gql`
     mutation userLogin($input: UserLoginInput!) {
   userLogin(input: $input) {

--- a/app/hooks/use-contact-transactions.ts
+++ b/app/hooks/use-contact-transactions.ts
@@ -49,13 +49,26 @@ export const useContactTransactions = (
   const generationRef = React.useRef(0)
 
   /**
+   * Mirrors how much is on screen so a rejected page can tell whether the reader has
+   * something to lose. Read from callbacks that must not re-run when the list grows.
+   */
+  const loadedCountRef = React.useRef(0)
+  loadedCountRef.current = transactions.length
+
+  /**
    * Whatever is loaded belongs to the contact it was read for. Pointing the hook at a new
    * one clears it during render, before anything is painted, so the incoming contact is
    * never shown the previous contact's payments while its own first page is in flight.
+   *
+   * The generation moves here rather than only in the focus effect, which runs a paint
+   * later: a page resolving in between would otherwise still pass for current and land on
+   * the contact that replaced it.
    */
   const loadedIdentifierRef = React.useRef(paymentIdentifier)
   if (loadedIdentifierRef.current !== paymentIdentifier) {
     loadedIdentifierRef.current = paymentIdentifier
+    generationRef.current += 1
+    isLoadingMoreRef.current = false
     setTransactions([])
     setCursor(null)
     setHasLoaded(false)
@@ -125,14 +138,37 @@ export const useContactTransactions = (
        * A page that fails leaves the cursor untouched and the list intact, so the reader
        * keeps what they were already looking at and the next scroll retries. Wiping the
        * screen over a page they have not seen yet would cost them the one they had.
+       *
+       * With nothing on screen there is nothing to protect, and no list to scroll into a
+       * retry either, so that failure is reported instead of swallowed.
        */
-      .catch(() => undefined)
+      .catch(() => {
+        if (generation !== generationRef.current) return
+        if (loadedCountRef.current === 0) setHasError(true)
+      })
       .finally(() => {
         if (generation === generationRef.current) isLoadingMoreRef.current = false
       })
   }, [canLoadMore, cursor, getTransactions, paymentIdentifier])
 
-  const isLoadingFirstPage = isEnabled && !hasLoaded
+  /**
+   * A page can come back with nothing for this contact and still leave more history to
+   * read, because matching happens on the client and a request stops at its page budget.
+   * An empty list has nothing to scroll, so no `onEndReached` will ever ask for the rest:
+   * it keeps reading here until something shows up or the history runs out.
+   */
+  const hasNothingToScroll = transactions.length === 0 && cursor !== null
+
+  React.useEffect(() => {
+    if (hasNothingToScroll) loadMore()
+  }, [hasNothingToScroll, loadMore])
+
+  /**
+   * Still loading while it has nothing to show and more to read, so the reader sees the
+   * search continue rather than an empty state that is about to be replaced.
+   */
+  const hasSettled = hasLoaded && !hasNothingToScroll
+  const isLoadingFirstPage = isEnabled && !hasSettled
 
   return {
     transactions,

--- a/app/hooks/use-contact-transactions.ts
+++ b/app/hooks/use-contact-transactions.ts
@@ -1,0 +1,143 @@
+import * as React from "react"
+
+import { useFocusEffect } from "@react-navigation/native"
+
+import { type NormalizedTransaction } from "@app/types/transaction"
+
+import { useContacts } from "./use-contacts"
+
+type ContactTransactionsResult = {
+  transactions: NormalizedTransaction[]
+  isLoading: boolean
+  hasError: boolean
+  loadMore: () => void
+}
+
+const dedupeById = (transactions: NormalizedTransaction[]): NormalizedTransaction[] => [
+  ...new Map(transactions.map((tx) => [tx.id, tx])).values(),
+]
+
+/**
+ * Pages a contact's transactions through whichever contact adapter is active, so the
+ * screen only has to render what it is handed.
+ *
+ * Enabling is left to the caller because the custodial screen resolves the same list
+ * through its own paginated query and must not run both.
+ */
+export const useContactTransactions = (
+  paymentIdentifier: string,
+  isEnabled: boolean,
+): ContactTransactionsResult => {
+  const { getTransactions, loading: contactsLoading } = useContacts()
+
+  const [transactions, setTransactions] = React.useState<NormalizedTransaction[]>([])
+  const [cursor, setCursor] = React.useState<string | null>(null)
+  const [hasLoaded, setHasLoaded] = React.useState(false)
+  const [hasError, setHasError] = React.useState(false)
+
+  /**
+   * A ref, not state: `onEndReached` can fire twice before React re-renders, and a state
+   * flag would still read stale on the second call and fetch the same page twice.
+   */
+  const isLoadingMoreRef = React.useRef(false)
+
+  /**
+   * Bumped every time the first page is re-read. A `loadMore` still in flight from before
+   * that read belongs to a cursor that no longer exists, so it compares the generation it
+   * captured and drops its answer instead of appending a stale page.
+   */
+  const generationRef = React.useRef(0)
+
+  /**
+   * Whatever is loaded belongs to the contact it was read for. Pointing the hook at a new
+   * one clears it during render, before anything is painted, so the incoming contact is
+   * never shown the previous contact's payments while its own first page is in flight.
+   */
+  const loadedIdentifierRef = React.useRef(paymentIdentifier)
+  if (loadedIdentifierRef.current !== paymentIdentifier) {
+    loadedIdentifierRef.current = paymentIdentifier
+    setTransactions([])
+    setCursor(null)
+    setHasLoaded(false)
+    setHasError(false)
+  }
+
+  /**
+   * The adapter answers from the wallet it is connected to, so asking before it is ready
+   * would resolve empty and flash the empty state at a contact that does have payments.
+   */
+  const shouldLoad = isEnabled && !contactsLoading
+
+  /**
+   * Coming back to the screen restarts from the first page rather than merging into what
+   * is already listed: the cursor is an offset into the wallet history, so a payment made
+   * while away shifts every later offset and pages read across that boundary would repeat
+   * or skip entries.
+   */
+  useFocusEffect(
+    React.useCallback(() => {
+      if (!shouldLoad) return undefined
+
+      generationRef.current += 1
+      isLoadingMoreRef.current = false
+
+      let isActive = true
+      setHasError(false)
+      getTransactions(paymentIdentifier)
+        .then((page) => {
+          if (!isActive) return
+          setTransactions(page.transactions)
+          setCursor(page.nextCursor)
+        })
+        .catch(() => {
+          if (isActive) setHasError(true)
+        })
+        .finally(() => {
+          if (isActive) setHasLoaded(true)
+        })
+
+      return () => {
+        isActive = false
+      }
+    }, [shouldLoad, paymentIdentifier, getTransactions]),
+  )
+
+  const canLoadMore = shouldLoad && cursor !== null
+
+  const loadMore = React.useCallback(() => {
+    if (!canLoadMore || isLoadingMoreRef.current) return
+
+    const generation = generationRef.current
+    isLoadingMoreRef.current = true
+
+    getTransactions(paymentIdentifier, cursor)
+      /**
+       * There is no unmount guard here on purpose: since React 18 a state write on an
+       * unmounted component is a silent no-op, so an `isMounted` ref would guard nothing
+       * while adding a flag that a re-run can leave stuck in the wrong position.
+       */
+      .then((page) => {
+        if (generation !== generationRef.current) return
+        setTransactions((previous) => dedupeById([...previous, ...page.transactions]))
+        setCursor(page.nextCursor)
+      })
+      /**
+       * A page that fails leaves the cursor untouched and the list intact, so the reader
+       * keeps what they were already looking at and the next scroll retries. Wiping the
+       * screen over a page they have not seen yet would cost them the one they had.
+       */
+      .catch(() => undefined)
+      .finally(() => {
+        if (generation === generationRef.current) isLoadingMoreRef.current = false
+      })
+  }, [canLoadMore, cursor, getTransactions, paymentIdentifier])
+
+  const isLoadingFirstPage = isEnabled && !hasLoaded
+
+  return {
+    transactions,
+    isLoading: isLoadingFirstPage,
+    hasError,
+    loadMore,
+  }
+}

--- a/app/hooks/use-contact-transactions.ts
+++ b/app/hooks/use-contact-transactions.ts
@@ -155,6 +155,12 @@ export const useContactTransactions = (
    * read, because matching happens on the client and a request stops at its page budget.
    * An empty list has nothing to scroll, so no `onEndReached` will ever ask for the rest:
    * it keeps reading here until something shows up or the history runs out.
+   *
+   * That budget bounds one request, not this walk. A contact with no payments in a large
+   * wallet is therefore read to the end, one round per 100 raw payments — some 100 rounds
+   * behind the spinner for a 10,000-payment wallet. It is the deliberate trade-off: giving
+   * up early would claim the contact has no transactions while history is still unread,
+   * and an empty list leaves the reader no scroll to resume the search with.
    */
   const hasNothingToScroll = transactions.length === 0 && cursor !== null
 

--- a/app/hooks/use-contact-transactions.ts
+++ b/app/hooks/use-contact-transactions.ts
@@ -28,7 +28,7 @@ export const useContactTransactions = (
   paymentIdentifier: string,
   isEnabled: boolean,
 ): ContactTransactionsResult => {
-  const { getTransactions, loading: contactsLoading } = useContacts()
+  const { getTransactions } = useContacts()
 
   const [transactions, setTransactions] = React.useState<NormalizedTransaction[]>([])
   const [cursor, setCursor] = React.useState<string | null>(null)
@@ -76,20 +76,19 @@ export const useContactTransactions = (
   }
 
   /**
-   * The adapter answers from the wallet it is connected to, so asking before it is ready
-   * would resolve empty and flash the empty state at a contact that does have payments.
-   */
-  const shouldLoad = isEnabled && !contactsLoading
-
-  /**
    * Coming back to the screen restarts from the first page rather than merging into what
    * is already listed: the cursor is an offset into the wallet history, so a payment made
    * while away shifts every later offset and pages read across that boundary would repeat
    * or skip entries.
+   *
+   * Reading does not wait on the contact list: `getTransactions` is keyed by payment
+   * identifier and never consults it, so a slow or failed list fetch has no answer to
+   * contribute here. Adapter readiness is what matters, and `getTransactions` changes
+   * identity when the wallet connects, which re-runs this effect on its own.
    */
   useFocusEffect(
     React.useCallback(() => {
-      if (!shouldLoad) return undefined
+      if (!isEnabled) return undefined
 
       generationRef.current += 1
       isLoadingMoreRef.current = false
@@ -112,10 +111,10 @@ export const useContactTransactions = (
       return () => {
         isActive = false
       }
-    }, [shouldLoad, paymentIdentifier, getTransactions]),
+    }, [isEnabled, paymentIdentifier, getTransactions]),
   )
 
-  const canLoadMore = shouldLoad && cursor !== null
+  const canLoadMore = isEnabled && cursor !== null
 
   const loadMore = React.useCallback(() => {
     if (!canLoadMore || isLoadingMoreRef.current) return

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -1086,7 +1086,7 @@ export const ContactNavigator = () => {
       <StackContacts.Screen
         name="contactDetail"
         component={ContactsDetailScreen}
-        options={{ headerShown: false }}
+        options={{ title: "" }}
       />
       <StackContacts.Screen
         name="allContacts"

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -52,13 +52,15 @@ export const ContactTransactions = ({ contact }: Props) => {
     NormalizedTransaction[]
   >([])
 
+  const shouldSkipContactQuery = !isAuthed || isSelfCustodial
+
   /**
    * The custodial query resolves through `me`, which a self-custodial account has no
    * session for, so it is skipped and the contact adapter answers instead.
    */
   const { error, data, fetchMore } = useTransactionListForContactQuery({
     variables: { username: contact.username },
-    skip: !isAuthed || isSelfCustodial,
+    skip: shouldSkipContactQuery,
   })
 
   useFocusEffect(
@@ -79,10 +81,12 @@ export const ContactTransactions = ({ contact }: Props) => {
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
   const custodialTransactions = data?.me?.contactByUsername?.transactions
 
-  const txs = React.useMemo(() => {
-    if (isSelfCustodial) return selfCustodialTxs
-    return custodialTransactions?.edges?.map((edge) => edge.node) ?? []
-  }, [isSelfCustodial, selfCustodialTxs, custodialTransactions])
+  const custodialTxs = React.useMemo(
+    () => custodialTransactions?.edges?.map((edge) => edge.node) ?? [],
+    [custodialTransactions],
+  )
+
+  const txs = isSelfCustodial ? selfCustodialTxs : custodialTxs
 
   const sections = React.useMemo(
     () => groupTransactionsByDate({ txs, LL, locale }),
@@ -110,6 +114,12 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
+  const ListEmptyContent = (
+    <View style={styles.noTransactionView} testID="contact-no-transactions">
+      <Text style={styles.noTransactionText}>{LL.TransactionScreen.noTransaction()}</Text>
+    </View>
+  )
+
   return (
     <View style={styles.screen}>
       <SectionList
@@ -123,13 +133,7 @@ export const ContactTransactions = ({ contact }: Props) => {
             <Text style={styles.sectionHeaderText}>{title}</Text>
           </View>
         )}
-        ListEmptyComponent={
-          <View style={styles.noTransactionView} testID="contact-no-transactions">
-            <Text style={styles.noTransactionText}>
-              {LL.TransactionScreen.noTransaction()}
-            </Text>
-          </View>
-        }
+        ListEmptyComponent={ListEmptyContent}
         sections={sections}
         keyExtractor={(item) => item.id}
         onEndReached={fetchNextTransactionsPage}

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -76,7 +76,12 @@ export const ContactTransactions = ({ contact }: Props) => {
    * The custodial query resolves through `me`, which a self-custodial account has no
    * session for, so it is skipped and the contact adapter answers instead.
    */
-  const { error, data, fetchMore } = useTransactionListForContactQuery({
+  const {
+    error,
+    data,
+    fetchMore,
+    loading: custodialLoading,
+  } = useTransactionListForContactQuery({
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
@@ -134,7 +139,15 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
-  const ListEmptyContent = isLoadingSelfCustodial ? (
+  /**
+   * Until the query answers there is nothing to say about this contact, so the custodial
+   * list spins rather than claiming it has no transactions. A skipped query never answers
+   * at all, which is why an absent `data` counts as still loading and not as empty.
+   */
+  const isLoadingCustodial = !isSelfCustodial && (custodialLoading || !data)
+  const isLoadingTransactions = isLoadingSelfCustodial || isLoadingCustodial
+
+  const ListEmptyContent = isLoadingTransactions ? (
     <View style={styles.activityIndicatorView} testID="contact-transactions-loading">
       <ActivityIndicator size="large" color={colors.primary} />
     </View>

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -71,6 +71,8 @@ export const ContactTransactions = ({ contact }: Props) => {
     fetchMore,
     loading: custodialLoading,
   } = useTransactionListForContactQuery({
+    /** The argument is a `Username` scalar, so this stays on the deprecated field even
+     *  though the adapter above is keyed by `handle`. */
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
@@ -120,10 +122,12 @@ export const ContactTransactions = ({ contact }: Props) => {
 
   /**
    * Until the query answers there is nothing to say about this contact, so the custodial
-   * list spins rather than claiming it has no transactions. A skipped query never answers
-   * at all, which is why an absent `data` counts as still loading and not as empty.
+   * list spins rather than claiming it has no transactions. An absent `data` counts as
+   * still loading, but only while the query is actually running: a skipped one never
+   * answers, and would otherwise spin forever.
    */
-  const isLoadingCustodial = !isSelfCustodial && (custodialLoading || !data)
+  const isCustodialQueryRunning = !shouldSkipContactQuery
+  const isLoadingCustodial = isCustodialQueryRunning && (custodialLoading || !data)
   const isLoadingTransactions = isLoadingSelfCustodial || isLoadingCustodial
 
   const ListEmptyContent = isLoadingTransactions ? (

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -183,7 +183,13 @@ export const ContactTransactions = ({ contact }: Props) => {
     })
   }, [hasTransactionsError, LL])
 
-  if (hasTransactionsError) return <></>
+  /**
+   * The failure is told through the toast, so the list itself has nothing to say — but it
+   * still holds its space, or the send button would climb the screen on the one contact
+   * whose history could not be read.
+   */
+  if (hasTransactionsError)
+    return <View style={styles.screen} testID="contact-transactions-unavailable" />
 
   /**
    * Until the query answers there is nothing to say about this contact, so the custodial
@@ -240,11 +246,11 @@ const useStyles = makeStyles(({ colors }) => ({
   },
 
   /**
-   * Grows only as far as the transactions reach, so the send button below sits under the
-   * last one rather than at the bottom of the screen, and shrinks to scroll past that.
+   * Takes the space between the header and the send button whatever the history holds, so
+   * the button keeps its place at the bottom instead of riding up under a short list.
    */
   screen: {
-    flexShrink: 1,
+    flex: 1,
   },
 
   sectionHeaderContainer: {

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -63,13 +63,15 @@ export const ContactTransactions = ({ contact }: Props) => {
     NormalizedTransaction[]
   >([])
 
+  const shouldSkipContactQuery = !isAuthed || isSelfCustodial
+
   /**
    * The custodial query resolves through `me`, which a self-custodial account has no
    * session for, so it is skipped and the contact adapter answers instead.
    */
   const { error, data, fetchMore } = useTransactionListForContactQuery({
     variables: { username: contact.username },
-    skip: !isAuthed || isSelfCustodial,
+    skip: shouldSkipContactQuery,
   })
 
   useFocusEffect(
@@ -90,10 +92,12 @@ export const ContactTransactions = ({ contact }: Props) => {
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
   const custodialTransactions = data?.me?.contactByUsername?.transactions
 
-  const txs = React.useMemo(() => {
-    if (isSelfCustodial) return selfCustodialTxs
-    return custodialTransactions?.edges?.map((edge) => edge.node) ?? []
-  }, [isSelfCustodial, selfCustodialTxs, custodialTransactions])
+  const custodialTxs = React.useMemo(
+    () => custodialTransactions?.edges?.map((edge) => edge.node) ?? [],
+    [custodialTransactions],
+  )
+
+  const txs = isSelfCustodial ? selfCustodialTxs : custodialTxs
 
   const sections = React.useMemo(
     () => groupTransactionsByDate({ txs, LL, locale }),
@@ -131,6 +135,12 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
+  const ListEmptyContent = (
+    <View style={styles.noTransactionView} testID="contact-no-transactions">
+      <Text style={styles.noTransactionText}>{LL.TransactionScreen.noTransaction()}</Text>
+    </View>
+  )
+
   return (
     <View style={styles.screen}>
       <SectionList
@@ -139,13 +149,7 @@ export const ContactTransactions = ({ contact }: Props) => {
         initialNumToRender={20}
         windowSize={TRANSACTION_LIST_WINDOW_SIZE}
         renderSectionHeader={renderSectionHeader}
-        ListEmptyComponent={
-          <View style={styles.noTransactionView} testID="contact-no-transactions">
-            <Text style={styles.noTransactionText}>
-              {LL.TransactionScreen.noTransaction()}
-            </Text>
-          </View>
-        }
+        ListEmptyComponent={ListEmptyContent}
         sections={sections}
         keyExtractor={keyExtractor}
         onEndReached={fetchNextTransactionsPage}

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -133,13 +133,21 @@ export const ContactTransactions = ({ contact }: Props) => {
 
   const hasTransactionsError = Boolean(error) || hasSelfCustodialError
 
-  if (hasTransactionsError) {
+  /**
+   * In an effect rather than the render body: the flag stays raised until the next read,
+   * so any unrelated re-render while it is up would queue a second toast for a failure
+   * the reader was already told about.
+   */
+  React.useEffect(() => {
+    if (!hasTransactionsError) return
+
     toastShow({
       message: (translations) => translations.common.transactionsError(),
       LL,
     })
-    return <></>
-  }
+  }, [hasTransactionsError, LL])
+
+  if (hasTransactionsError) return <></>
 
   /**
    * Until the query answers there is nothing to say about this contact, so the custodial

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -7,12 +7,10 @@ import { UserContact, useTransactionListForContactQuery } from "@app/graphql/gen
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
-import { useContacts } from "@app/hooks/use-contacts"
+import { useContactTransactions } from "@app/hooks/use-contact-transactions"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
-import { NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
-import { useFocusEffect } from "@react-navigation/native"
 import { makeStyles, useTheme } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
@@ -50,12 +48,16 @@ export const ContactTransactions = ({ contact }: Props) => {
   const { activeAccount } = useAccountRegistry()
   const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
-  const { getTransactions, loading: contactsLoading } = useContacts()
-  const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
-    NormalizedTransaction[]
-  >([])
-  const [hasLoadedSelfCustodial, setHasLoadedSelfCustodial] = React.useState(false)
-  const [hasSelfCustodialError, setHasSelfCustodialError] = React.useState(false)
+  /**
+   * The adapter matches payments by counterparty address, which is what `username` holds
+   * for a self-custodial contact, so it never has to resolve a contact list to answer.
+   */
+  const {
+    transactions: selfCustodialTransactions,
+    isLoading: isLoadingSelfCustodial,
+    hasError: hasSelfCustodialError,
+    loadMore: loadMoreSelfCustodial,
+  } = useContactTransactions(contact.handle, isSelfCustodial)
 
   const shouldSkipContactQuery = !isAuthed || isSelfCustodial
 
@@ -67,36 +69,6 @@ export const ContactTransactions = ({ contact }: Props) => {
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
-
-  /**
-   * The adapter matches payments against the contact's payment identifier, so asking it
-   * before its own contact list has loaded would only ever answer with an empty list and
-   * flash the empty state at a contact that does have payments.
-   */
-  const shouldLoadSelfCustodial = isSelfCustodial && !contactsLoading
-
-  useFocusEffect(
-    React.useCallback(() => {
-      if (!shouldLoadSelfCustodial) return undefined
-
-      let isActive = true
-      setHasSelfCustodialError(false)
-      getTransactions(contact.id)
-        .then((transactions) => {
-          if (isActive) setSelfCustodialTransactions(transactions)
-        })
-        .catch(() => {
-          if (isActive) setHasSelfCustodialError(true)
-        })
-        .finally(() => {
-          if (isActive) setHasLoadedSelfCustodial(true)
-        })
-
-      return () => {
-        isActive = false
-      }
-    }, [shouldLoadSelfCustodial, contact.id, getTransactions]),
-  )
 
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
   const custodialTransactions = data?.me?.contactByUsername?.transactions
@@ -114,6 +86,11 @@ export const ContactTransactions = ({ contact }: Props) => {
   )
 
   const fetchNextTransactionsPage = () => {
+    if (isSelfCustodial) {
+      loadMoreSelfCustodial()
+      return
+    }
+
     const pageInfo = custodialTransactions?.pageInfo
 
     if (pageInfo?.hasNextPage) {
@@ -135,8 +112,6 @@ export const ContactTransactions = ({ contact }: Props) => {
     })
     return <></>
   }
-
-  const isLoadingSelfCustodial = isSelfCustodial && !hasLoadedSelfCustodial
 
   const ListEmptyContent = isLoadingSelfCustodial ? (
     <View style={styles.activityIndicatorView} testID="contact-transactions-loading">

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -10,12 +10,10 @@ import { UserContact, useTransactionListForContactQuery } from "@app/graphql/gen
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
-import { useContacts } from "@app/hooks/use-contacts"
+import { useContactTransactions } from "@app/hooks/use-contact-transactions"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
-import { NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
-import { useFocusEffect } from "@react-navigation/native"
 import { makeStyles, useTheme } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
@@ -61,12 +59,16 @@ export const ContactTransactions = ({ contact }: Props) => {
   const { activeAccount } = useAccountRegistry()
   const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
-  const { getTransactions, loading: contactsLoading } = useContacts()
-  const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
-    NormalizedTransaction[]
-  >([])
-  const [hasLoadedSelfCustodial, setHasLoadedSelfCustodial] = React.useState(false)
-  const [hasSelfCustodialError, setHasSelfCustodialError] = React.useState(false)
+  /**
+   * The adapter matches payments by counterparty address, which is what `username` holds
+   * for a self-custodial contact, so it never has to resolve a contact list to answer.
+   */
+  const {
+    transactions: selfCustodialTransactions,
+    isLoading: isLoadingSelfCustodial,
+    hasError: hasSelfCustodialError,
+    loadMore: loadMoreSelfCustodial,
+  } = useContactTransactions(contact.handle, isSelfCustodial)
 
   const shouldSkipContactQuery = !isAuthed || isSelfCustodial
 
@@ -78,36 +80,6 @@ export const ContactTransactions = ({ contact }: Props) => {
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
-
-  /**
-   * The adapter matches payments against the contact's payment identifier, so asking it
-   * before its own contact list has loaded would only ever answer with an empty list and
-   * flash the empty state at a contact that does have payments.
-   */
-  const shouldLoadSelfCustodial = isSelfCustodial && !contactsLoading
-
-  useFocusEffect(
-    React.useCallback(() => {
-      if (!shouldLoadSelfCustodial) return undefined
-
-      let isActive = true
-      setHasSelfCustodialError(false)
-      getTransactions(contact.id)
-        .then((transactions) => {
-          if (isActive) setSelfCustodialTransactions(transactions)
-        })
-        .catch(() => {
-          if (isActive) setHasSelfCustodialError(true)
-        })
-        .finally(() => {
-          if (isActive) setHasLoadedSelfCustodial(true)
-        })
-
-      return () => {
-        isActive = false
-      }
-    }, [shouldLoadSelfCustodial, contact.id, getTransactions]),
-  )
 
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
   const custodialTransactions = data?.me?.contactByUsername?.transactions
@@ -135,6 +107,11 @@ export const ContactTransactions = ({ contact }: Props) => {
   )
 
   const fetchNextTransactionsPage = () => {
+    if (isSelfCustodial) {
+      loadMoreSelfCustodial()
+      return
+    }
+
     const pageInfo = custodialTransactions?.pageInfo
 
     if (pageInfo?.hasNextPage) {
@@ -156,8 +133,6 @@ export const ContactTransactions = ({ contact }: Props) => {
     })
     return <></>
   }
-
-  const isLoadingSelfCustodial = isSelfCustodial && !hasLoadedSelfCustodial
 
   const ListEmptyContent = isLoadingSelfCustodial ? (
     <View style={styles.activityIndicatorView} testID="contact-transactions-loading">

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { SectionList, Text, View } from "react-native"
+import { ActivityIndicator, SectionList, Text, View } from "react-native"
 
 import { gql } from "@apollo/client"
 import { MemoizedTransactionItem } from "@app/components/transaction-item"
@@ -13,7 +13,7 @@ import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/
 import { NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
 import { useFocusEffect } from "@react-navigation/native"
-import { makeStyles } from "@rn-vui/themed"
+import { makeStyles, useTheme } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
 
@@ -42,15 +42,20 @@ type Props = {
 
 export const ContactTransactions = ({ contact }: Props) => {
   const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
   const { LL, locale } = useI18nContext()
   const isAuthed = useIsAuthed()
   const { activeAccount } = useAccountRegistry()
   const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
-  const { getTransactions } = useContacts()
+  const { getTransactions, loading: contactsLoading } = useContacts()
   const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
     NormalizedTransaction[]
   >([])
+  const [hasLoadedSelfCustodial, setHasLoadedSelfCustodial] = React.useState(false)
+  const [hasSelfCustodialError, setHasSelfCustodialError] = React.useState(false)
 
   const shouldSkipContactQuery = !isAuthed || isSelfCustodial
 
@@ -63,19 +68,34 @@ export const ContactTransactions = ({ contact }: Props) => {
     skip: shouldSkipContactQuery,
   })
 
+  /**
+   * The adapter matches payments against the contact's payment identifier, so asking it
+   * before its own contact list has loaded would only ever answer with an empty list and
+   * flash the empty state at a contact that does have payments.
+   */
+  const shouldLoadSelfCustodial = isSelfCustodial && !contactsLoading
+
   useFocusEffect(
     React.useCallback(() => {
-      if (!isSelfCustodial) return undefined
+      if (!shouldLoadSelfCustodial) return undefined
 
       let isActive = true
-      getTransactions(contact.id).then((transactions) => {
-        if (isActive) setSelfCustodialTransactions(transactions)
-      })
+      setHasSelfCustodialError(false)
+      getTransactions(contact.id)
+        .then((transactions) => {
+          if (isActive) setSelfCustodialTransactions(transactions)
+        })
+        .catch(() => {
+          if (isActive) setHasSelfCustodialError(true)
+        })
+        .finally(() => {
+          if (isActive) setHasLoadedSelfCustodial(true)
+        })
 
       return () => {
         isActive = false
       }
-    }, [isSelfCustodial, contact.id, getTransactions]),
+    }, [shouldLoadSelfCustodial, contact.id, getTransactions]),
   )
 
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
@@ -106,7 +126,9 @@ export const ContactTransactions = ({ contact }: Props) => {
     }
   }
 
-  if (error) {
+  const hasTransactionsError = Boolean(error) || hasSelfCustodialError
+
+  if (hasTransactionsError) {
     toastShow({
       message: (translations) => translations.common.transactionsError(),
       LL,
@@ -114,7 +136,13 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
-  const ListEmptyContent = (
+  const isLoadingSelfCustodial = isSelfCustodial && !hasLoadedSelfCustodial
+
+  const ListEmptyContent = isLoadingSelfCustodial ? (
+    <View style={styles.activityIndicatorView} testID="contact-transactions-loading">
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  ) : (
     <View style={styles.noTransactionView} testID="contact-no-transactions">
       <Text style={styles.noTransactionText}>{LL.TransactionScreen.noTransaction()}</Text>
     </View>
@@ -144,6 +172,13 @@ export const ContactTransactions = ({ contact }: Props) => {
 }
 
 const useStyles = makeStyles(({ colors }) => ({
+  activityIndicatorView: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+    marginVertical: 48,
+  },
+
   noTransactionText: {
     fontSize: 24,
   },

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ActivityIndicator, SectionList, Text, View } from "react-native"
+import { ActivityIndicator, SectionList, StyleSheet, Text, View } from "react-native"
 
 import { gql } from "@apollo/client"
 import {
@@ -43,11 +43,47 @@ type Props = {
 
 const keyExtractor = (item: { id: string }) => item.id
 
+const GROUP_RADIUS = 8
+
+/** The date group reads as one card, so only its outer rows carry the corners. */
+const groupStyles = StyleSheet.create({
+  firstRow: {
+    borderTopLeftRadius: GROUP_RADIUS,
+    borderTopRightRadius: GROUP_RADIUS,
+    overflow: "hidden",
+  },
+  lastRow: {
+    borderBottomLeftRadius: GROUP_RADIUS,
+    borderBottomRightRadius: GROUP_RADIUS,
+    overflow: "hidden",
+  },
+})
+
 // Rows here are deliberately not pressable: this list only shows the history
 // with one contact, it does not navigate into a transaction.
-const renderItem = ({ item }: { item: { id: string } }) => (
-  <MemoizedTransactionItem txid={item.id} />
-)
+const renderItem = ({
+  item,
+  index,
+  section,
+}: {
+  item: { id: string }
+  index: number
+  section: { data: readonly { id: string }[] }
+}) => {
+  const isFirst = index === 0
+  const isLast = index === section.data.length - 1
+
+  return (
+    <View style={[isFirst && groupStyles.firstRow, isLast && groupStyles.lastRow]}>
+      <MemoizedTransactionItem
+        txid={item.id}
+        subtitle
+        isFirst={isFirst}
+        isLast={isLast}
+      />
+    </View>
+  )
+}
 
 export const ContactTransactions = ({ contact }: Props) => {
   const styles = useStyles()
@@ -190,7 +226,6 @@ export const ContactTransactions = ({ contact }: Props) => {
 const useStyles = makeStyles(({ colors }) => ({
   activityIndicatorView: {
     alignItems: "center",
-    flex: 1,
     justifyContent: "center",
     marginVertical: 48,
   },
@@ -201,27 +236,27 @@ const useStyles = makeStyles(({ colors }) => ({
 
   noTransactionView: {
     alignItems: "center",
-    flex: 1,
     marginVertical: 48,
   },
 
+  /**
+   * Grows only as far as the transactions reach, so the send button below sits under the
+   * last one rather than at the bottom of the screen, and shrinks to scroll past that.
+   */
   screen: {
-    flex: 1,
-    borderRadius: 10,
-    borderColor: colors.grey4,
-    borderWidth: 2,
-    overflow: "hidden",
+    flexShrink: 1,
   },
 
   sectionHeaderContainer: {
-    backgroundColor: colors.grey5,
     flexDirection: "row",
     justifyContent: "space-between",
-    padding: 10,
+    paddingBottom: 3,
+    paddingTop: 10,
   },
 
   sectionHeaderText: {
     color: colors.black,
-    fontSize: 18,
+    fontSize: 14,
+    lineHeight: 20,
   },
 }))

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { SectionList, Text, View } from "react-native"
+import { ActivityIndicator, SectionList, Text, View } from "react-native"
 
 import { gql } from "@apollo/client"
 import {
@@ -16,7 +16,7 @@ import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/
 import { NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
 import { useFocusEffect } from "@react-navigation/native"
-import { makeStyles } from "@rn-vui/themed"
+import { makeStyles, useTheme } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
 
@@ -53,15 +53,20 @@ const renderItem = ({ item }: { item: { id: string } }) => (
 
 export const ContactTransactions = ({ contact }: Props) => {
   const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
   const { LL, locale } = useI18nContext()
   const isAuthed = useIsAuthed()
   const { activeAccount } = useAccountRegistry()
   const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
-  const { getTransactions } = useContacts()
+  const { getTransactions, loading: contactsLoading } = useContacts()
   const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
     NormalizedTransaction[]
   >([])
+  const [hasLoadedSelfCustodial, setHasLoadedSelfCustodial] = React.useState(false)
+  const [hasSelfCustodialError, setHasSelfCustodialError] = React.useState(false)
 
   const shouldSkipContactQuery = !isAuthed || isSelfCustodial
 
@@ -74,19 +79,34 @@ export const ContactTransactions = ({ contact }: Props) => {
     skip: shouldSkipContactQuery,
   })
 
+  /**
+   * The adapter matches payments against the contact's payment identifier, so asking it
+   * before its own contact list has loaded would only ever answer with an empty list and
+   * flash the empty state at a contact that does have payments.
+   */
+  const shouldLoadSelfCustodial = isSelfCustodial && !contactsLoading
+
   useFocusEffect(
     React.useCallback(() => {
-      if (!isSelfCustodial) return undefined
+      if (!shouldLoadSelfCustodial) return undefined
 
       let isActive = true
-      getTransactions(contact.id).then((transactions) => {
-        if (isActive) setSelfCustodialTransactions(transactions)
-      })
+      setHasSelfCustodialError(false)
+      getTransactions(contact.id)
+        .then((transactions) => {
+          if (isActive) setSelfCustodialTransactions(transactions)
+        })
+        .catch(() => {
+          if (isActive) setHasSelfCustodialError(true)
+        })
+        .finally(() => {
+          if (isActive) setHasLoadedSelfCustodial(true)
+        })
 
       return () => {
         isActive = false
       }
-    }, [isSelfCustodial, contact.id, getTransactions]),
+    }, [shouldLoadSelfCustodial, contact.id, getTransactions]),
   )
 
   const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
@@ -127,7 +147,9 @@ export const ContactTransactions = ({ contact }: Props) => {
     }
   }
 
-  if (error) {
+  const hasTransactionsError = Boolean(error) || hasSelfCustodialError
+
+  if (hasTransactionsError) {
     toastShow({
       message: (translations) => translations.common.transactionsError(),
       LL,
@@ -135,7 +157,13 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
-  const ListEmptyContent = (
+  const isLoadingSelfCustodial = isSelfCustodial && !hasLoadedSelfCustodial
+
+  const ListEmptyContent = isLoadingSelfCustodial ? (
+    <View style={styles.activityIndicatorView} testID="contact-transactions-loading">
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  ) : (
     <View style={styles.noTransactionView} testID="contact-no-transactions">
       <Text style={styles.noTransactionText}>{LL.TransactionScreen.noTransaction()}</Text>
     </View>
@@ -160,6 +188,13 @@ export const ContactTransactions = ({ contact }: Props) => {
 }
 
 const useStyles = makeStyles(({ colors }) => ({
+  activityIndicatorView: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "center",
+    marginVertical: 48,
+  },
+
   noTransactionText: {
     fontSize: 24,
   },

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -112,13 +112,21 @@ export const ContactTransactions = ({ contact }: Props) => {
 
   const hasTransactionsError = Boolean(error) || hasSelfCustodialError
 
-  if (hasTransactionsError) {
+  /**
+   * In an effect rather than the render body: the flag stays raised until the next read,
+   * so any unrelated re-render while it is up would queue a second toast for a failure
+   * the reader was already told about.
+   */
+  React.useEffect(() => {
+    if (!hasTransactionsError) return
+
     toastShow({
       message: (translations) => translations.common.transactionsError(),
       LL,
     })
-    return <></>
-  }
+  }, [hasTransactionsError, LL])
+
+  if (hasTransactionsError) return <></>
 
   /**
    * Until the query answers there is nothing to say about this contact, so the custodial

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -3,10 +3,16 @@ import { SectionList, Text, View } from "react-native"
 
 import { gql } from "@apollo/client"
 import { MemoizedTransactionItem } from "@app/components/transaction-item"
-import { useTransactionListForContactQuery } from "@app/graphql/generated"
+import { UserContact, useTransactionListForContactQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
+import { useContacts } from "@app/hooks/use-contacts"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
+import { NormalizedTransaction } from "@app/types/transaction"
+import { AccountType } from "@app/types/wallet"
+import { useFocusEffect } from "@react-navigation/native"
 import { makeStyles } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
@@ -31,30 +37,70 @@ gql`
 `
 
 type Props = {
-  contactUsername: string
+  contact: UserContact
 }
 
-export const ContactTransactions = ({ contactUsername }: Props) => {
+export const ContactTransactions = ({ contact }: Props) => {
   const styles = useStyles()
   const { LL, locale } = useI18nContext()
   const isAuthed = useIsAuthed()
+  const { activeAccount } = useAccountRegistry()
+  const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
+  const { getTransactions } = useContacts()
+  const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
+    NormalizedTransaction[]
+  >([])
+
+  /**
+   * The custodial query resolves through `me`, which a self-custodial account has no
+   * session for, so it is skipped and the contact adapter answers instead.
+   */
   const { error, data, fetchMore } = useTransactionListForContactQuery({
-    variables: { username: contactUsername },
-    skip: !isAuthed,
+    variables: { username: contact.username },
+    skip: !isAuthed || isSelfCustodial,
   })
 
-  const transactions = data?.me?.contactByUsername?.transactions
+  useFocusEffect(
+    React.useCallback(() => {
+      if (!isSelfCustodial) return undefined
+
+      let isActive = true
+      getTransactions(contact.id).then((transactions) => {
+        if (isActive) setSelfCustodialTransactions(transactions)
+      })
+
+      return () => {
+        isActive = false
+      }
+    }, [isSelfCustodial, contact.id, getTransactions]),
+  )
+
+  const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
+  const custodialTransactions = data?.me?.contactByUsername?.transactions
+
+  const txs = React.useMemo(() => {
+    if (isSelfCustodial) return selfCustodialTxs
+    return custodialTransactions?.edges?.map((edge) => edge.node) ?? []
+  }, [isSelfCustodial, selfCustodialTxs, custodialTransactions])
 
   const sections = React.useMemo(
-    () =>
-      groupTransactionsByDate({
-        txs: transactions?.edges?.map((edge) => edge.node) ?? [],
-        LL,
-        locale,
-      }),
-    [transactions, LL, locale],
+    () => groupTransactionsByDate({ txs, LL, locale }),
+    [txs, LL, locale],
   )
+
+  const fetchNextTransactionsPage = () => {
+    const pageInfo = custodialTransactions?.pageInfo
+
+    if (pageInfo?.hasNextPage) {
+      fetchMore({
+        variables: {
+          username: contact.username,
+          after: pageInfo.endCursor,
+        },
+      })
+    }
+  }
 
   if (error) {
     toastShow({
@@ -64,26 +110,10 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
     return <></>
   }
 
-  if (!transactions) {
-    return <></>
-  }
-
-  const fetchNextTransactionsPage = () => {
-    const pageInfo = transactions?.pageInfo
-
-    if (pageInfo.hasNextPage) {
-      fetchMore({
-        variables: {
-          username: contactUsername,
-          after: pageInfo.endCursor,
-        },
-      })
-    }
-  }
-
   return (
     <View style={styles.screen}>
       <SectionList
+        testID="contact-transactions-list"
         renderItem={({ item }) => (
           <MemoizedTransactionItem key={`txn-${item.id}`} txid={item.id} />
         )}
@@ -94,7 +124,7 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
           </View>
         )}
         ListEmptyComponent={
-          <View style={styles.noTransactionView}>
+          <View style={styles.noTransactionView} testID="contact-no-transactions">
             <Text style={styles.noTransactionText}>
               {LL.TransactionScreen.noTransaction()}
             </Text>

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -65,7 +65,12 @@ export const ContactTransactions = ({ contact }: Props) => {
    * The custodial query resolves through `me`, which a self-custodial account has no
    * session for, so it is skipped and the contact adapter answers instead.
    */
-  const { error, data, fetchMore } = useTransactionListForContactQuery({
+  const {
+    error,
+    data,
+    fetchMore,
+    loading: custodialLoading,
+  } = useTransactionListForContactQuery({
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
@@ -113,7 +118,15 @@ export const ContactTransactions = ({ contact }: Props) => {
     return <></>
   }
 
-  const ListEmptyContent = isLoadingSelfCustodial ? (
+  /**
+   * Until the query answers there is nothing to say about this contact, so the custodial
+   * list spins rather than claiming it has no transactions. A skipped query never answers
+   * at all, which is why an absent `data` counts as still loading and not as empty.
+   */
+  const isLoadingCustodial = !isSelfCustodial && (custodialLoading || !data)
+  const isLoadingTransactions = isLoadingSelfCustodial || isLoadingCustodial
+
+  const ListEmptyContent = isLoadingTransactions ? (
     <View style={styles.activityIndicatorView} testID="contact-transactions-loading">
       <ActivityIndicator size="large" color={colors.primary} />
     </View>

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -6,10 +6,16 @@ import {
   MemoizedTransactionItem,
   TRANSACTION_LIST_WINDOW_SIZE,
 } from "@app/components/transaction-item"
-import { useTransactionListForContactQuery } from "@app/graphql/generated"
+import { UserContact, useTransactionListForContactQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
+import { useContacts } from "@app/hooks/use-contacts"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
+import { NormalizedTransaction } from "@app/types/transaction"
+import { AccountType } from "@app/types/wallet"
+import { useFocusEffect } from "@react-navigation/native"
 import { makeStyles } from "@rn-vui/themed"
 
 import { toastShow } from "../../../utils/toast"
@@ -34,7 +40,7 @@ gql`
 `
 
 type Props = {
-  contactUsername: string
+  contact: UserContact
 }
 
 const keyExtractor = (item: { id: string }) => item.id
@@ -45,26 +51,53 @@ const renderItem = ({ item }: { item: { id: string } }) => (
   <MemoizedTransactionItem txid={item.id} />
 )
 
-export const ContactTransactions = ({ contactUsername }: Props) => {
+export const ContactTransactions = ({ contact }: Props) => {
   const styles = useStyles()
   const { LL, locale } = useI18nContext()
   const isAuthed = useIsAuthed()
+  const { activeAccount } = useAccountRegistry()
+  const isSelfCustodial = activeAccount?.type === AccountType.SelfCustodial
 
+  const { getTransactions } = useContacts()
+  const [selfCustodialTransactions, setSelfCustodialTransactions] = React.useState<
+    NormalizedTransaction[]
+  >([])
+
+  /**
+   * The custodial query resolves through `me`, which a self-custodial account has no
+   * session for, so it is skipped and the contact adapter answers instead.
+   */
   const { error, data, fetchMore } = useTransactionListForContactQuery({
-    variables: { username: contactUsername },
-    skip: !isAuthed,
+    variables: { username: contact.username },
+    skip: !isAuthed || isSelfCustodial,
   })
 
-  const transactions = data?.me?.contactByUsername?.transactions
+  useFocusEffect(
+    React.useCallback(() => {
+      if (!isSelfCustodial) return undefined
+
+      let isActive = true
+      getTransactions(contact.id).then((transactions) => {
+        if (isActive) setSelfCustodialTransactions(transactions)
+      })
+
+      return () => {
+        isActive = false
+      }
+    }, [isSelfCustodial, contact.id, getTransactions]),
+  )
+
+  const selfCustodialTxs = useSelfCustodialTransactionFragments(selfCustodialTransactions)
+  const custodialTransactions = data?.me?.contactByUsername?.transactions
+
+  const txs = React.useMemo(() => {
+    if (isSelfCustodial) return selfCustodialTxs
+    return custodialTransactions?.edges?.map((edge) => edge.node) ?? []
+  }, [isSelfCustodial, selfCustodialTxs, custodialTransactions])
 
   const sections = React.useMemo(
-    () =>
-      groupTransactionsByDate({
-        txs: transactions?.edges?.map((edge) => edge.node) ?? [],
-        LL,
-        locale,
-      }),
-    [transactions, LL, locale],
+    () => groupTransactionsByDate({ txs, LL, locale }),
+    [txs, LL, locale],
   )
 
   // Declared above the early returns below to keep hook order stable.
@@ -77,6 +110,19 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
     [styles.sectionHeaderContainer, styles.sectionHeaderText],
   )
 
+  const fetchNextTransactionsPage = () => {
+    const pageInfo = custodialTransactions?.pageInfo
+
+    if (pageInfo?.hasNextPage) {
+      fetchMore({
+        variables: {
+          username: contact.username,
+          after: pageInfo.endCursor,
+        },
+      })
+    }
+  }
+
   if (error) {
     toastShow({
       message: (translations) => translations.common.transactionsError(),
@@ -85,32 +131,16 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
     return <></>
   }
 
-  if (!transactions) {
-    return <></>
-  }
-
-  const fetchNextTransactionsPage = () => {
-    const pageInfo = transactions?.pageInfo
-
-    if (pageInfo.hasNextPage) {
-      fetchMore({
-        variables: {
-          username: contactUsername,
-          after: pageInfo.endCursor,
-        },
-      })
-    }
-  }
-
   return (
     <View style={styles.screen}>
       <SectionList
+        testID="contact-transactions-list"
         renderItem={renderItem}
         initialNumToRender={20}
         windowSize={TRANSACTION_LIST_WINDOW_SIZE}
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
-          <View style={styles.noTransactionView}>
+          <View style={styles.noTransactionView} testID="contact-no-transactions">
             <Text style={styles.noTransactionText}>
               {LL.TransactionScreen.noTransaction()}
             </Text>

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -82,6 +82,8 @@ export const ContactTransactions = ({ contact }: Props) => {
     fetchMore,
     loading: custodialLoading,
   } = useTransactionListForContactQuery({
+    /** The argument is a `Username` scalar, so this stays on the deprecated field even
+     *  though the adapter above is keyed by `handle`. */
     variables: { username: contact.username },
     skip: shouldSkipContactQuery,
   })
@@ -141,10 +143,12 @@ export const ContactTransactions = ({ contact }: Props) => {
 
   /**
    * Until the query answers there is nothing to say about this contact, so the custodial
-   * list spins rather than claiming it has no transactions. A skipped query never answers
-   * at all, which is why an absent `data` counts as still loading and not as empty.
+   * list spins rather than claiming it has no transactions. An absent `data` counts as
+   * still loading, but only while the query is actually running: a skipped one never
+   * answers, and would otherwise spin forever.
    */
-  const isLoadingCustodial = !isSelfCustodial && (custodialLoading || !data)
+  const isCustodialQueryRunning = !shouldSkipContactQuery
+  const isLoadingCustodial = isCustodialQueryRunning && (custodialLoading || !data)
   const isLoadingTransactions = isLoadingSelfCustodial || isLoadingCustodial
 
   const ListEmptyContent = isLoadingTransactions ? (

--- a/app/screens/people-screen/contacts/contacts-detail.tsx
+++ b/app/screens/people-screen/contacts/contacts-detail.tsx
@@ -1,16 +1,15 @@
 import * as React from "react"
 import { View } from "react-native"
-import { gql } from "@apollo/client"
-import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { GaloyIconButton } from "@app/components/atomic/galoy-icon-button"
-import { UserContact, useUserContactUpdateAliasMutation } from "@app/graphql/generated"
+import { IconHero } from "@app/components/icon-hero"
+import { UserContact } from "@app/graphql/generated"
+import { useAppConfig } from "@app/hooks"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { isIos } from "@app/utils/helper"
+import { getLightningAddress } from "@app/utils/pay-links"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
-import { makeStyles, Text, useTheme, Input } from "@rn-vui/themed"
+import { makeStyles, useTheme } from "@rn-vui/themed"
 
-import { CloseCross } from "../../../components/close-cross"
 import { Screen } from "../../../components/screen"
 import type {
   PeopleStackParamList,
@@ -31,20 +30,6 @@ type ContactDetailScreenProps = {
   contact: UserContact
 }
 
-gql`
-  mutation userContactUpdateAlias($input: UserContactUpdateAliasInput!) {
-    userContactUpdateAlias(input: $input) {
-      errors {
-        message
-      }
-      contact {
-        alias
-        id
-      }
-    }
-  }
-`
-
 export const ContactsDetailScreenJSX: React.FC<ContactDetailScreenProps> = ({
   contact,
 }) => {
@@ -56,51 +41,24 @@ export const ContactsDetailScreenJSX: React.FC<ContactDetailScreenProps> = ({
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList, "transactionHistory">>()
 
-  const [contactName, setContactName] = React.useState(contact.alias)
   const { LL } = useI18nContext()
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname },
+    },
+  } = useAppConfig()
 
-  // TODO: feature seems broken. need to fix.
-  const [userContactUpdateAlias] = useUserContactUpdateAliasMutation({})
-
-  const updateName = async () => {
-    // TODO: need optimistic updates
-    // FIXME this one doesn't work
-    if (contactName) {
-      await userContactUpdateAlias({
-        variables: { input: { username: contact.username, alias: contactName } },
-      })
-    }
-  }
+  /** An address is only built from a handle there is one: the helper would otherwise
+   *  hand the header a bare "@domain". */
+  const handle = contact.handle.trim()
+  const lightningAddress = handle ? getLightningAddress(lnAddressHostname, handle) : ""
 
   return (
-    <Screen headerShown={false}>
-      <View style={styles.aliasView}>
-        <GaloyIcon name="user" size={86} color={colors.black} />
-        <View style={styles.inputContainer}>
-          <Input
-            style={styles.alias}
-            inputStyle={styles.inputStyle}
-            inputContainerStyle={{ borderColor: colors.black }}
-            onChangeText={setContactName}
-            onSubmitEditing={updateName}
-            onBlur={updateName}
-            returnKeyType="done"
-          >
-            {contact.alias}
-          </Input>
-        </View>
-        <Text type="p1">{`${LL.common.username()}: ${contact.username}`}</Text>
-      </View>
-      <View style={styles.contactBodyContainer}>
-        <View style={styles.transactionsView}>
-          <Text style={styles.screenTitle}>
-            {LL.ContactDetailsScreen.title({
-              username: contact.alias || contact.username,
-            })}
-          </Text>
-          <ContactTransactions contact={contact} />
-        </View>
-        <View style={styles.actionsContainer}>
+    <Screen>
+      <IconHero icon="user" iconColor={colors.black} title={lightningAddress} />
+      <View style={styles.body}>
+        <ContactTransactions contact={contact} />
+        <View style={styles.sendContainer}>
           <GaloyIconButton
             name={"send"}
             size="large"
@@ -113,48 +71,18 @@ export const ContactsDetailScreenJSX: React.FC<ContactDetailScreenProps> = ({
           />
         </View>
       </View>
-
-      <CloseCross color={colors.black} onPress={navigation.goBack} />
     </Screen>
   )
 }
 
 const useStyles = makeStyles(() => ({
-  actionsContainer: {
-    margin: 12,
+  body: {
+    flex: 1,
+    gap: 14,
+    paddingHorizontal: 20,
   },
 
-  alias: {
-    fontSize: 36,
-  },
-
-  aliasView: {
+  sendContainer: {
     alignItems: "center",
-    paddingBottom: 6,
-    paddingTop: isIos ? 40 : 10,
-  },
-
-  contactBodyContainer: {
-    flex: 1,
-  },
-
-  inputContainer: {
-    flexDirection: "row",
-  },
-
-  inputStyle: {
-    textAlign: "center",
-    textDecorationLine: "underline",
-  },
-
-  screenTitle: {
-    fontSize: 18,
-    marginBottom: 12,
-    marginTop: 18,
-  },
-
-  transactionsView: {
-    flex: 1,
-    marginHorizontal: 30,
   },
 }))

--- a/app/screens/people-screen/contacts/contacts-detail.tsx
+++ b/app/screens/people-screen/contacts/contacts-detail.tsx
@@ -17,6 +17,9 @@ import type {
 } from "../../../navigation/stack-param-lists"
 import { ContactTransactions } from "./contact-transactions"
 
+/** An address is one unbreakable thing: it is cut short rather than wrapped. */
+const ADDRESS_LINES = 1
+
 type ContactDetailProps = {
   route: RouteProp<PeopleStackParamList, "contactDetail">
 }
@@ -55,7 +58,12 @@ export const ContactsDetailScreenJSX: React.FC<ContactDetailScreenProps> = ({
 
   return (
     <Screen>
-      <IconHero icon="user" iconColor={colors.black} title={lightningAddress} />
+      <IconHero
+        icon="user"
+        iconColor={colors.black}
+        title={lightningAddress}
+        titleLines={ADDRESS_LINES}
+      />
       <View style={styles.body}>
         <ContactTransactions contact={contact} />
         <View style={styles.sendContainer}>

--- a/app/screens/people-screen/contacts/contacts-detail.tsx
+++ b/app/screens/people-screen/contacts/contacts-detail.tsx
@@ -80,6 +80,7 @@ const useStyles = makeStyles(() => ({
     flex: 1,
     gap: 14,
     paddingHorizontal: 20,
+    paddingTop: 20,
   },
 
   sendContainer: {

--- a/app/screens/people-screen/contacts/contacts-detail.tsx
+++ b/app/screens/people-screen/contacts/contacts-detail.tsx
@@ -98,7 +98,7 @@ export const ContactsDetailScreenJSX: React.FC<ContactDetailScreenProps> = ({
               username: contact.alias || contact.username,
             })}
           </Text>
-          <ContactTransactions contactUsername={contact.username} />
+          <ContactTransactions contact={contact} />
         </View>
         <View style={styles.actionsContainer}>
           <GaloyIconButton

--- a/app/screens/transaction-history/transaction-history-screen.tsx
+++ b/app/screens/transaction-history/transaction-history-screen.tsx
@@ -1,14 +1,13 @@
 import * as React from "react"
 import { InteractionManager, SectionList, Text, View } from "react-native"
 import { makeStyles } from "@rn-vui/themed"
-import { gql, useApolloClient } from "@apollo/client"
+import { gql } from "@apollo/client"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { useNavigation, RouteProp } from "@react-navigation/native"
 
 import { Screen } from "@app/components/screen"
 import {
   TransactionFragment,
-  TransactionFragmentDoc,
   useTransactionListForDefaultAccountQuery,
   useWalletOverviewScreenQuery,
   WalletCurrency,
@@ -18,12 +17,10 @@ import {
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
-import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { usePriceConversion } from "@app/hooks/use-price-conversion"
 import { shouldHighlightById } from "@app/custodial/mappers/transaction-highlight"
-import { getTransactionDescription } from "@app/self-custodial/mappers/transaction-description"
-import { toTransactionFragments } from "@app/self-custodial/mappers/to-transaction-fragment"
+import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
+import { NormalizedTransaction } from "@app/types/transaction"
 import {
   resolveHighlightBaseline,
   shouldHighlightByTimestamp,
@@ -65,6 +62,9 @@ gql`
   }
 `
 
+/** Stable identity so the fragment hook does not re-run on every custodial render. */
+const EMPTY_TRANSACTIONS: NormalizedTransaction[] = []
+
 const INITIAL_ITEMS_TO_RENDER = 14
 const RENDER_BATCH_SIZE = 14
 const QUERY_BATCH_SIZE = INITIAL_ITEMS_TO_RENDER * 1.5
@@ -84,7 +84,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
   )
 
   const isAuthed = useIsAuthed()
-  const client = useApolloClient()
   const activeWallet = useActiveWallet()
   const {
     allTransactions: selfCustodialAllTransactions,
@@ -92,8 +91,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     refreshWallets: refreshSelfCustodialWallets,
   } = useSelfCustodialWallet()
   const [selfCustodialRefreshing, setSelfCustodialRefreshing] = React.useState(false)
-  const { convertMoneyAmount, displayCurrency } = usePriceConversion()
-  const { fractionDigits } = useDisplayCurrency()
   const { feeReimbursementMemo } = useRemoteConfig()
   const hasTransitioned = useHasTransitioned()
 
@@ -161,33 +158,15 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     dataToRender?.me?.defaultAccount?.pendingIncomingTransactions
   const transactions = dataToRender?.me?.defaultAccount?.transactions
 
-  const selfCustodialDisplayInfo = React.useMemo(
+  const selfCustodialSourceTransactions = React.useMemo(
     () =>
-      convertMoneyAmount
-        ? { displayCurrency, convertMoneyAmount, fractionDigits }
-        : undefined,
-    [convertMoneyAmount, displayCurrency, fractionDigits],
+      activeWallet.isSelfCustodial ? selfCustodialAllTransactions : EMPTY_TRANSACTIONS,
+    [activeWallet.isSelfCustodial, selfCustodialAllTransactions],
   )
 
-  const allSelfCustodialFragments = React.useMemo(() => {
-    if (!activeWallet.isSelfCustodial) return []
-
-    const describe = (tx: Parameters<typeof getTransactionDescription>[0]) =>
-      getTransactionDescription(tx, LL)
-
-    const fragments = toTransactionFragments(
-      selfCustodialAllTransactions,
-      selfCustodialDisplayInfo,
-      describe,
-    )
-
-    return fragments.filter((tx) => tx.status !== TxStatus.Failure)
-  }, [
-    activeWallet.isSelfCustodial,
-    selfCustodialAllTransactions,
-    selfCustodialDisplayInfo,
-    LL,
-  ])
+  const allSelfCustodialFragments = useSelfCustodialTransactionFragments(
+    selfCustodialSourceTransactions,
+  )
 
   const selfCustodialFragments = React.useMemo(() => {
     if (walletFilter === "ALL") return allSelfCustodialFragments
@@ -205,25 +184,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     () => selfCustodialFragments.filter((tx) => tx.status === TxStatus.Pending),
     [selfCustodialFragments],
   )
-
-  React.useEffect(() => {
-    if (allSelfCustodialFragments.length === 0) return
-    const task = InteractionManager.runAfterInteractions(() => {
-      client.cache.batch({
-        update: (cache) => {
-          allSelfCustodialFragments.forEach((tx) => {
-            cache.writeFragment({
-              id: cache.identify({ __typename: "Transaction", id: tx.id }),
-              fragment: TransactionFragmentDoc,
-              fragmentName: "Transaction",
-              data: tx,
-            })
-          })
-        },
-      })
-    })
-    return () => task.cancel()
-  }, [client, allSelfCustodialFragments])
 
   const settledTxs = React.useMemo(() => {
     if (activeWallet.isSelfCustodial) return selfCustodialSettled

--- a/app/screens/transaction-history/transaction-history-screen.tsx
+++ b/app/screens/transaction-history/transaction-history-screen.tsx
@@ -1,14 +1,13 @@
 import * as React from "react"
 import { InteractionManager, SectionList, Text, View } from "react-native"
 import { makeStyles } from "@rn-vui/themed"
-import { gql, useApolloClient } from "@apollo/client"
+import { gql } from "@apollo/client"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { useNavigation, RouteProp } from "@react-navigation/native"
 
 import { Screen } from "@app/components/screen"
 import {
   TransactionFragment,
-  TransactionFragmentDoc,
   useTransactionListForDefaultAccountQuery,
   useWalletOverviewScreenQuery,
   WalletCurrency,
@@ -18,12 +17,10 @@ import {
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
-import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { usePriceConversion } from "@app/hooks/use-price-conversion"
 import { shouldHighlightById } from "@app/custodial/mappers/transaction-highlight"
-import { getTransactionDescription } from "@app/self-custodial/mappers/transaction-description"
-import { toTransactionFragments } from "@app/self-custodial/mappers/to-transaction-fragment"
+import { useSelfCustodialTransactionFragments } from "@app/self-custodial/hooks/use-self-custodial-transaction-fragments"
+import { NormalizedTransaction } from "@app/types/transaction"
 import {
   resolveHighlightBaseline,
   shouldHighlightByTimestamp,
@@ -68,6 +65,9 @@ gql`
   }
 `
 
+/** Stable identity so the fragment hook does not re-run on every custodial render. */
+const EMPTY_TRANSACTIONS: NormalizedTransaction[] = []
+
 const INITIAL_ITEMS_TO_RENDER = 14
 const RENDER_BATCH_SIZE = 14
 const QUERY_BATCH_SIZE = INITIAL_ITEMS_TO_RENDER * 1.5
@@ -89,7 +89,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
   )
 
   const isAuthed = useIsAuthed()
-  const client = useApolloClient()
   const activeWallet = useActiveWallet()
   const {
     allTransactions: selfCustodialAllTransactions,
@@ -97,8 +96,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     refreshWallets: refreshSelfCustodialWallets,
   } = useSelfCustodialWallet()
   const [selfCustodialRefreshing, setSelfCustodialRefreshing] = React.useState(false)
-  const { convertMoneyAmount, displayCurrency } = usePriceConversion()
-  const { fractionDigits } = useDisplayCurrency()
   const { feeReimbursementMemo } = useRemoteConfig()
   const hasTransitioned = useHasTransitioned()
 
@@ -166,33 +163,15 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     dataToRender?.me?.defaultAccount?.pendingIncomingTransactions
   const transactions = dataToRender?.me?.defaultAccount?.transactions
 
-  const selfCustodialDisplayInfo = React.useMemo(
+  const selfCustodialSourceTransactions = React.useMemo(
     () =>
-      convertMoneyAmount
-        ? { displayCurrency, convertMoneyAmount, fractionDigits }
-        : undefined,
-    [convertMoneyAmount, displayCurrency, fractionDigits],
+      activeWallet.isSelfCustodial ? selfCustodialAllTransactions : EMPTY_TRANSACTIONS,
+    [activeWallet.isSelfCustodial, selfCustodialAllTransactions],
   )
 
-  const allSelfCustodialFragments = React.useMemo(() => {
-    if (!activeWallet.isSelfCustodial) return []
-
-    const describe = (tx: Parameters<typeof getTransactionDescription>[0]) =>
-      getTransactionDescription(tx, LL)
-
-    const fragments = toTransactionFragments(
-      selfCustodialAllTransactions,
-      selfCustodialDisplayInfo,
-      describe,
-    )
-
-    return fragments.filter((tx) => tx.status !== TxStatus.Failure)
-  }, [
-    activeWallet.isSelfCustodial,
-    selfCustodialAllTransactions,
-    selfCustodialDisplayInfo,
-    LL,
-  ])
+  const allSelfCustodialFragments = useSelfCustodialTransactionFragments(
+    selfCustodialSourceTransactions,
+  )
 
   const selfCustodialFragments = React.useMemo(() => {
     if (walletFilter === "ALL") return allSelfCustodialFragments
@@ -210,25 +189,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     () => selfCustodialFragments.filter((tx) => tx.status === TxStatus.Pending),
     [selfCustodialFragments],
   )
-
-  React.useEffect(() => {
-    if (allSelfCustodialFragments.length === 0) return
-    const task = InteractionManager.runAfterInteractions(() => {
-      client.cache.batch({
-        update: (cache) => {
-          allSelfCustodialFragments.forEach((tx) => {
-            cache.writeFragment({
-              id: cache.identify({ __typename: "Transaction", id: tx.id }),
-              fragment: TransactionFragmentDoc,
-              fragmentName: "Transaction",
-              data: tx,
-            })
-          })
-        },
-      })
-    })
-    return () => task.cancel()
-  }, [client, allSelfCustodialFragments])
 
   const settledTxs = React.useMemo(() => {
     if (activeWallet.isSelfCustodial) return selfCustodialSettled

--- a/app/self-custodial/hooks/use-self-custodial-contacts.ts
+++ b/app/self-custodial/hooks/use-self-custodial-contacts.ts
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useState } from "react"
 
 import {
-  PaymentDetails_Tags as PaymentDetailsTags,
-  PaymentType as SdkPaymentType,
   type BreezSdkInterface,
   type Contact as SdkContact,
 } from "@breeztech/breez-sdk-spark-react-native"
@@ -11,22 +9,33 @@ import {
   type Contact,
   type ContactAdapter,
   type ContactListResult,
+  type ContactTransactionsPage,
 } from "@app/types/contact"
-import { type NormalizedTransaction } from "@app/types/transaction"
 import { AccountType } from "@app/types/wallet"
-import { normalizeString } from "@app/utils/helper"
 
 import {
   findOrCreateContact as bridgeFindOrCreateContact,
   deleteContact as bridgeDeleteContact,
   listContacts as bridgeListContacts,
-  listPayments as bridgeListPayments,
   updateContact as bridgeUpdateContact,
 } from "../bridge"
-import { mapSelfCustodialTransactions } from "../mappers/transaction"
+import { fetchContactPaymentsPage } from "../providers/contact-payments"
 import { useSelfCustodialWallet } from "../providers/wallet"
 
-const MATCHED_PAYMENTS_LIMIT = 100
+const EMPTY_TRANSACTIONS_PAGE: ContactTransactionsPage = {
+  transactions: [],
+  nextCursor: null,
+}
+
+/**
+ * The cursor this adapter hands out is a stringified SDK offset. Anything else is not
+ * ours to interpret, so it restarts from the beginning rather than passing NaN to the SDK
+ * and looping forever on a request that can never advance.
+ */
+const toRawOffset = (cursor?: string | null): number => {
+  const offset = Number(cursor)
+  return Number.isSafeInteger(offset) && offset >= 0 ? offset : 0
+}
 
 const mapSdkContact = (c: SdkContact): Contact => ({
   id: c.id,
@@ -129,29 +138,24 @@ export const useSelfCustodialContacts = (): ContactAdapter & {
   )
 
   const getTransactions = useCallback(
-    async (contactId: string): Promise<NormalizedTransaction[]> => {
-      if (!sdk) return []
-      const target = contacts.find((c) => c.id === contactId)
-      if (!target) return []
+    async (
+      paymentIdentifier: string,
+      cursor?: string | null,
+    ): Promise<ContactTransactionsPage> => {
+      if (!sdk) return EMPTY_TRANSACTIONS_PAGE
 
-      const normalizedIdentifier = normalizeString(target.paymentIdentifier)
-      const response = await bridgeListPayments(sdk, 0, MATCHED_PAYMENTS_LIMIT)
+      const page = await fetchContactPaymentsPage(
+        sdk,
+        paymentIdentifier,
+        toRawOffset(cursor),
+      )
 
-      const matched = response.payments.filter((payment) => {
-        if (payment.paymentType !== SdkPaymentType.Send) return false
-
-        const details = payment.details
-        if (!details || details.tag !== PaymentDetailsTags.Lightning) return false
-
-        const lnAddress = details.inner.lnurlPayInfo?.lnAddress
-        if (!lnAddress) return false
-
-        return normalizeString(lnAddress) === normalizedIdentifier
-      })
-
-      return mapSelfCustodialTransactions(matched)
+      return {
+        transactions: page.transactions,
+        nextCursor: page.hasMore ? String(page.rawOffset) : null,
+      }
     },
-    [contacts, sdk],
+    [sdk],
   )
 
   return {

--- a/app/self-custodial/hooks/use-self-custodial-transaction-fragments.ts
+++ b/app/self-custodial/hooks/use-self-custodial-transaction-fragments.ts
@@ -44,7 +44,7 @@ export const useSelfCustodialTransactionFragments = (
     const describe = (tx: Parameters<typeof getTransactionDescription>[0]) =>
       getTransactionDescription(tx, LL)
 
-    return toTransactionFragments([...transactions], displayInfo, describe).filter(
+    return toTransactionFragments(transactions, displayInfo, describe).filter(
       (tx) => tx.status !== TxStatus.Failure,
     )
   }, [transactions, displayInfo, LL])

--- a/app/self-custodial/hooks/use-self-custodial-transaction-fragments.ts
+++ b/app/self-custodial/hooks/use-self-custodial-transaction-fragments.ts
@@ -1,0 +1,75 @@
+import { useEffect, useMemo } from "react"
+import { InteractionManager } from "react-native"
+
+import { useApolloClient } from "@apollo/client"
+
+import {
+  TransactionFragment,
+  TransactionFragmentDoc,
+  TxStatus,
+} from "@app/graphql/generated"
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { usePriceConversion } from "@app/hooks/use-price-conversion"
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { toTransactionFragments } from "@app/self-custodial/mappers/to-transaction-fragment"
+import { getTransactionDescription } from "@app/self-custodial/mappers/transaction-description"
+import { NormalizedTransaction } from "@app/types/transaction"
+
+/**
+ * Turns self-custodial transactions into the shared `TransactionFragment` shape and
+ * primes the Apollo cache with them, because `TransactionItem` reads its data from the
+ * cache by id and has no other way to see wallet-sourced transactions. Failed payments
+ * are dropped: they are noise in a history list, not entries a user acted on.
+ *
+ * Every screen that lists self-custodial transactions needs both halves, so they live
+ * here instead of being copied per screen.
+ */
+export const useSelfCustodialTransactionFragments = (
+  transactions: readonly NormalizedTransaction[],
+): TransactionFragment[] => {
+  const client = useApolloClient()
+  const { LL } = useI18nContext()
+  const { convertMoneyAmount, displayCurrency } = usePriceConversion()
+  const { fractionDigits } = useDisplayCurrency()
+
+  const displayInfo = useMemo(
+    () =>
+      convertMoneyAmount
+        ? { displayCurrency, convertMoneyAmount, fractionDigits }
+        : undefined,
+    [convertMoneyAmount, displayCurrency, fractionDigits],
+  )
+
+  const fragments = useMemo(() => {
+    const describe = (tx: Parameters<typeof getTransactionDescription>[0]) =>
+      getTransactionDescription(tx, LL)
+
+    return toTransactionFragments([...transactions], displayInfo, describe).filter(
+      (tx) => tx.status !== TxStatus.Failure,
+    )
+  }, [transactions, displayInfo, LL])
+
+  useEffect(() => {
+    if (fragments.length === 0) return
+
+    /** Deferred so a long transaction list never writes to the cache mid-interaction. */
+    const task = InteractionManager.runAfterInteractions(() => {
+      client.cache.batch({
+        update: (cache) => {
+          fragments.forEach((tx) => {
+            cache.writeFragment({
+              id: cache.identify({ __typename: "Transaction", id: tx.id }),
+              fragment: TransactionFragmentDoc,
+              fragmentName: "Transaction",
+              data: tx,
+            })
+          })
+        },
+      })
+    })
+
+    return () => task.cancel()
+  }, [client, fragments])
+
+  return fragments
+}

--- a/app/self-custodial/mappers/to-transaction-fragment.ts
+++ b/app/self-custodial/mappers/to-transaction-fragment.ts
@@ -195,7 +195,7 @@ export const toTransactionFragment = (
 }
 
 export const toTransactionFragments = (
-  txs: NormalizedTransaction[],
+  txs: readonly NormalizedTransaction[],
   display?: DisplayInfo,
   resolveDescription?: DescriptionResolver,
 ): TransactionFragment[] =>

--- a/app/self-custodial/providers/contact-payments.ts
+++ b/app/self-custodial/providers/contact-payments.ts
@@ -41,6 +41,10 @@ const matchesContact = (tx: NormalizedTransaction, identifier: string): boolean 
  * empty page would stall an infinite scroll, because the list would not grow and so would
  * never ask for more. This keeps pulling raw pages until it fills a page, exhausts the
  * history or reaches its page budget, and reports the offset it stopped at.
+ *
+ * `TRANSACTIONS_PER_PAGE` is a floor, not a cap: the raw page that crosses it contributes
+ * all of its matches, so a page can come back with close to twice that many. Callers
+ * append and dedupe by id, so the overshoot only means the reader gets more at once.
  */
 export const fetchContactPaymentsPage = async (
   sdk: BreezSdkInterface,

--- a/app/self-custodial/providers/contact-payments.ts
+++ b/app/self-custodial/providers/contact-payments.ts
@@ -1,6 +1,6 @@
 import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 
-import { TransactionDirection, type NormalizedTransaction } from "@app/types/transaction"
+import { type NormalizedTransaction } from "@app/types/transaction"
 import { normalizeString } from "@app/utils/helper"
 
 import { fetchAndMapPayments, TRANSACTIONS_PER_PAGE } from "./payments-page"
@@ -25,14 +25,13 @@ export type ContactPaymentsPage = {
  * The SDK cannot filter payments by counterparty, so a contact's history is found by
  * matching the lightning address the mapper already carries on each transaction.
  *
- * Restricted to sends: `lnAddress` comes from `lnurlPayInfo`, which on a receive holds
- * the address the payer resolved, so an unrestricted match would list a user's own
- * incoming payments as payments with this contact.
+ * Both directions count: a conversation with a contact is what they were paid and what
+ * they paid back, and the history screen already reads a received payment's address as
+ * its counterparty. The address itself is the filter, so a receive that carries the
+ * user's own address instead of the sender's simply never matches a contact.
  */
 const matchesContact = (tx: NormalizedTransaction, identifier: string): boolean =>
-  tx.direction === TransactionDirection.Send &&
-  tx.lnAddress !== undefined &&
-  normalizeString(tx.lnAddress) === identifier
+  tx.lnAddress !== undefined && normalizeString(tx.lnAddress) === identifier
 
 /**
  * Reads one page of a contact's payments, resuming from `rawOffset`.

--- a/app/self-custodial/providers/contact-payments.ts
+++ b/app/self-custodial/providers/contact-payments.ts
@@ -1,0 +1,76 @@
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
+import { TransactionDirection, type NormalizedTransaction } from "@app/types/transaction"
+import { normalizeString } from "@app/utils/helper"
+
+import { fetchAndMapPayments, TRANSACTIONS_PER_PAGE } from "./payments-page"
+
+/**
+ * How many raw pages one request may read before answering with whatever it found.
+ *
+ * Matching happens on the client, so a contact with few payments spread across a long
+ * history would otherwise walk the whole wallet before the screen could paint. This caps
+ * the work per request; the page comes back short with more still to read, and the next
+ * scroll resumes from where this one stopped.
+ */
+const MAX_PAGES_PER_REQUEST = 5
+
+export type ContactPaymentsPage = {
+  transactions: NormalizedTransaction[]
+  rawOffset: number
+  hasMore: boolean
+}
+
+/**
+ * The SDK cannot filter payments by counterparty, so a contact's history is found by
+ * matching the lightning address the mapper already carries on each transaction.
+ *
+ * Restricted to sends: `lnAddress` comes from `lnurlPayInfo`, which on a receive holds
+ * the address the payer resolved, so an unrestricted match would list a user's own
+ * incoming payments as payments with this contact.
+ */
+const matchesContact = (tx: NormalizedTransaction, identifier: string): boolean =>
+  tx.direction === TransactionDirection.Send &&
+  tx.lnAddress !== undefined &&
+  normalizeString(tx.lnAddress) === identifier
+
+/**
+ * Reads one page of a contact's payments, resuming from `rawOffset`.
+ *
+ * A raw page of wallet payments may contain nothing for this contact. Returning that
+ * empty page would stall an infinite scroll, because the list would not grow and so would
+ * never ask for more. This keeps pulling raw pages until it fills a page, exhausts the
+ * history or reaches its page budget, and reports the offset it stopped at.
+ */
+export const fetchContactPaymentsPage = async (
+  sdk: BreezSdkInterface,
+  paymentIdentifier: string,
+  rawOffset: number,
+): Promise<ContactPaymentsPage> => {
+  const identifier = normalizeString(paymentIdentifier)
+  const transactions: NormalizedTransaction[] = []
+
+  let offset = rawOffset
+  let hasMore = true
+  let pagesRead = 0
+
+  while (
+    hasMore &&
+    transactions.length < TRANSACTIONS_PER_PAGE &&
+    pagesRead < MAX_PAGES_PER_REQUEST
+  ) {
+    const page = await fetchAndMapPayments(sdk, offset)
+    pagesRead += 1
+
+    if (page.rawCount === 0) {
+      hasMore = false
+      break
+    }
+
+    transactions.push(...page.transactions.filter((tx) => matchesContact(tx, identifier)))
+    offset += page.rawCount
+    hasMore = page.hasMore
+  }
+
+  return { transactions, rawOffset: offset, hasMore }
+}

--- a/app/self-custodial/providers/payments-page.ts
+++ b/app/self-custodial/providers/payments-page.ts
@@ -1,0 +1,41 @@
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
+import { type NormalizedTransaction } from "@app/types/transaction"
+
+import { listPayments } from "../bridge"
+import { isKnownPayment, mapSelfCustodialTransactions } from "../mappers/transaction"
+
+/**
+ * How many raw SDK payments each request asks for. Everything that pages through the
+ * wallet history reads the same page size, so a screen never has to guess how far a
+ * cursor advanced.
+ */
+export const TRANSACTIONS_PER_PAGE = 20
+
+export type PaymentsPage = {
+  transactions: NormalizedTransaction[]
+  rawCount: number
+  hasMore: boolean
+}
+
+/**
+ * Reads one page of payments starting at `offset` and normalizes it. `rawCount` counts
+ * the payments the SDK answered with, not the ones that survived mapping, so a caller
+ * can advance its offset past entries that were dropped. A caller that walks the history
+ * for one entry rather than showing it can widen the page it reads.
+ */
+export const fetchAndMapPayments = async (
+  sdk: BreezSdkInterface,
+  offset: number,
+  pageSize: number = TRANSACTIONS_PER_PAGE,
+): Promise<PaymentsPage> => {
+  const response = await listPayments(sdk, offset, pageSize)
+  const transactions = mapSelfCustodialTransactions(
+    response.payments.filter(isKnownPayment),
+  )
+  return {
+    transactions,
+    rawCount: response.payments.length,
+    hasMore: response.payments.length >= pageSize,
+  }
+}

--- a/app/self-custodial/providers/payments-page.ts
+++ b/app/self-custodial/providers/payments-page.ts
@@ -1,0 +1,61 @@
+import {
+  PaymentDetails,
+  PaymentMethod,
+  type BreezSdkInterface,
+  type Payment,
+} from "@breeztech/breez-sdk-spark-react-native"
+
+import { type NormalizedTransaction } from "@app/types/transaction"
+
+import { listPayments } from "../bridge"
+import { requireSparkTokenIdentifier } from "../config"
+import { recordErrorOnce } from "../logging"
+import { mapSelfCustodialTransactions } from "../mappers/transaction"
+
+/**
+ * How many raw SDK payments each request asks for. Everything that pages through the
+ * wallet history reads the same page size, so a screen never has to guess how far a
+ * cursor advanced.
+ */
+export const TRANSACTIONS_PER_PAGE = 20
+
+const isKnownPayment = (payment: Payment): boolean => {
+  if (payment.method !== PaymentMethod.Token) return true
+  if (!payment.details || !PaymentDetails.Token.instanceOf(payment.details)) return false
+  const expectedIdentifier = requireSparkTokenIdentifier()
+  const observedIdentifier = payment.details.inner.metadata.identifier
+  if (observedIdentifier === expectedIdentifier) return true
+  recordErrorOnce(
+    `spark-unknown-token-payment:${observedIdentifier}`,
+    new Error(
+      `Unknown token payment dropped: id=${observedIdentifier} expected=${expectedIdentifier}`,
+    ),
+  )
+  return false
+}
+
+export type PaymentsPage = {
+  transactions: NormalizedTransaction[]
+  rawCount: number
+  hasMore: boolean
+}
+
+/**
+ * Reads one page of payments starting at `offset` and normalizes it. `rawCount` counts
+ * the payments the SDK answered with, not the ones that survived mapping, so a caller
+ * can advance its offset past entries that were dropped.
+ */
+export const fetchAndMapPayments = async (
+  sdk: BreezSdkInterface,
+  offset: number,
+): Promise<PaymentsPage> => {
+  const response = await listPayments(sdk, offset, TRANSACTIONS_PER_PAGE)
+  const transactions = mapSelfCustodialTransactions(
+    response.payments.filter(isKnownPayment),
+  )
+  return {
+    transactions,
+    rawCount: response.payments.length,
+    hasMore: response.payments.length >= TRANSACTIONS_PER_PAGE,
+  }
+}

--- a/app/self-custodial/providers/wallet-snapshot.ts
+++ b/app/self-custodial/providers/wallet-snapshot.ts
@@ -9,39 +9,20 @@ import { toWalletMoneyAmount } from "@app/types/amounts"
 import { type NormalizedTransaction } from "@app/types/transaction"
 import { toWalletId, type WalletState } from "@app/types/wallet"
 
-import { findUsdbToken, getWalletInfo, listPayments } from "../bridge"
+import { findUsdbToken, getWalletInfo } from "../bridge"
 import { recordErrorOnce } from "../logging"
-import { isKnownPayment, mapSelfCustodialTransactions } from "../mappers/transaction"
 import { latestOnchainReceiptId } from "../storage/onchain-address"
 
-const TRANSACTIONS_PER_PAGE = 20
+import {
+  fetchAndMapPayments,
+  TRANSACTIONS_PER_PAGE,
+  type PaymentsPage,
+} from "./payments-page"
 
 const getStableBalance = (token: TokenBalance | undefined): number => {
   if (!token) return 0
   const decimals = token.tokenMetadata?.decimals ?? 0
   return tokenBaseUnitsToCents(Number(token.balance), decimals)
-}
-
-type PaymentsPage = {
-  transactions: NormalizedTransaction[]
-  rawCount: number
-  hasMore: boolean
-}
-
-const fetchAndMapPayments = async (
-  sdk: BreezSdkInterface,
-  offset: number,
-  pageSize: number = TRANSACTIONS_PER_PAGE,
-): Promise<PaymentsPage> => {
-  const response = await listPayments(sdk, offset, pageSize)
-  const transactions = mapSelfCustodialTransactions(
-    response.payments.filter(isKnownPayment),
-  )
-  return {
-    transactions,
-    rawCount: response.payments.length,
-    hasMore: response.payments.length >= pageSize,
-  }
 }
 
 type WalletBalances = {

--- a/app/self-custodial/providers/wallet-snapshot.ts
+++ b/app/self-custodial/providers/wallet-snapshot.ts
@@ -1,8 +1,5 @@
 import {
-  PaymentDetails,
-  PaymentMethod,
   type BreezSdkInterface,
-  type Payment,
   type TokenBalance,
 } from "@breeztech/breez-sdk-spark-react-native"
 
@@ -12,53 +9,19 @@ import { toWalletMoneyAmount } from "@app/types/amounts"
 import { type NormalizedTransaction } from "@app/types/transaction"
 import { toWalletId, type WalletState } from "@app/types/wallet"
 
-import { findUsdbToken, getWalletInfo, listPayments } from "../bridge"
-import { requireSparkTokenIdentifier } from "../config"
+import { findUsdbToken, getWalletInfo } from "../bridge"
 import { recordErrorOnce } from "../logging"
-import { mapSelfCustodialTransactions } from "../mappers/transaction"
 
-const TRANSACTIONS_PER_PAGE = 20
+import {
+  fetchAndMapPayments,
+  TRANSACTIONS_PER_PAGE,
+  type PaymentsPage,
+} from "./payments-page"
 
 const getStableBalance = (token: TokenBalance | undefined): number => {
   if (!token) return 0
   const decimals = token.tokenMetadata?.decimals ?? 0
   return tokenBaseUnitsToCents(Number(token.balance), decimals)
-}
-
-const isKnownPayment = (payment: Payment): boolean => {
-  if (payment.method !== PaymentMethod.Token) return true
-  if (!payment.details || !PaymentDetails.Token.instanceOf(payment.details)) return false
-  const expectedIdentifier = requireSparkTokenIdentifier()
-  const observedIdentifier = payment.details.inner.metadata.identifier
-  if (observedIdentifier === expectedIdentifier) return true
-  recordErrorOnce(
-    `spark-unknown-token-payment:${observedIdentifier}`,
-    new Error(
-      `Unknown token payment dropped: id=${observedIdentifier} expected=${expectedIdentifier}`,
-    ),
-  )
-  return false
-}
-
-type PaymentsPage = {
-  transactions: NormalizedTransaction[]
-  rawCount: number
-  hasMore: boolean
-}
-
-const fetchAndMapPayments = async (
-  sdk: BreezSdkInterface,
-  offset: number,
-): Promise<PaymentsPage> => {
-  const response = await listPayments(sdk, offset, TRANSACTIONS_PER_PAGE)
-  const transactions = mapSelfCustodialTransactions(
-    response.payments.filter(isKnownPayment),
-  )
-  return {
-    transactions,
-    rawCount: response.payments.length,
-    hasMore: response.payments.length >= TRANSACTIONS_PER_PAGE,
-  }
 }
 
 type WalletBalances = {

--- a/app/types/contact.ts
+++ b/app/types/contact.ts
@@ -20,6 +20,17 @@ export type ContactListResult = {
   errors?: Array<{ message: string }>
 }
 
+/**
+ * One page of a contact's transactions. `nextCursor` is opaque to the caller: it hands
+ * back whatever it received to ask for the following page, and `null` means the history
+ * is exhausted. Keeping it opaque lets each adapter page the way its source allows
+ * without the screen knowing whether that is an SDK offset or a backend cursor.
+ */
+export type ContactTransactionsPage = {
+  transactions: NormalizedTransaction[]
+  nextCursor: string | null
+}
+
 export type ContactAdapter = {
   capabilities: ContactCapabilities
   list: () => Promise<ContactListResult>
@@ -31,5 +42,12 @@ export type ContactAdapter = {
     contact: Partial<Omit<Contact, "id" | "sourceAccountType">>,
   ) => Promise<ContactListResult>
   delete: (id: string) => Promise<ContactListResult>
-  getTransactions: (contactId: string) => Promise<NormalizedTransaction[]>
+  /**
+   * Keyed by payment identifier rather than contact id: it is what a payment carries, so
+   * an adapter never has to resolve its own contact list first just to answer.
+   */
+  getTransactions: (
+    paymentIdentifier: string,
+    cursor?: string | null,
+  ) => Promise<ContactTransactionsPage>
 }


### PR DESCRIPTION
## Summary

The contact detail screen fetched its transactions through `me { contactByUsername { transactions } }` with no account-type guard. A self-custodial account has no session behind `me`, so the query answered with nothing, the component returned early on `!transactions`, and the "Transactions with …" section rendered as an empty hole with no list and no empty state.

The contact adapter already had the answer: `ContactAdapter.getTransactions` is implemented in `use-self-custodial-contacts` and matches payments by the counterparty lightning address. Nothing was calling it. This wires the screen to the adapter, the same way `all-contacts.tsx` already resolves its list per account type, and gives that path real pagination instead of a single truncated read.

The screen itself was then redesigned to the current spec: the stack's own back arrow instead of the close cross, the shared `IconHero` carrying the lightning address, and the history as a rounded date group with the send button under it.

Refs blinkbitcoin/blink-wip#936

The report suggests hiding the People tab instead. This repairs it rather than hiding it, so the tab keeps working while that call is made: whether to rework the UI can be decided later, on a screen that is no longer broken.

## Changes

- `app/self-custodial/providers/payments-page.ts` (new): the raw page primitive — `TRANSACTIONS_PER_PAGE` and `fetchAndMapPayments` — lifted out of `wallet-snapshot.ts`, which kept it private, so the wallet snapshot and the new contact paging both depend on it and neither depends on the other. Pure move, no behaviour change.
- `app/self-custodial/providers/contact-payments.ts` (new): reads a contact's payments a page at a time. The SDK cannot filter by counterparty, so matching happens on the client over the `lnAddress` the mapper already carries, in either direction, and the loop keeps pulling raw pages until it fills one, exhausts the history, or reaches a page budget.
- `app/types/contact.ts`: `getTransactions` is keyed by payment identifier rather than contact id, and returns a page whose cursor is opaque to the caller.
- `app/hooks/use-contact-transactions.ts` (new): owns the paging state. A page from a superseded read is dropped rather than appended, repeats are deduped by id, and a failed page leaves the list intact.
- `app/screens/people-screen/contacts/contact-transactions.tsx`: pages through the adapter for a self-custodial account, with `onEndReached` serving both paths. The list always renders, so an account with no matching payments gets the empty state instead of a blank area. Restyled to the design: the date is plain text above a rounded grey group rather than a bar inside a bordered box, and each row carries its relative time. It also holds the room between the header and the send button whatever the history holds — one payment or twenty — so the button keeps its place instead of riding up a short list, including when the history cannot be read at all.
- `app/screens/people-screen/contacts/contacts-detail.tsx`: rebuilt around `IconHero` with the contact's lightning address, the list, and the send button. The 86pt icon, the alias input, the "Username: …" line and the "Transactions with …" title are gone, and the close cross gives way to the header back arrow the rest of the stack uses.
- `app/components/icon-hero/icon-hero.tsx`: an optional `titleLines`, which the contact screen sets to 1. An address is one unbreakable thing, so it is cut short with the middle ellipsis the app already uses for a payment destination rather than wrapped across two lines. A heading with no cap still wraps, so the onboarding screens are untouched.
- `app/navigation/root-navigator.tsx`: `contactDetail` shows the stack header with an empty title, which is where that back arrow comes from.
- `app/custodial/contact-adapter.ts`: takes over the `userContactUpdateAlias` document, its only remaining caller now that the screen no longer edits aliases. `generated.ts` is unchanged.
- `app/components/transaction-item/transaction-item.tsx`: the date under a description is `grey2`, the colour `card-transaction-item` already uses for the same line. Received amounts were already `_green`.
- `app/self-custodial/hooks/use-self-custodial-transaction-fragments.ts` (new): the mapping into `TransactionFragment` plus the Apollo cache priming, extracted from the transaction history screen because both screens need both halves. `transaction-history-screen.tsx` now consumes it, unchanged in behaviour.

## Notes for review

The paging cursor is an offset into a live wallet history, so returning to the screen restarts from the first page rather than merging across a boundary a new payment may have shifted.

Contact matching runs in both directions, since a conversation with a contact is what they were paid and what they paid back. In practice only sends surface today: verified on device, an incoming Lightning payment carries no `lnAddress` at all — the SDK's receive-side record (`LnurlReceiveMetadata`) holds a nostr zap request and a sender comment, and no identity — so a receive has no counterparty to match against. The matcher is ready for the day one arrives; nothing client-side can conjure it.

A separate, pre-existing backend limit affects the custodial path, tracked in #4193. `contactByUsername` is the only lookup the schema offers, and it resolves only contacts stored under a username. A contact stored as an address answers `NoContactForUsernameError`, and passing the address itself fails the `Username` scalar, so that contact's history cannot be listed at all. It needs a handle-keyed lookup on the backend; once that ships, the app side is a one-field change — query `contactByHandle(handle: $handle)` and pass `contact.handle` — which belongs in its own PR rather than here.

## Test plan

- Coverage on every file this touches: **100% statements, branches, functions and lines** across `contacts-detail.tsx`, `contact-transactions.tsx`, `icon-hero.tsx`, `use-contact-transactions.ts`, `contact-payments.ts`, `payments-page.ts`, `use-self-custodial-contacts.ts`, `use-self-custodial-transaction-fragments.ts` and `contact-adapter.ts` — 288 tests in 16 suites, no console output
- Every guard in the paging hook was verified by mutation, each broken on purpose to confirm a test fails
- `yarn jest __tests__/hooks/ __tests__/custodial/ __tests__/self-custodial/ __tests__/screens/people-screen/`: 2085 passed in 161 suites
- `yarn jest` on the transaction-history and wallet-snapshot suites, the ones the extraction could reach: 47 passed
- `yarn check-code` (the CI command: tsc, eslint, translations, codegen, graphql validation): clean
- Device (Android emulator): custodial and self-custodial contacts, pagination exercised by temporarily lowering the page size so a short history spans several pages, and both design notes checked against a synthetic long address — the address truncates on one line, and the send button holds the same position with one payment and with a full month

## Screenshots

| Before | After — custodial | After — self-custodial |
| :---: | :---: | :---: |
| <img width="250" alt="936-1-before" src="https://github.com/user-attachments/assets/fe3bfa44-bf79-49d1-9f50-86de70c6f055" /> | <img width="250" alt="Screenshot from 2026-08-21 11-26-27" src="https://github.com/user-attachments/assets/dc40b208-11ec-43e3-a394-e42cf982ca26" /> | <img width="250" alt="Screenshot from 2026-08-21 11-27-12" src="https://github.com/user-attachments/assets/f611cfe6-ae15-4295-9552-e23ab655f110" /> |

Before: the section renders its title and then nothing at all. After: the contact's payments are listed and grouped by date, under the redesigned header. Amounts are masked by the app's hide-balance toggle.
