### PR TITLE
fix(home): keep the pending deposit amount visible beside the balance

### DIFF
--- a/__tests__/components/balance-header/balance-header.spec.tsx
+++ b/__tests__/components/balance-header/balance-header.spec.tsx
@@ -145,4 +145,14 @@ describe("BalanceHeader", () => {
 
     expect(queryByTestId("balance-status-badge")).toBeNull()
   })
+
+  it("does not render the status badge while amounts are hidden", () => {
+    mockHideAmount = true
+
+    const { queryByTestId } = renderHeader({
+      statusBadge: { label: "+$1.00 pending", status: "warning" },
+    })
+
+    expect(queryByTestId("balance-status-badge")).toBeNull()
+  })
 })

--- a/__tests__/components/balance-header/balance-header.spec.tsx
+++ b/__tests__/components/balance-header/balance-header.spec.tsx
@@ -1,9 +1,11 @@
 import React from "react"
+import { StyleSheet } from "react-native"
 import { fireEvent, render } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
 import theme from "@app/rne-theme/theme"
 import { BalanceMode } from "@app/hooks/use-balance-mode"
+import { StatusPill } from "@app/components/status-pill"
 
 import { BalanceHeader } from "@app/components/balance-header/balance-header"
 
@@ -144,6 +146,24 @@ describe("BalanceHeader", () => {
     })
 
     expect(queryByTestId("balance-status-badge")).toBeNull()
+  })
+
+  it("caps and shrinks the real pill and the centering ghost identically", () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getAllByType } = renderHeader({
+      statusBadge: { label: "+$1,234,567.89 pending", status: "warning" },
+    })
+
+    const pills = UNSAFE_getAllByType(StatusPill)
+    expect(pills).toHaveLength(2)
+
+    const [ghostStyle, realStyle] = pills.map((pill) =>
+      StyleSheet.flatten(pill.props.style),
+    )
+    expect(ghostStyle.flexShrink).toBe(1)
+    expect(realStyle.flexShrink).toBe(1)
+    expect(ghostStyle.maxWidth).toBeDefined()
+    expect(ghostStyle.maxWidth).toBe(realStyle.maxWidth)
   })
 
   it("does not render the status badge while amounts are hidden", () => {

--- a/__tests__/components/balance-header/balance-header.spec.tsx
+++ b/__tests__/components/balance-header/balance-header.spec.tsx
@@ -166,6 +166,18 @@ describe("BalanceHeader", () => {
     expect(ghostStyle.maxWidth).toBe(realStyle.maxWidth)
   })
 
+  it("forwards the badge onPress so the pill can carry an action", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = renderHeader({
+      statusBadge: { label: "+$1.00 pending", status: "warning", onPress },
+    })
+
+    fireEvent.press(getByTestId("balance-status-badge"))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+    expect(mockSwitchMemoryHideAmount).not.toHaveBeenCalled()
+  })
+
   it("does not render the status badge while amounts are hidden", () => {
     mockHideAmount = true
 

--- a/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
+++ b/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react-native"
 
 import { usePendingReceiveAmount } from "@app/components/balance-header/use-pending-receive-amount"
 import { TransactionFragment, TxDirection, WalletCurrency } from "@app/graphql/generated"
+import { DisplayCurrency } from "@app/types/amounts"
 import { DepositStatus, PendingDeposit } from "@app/types/payment"
 
 const mockConvertMoneyAmount = jest.fn()
@@ -10,9 +11,9 @@ const mockFormatMoneyAmount = jest.fn(
     `$${(moneyAmount.amount / 100).toFixed(2)}`,
 )
 const mockUseActiveWallet = jest.fn()
-const mockUsePendingDeposits = jest.fn()
 
 jest.mock("@app/hooks", () => ({
+  ...jest.requireActual("@app/hooks"),
   usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount() }),
 }))
 
@@ -24,15 +25,20 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => mockUseActiveWallet(),
 }))
 
-jest.mock("@app/self-custodial/hooks", () => ({
-  usePendingDeposits: () => mockUsePendingDeposits(),
-}))
+/**
+ * BTC passes through, USD is scaled by a distinct factor. A converter that
+ * ignored the incoming currency would still make a BTC-only total add up, so
+ * the mix has to be priced per settlement currency to reach the expected sum.
+ */
+const USD_TO_DISPLAY_FACTOR = 10
 
-const identityConverter = ({ amount }: { amount: number }) => ({
-  amount,
-  currency: "DisplayCurrency",
-  currencyCode: "USD",
-})
+const mockConverter = jest.fn(
+  ({ amount, currency }: { amount: number; currency: string }) => ({
+    amount: currency === WalletCurrency.Usd ? amount * USD_TO_DISPLAY_FACTOR : amount,
+    currency: "DisplayCurrency",
+    currencyCode: "USD",
+  }),
+)
 
 const pendingReceiveTx = (
   overrides: Partial<TransactionFragment> = {},
@@ -59,9 +65,8 @@ const deposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit => ({
 describe("usePendingReceiveAmount", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockConvertMoneyAmount.mockReturnValue(identityConverter)
+    mockConvertMoneyAmount.mockReturnValue(mockConverter)
     mockUseActiveWallet.mockReturnValue({ isSelfCustodial: false })
-    mockUsePendingDeposits.mockReturnValue({ deposits: [] })
   })
 
   describe("custodial", () => {
@@ -87,7 +92,12 @@ describe("usePendingReceiveAmount", () => {
         }),
       )
 
-      expect(result.current.pendingReceiveAmountText).toBe("$120.00")
+      // 10_000 sats + (2_000 cents x 10), i.e. each priced by its own currency
+      expect(result.current.pendingReceiveAmountText).toBe("$300.00")
+      expect(mockConverter).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: 2_000, currency: WalletCurrency.Usd }),
+        DisplayCurrency,
+      )
     })
 
     it("returns null when there are no pending transactions", () => {
@@ -162,35 +172,43 @@ describe("usePendingReceiveAmount", () => {
     })
 
     it("sums immature (unconfirmed) deposits", () => {
-      mockUsePendingDeposits.mockReturnValue({
-        deposits: [
-          deposit({
-            id: "a:0",
-            amount: { amount: 4_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-          }),
-          deposit({
-            id: "b:1",
-            amount: { amount: 6_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-          }),
-        ],
-      })
-
-      const { result } = renderHook(() => usePendingReceiveAmount({}))
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          deposits: [
+            deposit({
+              id: "a:0",
+              amount: {
+                amount: 4_000,
+                currency: WalletCurrency.Btc,
+                currencyCode: "BTC",
+              },
+            }),
+            deposit({
+              id: "b:1",
+              amount: {
+                amount: 6_000,
+                currency: WalletCurrency.Btc,
+                currencyCode: "BTC",
+              },
+            }),
+          ],
+        }),
+      )
 
       expect(result.current.pendingReceiveAmountText).toBe("$100.00")
     })
 
     it("excludes non-immature deposits (claimable, error, refunded are the banner's job)", () => {
-      mockUsePendingDeposits.mockReturnValue({
-        deposits: [
-          deposit({ id: "a:0", status: DepositStatus.Claimable }),
-          deposit({ id: "b:0", status: DepositStatus.FeeExceeded }),
-          deposit({ id: "c:0", status: DepositStatus.Error }),
-          deposit({ id: "d:0", status: DepositStatus.Refunded }),
-        ],
-      })
-
-      const { result } = renderHook(() => usePendingReceiveAmount({}))
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          deposits: [
+            deposit({ id: "a:0", status: DepositStatus.Claimable }),
+            deposit({ id: "b:0", status: DepositStatus.FeeExceeded }),
+            deposit({ id: "c:0", status: DepositStatus.Error }),
+            deposit({ id: "d:0", status: DepositStatus.Refunded }),
+          ],
+        }),
+      )
 
       expect(result.current.pendingReceiveAmountText).toBeNull()
     })
@@ -202,16 +220,16 @@ describe("usePendingReceiveAmount", () => {
     })
 
     it("returns null when the only immature deposit has a zero amount", () => {
-      mockUsePendingDeposits.mockReturnValue({
-        deposits: [
-          deposit({
-            id: "z:0",
-            amount: { amount: 0, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-          }),
-        ],
-      })
-
-      const { result } = renderHook(() => usePendingReceiveAmount({}))
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          deposits: [
+            deposit({
+              id: "z:0",
+              amount: { amount: 0, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+            }),
+          ],
+        }),
+      )
 
       expect(result.current.pendingReceiveAmountText).toBeNull()
     })

--- a/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
+++ b/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
@@ -128,6 +128,32 @@ describe("usePendingReceiveAmount", () => {
 
       expect(result.current.pendingReceiveAmountText).toBeNull()
     })
+
+    it("ignores negative-amount transactions (defensive: pending receives are positive)", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({ id: "tx-neg", settlementAmount: -500 }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("returns null when conversion rounds the total to zero", () => {
+      mockConvertMoneyAmount.mockReturnValue(() => ({
+        amount: 0,
+        currency: "DisplayCurrency",
+        currencyCode: "USD",
+      }))
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
   })
 
   describe("self-custodial", () => {
@@ -170,6 +196,21 @@ describe("usePendingReceiveAmount", () => {
     })
 
     it("returns null when there are no deposits", () => {
+      const { result } = renderHook(() => usePendingReceiveAmount({}))
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("returns null when the only immature deposit has a zero amount", () => {
+      mockUsePendingDeposits.mockReturnValue({
+        deposits: [
+          deposit({
+            id: "z:0",
+            amount: { amount: 0, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+          }),
+        ],
+      })
+
       const { result } = renderHook(() => usePendingReceiveAmount({}))
 
       expect(result.current.pendingReceiveAmountText).toBeNull()

--- a/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
+++ b/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
@@ -1,0 +1,186 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { usePendingReceiveAmount } from "@app/components/balance-header/use-pending-receive-amount"
+import { TransactionFragment, TxDirection, WalletCurrency } from "@app/graphql/generated"
+import { DepositStatus, PendingDeposit } from "@app/types/payment"
+
+const mockConvertMoneyAmount = jest.fn()
+const mockFormatMoneyAmount = jest.fn(
+  ({ moneyAmount }: { moneyAmount: { amount: number } }) =>
+    `$${(moneyAmount.amount / 100).toFixed(2)}`,
+)
+const mockUseActiveWallet = jest.fn()
+const mockUsePendingDeposits = jest.fn()
+
+jest.mock("@app/hooks", () => ({
+  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount() }),
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
+}))
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => mockUseActiveWallet(),
+}))
+
+jest.mock("@app/self-custodial/hooks", () => ({
+  usePendingDeposits: () => mockUsePendingDeposits(),
+}))
+
+const identityConverter = ({ amount }: { amount: number }) => ({
+  amount,
+  currency: "DisplayCurrency",
+  currencyCode: "USD",
+})
+
+const pendingReceiveTx = (
+  overrides: Partial<TransactionFragment> = {},
+): TransactionFragment =>
+  ({
+    id: "tx-1",
+    direction: TxDirection.Receive,
+    status: "PENDING",
+    settlementAmount: 12_345,
+    settlementCurrency: WalletCurrency.Btc,
+    ...overrides,
+  }) as TransactionFragment
+
+const deposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit => ({
+  id: "abc:0",
+  txid: "abc",
+  vout: 0,
+  amount: { amount: 5_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+  status: DepositStatus.Immature,
+  errorReason: null,
+  ...overrides,
+})
+
+describe("usePendingReceiveAmount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConvertMoneyAmount.mockReturnValue(identityConverter)
+    mockUseActiveWallet.mockReturnValue({ isSelfCustodial: false })
+    mockUsePendingDeposits.mockReturnValue({ deposits: [] })
+  })
+
+  describe("custodial", () => {
+    it("formats the amount of a single pending incoming transaction", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$123.45")
+    })
+
+    it("sums pending transactions across BTC and USD wallets", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({ id: "tx-btc", settlementAmount: 10_000 }),
+            pendingReceiveTx({
+              id: "tx-usd",
+              settlementAmount: 2_000,
+              settlementCurrency: WalletCurrency.Usd,
+            }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$120.00")
+    })
+
+    it("returns null when there are no pending transactions", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("returns null when transactions are undefined (query still loading)", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: undefined }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("ignores outgoing and zero-amount transactions", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({ id: "tx-out", direction: TxDirection.Send }),
+            pendingReceiveTx({ id: "tx-zero", settlementAmount: 0 }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("returns null while price conversion is bootstrapping", () => {
+      mockConvertMoneyAmount.mockReturnValue(undefined)
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+  })
+
+  describe("self-custodial", () => {
+    beforeEach(() => {
+      mockUseActiveWallet.mockReturnValue({ isSelfCustodial: true })
+    })
+
+    it("sums immature (unconfirmed) deposits", () => {
+      mockUsePendingDeposits.mockReturnValue({
+        deposits: [
+          deposit({
+            id: "a:0",
+            amount: { amount: 4_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+          }),
+          deposit({
+            id: "b:1",
+            amount: { amount: 6_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+          }),
+        ],
+      })
+
+      const { result } = renderHook(() => usePendingReceiveAmount({}))
+
+      expect(result.current.pendingReceiveAmountText).toBe("$100.00")
+    })
+
+    it("excludes non-immature deposits (claimable, error, refunded are the banner's job)", () => {
+      mockUsePendingDeposits.mockReturnValue({
+        deposits: [
+          deposit({ id: "a:0", status: DepositStatus.Claimable }),
+          deposit({ id: "b:0", status: DepositStatus.FeeExceeded }),
+          deposit({ id: "c:0", status: DepositStatus.Error }),
+          deposit({ id: "d:0", status: DepositStatus.Refunded }),
+        ],
+      })
+
+      const { result } = renderHook(() => usePendingReceiveAmount({}))
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("returns null when there are no deposits", () => {
+      const { result } = renderHook(() => usePendingReceiveAmount({}))
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+
+    it("ignores custodial pending transactions in self-custodial mode", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+    })
+  })
+})

--- a/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
+++ b/__tests__/components/balance-header/use-pending-receive-amount.spec.tsx
@@ -4,13 +4,26 @@ import { usePendingReceiveAmount } from "@app/components/balance-header/use-pend
 import { TransactionFragment, TxDirection, WalletCurrency } from "@app/graphql/generated"
 import { DisplayCurrency } from "@app/types/amounts"
 import { DepositStatus, PendingDeposit } from "@app/types/payment"
+import { AccountType } from "@app/types/wallet"
 
 const mockConvertMoneyAmount = jest.fn()
 const mockFormatMoneyAmount = jest.fn(
   ({ moneyAmount }: { moneyAmount: { amount: number } }) =>
     `$${(moneyAmount.amount / 100).toFixed(2)}`,
 )
-const mockUseActiveWallet = jest.fn()
+/** Mirrors formatCurrencyHelper: Number()s string majors, 2 fraction digits. */
+const mockFormatCurrency = jest.fn(
+  ({
+    amountInMajorUnits,
+    currency,
+  }: {
+    amountInMajorUnits: number | string
+    currency: string
+  }) => `${currency} ${Number(amountInMajorUnits).toFixed(2)}`,
+)
+let mockDisplayCurrency = "USD"
+let mockLoadedCurrencyCode = "USD"
+const mockUseAccountRegistry = jest.fn()
 
 jest.mock("@app/hooks", () => ({
   ...jest.requireActual("@app/hooks"),
@@ -18,11 +31,16 @@ jest.mock("@app/hooks", () => ({
 }))
 
 jest.mock("@app/hooks/use-display-currency", () => ({
-  useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: mockFormatMoneyAmount,
+    formatCurrency: mockFormatCurrency,
+    displayCurrency: mockDisplayCurrency,
+    currencyInfo: { DisplayCurrency: { currencyCode: mockLoadedCurrencyCode } },
+  }),
 }))
 
-jest.mock("@app/hooks/use-active-wallet", () => ({
-  useActiveWallet: () => mockUseActiveWallet(),
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => mockUseAccountRegistry(),
 }))
 
 /**
@@ -65,8 +83,12 @@ const deposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit => ({
 describe("usePendingReceiveAmount", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDisplayCurrency = "USD"
+    mockLoadedCurrencyCode = "USD"
     mockConvertMoneyAmount.mockReturnValue(mockConverter)
-    mockUseActiveWallet.mockReturnValue({ isSelfCustodial: false })
+    mockUseAccountRegistry.mockReturnValue({
+      activeAccount: { type: AccountType.Custodial },
+    })
   })
 
   describe("custodial", () => {
@@ -164,11 +186,184 @@ describe("usePendingReceiveAmount", () => {
 
       expect(result.current.pendingReceiveAmountText).toBeNull()
     })
+
+    it("sums server-locked settlementDisplayAmounts — the same source the unseen-tx badge formats", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              id: "a",
+              settlementDisplayAmount: "500.00",
+              settlementDisplayCurrency: "USD",
+            }),
+            pendingReceiveTx({
+              id: "b",
+              settlementDisplayAmount: "0.50",
+              settlementDisplayCurrency: "USD",
+            }),
+          ],
+        }),
+      )
+
+      expect(mockFormatCurrency).toHaveBeenCalledWith({
+        amountInMajorUnits: 500.5,
+        currency: "USD",
+      })
+      expect(result.current.pendingReceiveAmountText).toBe("USD 500.50")
+      expect(mockConverter).not.toHaveBeenCalled()
+    })
+
+    it("matches the unseen-tx badge amount for a single pending receive", () => {
+      const tx = pendingReceiveTx({
+        settlementDisplayAmount: "500.00",
+        settlementDisplayCurrency: "USD",
+      })
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [tx] }),
+      )
+
+      // Exactly what use-unseen-tx-amount-badge feeds formatCurrency.
+      const badgeText = mockFormatCurrency({
+        amountInMajorUnits: tx.settlementDisplayAmount as string,
+        currency: tx.settlementDisplayCurrency as string,
+      })
+      expect(result.current.pendingReceiveAmountText).toBe(badgeText)
+    })
+
+    it("renders from display amounts even while price conversion is bootstrapping", () => {
+      mockConvertMoneyAmount.mockReturnValue(undefined)
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              settlementDisplayAmount: "12.34",
+              settlementDisplayCurrency: "EUR",
+            }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("EUR 12.34")
+    })
+
+    it("falls back to live-rate conversion when a display amount is missing", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              id: "with-display",
+              settlementAmount: 10_000,
+              settlementDisplayAmount: "100.00",
+              settlementDisplayCurrency: "USD",
+            }),
+            pendingReceiveTx({ id: "without-display", settlementAmount: 2_345 }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$123.45")
+      expect(mockFormatCurrency).not.toHaveBeenCalled()
+    })
+
+    it("falls back to live-rate conversion when display currencies disagree", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              id: "usd",
+              settlementAmount: 10_000,
+              settlementDisplayAmount: "100.00",
+              settlementDisplayCurrency: "USD",
+            }),
+            pendingReceiveTx({
+              id: "eur",
+              settlementAmount: 2_345,
+              settlementDisplayAmount: "90.00",
+              settlementDisplayCurrency: "EUR",
+            }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$123.45")
+    })
+
+    it("falls back to live-rate conversion when a display amount is not numeric", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              settlementAmount: 10_000,
+              settlementDisplayAmount: "not-a-number",
+              settlementDisplayCurrency: "USD",
+            }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$100.00")
+      expect(mockFormatCurrency).not.toHaveBeenCalled()
+    })
+
+    it("falls through to conversion when the locked display total is zero (dust)", () => {
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              settlementAmount: 300,
+              settlementDisplayAmount: "0.00",
+              settlementDisplayCurrency: "USD",
+            }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$3.00")
+      expect(mockFormatCurrency).not.toHaveBeenCalled()
+    })
+
+    it("sums before converting so several sub-display-unit receives keep the pill nonzero", () => {
+      // 0.001 display-minor-units per sat with per-call rounding: each 400-sat
+      // receive alone rounds to 0; only a pre-conversion sum survives.
+      mockConvertMoneyAmount.mockReturnValue(({ amount }: { amount: number }) => ({
+        amount: Math.round(amount * 0.001),
+        currency: "DisplayCurrency",
+        currencyCode: "USD",
+      }))
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({ id: "a", settlementAmount: 400 }),
+            pendingReceiveTx({ id: "b", settlementAmount: 400 }),
+            pendingReceiveTx({ id: "c", settlementAmount: 400 }),
+          ],
+        }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBe("$0.01")
+    })
+
+    it("suppresses the conversion-fallback pill until the display currency has loaded", () => {
+      mockDisplayCurrency = "EUR"
+      mockLoadedCurrencyCode = "USD" // currency list not loaded yet
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+      expect(mockFormatMoneyAmount).not.toHaveBeenCalled()
+    })
   })
 
   describe("self-custodial", () => {
     beforeEach(() => {
-      mockUseActiveWallet.mockReturnValue({ isSelfCustodial: true })
+      mockUseAccountRegistry.mockReturnValue({
+        activeAccount: { type: AccountType.SelfCustodial },
+      })
     })
 
     it("sums immature (unconfirmed) deposits", () => {
@@ -234,12 +429,35 @@ describe("usePendingReceiveAmount", () => {
       expect(result.current.pendingReceiveAmountText).toBeNull()
     })
 
-    it("ignores custodial pending transactions in self-custodial mode", () => {
+    it("ignores custodial pending transactions even while the SDK is still connecting", () => {
+      // The account registry says self-custodial; wallet status is irrelevant —
+      // the old `useActiveWallet().isSelfCustodial` predicate flipped false
+      // while the Spark SDK connected and leaked custodial data in here.
       const { result } = renderHook(() =>
-        usePendingReceiveAmount({ pendingIncomingTransactions: [pendingReceiveTx()] }),
+        usePendingReceiveAmount({
+          pendingIncomingTransactions: [
+            pendingReceiveTx({
+              settlementDisplayAmount: "500.00",
+              settlementDisplayCurrency: "USD",
+            }),
+          ],
+        }),
       )
 
       expect(result.current.pendingReceiveAmountText).toBeNull()
+      expect(mockFormatCurrency).not.toHaveBeenCalled()
+    })
+
+    it("suppresses the pill until the display currency has loaded (no degraded string)", () => {
+      mockDisplayCurrency = "EUR"
+      mockLoadedCurrencyCode = "USD"
+
+      const { result } = renderHook(() =>
+        usePendingReceiveAmount({ deposits: [deposit()] }),
+      )
+
+      expect(result.current.pendingReceiveAmountText).toBeNull()
+      expect(mockFormatMoneyAmount).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/components/status-pill.spec.tsx
+++ b/__tests__/components/status-pill.spec.tsx
@@ -70,6 +70,15 @@ describe("StatusPill", () => {
     expect(onPress).toHaveBeenCalledTimes(1)
   })
 
+  it("stays reachable by its label when pressable without a testID", () => {
+    const onPress = jest.fn()
+    const { getByLabelText } = renderPill({ label: "STALE", status: "warning", onPress })
+
+    fireEvent.press(getByLabelText("STALE"))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
+  })
+
   it("hides itself from accessibility and ignores the testID when ghost", () => {
     const { queryByTestId } = renderPill({
       label: "STALE",

--- a/__tests__/components/status-pill.spec.tsx
+++ b/__tests__/components/status-pill.spec.tsx
@@ -39,6 +39,17 @@ describe("StatusPill", () => {
     expect(getByTestId("balance-stale-pill")).toBeTruthy()
   })
 
+  it("truncates long labels to a single line instead of wrapping", () => {
+    const { getByText } = renderPill({
+      label: "PENDING +$1,234,567.89",
+      status: "warning",
+    })
+
+    const label = getByText("PENDING +$1,234,567.89")
+    expect(label.props.numberOfLines).toBe(1)
+    expect(label.props.ellipsizeMode).toBe("tail")
+  })
+
   it("hides itself from accessibility and ignores the testID when ghost", () => {
     const { queryByTestId } = renderPill({
       label: "STALE",

--- a/__tests__/components/status-pill.spec.tsx
+++ b/__tests__/components/status-pill.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
+import { fireEvent, render } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
 import theme from "@app/rne-theme/theme"
@@ -48,6 +48,26 @@ describe("StatusPill", () => {
     const label = getByText("PENDING +$1,234,567.89")
     expect(label.props.numberOfLines).toBe(1)
     expect(label.props.ellipsizeMode).toBe("tail")
+  })
+
+  it("caps font scaling on the label so the fixed-width pill cannot clip scaled amounts", () => {
+    const { getByText } = renderPill({ label: "STALE", status: "warning" })
+
+    expect(getByText("STALE").props.maxFontSizeMultiplier).toBeLessThanOrEqual(1.5)
+  })
+
+  it("invokes onPress when tapped", () => {
+    const onPress = jest.fn()
+    const { getByTestId } = renderPill({
+      label: "STALE",
+      status: "warning",
+      testID: "pill",
+      onPress,
+    })
+
+    fireEvent.press(getByTestId("pill"))
+
+    expect(onPress).toHaveBeenCalledTimes(1)
   })
 
   it("hides itself from accessibility and ignores the testID when ghost", () => {

--- a/__tests__/components/unclaimed-deposit-banner/unclaimed-deposit-banner.spec.tsx
+++ b/__tests__/components/unclaimed-deposit-banner/unclaimed-deposit-banner.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { fireEvent, render } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
 import theme from "@app/rne-theme/theme"
@@ -8,24 +8,9 @@ import { DepositStatus, type PendingDeposit } from "@app/types/payment"
 import { WalletCurrency } from "@app/graphql/generated"
 
 const mockNavigate = jest.fn()
-const mockListPendingDeposits = jest.fn()
-let mockWallets: unknown[] = []
-let mockListPendingDepositsImpl: typeof mockListPendingDeposits | undefined =
-  mockListPendingDeposits
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ navigate: mockNavigate }),
-  useFocusEffect: (cb: () => void) => {
-    cb()
-  },
-}))
-
-jest.mock("@app/hooks/use-payments", () => ({
-  usePayments: () => ({ listPendingDeposits: mockListPendingDepositsImpl }),
-}))
-
-jest.mock("@app/self-custodial/providers/wallet", () => ({
-  useSelfCustodialWallet: () => ({ wallets: mockWallets }),
 }))
 
 jest.mock("@app/i18n/i18n-react", () => ({
@@ -49,86 +34,67 @@ const buildDeposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit =
   ...overrides,
 })
 
-const renderBanner = () =>
+const renderBanner = (deposits: PendingDeposit[] = []) =>
   render(
     <ThemeProvider theme={theme}>
-      <UnclaimedDepositBanner />
+      <UnclaimedDepositBanner deposits={deposits} />
     </ThemeProvider>,
   )
 
 describe("UnclaimedDepositBanner", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockWallets = []
-    mockListPendingDepositsImpl = mockListPendingDeposits
-    mockListPendingDeposits.mockResolvedValue({ deposits: [] })
   })
 
-  it("renders nothing when there are no pending deposits", async () => {
+  it("renders nothing when there are no pending deposits", () => {
     const { queryByTestId } = renderBanner()
-
-    await waitFor(() => expect(mockListPendingDeposits).toHaveBeenCalled())
 
     expect(queryByTestId("unclaimed-deposit-banner")).toBeNull()
   })
 
-  it("renders count and total sats when deposits are pending", async () => {
-    mockListPendingDeposits.mockResolvedValue({
-      deposits: [
-        buildDeposit({
-          id: "1",
-          amount: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-        }),
-        buildDeposit({
-          id: "2",
-          amount: { amount: 2500, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-        }),
-      ],
-    })
+  it("renders count and total sats when deposits are pending", () => {
+    const { getByText } = renderBanner([
+      buildDeposit({
+        id: "1",
+        amount: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+      }),
+      buildDeposit({
+        id: "2",
+        amount: { amount: 2500, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+      }),
+    ])
 
-    const { findByText } = renderBanner()
-
-    expect(await findByText("2 pending")).toBeTruthy()
-    expect(await findByText("3500 sats")).toBeTruthy()
+    expect(getByText("2 pending")).toBeTruthy()
+    expect(getByText("3500 sats")).toBeTruthy()
   })
 
-  it("filters out refunded deposits from the count and total", async () => {
-    mockListPendingDeposits.mockResolvedValue({
-      deposits: [
-        buildDeposit({ id: "1", status: DepositStatus.Claimable }),
-        buildDeposit({
-          id: "2",
-          status: DepositStatus.Refunded,
-          amount: { amount: 9999, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-        }),
-      ],
-    })
+  it("filters out refunded deposits from the count and total", () => {
+    const { getByText } = renderBanner([
+      buildDeposit({ id: "1", status: DepositStatus.Claimable }),
+      buildDeposit({
+        id: "2",
+        status: DepositStatus.Refunded,
+        amount: { amount: 9999, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+      }),
+    ])
 
-    const { findByText } = renderBanner()
-
-    expect(await findByText("1 pending")).toBeTruthy()
-    expect(await findByText("1000 sats")).toBeTruthy()
+    expect(getByText("1 pending")).toBeTruthy()
+    expect(getByText("1000 sats")).toBeTruthy()
   })
 
-  it("navigates to the unclaimed-deposits screen on press", async () => {
-    mockListPendingDeposits.mockResolvedValue({
-      deposits: [buildDeposit()],
-    })
+  it("renders nothing when every deposit is refunded", () => {
+    const { queryByTestId } = renderBanner([
+      buildDeposit({ id: "1", status: DepositStatus.Refunded }),
+    ])
 
-    const { findByTestId } = renderBanner()
-    const banner = await findByTestId("unclaimed-deposit-banner")
+    expect(queryByTestId("unclaimed-deposit-banner")).toBeNull()
+  })
 
-    fireEvent.press(banner)
+  it("navigates to the unclaimed-deposits screen on press", () => {
+    const { getByTestId } = renderBanner([buildDeposit()])
+
+    fireEvent.press(getByTestId("unclaimed-deposit-banner"))
 
     expect(mockNavigate).toHaveBeenCalledWith("unclaimedDepositsScreen")
-  })
-
-  it("does nothing when listPendingDeposits is undefined (custodial / loading)", () => {
-    mockListPendingDepositsImpl = undefined
-
-    const { queryByTestId } = renderBanner()
-
-    expect(queryByTestId("unclaimed-deposit-banner")).toBeNull()
-    expect(mockListPendingDeposits).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/components/unclaimed-deposit-banner/unclaimed-deposit-banner.spec.tsx
+++ b/__tests__/components/unclaimed-deposit-banner/unclaimed-deposit-banner.spec.tsx
@@ -90,6 +90,37 @@ describe("UnclaimedDepositBanner", () => {
     expect(queryByTestId("unclaimed-deposit-banner")).toBeNull()
   })
 
+  it("excludes immature deposits — the balance pill owns them until they confirm", () => {
+    const { getByText } = renderBanner([
+      buildDeposit({ id: "1", status: DepositStatus.Claimable }),
+      buildDeposit({
+        id: "2",
+        status: DepositStatus.Immature,
+        amount: { amount: 7777, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+      }),
+    ])
+
+    expect(getByText("1 pending")).toBeTruthy()
+    expect(getByText("1000 sats")).toBeTruthy()
+  })
+
+  it("renders nothing when every deposit is immature", () => {
+    const { queryByTestId } = renderBanner([
+      buildDeposit({ id: "1", status: DepositStatus.Immature }),
+    ])
+
+    expect(queryByTestId("unclaimed-deposit-banner")).toBeNull()
+  })
+
+  it("still counts fee-exceeded and errored deposits", () => {
+    const { getByText } = renderBanner([
+      buildDeposit({ id: "1", status: DepositStatus.FeeExceeded }),
+      buildDeposit({ id: "2", status: DepositStatus.Error }),
+    ])
+
+    expect(getByText("2 pending")).toBeTruthy()
+  })
+
   it("navigates to the unclaimed-deposits screen on press", () => {
     const { getByTestId } = renderBanner([buildDeposit()])
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -2044,6 +2044,25 @@ describe("HomeScreen pending receive badge", () => {
       expect(queryByTestId("balance-status-badge")).toBeNull()
     })
 
+    it("opens the unclaimed-deposits screen when the immature-deposit pill is tapped", async () => {
+      // The banner no longer counts immature deposits, so the pill carries
+      // their inspection path (txid / mempool link) to that screen.
+      mockActiveWalletOverride = selfCustodialWallet
+      mockPendingDepositsOverride = { deposits: [sparkDeposit("immature")] }
+
+      const { findByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+
+      fireEvent.press(await findByTestId("balance-status-badge"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("unclaimedDepositsScreen")
+
+      await flushEffects()
+    })
+
     it("leaves the badge to the unclaimed-deposit banner for claimable deposits", async () => {
       mockActiveWalletOverride = selfCustodialWallet
       mockPendingDepositsOverride = { deposits: [sparkDeposit("claimable")] }

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -216,7 +216,6 @@ jest.mock("@app/components/migration-reminder-bulletin", () => {
 })
 
 const mockUseNonCustodialConversionLimits = jest.fn()
-// eslint-disable-next-line prefer-const
 let mockPendingDepositsOverride: { deposits: unknown[] } | null = null
 
 jest.mock("@app/self-custodial/hooks", () => {

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -96,6 +96,22 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
     },
 }))
 
+// eslint-disable-next-line prefer-const
+let mockActiveAccountOverride: Record<string, unknown> | null = null
+
+jest.mock("@app/hooks/use-account-registry", () => {
+  const actual = jest.requireActual("@app/hooks/use-account-registry")
+  return {
+    ...actual,
+    useAccountRegistry: () => {
+      const registry = actual.useAccountRegistry()
+      return mockActiveAccountOverride
+        ? { ...registry, activeAccount: mockActiveAccountOverride }
+        : registry
+    },
+  }
+})
+
 jest.mock("@app/config/feature-flags-context", () => {
   const actual = jest.requireActual<typeof import("@app/config/feature-flags-context")>(
     "@app/config/feature-flags-context",
@@ -789,6 +805,7 @@ const runRestrictionInvariantCase = async ({
 const resetHomeScreenMocks = () => {
   currentMocks = []
   mockActiveWalletOverride = null
+  mockActiveAccountOverride = null
   mockDollarBalanceRestrictedOverride = false
   mockMigratePromptVisible = false
   mockCanReopen = false
@@ -1962,9 +1979,21 @@ describe("HomeScreen pending receive badge", () => {
       status,
       errorReason: null,
     })
+    const selfCustodialActiveAccount = {
+      id: "self-custodial-default",
+      type: "self-custodial",
+      label: "Self-custodial",
+      selected: true,
+      status: "available",
+    }
+
+    beforeEach(() => {
+      mockActiveAccountOverride = selfCustodialActiveAccount
+    })
 
     afterEach(() => {
       mockActiveWalletOverride = null
+      mockActiveAccountOverride = null
       mockPendingDepositsOverride = null
     })
 
@@ -1981,6 +2010,32 @@ describe("HomeScreen pending receive badge", () => {
       expect(await findByTestId("balance-status-badge")).toBeTruthy()
 
       await flushEffects()
+    })
+
+    it("ignores custodial pending receives while the Spark SDK is still connecting", async () => {
+      // Account registry: self-custodial. Wallet: still Unavailable, so the
+      // useActiveWallet predicate reports isSelfCustodial=false and the home
+      // query is NOT skipped — its pendingIncomingTransactions must not
+      // produce a pill beside the self-custodial balance.
+      mockActiveWalletOverride = {
+        wallets: [],
+        status: "unavailable",
+        accountType: "self-custodial",
+        isReady: false,
+        isSelfCustodial: false,
+        needsBackendAuth: false,
+      }
+      currentMocks = mocksWithPendingDeposit()
+
+      const { queryByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+
+      await flushEffects()
+
+      expect(queryByTestId("balance-status-badge")).toBeNull()
     })
 
     it("leaves the badge to the unclaimed-deposit banner for claimable deposits", async () => {

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
-import { StyleSheet } from "react-native"
+import { RefreshControl, StyleSheet } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 
 import { HomeScreen } from "../../app/screens/home-screen"
@@ -1906,6 +1906,50 @@ describe("HomeScreen pending receive badge", () => {
     await flushEffects()
 
     expect(queryByTestId("balance-status-badge")).toBeNull()
+  })
+})
+
+describe("HomeScreen pull-to-refresh", () => {
+  beforeEach(resetHomeScreenMocks)
+
+  /** iOS renders a programmatically-pinned UIRefreshControl as a frozen,
+   *  non-spinning spinner. The control must reflect only user-initiated pulls
+   *  (which the gesture animates natively), never background query loading —
+   *  binding it to `loading` pinned a dead spinner on every mount and forever
+   *  while a self-custodial wallet connects. */
+  it("does not pin the refresh spinner while queries load in the background", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false)
+
+    await flushEffects()
+
+    expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false)
+  })
+
+  it("spins only for the duration of a user-initiated refresh", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    act(() => {
+      UNSAFE_getByType(RefreshControl).props.onRefresh()
+    })
+
+    expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(true)
+
+    await waitFor(() =>
+      expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false),
+    )
   })
 })
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -232,7 +232,10 @@ jest.mock("@app/components/migration-reminder-bulletin", () => {
 })
 
 const mockUseNonCustodialConversionLimits = jest.fn()
-let mockPendingDepositsOverride: { deposits: unknown[] } | null = null
+let mockPendingDepositsOverride: {
+  deposits: unknown[]
+  refetch?: () => Promise<void>
+} | null = null
 
 jest.mock("@app/self-custodial/hooks", () => {
   const actual = jest.requireActual("@app/self-custodial/hooks")
@@ -240,7 +243,10 @@ jest.mock("@app/self-custodial/hooks", () => {
     ...actual,
     useNonCustodialConversionLimits: (direction: string | undefined) =>
       mockUseNonCustodialConversionLimits(direction),
-    usePendingDeposits: () => mockPendingDepositsOverride ?? actual.usePendingDeposits(),
+    usePendingDeposits: () =>
+      mockPendingDepositsOverride
+        ? { refetch: async () => {}, ...mockPendingDepositsOverride }
+        : actual.usePendingDeposits(),
   }
 })
 
@@ -2141,6 +2147,37 @@ describe("HomeScreen pull-to-refresh", () => {
     } finally {
       mockActiveWalletOverride = null
       mockSelfCustodialWalletOverride = null
+    }
+  })
+
+  it("refreshes the pending deposits before a self-custodial pull retracts", async () => {
+    const refetchDeposits = jest.fn().mockResolvedValue(undefined)
+    mockActiveWalletOverride = {
+      wallets: [],
+      status: "ready",
+      accountType: "self-custodial",
+      isReady: true,
+      isSelfCustodial: true,
+      needsBackendAuth: false,
+    }
+    mockPendingDepositsOverride = { deposits: [], refetch: refetchDeposits }
+    try {
+      // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+      const { UNSAFE_getByType } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      await act(async () => {
+        await UNSAFE_getByType(RefreshControl).props.onRefresh()
+      })
+
+      expect(refetchDeposits).toHaveBeenCalledTimes(1)
+    } finally {
+      mockActiveWalletOverride = null
+      mockPendingDepositsOverride = null
     }
   })
 })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -216,12 +216,18 @@ jest.mock("@app/components/migration-reminder-bulletin", () => {
 })
 
 const mockUseNonCustodialConversionLimits = jest.fn()
+// eslint-disable-next-line prefer-const
+let mockPendingDepositsOverride: { deposits: unknown[] } | null = null
 
-jest.mock("@app/self-custodial/hooks", () => ({
-  ...jest.requireActual("@app/self-custodial/hooks"),
-  useNonCustodialConversionLimits: (direction: string | undefined) =>
-    mockUseNonCustodialConversionLimits(direction),
-}))
+jest.mock("@app/self-custodial/hooks", () => {
+  const actual = jest.requireActual("@app/self-custodial/hooks")
+  return {
+    ...actual,
+    useNonCustodialConversionLimits: (direction: string | undefined) =>
+      mockUseNonCustodialConversionLimits(direction),
+    usePendingDeposits: () => mockPendingDepositsOverride ?? actual.usePendingDeposits(),
+  }
+})
 
 jest.mock("@app/components/dollar-balance-restriction-modal", () => {
   const ReactActual = jest.requireActual("react")
@@ -1906,6 +1912,67 @@ describe("HomeScreen pending receive badge", () => {
     await flushEffects()
 
     expect(queryByTestId("balance-status-badge")).toBeNull()
+  })
+
+  describe("self-custodial", () => {
+    const selfCustodialWallet = {
+      wallets: [
+        {
+          id: "btc-1",
+          walletCurrency: "BTC",
+          balance: { amount: 0, currency: "BTC", currencyCode: "BTC" },
+          transactions: [],
+        },
+      ],
+      status: "ready",
+      accountType: "self-custodial",
+      isReady: true,
+      isSelfCustodial: true,
+      needsBackendAuth: false,
+    }
+    const sparkDeposit = (status: string) => ({
+      id: "abc:0",
+      txid: "abc",
+      vout: 0,
+      amount: { amount: 50_000, currency: "BTC", currencyCode: "BTC" },
+      status,
+      errorReason: null,
+    })
+
+    afterEach(() => {
+      mockActiveWalletOverride = null
+      mockPendingDepositsOverride = null
+    })
+
+    it("shows the badge for an immature (unconfirmed) Spark deposit", async () => {
+      mockActiveWalletOverride = selfCustodialWallet
+      mockPendingDepositsOverride = { deposits: [sparkDeposit("immature")] }
+
+      const { findByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+
+      expect(await findByTestId("balance-status-badge")).toBeTruthy()
+
+      await flushEffects()
+    })
+
+    it("leaves the badge to the unclaimed-deposit banner for claimable deposits", async () => {
+      mockActiveWalletOverride = selfCustodialWallet
+      mockPendingDepositsOverride = { deposits: [sparkDeposit("claimable")] }
+
+      const { queryByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+
+      await flushEffects()
+
+      expect(queryByTestId("balance-status-badge")).toBeNull()
+    })
   })
 })
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -1951,6 +1951,52 @@ describe("HomeScreen pull-to-refresh", () => {
       expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false),
     )
   })
+
+  /** A failed pull (offline is routine) must unpin the spinner and must not
+   *  escape as an unhandled rejection — RefreshControl ignores the promise. */
+  it("recovers the spinner when the refresh fails", async () => {
+    mockActiveWalletOverride = {
+      wallets: [],
+      status: "ready",
+      accountType: "self-custodial",
+      isReady: true,
+      isSelfCustodial: true,
+      needsBackendAuth: false,
+    }
+    mockSelfCustodialWalletOverride = {
+      sdk: null,
+      wallets: [],
+      status: "ready",
+      isStableBalanceActive: false,
+      lastReceivedPaymentId: null,
+      hasMoreTransactions: false,
+      loadingMore: false,
+      loadMore: jest.fn(),
+      refreshWallets: jest.fn().mockRejectedValue(new Error("offline")),
+      refreshStableBalanceActive: jest.fn(),
+      retry: jest.fn(),
+    }
+    try {
+      // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+      const { UNSAFE_getByType } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      await act(async () => {
+        await expect(
+          UNSAFE_getByType(RefreshControl).props.onRefresh(),
+        ).resolves.toBeUndefined()
+      })
+
+      expect(UNSAFE_getByType(RefreshControl).props.refreshing).toBe(false)
+    } finally {
+      mockActiveWalletOverride = null
+      mockSelfCustodialWalletOverride = null
+    }
+  })
 })
 
 describe("bulletins auth gating", () => {

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 import { StyleSheet } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 
@@ -408,11 +408,13 @@ export const generateHomeMock = ({
   network,
   btcBalance,
   usdBalance,
+  pendingIncomingTransactions = [],
 }: {
   level: AccountLevel
   network: Network
   btcBalance: number
   usdBalance: number
+  pendingIncomingTransactions?: Array<Record<string, unknown>>
 }): MockedResponse[] => {
   return [
     {
@@ -477,13 +479,46 @@ export const generateHomeMock = ({
                   endCursor: null,
                 },
               },
-              pendingIncomingTransactions: [],
+              pendingIncomingTransactions,
             },
           },
         },
       },
     },
   ]
+}
+
+/** Unconfirmed onchain deposit, shaped to the full Transaction fragment so the
+ *  Apollo cache accepts it without data-loss warnings. */
+const pendingOnchainReceiveTx = {
+  __typename: "Transaction",
+  id: "pending-onchain-receive-1",
+  status: "PENDING",
+  direction: "RECEIVE",
+  memo: null,
+  createdAt: 1678093528,
+  settlementAmount: 50_000,
+  settlementFee: 0,
+  settlementDisplayFee: "0.00",
+  settlementCurrency: "BTC",
+  settlementDisplayAmount: "500.00",
+  settlementDisplayCurrency: "USD",
+  settlementPrice: {
+    base: 10320000000000,
+    offset: 12,
+    currencyUnit: "USDCENT",
+    formattedAmount: "10.32",
+    __typename: "Price",
+  },
+  initiationVia: {
+    __typename: "InitiationViaOnChain",
+    address: "bc1q-pending-deposit-address",
+  },
+  settlementVia: {
+    __typename: "SettlementViaOnChain",
+    transactionHash: "pending-tx-hash",
+    arrivalInMempoolEstimatedAt: null,
+  },
 }
 
 type ConvertButtonCase = {
@@ -1796,6 +1831,81 @@ describe("HomeScreen wind-down states", () => {
     onMigrate()
 
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationEntry")
+  })
+})
+
+describe("HomeScreen pending receive badge", () => {
+  beforeEach(resetHomeScreenMocks)
+
+  const mocksWithPendingDeposit = () =>
+    generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+      pendingIncomingTransactions: [pendingOnchainReceiveTx],
+    })
+
+  it("shows the pending amount beside the balance while a deposit is unconfirmed", async () => {
+    currentMocks = mocksWithPendingDeposit()
+
+    const { findByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    expect(await findByTestId("balance-status-badge")).toBeTruthy()
+
+    await flushEffects()
+  })
+
+  /** The regression in blink-wip#937: the only pending signal at the top was the
+   *  unseen-tx badge, which auto-dismisses after ~5s. The pending badge is
+   *  state-driven and must outlive that window. */
+  it("keeps the pending badge past the unseen-badge auto-dismiss window", async () => {
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+    try {
+      currentMocks = mocksWithPendingDeposit()
+
+      const { findByTestId, getByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+
+      expect(await findByTestId("balance-status-badge")).toBeTruthy()
+
+      // 5s auto-seen delay + 180ms hide-to-mark gap + slack
+      act(() => {
+        jest.advanceTimersByTime(5_500)
+      })
+
+      expect(getByTestId("balance-status-badge")).toBeTruthy()
+
+      await flushEffects()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("hides the badge while nothing is pending", async () => {
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    const { queryByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(queryByTestId("balance-status-badge")).toBeNull()
   })
 })
 

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -228,6 +228,20 @@ describe("usePendingDeposits", () => {
     expect(result.current.deposits).toEqual([deposit()])
   })
 
+  it("keeps the empty list's identity across an account change (no redundant commit)", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    const empty = result.current.deposits
+
+    mockActiveAccount = { id: "acct-2" }
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toBe(empty)
+  })
+
   it("refetch converges on a superseding listing before resolving", async () => {
     mockListPendingDeposits.mockResolvedValue({ deposits: [] })
 

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -71,6 +71,41 @@ describe("usePendingDeposits", () => {
     expect(result.current.deposits).toEqual([])
   })
 
+  /** The adapter reports SDK failures as an empty list plus `errors`, so
+   *  committing it would wipe the badge and the banner as if the deposit had
+   *  confirmed. A pull that failed has to leave the screen as it was. */
+  it("keeps the known deposits when the listing comes back with errors", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    expect(result.current.deposits).toEqual([deposit()])
+
+    mockListPendingDeposits.mockResolvedValue({
+      deposits: [],
+      errors: [{ message: "offline" }],
+    })
+    mockWallets = [{ id: "refreshed" }]
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toEqual([deposit()])
+  })
+
+  it("commits an empty list when the listing succeeds with no deposits", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+
+    mockListPendingDeposits.mockResolvedValue({ deposits: [], errors: [] })
+    mockWallets = [{ id: "refreshed" }]
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toEqual([])
+  })
+
   it("keeps the same array identity when a refetch returns an unchanged list", async () => {
     mockListPendingDeposits.mockImplementation(() =>
       // A fresh array each call: only the identity guard can keep state stable.

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -27,6 +27,12 @@ jest.mock("@app/hooks/use-payments", () => ({
   usePayments: () => ({ listPendingDeposits: mockListPendingDepositsImpl }),
 }))
 
+let mockActiveAccount: { id: string } | null = { id: "acct-1" }
+
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ activeAccount: mockActiveAccount }),
+}))
+
 jest.mock("@app/self-custodial/providers/wallet", () => ({
   useSelfCustodialWallet: () => ({ wallets: mockWallets }),
 }))
@@ -51,6 +57,7 @@ describe("usePendingDeposits", () => {
     jest.clearAllMocks()
     mockListPendingDepositsImpl = mockListPendingDeposits
     mockWallets = []
+    mockActiveAccount = { id: "acct-1" }
   })
 
   it("returns the fetched deposits", async () => {
@@ -152,13 +159,31 @@ describe("usePendingDeposits", () => {
     expect(mockListPendingDeposits).toHaveBeenCalledTimes(1)
   })
 
-  it("clears the deposits when the adapter disappears (account switch / SDK teardown)", async () => {
+  it("keeps the deposits through a same-account SDK teardown (transient adapter loss)", async () => {
     mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
 
     const { result, rerender } = renderHook(() => usePendingDeposits())
     await flush()
     expect(result.current.deposits).toEqual([deposit()])
 
+    // Spark-network flip / manual retry: the lifecycle effect nulls the sdk and
+    // empties the wallets while the SAME account reconnects.
+    mockListPendingDepositsImpl = undefined
+    mockWallets = []
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toEqual([deposit()])
+  })
+
+  it("clears the deposits when the active account changes", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    expect(result.current.deposits).toEqual([deposit()])
+
+    mockActiveAccount = { id: "acct-2" }
     mockListPendingDepositsImpl = undefined
     rerender({})
     await flush()
@@ -200,6 +225,59 @@ describe("usePendingDeposits", () => {
       await result.current.refetch()
     })
 
+    expect(result.current.deposits).toEqual([deposit()])
+  })
+
+  it("refetch converges on a superseding listing before resolving", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+
+    // First explicit refetch listing, deferred.
+    let resolveFirst: (value: { deposits: PendingDeposit[] }) => void = () => {}
+    mockListPendingDeposits.mockReturnValueOnce(
+      new Promise<{ deposits: PendingDeposit[] }>((resolve) => {
+        resolveFirst = resolve
+      }),
+    )
+    // The superseding listing (fired by the wallets refresh), also deferred.
+    let resolveSecond: (value: { deposits: PendingDeposit[] }) => void = () => {}
+    mockListPendingDeposits.mockReturnValueOnce(
+      new Promise<{ deposits: PendingDeposit[] }>((resolve) => {
+        resolveSecond = resolve
+      }),
+    )
+
+    let refetchSettled = false
+    let refetchPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      refetchPromise = result.current.refetch().then(() => {
+        refetchSettled = true
+      })
+    })
+
+    // A wallet refresh lands mid-listing and supersedes the refetch's fetch.
+    mockWallets = [{ id: "refreshed" }]
+    rerender({})
+    await flush()
+
+    act(() => {
+      resolveFirst({ deposits: [deposit({ id: "stale:0", txid: "stale" })] })
+    })
+    await flush()
+    // The superseded listing was discarded — refetch must keep waiting.
+    expect(refetchSettled).toBe(false)
+    expect(result.current.deposits).toEqual([])
+
+    act(() => {
+      resolveSecond({ deposits: [deposit()] })
+    })
+    await act(async () => {
+      await refetchPromise
+    })
+
+    expect(refetchSettled).toBe(true)
     expect(result.current.deposits).toEqual([deposit()])
   })
 

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -9,11 +9,19 @@ let mockListPendingDepositsImpl: typeof mockListPendingDeposits | undefined =
   mockListPendingDeposits
 let mockWallets: unknown[] = []
 
-jest.mock("@react-navigation/native", () => ({
-  useFocusEffect: (cb: () => void) => {
-    cb()
-  },
-}))
+/**
+ * Stands in for a screen that is focused from mount onwards: react-navigation
+ * runs the effect in a real useEffect and honours the cleanup it returns, so
+ * the hook's generation guard is exercised the way it is in the app.
+ */
+jest.mock("@react-navigation/native", () => {
+  const ReactActual = jest.requireActual("react")
+  return {
+    useFocusEffect: (effect: () => (() => void) | undefined) => {
+      ReactActual.useEffect(effect, [effect])
+    },
+  }
+})
 
 jest.mock("@app/hooks/use-payments", () => ({
   usePayments: () => ({ listPendingDeposits: mockListPendingDepositsImpl }),

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -143,6 +143,66 @@ describe("usePendingDeposits", () => {
     expect(result.current.deposits[0].status).toBe(DepositStatus.Claimable)
   })
 
+  it("fetches once on mount (the focus effect owns the mount fetch)", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [] })
+
+    renderHook(() => usePendingDeposits())
+    await flush()
+
+    expect(mockListPendingDeposits).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears the deposits when the adapter disappears (account switch / SDK teardown)", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    expect(result.current.deposits).toEqual([deposit()])
+
+    mockListPendingDepositsImpl = undefined
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toEqual([])
+  })
+
+  it("ignores an in-flight listing that resolves after the adapter disappears", async () => {
+    let resolveListing: (value: { deposits: PendingDeposit[] }) => void = () => {}
+    mockListPendingDeposits.mockReturnValue(
+      new Promise<{ deposits: PendingDeposit[] }>((resolve) => {
+        resolveListing = resolve
+      }),
+    )
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+
+    mockListPendingDepositsImpl = undefined
+    rerender({})
+    await flush()
+    expect(result.current.deposits).toEqual([])
+
+    act(() => {
+      resolveListing({ deposits: [deposit()] })
+    })
+    await flush()
+
+    expect(result.current.deposits).toEqual([])
+  })
+
+  it("exposes refetch, resolving after the fresh listing is committed", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [] })
+
+    const { result } = renderHook(() => usePendingDeposits())
+    await flush()
+
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.deposits).toEqual([deposit()])
+  })
+
   it("ignores a stale fetch that resolves after a newer one started", async () => {
     let resolveStale: (value: { deposits: PendingDeposit[] }) => void = () => {}
     const stale = new Promise<{ deposits: PendingDeposit[] }>((resolve) => {

--- a/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
+++ b/__tests__/self-custodial/hooks/use-pending-deposits.spec.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { usePendingDeposits } from "@app/self-custodial/hooks"
+import { DepositStatus, type PendingDeposit } from "@app/types/payment"
+import { WalletCurrency } from "@app/graphql/generated"
+
+const mockListPendingDeposits = jest.fn()
+let mockListPendingDepositsImpl: typeof mockListPendingDeposits | undefined =
+  mockListPendingDeposits
+let mockWallets: unknown[] = []
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (cb: () => void) => {
+    cb()
+  },
+}))
+
+jest.mock("@app/hooks/use-payments", () => ({
+  usePayments: () => ({ listPendingDeposits: mockListPendingDepositsImpl }),
+}))
+
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => ({ wallets: mockWallets }),
+}))
+
+const deposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit => ({
+  id: "abc:0",
+  txid: "abc",
+  vout: 0,
+  amount: { amount: 5_000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+  status: DepositStatus.Immature,
+  errorReason: null,
+  ...overrides,
+})
+
+const flush = () =>
+  act(async () => {
+    await Promise.resolve()
+  })
+
+describe("usePendingDeposits", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockListPendingDepositsImpl = mockListPendingDeposits
+    mockWallets = []
+  })
+
+  it("returns the fetched deposits", async () => {
+    mockListPendingDeposits.mockResolvedValue({ deposits: [deposit()] })
+
+    const { result } = renderHook(() => usePendingDeposits())
+    await flush()
+
+    expect(result.current.deposits).toEqual([deposit()])
+  })
+
+  it("no-ops without a listPendingDeposits adapter (custodial / loading)", async () => {
+    mockListPendingDepositsImpl = undefined
+
+    const { result } = renderHook(() => usePendingDeposits())
+    await flush()
+
+    expect(result.current.deposits).toEqual([])
+  })
+
+  it("keeps the same array identity when a refetch returns an unchanged list", async () => {
+    mockListPendingDeposits.mockImplementation(() =>
+      // A fresh array each call: only the identity guard can keep state stable.
+      Promise.resolve({ deposits: [deposit()] }),
+    )
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    const first = result.current.deposits
+
+    mockWallets = [{ id: "refreshed" }] // wallet refresh triggers a refetch
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits).toEqual([deposit()])
+    expect(result.current.deposits).toBe(first)
+  })
+
+  it("commits a status-only change so Immature -> Claimable propagates", async () => {
+    mockListPendingDeposits.mockResolvedValue({
+      deposits: [deposit({ status: DepositStatus.Immature })],
+    })
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+    await flush()
+    expect(result.current.deposits[0].status).toBe(DepositStatus.Immature)
+
+    mockListPendingDeposits.mockResolvedValue({
+      deposits: [deposit({ status: DepositStatus.Claimable })],
+    })
+    mockWallets = [{ id: "refreshed" }]
+    rerender({})
+    await flush()
+
+    expect(result.current.deposits[0].status).toBe(DepositStatus.Claimable)
+  })
+
+  it("ignores a stale fetch that resolves after a newer one started", async () => {
+    let resolveStale: (value: { deposits: PendingDeposit[] }) => void = () => {}
+    const stale = new Promise<{ deposits: PendingDeposit[] }>((resolve) => {
+      resolveStale = resolve
+    })
+    mockListPendingDeposits.mockReturnValue(stale)
+
+    const { result, rerender } = renderHook(() => usePendingDeposits())
+
+    mockListPendingDeposits.mockResolvedValue({
+      deposits: [deposit({ id: "fresh:0", txid: "fresh" })],
+    })
+    mockWallets = [{ id: "refreshed" }]
+    rerender({})
+    await flush()
+    expect(result.current.deposits[0]?.id).toBe("fresh:0")
+
+    act(() => {
+      resolveStale({ deposits: [deposit({ id: "stale:0", txid: "stale" })] })
+    })
+    await flush()
+
+    expect(result.current.deposits[0]?.id).toBe("fresh:0")
+  })
+})

--- a/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
+++ b/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
@@ -611,7 +611,9 @@ describe("useSdkLifecycle", () => {
       await finishIteration() // iteration 2 completes → the pull settles
       expect(pullSettled).toBe(true)
       // The loop is still draining the third caller.
-      expect(pendingSnapshots.length + mockGetSnapshot.mock.calls.length).toBeGreaterThan(0)
+      expect(pendingSnapshots.length + mockGetSnapshot.mock.calls.length).toBeGreaterThan(
+        0,
+      )
 
       await finishIteration() // let iteration 3 finish cleanly
     })

--- a/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
+++ b/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
@@ -553,6 +553,78 @@ describe("useSdkLifecycle", () => {
       })
       expect(result.current.status).toBe(ActiveWalletStatus.Ready)
     })
+
+    it("hands overlapping callers the in-flight run's completion (pull-to-refresh must not retract early)", async () => {
+      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
+      captureListener()
+      mockGetSnapshot.mockResolvedValue({
+        wallets: [],
+        hasMore: false,
+        rawTransactionCount: 0,
+      })
+
+      const { result } = renderHook(() => useSdkLifecycle("acct-1", 0))
+      await waitFor(() => {
+        expect(result.current.status).toBe(ActiveWalletStatus.Ready)
+      })
+
+      type Snapshot = {
+        wallets: unknown[]
+        hasMore: boolean
+        rawTransactionCount: number
+      }
+      const emptySnapshot: Snapshot = {
+        wallets: [],
+        hasMore: false,
+        rawTransactionCount: 0,
+      }
+      let resolveSnapshot: (value: Snapshot) => void = () => {}
+      mockGetSnapshot.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSnapshot = resolve
+          }),
+      )
+
+      let firstSettled = false
+      let secondSettled = false
+      let first: Promise<void> = Promise.resolve()
+      let second: Promise<void> = Promise.resolve()
+      act(() => {
+        first = result.current.refreshWallets().then(() => {
+          firstSettled = true
+        })
+        second = result.current.refreshWallets().then(() => {
+          secondSettled = true
+        })
+      })
+
+      await act(async () => {
+        await new Promise<void>((r) => {
+          setImmediate(r)
+        })
+      })
+      // The overlapping call must not resolve before any snapshot landed.
+      expect(secondSettled).toBe(false)
+
+      // The queued rerun issues a second snapshot fetch; drain both.
+      await act(async () => {
+        resolveSnapshot(emptySnapshot)
+        await new Promise<void>((r) => {
+          setImmediate(r)
+        })
+        resolveSnapshot(emptySnapshot)
+        await new Promise<void>((r) => {
+          setImmediate(r)
+        })
+      })
+
+      await act(async () => {
+        await Promise.all([first, second])
+      })
+      expect(firstSettled).toBe(true)
+      expect(secondSettled).toBe(true)
+    })
   })
 
   describe("offline / degraded transitions", () => {

--- a/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
+++ b/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
@@ -554,7 +554,69 @@ describe("useSdkLifecycle", () => {
       expect(result.current.status).toBe(ActiveWalletStatus.Ready)
     })
 
-    it("hands overlapping callers the in-flight run's completion (pull-to-refresh must not retract early)", async () => {
+    it("resolves each caller after its own iteration even while others keep re-arming the loop", async () => {
+      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
+      captureListener()
+      mockGetSnapshot.mockResolvedValue({
+        wallets: [],
+        hasMore: false,
+        rawTransactionCount: 0,
+      })
+
+      const { result } = renderHook(() => useSdkLifecycle("acct-1", 0))
+      await waitFor(() => {
+        expect(result.current.status).toBe(ActiveWalletStatus.Ready)
+      })
+
+      const emptySnapshot = {
+        wallets: [],
+        hasMore: false,
+        rawTransactionCount: 0,
+      }
+      const pendingSnapshots: ((value: typeof emptySnapshot) => void)[] = []
+      mockGetSnapshot.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            pendingSnapshots.push(resolve)
+          }),
+      )
+      const finishIteration = async () => {
+        await act(async () => {
+          pendingSnapshots.shift()?.(emptySnapshot)
+          await new Promise<void>((r) => {
+            setImmediate(r)
+          })
+        })
+      }
+
+      let pullSettled = false
+      act(() => {
+        // Iteration 1: the background poll's refresh is in flight.
+        result.current.refreshWallets()
+        // The user's pull arrives mid-iteration → served by iteration 2.
+        result.current.refreshWallets().then(() => {
+          pullSettled = true
+        })
+      })
+
+      await finishIteration() // iteration 1 completes; iteration 2 starts
+      expect(pullSettled).toBe(false)
+
+      act(() => {
+        // Another poll tick re-arms the loop mid-iteration-2 — offline, this
+        // repeats forever; the pull must not inherit that lifetime.
+        result.current.refreshWallets()
+      })
+
+      await finishIteration() // iteration 2 completes → the pull settles
+      expect(pullSettled).toBe(true)
+      // The loop is still draining the third caller.
+      expect(pendingSnapshots.length + mockGetSnapshot.mock.calls.length).toBeGreaterThan(0)
+
+      await finishIteration() // let iteration 3 finish cleanly
+    })
+
+    it("hands overlapping callers the completion of the iteration serving them (pull-to-refresh must not retract early)", async () => {
       mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
       captureListener()
       mockGetSnapshot.mockResolvedValue({

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -15,6 +15,11 @@ import { StatusPill, type StatusPillVariant } from "../status-pill"
  *  uncapped Dynamic Type makes it overrun the username row above. */
 const MAX_BALANCE_FONT_SIZE_MULTIPLIER = 1.4
 
+/** Long pending amounts must not push the balance off-center: the real pill and
+ *  the centering ghost cap at the same width and shrink together, otherwise the
+ *  double-width centering trick breaks asymmetrically. */
+const MAX_STATUS_PILL_WIDTH = 120
+
 const Loader = () => {
   const styles = useStyles()
   return (
@@ -165,9 +170,13 @@ const useStyles = makeStyles(({ colors }) => ({
   statusPill: {
     marginLeft: 6,
     marginTop: 2,
+    flexShrink: 1,
+    maxWidth: MAX_STATUS_PILL_WIDTH,
   },
   statusPillGhost: {
     marginRight: 6,
     marginTop: 2,
+    flexShrink: 1,
+    maxWidth: MAX_STATUS_PILL_WIDTH,
   },
 }))

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -39,6 +39,7 @@ const Loader = () => {
 export type StatusBadge = {
   label: string
   status: StatusPillVariant
+  onPress?: () => void
 }
 
 type Props = {
@@ -110,6 +111,7 @@ export const BalanceHeader: React.FC<Props> = ({
               <StatusPill
                 label={statusBadge.label}
                 status={statusBadge.status}
+                onPress={statusBadge.onPress}
                 testID="balance-status-badge"
                 style={styles.statusPill}
               />

--- a/app/components/balance-header/index.ts
+++ b/app/components/balance-header/index.ts
@@ -1,2 +1,3 @@
 export * from "./balance-header"
 export * from "./use-total-balance"
+export * from "./use-pending-receive-amount"

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -1,10 +1,6 @@
 import { useMemo } from "react"
 
-import {
-  TransactionFragment,
-  TxDirection,
-  WalletCurrency,
-} from "@app/graphql/generated"
+import { TransactionFragment, TxDirection, WalletCurrency } from "@app/graphql/generated"
 import { usePriceConversion } from "@app/hooks"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -4,7 +4,6 @@ import { TransactionFragment, TxDirection } from "@app/graphql/generated"
 import { usePriceConversion } from "@app/hooks"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
-import { usePendingDeposits } from "@app/self-custodial/hooks"
 import {
   addMoneyAmounts,
   DisplayCurrency,
@@ -12,26 +11,31 @@ import {
   toBtcMoneyAmount,
   toWalletMoneyAmount,
 } from "@app/types/amounts"
-import { DepositStatus } from "@app/types/payment"
+import { DepositStatus, type PendingDeposit } from "@app/types/payment"
 
 type Params = {
   pendingIncomingTransactions?: readonly TransactionFragment[] | null
+  deposits?: readonly PendingDeposit[]
 }
+
+/** Stable empty default, so an absent deposit list does not rebuild the memo. */
+const NO_DEPOSITS: readonly PendingDeposit[] = []
 
 /**
  * Total unconfirmed incoming amount for the balance header, in display
  * currency. Custodial reads the home query's pendingIncomingTransactions;
- * self-custodial reads immature (unconfirmed) Spark deposits — claimable and
- * errored deposits stay with the UnclaimedDepositBanner, which carries the
- * action to resolve them.
+ * self-custodial reads the immature (unconfirmed) Spark deposits passed in by
+ * the screen. Claimable and errored ones stay with the UnclaimedDepositBanner,
+ * which carries the action to resolve them. The screen owns the deposit fetch
+ * so the header and that banner always read the same list.
  */
 export const usePendingReceiveAmount = ({
   pendingIncomingTransactions,
+  deposits = NO_DEPOSITS,
 }: Params): { pendingReceiveAmountText: string | null } => {
   const { formatMoneyAmount } = useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
   const { isSelfCustodial } = useActiveWallet()
-  const { deposits } = usePendingDeposits()
 
   const totalPendingDisplayAmount = useMemo(():
     | MoneyAmount<typeof DisplayCurrency>

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -93,10 +93,11 @@ export const usePendingReceiveAmount = ({
       )
     }
 
+    // An empty list needs no guard: the display sum resolves to null and the
+    // conversion fallback to a zero total, both of which render nothing.
     const pendingReceives = (pendingIncomingTransactions ?? []).filter(
       (tx) => tx.direction === TxDirection.Receive && tx.settlementAmount > 0,
     )
-    if (pendingReceives.length === 0) return null
 
     const displayTotal = sumSettlementDisplayAmounts(pendingReceives)
     if (displayTotal && displayTotal.amount > 0) {

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -27,8 +27,9 @@ const NO_DEPOSITS: readonly PendingDeposit[] = []
  * settlement time), so the pill sums the same source — otherwise the two
  * indicators show different numbers for the same receive. Returns null when any
  * transaction lacks a usable display amount or the display currencies disagree;
- * the caller then falls back to live-rate conversion, mirroring the badge's
- * own fallback in use-unseen-tx-amount-badge.ts.
+ * the caller then falls back to live-rate conversion. (The badge's own
+ * fallback formats the raw wallet amount instead, so the two can differ there
+ * — an edge the schema makes rare: settlementDisplayAmount is non-nullable.)
  */
 const sumSettlementDisplayAmounts = (
   txs: readonly TransactionFragment[],
@@ -64,9 +65,10 @@ export const usePendingReceiveAmount = ({
   const { convertMoneyAmount } = usePriceConversion()
   const { activeAccount } = useAccountRegistry()
   // Branch on the account type alone (same predicate as use-price-conversion):
-  // `useActiveWallet().isSelfCustodial` also encodes SDK readiness, so it is
-  // false while the Spark SDK connects — and the custodial account's pending
-  // receives would leak in beside the self-custodial balance.
+  // `useActiveWallet().isSelfCustodial` also encodes SDK availability, so it
+  // is false during the Unavailable renders at cold start / right after an
+  // account switch — exactly when the custodial account's pending receives
+  // would leak in beside the self-custodial balance.
   const isSelfCustodialAccount = activeAccount?.type === AccountType.SelfCustodial
 
   // Until the currency list resolves the preferred display currency (cold

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -1,8 +1,12 @@
 import { useMemo } from "react"
 
-import { TransactionFragment, TxDirection } from "@app/graphql/generated"
+import {
+  TransactionFragment,
+  TxDirection,
+  WalletCurrency,
+} from "@app/graphql/generated"
 import { usePriceConversion } from "@app/hooks"
-import { useActiveWallet } from "@app/hooks/use-active-wallet"
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import {
   addMoneyAmounts,
@@ -12,6 +16,7 @@ import {
   toWalletMoneyAmount,
 } from "@app/types/amounts"
 import { DepositStatus, type PendingDeposit } from "@app/types/payment"
+import { AccountType } from "@app/types/wallet"
 
 type Params = {
   pendingIncomingTransactions?: readonly TransactionFragment[] | null
@@ -20,6 +25,31 @@ type Params = {
 
 /** Stable empty default, so an absent deposit list does not rebuild the memo. */
 const NO_DEPOSITS: readonly PendingDeposit[] = []
+
+/**
+ * The unseen-tx badge renders `settlementDisplayAmount` (locked server-side at
+ * settlement time), so the pill sums the same source — otherwise the two
+ * indicators show different numbers for the same receive. Returns null when any
+ * transaction lacks a usable display amount or the display currencies disagree;
+ * the caller then falls back to live-rate conversion, mirroring the badge's
+ * own fallback in use-unseen-tx-amount-badge.ts.
+ */
+const sumSettlementDisplayAmounts = (
+  txs: readonly TransactionFragment[],
+): { amount: number; currency: string } | null => {
+  let total = 0
+  let currency: string | null = null
+  for (const tx of txs) {
+    const { settlementDisplayAmount, settlementDisplayCurrency } = tx
+    if (!settlementDisplayAmount || !settlementDisplayCurrency) return null
+    if (currency !== null && currency !== settlementDisplayCurrency) return null
+    const amount = Number(settlementDisplayAmount)
+    if (Number.isNaN(amount)) return null
+    currency = settlementDisplayCurrency
+    total += amount
+  }
+  return currency === null ? null : { amount: total, currency }
+}
 
 /**
  * Total unconfirmed incoming amount for the balance header, in display
@@ -33,47 +63,80 @@ export const usePendingReceiveAmount = ({
   pendingIncomingTransactions,
   deposits = NO_DEPOSITS,
 }: Params): { pendingReceiveAmountText: string | null } => {
-  const { formatMoneyAmount } = useDisplayCurrency()
+  const { formatMoneyAmount, formatCurrency, currencyInfo, displayCurrency } =
+    useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
-  const { isSelfCustodial } = useActiveWallet()
+  const { activeAccount } = useAccountRegistry()
+  // Branch on the account type alone (same predicate as use-price-conversion):
+  // `useActiveWallet().isSelfCustodial` also encodes SDK readiness, so it is
+  // false while the Spark SDK connects — and the custodial account's pending
+  // receives would leak in beside the self-custodial balance.
+  const isSelfCustodialAccount = activeAccount?.type === AccountType.SelfCustodial
 
-  const totalPendingDisplayAmount = useMemo(():
-    | MoneyAmount<typeof DisplayCurrency>
-    | undefined => {
-    if (!convertMoneyAmount) return undefined
+  // Until the currency list resolves the preferred display currency (cold
+  // start with a non-USD display currency), formatMoneyAmount degrades to the
+  // app-wide "Currency issue. Refresh needed" placeholder — suppress the pill
+  // rather than render that inside it.
+  const displayCurrencyReady =
+    currencyInfo[DisplayCurrency].currencyCode === displayCurrency
 
-    if (isSelfCustodial) {
+  const pendingReceiveAmountText = useMemo((): string | null => {
+    const formatConverted = (
+      totalAmount: MoneyAmount<typeof DisplayCurrency>,
+    ): string | null =>
+      totalAmount.amount <= 0 ? null : formatMoneyAmount({ moneyAmount: totalAmount })
+
+    if (isSelfCustodialAccount) {
       const immatureSats = deposits
         .filter(({ status }) => status === DepositStatus.Immature)
         .reduce((sum, { amount }) => sum + amount.amount, 0)
-      if (immatureSats === 0) return undefined
-      return convertMoneyAmount(toBtcMoneyAmount(immatureSats), DisplayCurrency)
+      if (immatureSats === 0) return null
+      if (!convertMoneyAmount || !displayCurrencyReady) return null
+      return formatConverted(
+        convertMoneyAmount(toBtcMoneyAmount(immatureSats), DisplayCurrency),
+      )
     }
 
     const pendingReceives = (pendingIncomingTransactions ?? []).filter(
       (tx) => tx.direction === TxDirection.Receive && tx.settlementAmount > 0,
     )
-    if (pendingReceives.length === 0) return undefined
-    return pendingReceives.reduce(
-      (total, tx) =>
-        addMoneyAmounts({
-          a: total,
-          b: convertMoneyAmount(
-            toWalletMoneyAmount(tx.settlementAmount, tx.settlementCurrency),
-            DisplayCurrency,
-          ),
-        }),
-      convertMoneyAmount(toBtcMoneyAmount(0), DisplayCurrency),
-    )
-  }, [convertMoneyAmount, isSelfCustodial, deposits, pendingIncomingTransactions])
+    if (pendingReceives.length === 0) return null
 
-  if (!totalPendingDisplayAmount || totalPendingDisplayAmount.amount <= 0) {
-    return { pendingReceiveAmountText: null }
-  }
+    const displayTotal = sumSettlementDisplayAmounts(pendingReceives)
+    if (displayTotal && displayTotal.amount > 0) {
+      return formatCurrency({
+        amountInMajorUnits: displayTotal.amount,
+        currency: displayTotal.currency,
+      })
+    }
 
-  return {
-    pendingReceiveAmountText: formatMoneyAmount({
-      moneyAmount: totalPendingDisplayAmount,
-    }),
-  }
+    // Fallback: sum each settlement currency before converting, so per-call
+    // rounding cannot floor several sub-display-unit receives to zero.
+    if (!convertMoneyAmount || !displayCurrencyReady) return null
+    const settlementTotals = new Map<WalletCurrency, number>()
+    for (const tx of pendingReceives) {
+      settlementTotals.set(
+        tx.settlementCurrency,
+        (settlementTotals.get(tx.settlementCurrency) ?? 0) + tx.settlementAmount,
+      )
+    }
+    let total = convertMoneyAmount(toBtcMoneyAmount(0), DisplayCurrency)
+    for (const [currency, amount] of settlementTotals) {
+      total = addMoneyAmounts({
+        a: total,
+        b: convertMoneyAmount(toWalletMoneyAmount(amount, currency), DisplayCurrency),
+      })
+    }
+    return formatConverted(total)
+  }, [
+    isSelfCustodialAccount,
+    deposits,
+    pendingIncomingTransactions,
+    convertMoneyAmount,
+    displayCurrencyReady,
+    formatCurrency,
+    formatMoneyAmount,
+  ])
+
+  return { pendingReceiveAmountText }
 }

--- a/app/components/balance-header/use-pending-receive-amount.ts
+++ b/app/components/balance-header/use-pending-receive-amount.ts
@@ -1,0 +1,75 @@
+import { useMemo } from "react"
+
+import { TransactionFragment, TxDirection } from "@app/graphql/generated"
+import { usePriceConversion } from "@app/hooks"
+import { useActiveWallet } from "@app/hooks/use-active-wallet"
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { usePendingDeposits } from "@app/self-custodial/hooks"
+import {
+  addMoneyAmounts,
+  DisplayCurrency,
+  MoneyAmount,
+  toBtcMoneyAmount,
+  toWalletMoneyAmount,
+} from "@app/types/amounts"
+import { DepositStatus } from "@app/types/payment"
+
+type Params = {
+  pendingIncomingTransactions?: readonly TransactionFragment[] | null
+}
+
+/**
+ * Total unconfirmed incoming amount for the balance header, in display
+ * currency. Custodial reads the home query's pendingIncomingTransactions;
+ * self-custodial reads immature (unconfirmed) Spark deposits — claimable and
+ * errored deposits stay with the UnclaimedDepositBanner, which carries the
+ * action to resolve them.
+ */
+export const usePendingReceiveAmount = ({
+  pendingIncomingTransactions,
+}: Params): { pendingReceiveAmountText: string | null } => {
+  const { formatMoneyAmount } = useDisplayCurrency()
+  const { convertMoneyAmount } = usePriceConversion()
+  const { isSelfCustodial } = useActiveWallet()
+  const { deposits } = usePendingDeposits()
+
+  const totalPendingDisplayAmount = useMemo(():
+    | MoneyAmount<typeof DisplayCurrency>
+    | undefined => {
+    if (!convertMoneyAmount) return undefined
+
+    if (isSelfCustodial) {
+      const immatureSats = deposits
+        .filter(({ status }) => status === DepositStatus.Immature)
+        .reduce((sum, { amount }) => sum + amount.amount, 0)
+      if (immatureSats === 0) return undefined
+      return convertMoneyAmount(toBtcMoneyAmount(immatureSats), DisplayCurrency)
+    }
+
+    const pendingReceives = (pendingIncomingTransactions ?? []).filter(
+      (tx) => tx.direction === TxDirection.Receive && tx.settlementAmount > 0,
+    )
+    if (pendingReceives.length === 0) return undefined
+    return pendingReceives.reduce(
+      (total, tx) =>
+        addMoneyAmounts({
+          a: total,
+          b: convertMoneyAmount(
+            toWalletMoneyAmount(tx.settlementAmount, tx.settlementCurrency),
+            DisplayCurrency,
+          ),
+        }),
+      convertMoneyAmount(toBtcMoneyAmount(0), DisplayCurrency),
+    )
+  }, [convertMoneyAmount, isSelfCustodial, deposits, pendingIncomingTransactions])
+
+  if (!totalPendingDisplayAmount || totalPendingDisplayAmount.amount <= 0) {
+    return { pendingReceiveAmountText: null }
+  }
+
+  return {
+    pendingReceiveAmountText: formatMoneyAmount({
+      moneyAmount: totalPendingDisplayAmount,
+    }),
+  }
+}

--- a/app/components/status-pill/status-pill.tsx
+++ b/app/components/status-pill/status-pill.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { StyleProp, View, ViewStyle } from "react-native"
+import { Pressable, StyleProp, View, ViewStyle } from "react-native"
 
 import { makeStyles, Text } from "@rn-vui/themed"
 
@@ -7,19 +7,36 @@ import { testProps } from "@app/utils/testProps"
 
 export type StatusPillVariant = "warning" | "error" | "success" | "primary"
 
+/** The pill can sit in width-capped rows (balance header), so its label must
+ *  not outgrow the cap under iOS Dynamic Type — same ceiling as the header. */
+const MAX_LABEL_FONT_SIZE_MULTIPLIER = 1.4
+
 type Props = {
   label: string
   status: StatusPillVariant
   ghost?: boolean
   testID?: string
   style?: StyleProp<ViewStyle>
+  onPress?: () => void
 }
 
-export const StatusPill: React.FC<Props> = ({ label, status, ghost, testID, style }) => {
+export const StatusPill: React.FC<Props> = ({
+  label,
+  status,
+  ghost,
+  testID,
+  style,
+  onPress,
+}) => {
   const styles = useStyles({ status })
 
   const body = (
-    <Text style={styles.label} numberOfLines={1} ellipsizeMode="tail">
+    <Text
+      style={styles.label}
+      numberOfLines={1}
+      ellipsizeMode="tail"
+      maxFontSizeMultiplier={MAX_LABEL_FONT_SIZE_MULTIPLIER}
+    >
       {label}
     </Text>
   )
@@ -34,6 +51,19 @@ export const StatusPill: React.FC<Props> = ({ label, status, ghost, testID, styl
       >
         {body}
       </View>
+    )
+  }
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="button"
+        style={[styles.pill, style]}
+        {...(testID ? testProps(testID) : { accessibilityLabel: label })}
+      >
+        {body}
+      </Pressable>
     )
   }
 

--- a/app/components/status-pill/status-pill.tsx
+++ b/app/components/status-pill/status-pill.tsx
@@ -18,7 +18,11 @@ type Props = {
 export const StatusPill: React.FC<Props> = ({ label, status, ghost, testID, style }) => {
   const styles = useStyles({ status })
 
-  const body = <Text style={styles.label}>{label}</Text>
+  const body = (
+    <Text style={styles.label} numberOfLines={1} ellipsizeMode="tail">
+      {label}
+    </Text>
+  )
 
   if (ghost) {
     return (

--- a/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
+++ b/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
@@ -7,20 +7,27 @@ import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
-import { usePendingDeposits } from "@app/self-custodial/hooks"
-import { DepositStatus } from "@app/types/payment"
+import { DepositStatus, type PendingDeposit } from "@app/types/payment"
 import { testProps } from "@app/utils/testProps"
 
 import { GaloyIcon } from "../atomic/galoy-icon"
 
-export const UnclaimedDepositBanner: React.FC = () => {
+type Props = {
+  deposits: readonly PendingDeposit[]
+}
+
+/**
+ * The screen owns the deposit fetch (usePendingDeposits) and feeds both this
+ * banner and the balance header's pending pill, so the two can never disagree
+ * about the same deposits.
+ */
+export const UnclaimedDepositBanner: React.FC<Props> = ({ deposits }) => {
   const styles = useStyles()
   const {
     theme: { colors },
   } = useTheme()
   const { LL } = useI18nContext()
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-  const { deposits } = usePendingDeposits()
 
   const { count, totalSats } = useMemo(() => {
     const active = deposits.filter(({ status }) => status !== DepositStatus.Refunded)

--- a/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
+++ b/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
@@ -30,10 +30,17 @@ export const UnclaimedDepositBanner: React.FC<Props> = ({ deposits }) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
   const { count, totalSats } = useMemo(() => {
-    const active = deposits.filter(({ status }) => status !== DepositStatus.Refunded)
+    // Only actionable deposits belong in this banner: Immature ones are the
+    // balance header pill's job until they confirm, and Refunded ones are
+    // already resolved. The remaining statuses (Claimable, FeeExceeded, Error)
+    // all carry an action on the unclaimed-deposits screen.
+    const actionable = deposits.filter(
+      ({ status }) =>
+        status !== DepositStatus.Immature && status !== DepositStatus.Refunded,
+    )
     return {
-      count: active.length,
-      totalSats: active.reduce((sum, { amount }) => sum + amount.amount, 0),
+      count: actionable.length,
+      totalSats: actionable.reduce((sum, { amount }) => sum + amount.amount, 0),
     }
   }, [deposits])
 

--- a/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
+++ b/app/components/unclaimed-deposit-banner/unclaimed-deposit-banner.tsx
@@ -1,14 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { useMemo } from "react"
 import { Pressable, View } from "react-native"
 
-import { useFocusEffect, useNavigation } from "@react-navigation/native"
+import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
-import { usePayments } from "@app/hooks/use-payments"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
-import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+import { usePendingDeposits } from "@app/self-custodial/hooks"
 import { DepositStatus } from "@app/types/payment"
 import { testProps } from "@app/utils/testProps"
 
@@ -21,34 +20,15 @@ export const UnclaimedDepositBanner: React.FC = () => {
   } = useTheme()
   const { LL } = useI18nContext()
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-  const { listPendingDeposits } = usePayments()
-  // Re-fetch whenever wallets refresh (e.g. ClaimedDeposits / NewDeposits SDK events).
-  const { wallets } = useSelfCustodialWallet()
-  const [count, setCount] = useState(0)
-  const [totalSats, setTotalSats] = useState(0)
-  // Coordinates concurrent fetches (focus + wallet-refresh) so only the latest
-  // in-flight resolution commits state.
-  const fetchGenerationRef = useRef(0)
+  const { deposits } = usePendingDeposits()
 
-  const fetchDeposits = useCallback(() => {
-    if (!listPendingDeposits) return
-    fetchGenerationRef.current += 1
-    const generation = fetchGenerationRef.current
-    listPendingDeposits().then(({ deposits }) => {
-      if (generation !== fetchGenerationRef.current) return
-      const active = deposits.filter(({ status }) => status !== DepositStatus.Refunded)
-      setCount(active.length)
-      setTotalSats(active.reduce((sum, { amount }) => sum + amount.amount, 0))
-    })
-    return () => {
-      fetchGenerationRef.current += 1
+  const { count, totalSats } = useMemo(() => {
+    const active = deposits.filter(({ status }) => status !== DepositStatus.Refunded)
+    return {
+      count: active.length,
+      totalSats: active.reduce((sum, { amount }) => sum + amount.amount, 0),
     }
-  }, [listPendingDeposits])
-
-  // Re-fetch on SDK wallet refresh + every time the banner comes back into focus
-  // (covers the user returning from the unclaimed-deposits screen after claiming).
-  useFocusEffect(fetchDeposits)
-  useEffect(fetchDeposits, [fetchDeposits, wallets])
+  }, [deposits])
 
   if (count === 0) return null
 

--- a/app/hooks/use-active-wallet.ts
+++ b/app/hooks/use-active-wallet.ts
@@ -48,9 +48,11 @@ export const useActiveWallet = (): ActiveWalletResult => {
       isReady:
         base.status === ActiveWalletStatus.Ready ||
         base.status === ActiveWalletStatus.Degraded,
-      // Encodes SDK readiness, not just account type: false while the Spark
-      // SDK is still connecting (status Unavailable). To ask "is the active
-      // account self-custodial?", branch on
+      // Encodes SDK availability, not just account type: false whenever the
+      // status is Unavailable — the initial renders at cold start or right
+      // after an account switch (before the SDK lifecycle effect commits
+      // Loading), and when no mnemonic exists. To ask "is the active account
+      // self-custodial?", branch on
       // `useAccountRegistry().activeAccount?.type === AccountType.SelfCustodial`
       // instead (see use-price-conversion / use-pending-receive-amount).
       isSelfCustodial:

--- a/app/hooks/use-active-wallet.ts
+++ b/app/hooks/use-active-wallet.ts
@@ -48,6 +48,11 @@ export const useActiveWallet = (): ActiveWalletResult => {
       isReady:
         base.status === ActiveWalletStatus.Ready ||
         base.status === ActiveWalletStatus.Degraded,
+      // Encodes SDK readiness, not just account type: false while the Spark
+      // SDK is still connecting (status Unavailable). To ask "is the active
+      // account self-custodial?", branch on
+      // `useAccountRegistry().activeAccount?.type === AccountType.SelfCustodial`
+      // instead (see use-price-conversion / use-pending-receive-amount).
       isSelfCustodial:
         base.accountType === AccountType.SelfCustodial &&
         base.status !== ActiveWalletStatus.Unavailable,

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2113,6 +2113,7 @@ const en: BaseTranslation = {
     error: "Oops. Something went wrong while getting your location",
   },
   HomeScreen: {
+    pendingReceiveBadge: "+{amount: string} pending",
     receive: "Receive",
     send: "Send",
     title: "Home",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6538,6 +6538,11 @@ type RootTranslation = {
 	}
 	HomeScreen: {
 		/**
+		 * +​{​a​m​o​u​n​t​}​ ​p​e​n​d​i​n​g
+		 * @param {string} amount
+		 */
+		pendingReceiveBadge: RequiredParams<'amount'>
+		/**
 		 * R​e​c​e​i​v​e
 		 */
 		receive: string
@@ -19682,6 +19687,10 @@ export type TranslationFunctions = {
 		error: () => LocalizedString
 	}
 	HomeScreen: {
+		/**
+		 * +{amount} pending
+		 */
+		pendingReceiveBadge: (arg: { amount: string }) => LocalizedString
 		/**
 		 * Receive
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2076,6 +2076,7 @@
         "error": "Oops. Something went wrong while getting your location"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} pending",
         "receive": "Receive",
         "send": "Send",
         "title": "Home",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2110,6 +2110,7 @@
     "error": "Oeps. Iets het verkeerd gegaan terwyl jou ligging bepaal is"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} hangend",
     "receive": "Ontvang",
     "send": "Stuur",
     "title": "Tuis",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2110,6 +2110,7 @@
     "error": "عفوًا. حدث خطأ أثناء الحصول على موقعك"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} يتم الارسال",
     "receive": "استقبال",
     "send": "إرسال",
     "title": "الرئيسية",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2110,7 +2110,7 @@
     "error": "عفوًا. حدث خطأ أثناء الحصول على موقعك"
   },
   "HomeScreen": {
-    "pendingReceiveBadge": "+{amount: string} يتم الارسال",
+    "pendingReceiveBadge": "+{amount: string} قيد الانتظار",
     "receive": "استقبال",
     "send": "إرسال",
     "title": "الرئيسية",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2110,6 +2110,7 @@
     "error": "Oops. Alguna cosa ha anat malament mentre s'obtenia la teva ubicació."
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} pendent",
     "receive": "Rebre",
     "send": "Enviar",
     "title": "Inici",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2110,6 +2110,7 @@
     "error": "Ups. Při zjišťování vaší polohy se něco pokazilo"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} čekající",
     "receive": "Přijmout",
     "send": "Odeslat",
     "title": "Domů",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2110,6 +2110,7 @@
     "error": "Oops. Something went wrong while getting your location"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} afventende",
     "receive": "Modtag",
     "send": "Send",
     "title": "Hjem",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2110,6 +2110,7 @@
         "error": "Ups. Bei der Ermittlung Ihres Standorts ist etwas schief gelaufen"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} Ausstehend",
         "receive": "Erhalten",
         "send": "Senden",
         "title": "Home",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2110,6 +2110,7 @@
     "error": "Ωπ! Κάτι πήγε στραβά κατά τη λήψη της τοποθεσίας σας"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} σε αναμονή",
     "receive": "Λήψη",
     "send": "Αποστολή",
     "title": "Αρχική σελίδα ",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2110,6 +2110,7 @@
         "error": "Ups. Algo salió mal al obtener tu ubicación"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} pendiente",
         "receive": "Recibir",
         "send": "Enviar",
         "title": "Inicio",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2110,6 +2110,7 @@
         "error": "Oups. Un problème est survenu lors de la récupération de votre position"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} en attente",
         "receive": "Recevoir",
         "send": "Envoyer",
         "title": "Accueil",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2110,6 +2110,7 @@
     "error": "Ups. Nešto je pošlo po zlu prilikom dohvaćanja vaše lokacije"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} u tijeku",
     "receive": "Primi",
     "send": "Šalji",
     "title": "Doma",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2110,6 +2110,7 @@
     "error": "Valami hiba történt a helyzeted lekérdezése közben"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} Függőben",
     "receive": "Fogadás",
     "send": "Küldés",
     "title": "Kezdőlap",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2110,6 +2110,7 @@
     "error": "Վայ։ Ինչ-որ բան այնպես չգնաց ձեր տեղադրությունը ստանալիս"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} ընթացքի մեջ",
     "receive": "Ստանալ",
     "send": "Ուղարկել",
     "title": "Ընդհանուր",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2110,6 +2110,7 @@
     "error": "Ups. Terjadi kesalahan saat mendapatkan lokasi Anda."
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} tertunda",
     "receive": "Terima",
     "send": "Kirim",
     "title": "Beranda",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2110,6 +2110,7 @@
         "error": "Oops. Qualcosa è andato storto durante il recupero della tua posizione"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} in attesa",
         "receive": "Ricevi",
         "send": "Invia",
         "title": "Home",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2110,6 +2110,7 @@
         "error": "位置情報の取得中にエラーが発生しました"
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} 保留",
         "receive": "受金",
         "send": "送金",
         "title": "ホーム",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2110,7 +2110,7 @@
         "error": "位置情報の取得中にエラーが発生しました"
     },
     "HomeScreen": {
-        "pendingReceiveBadge": "+{amount: string} 保留",
+        "pendingReceiveBadge": "+{amount: string} 保留中",
         "receive": "受金",
         "send": "送金",
         "title": "ホーム",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2110,6 +2110,7 @@
     "error": "Oops. Waliwo ekyatambude bulungi kukufuna ekifo kyo"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} tekinagwa",
     "receive": "Funa",
     "send": "Sindika",
     "title": "Ewaka",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2110,6 +2110,7 @@
     "error": "Alamak. Sesuatu tidak kena semasa mendapatkan lokasi anda"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} tergendala",
     "receive": "Terima",
     "send": "Hantar",
     "title": "Rumah",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2110,6 +2110,7 @@
     "error": "Oeps. Er is iets misgegaan bij het ophalen van je locatie"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} In behandeling",
     "receive": "Ontvang",
     "send": "Verzend",
     "title": "Thuisscherm",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2110,6 +2110,7 @@
         "error": "Oops. Algo deu errado ao obter sua localização."
     },
     "HomeScreen": {
+        "pendingReceiveBadge": "+{amount: string} pendente",
         "receive": "Receber",
         "send": "Enviar",
         "title": "Página Inicial",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2110,6 +2110,7 @@
     "error": "Uyuyuy. Imapas mana allinchu kasqa maypi kasqaykita maskhashaspa"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} Kanqaqmi",
     "receive": "Allinmi",
     "send": "Kawsaynin",
     "title": "Ayllu",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2110,6 +2110,7 @@
     "error": "Hopa! A apărut o eroare la obținerea locației dvs"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} în aşteptare",
     "receive": "Primește",
     "send": "Trimite",
     "title": "Acasă",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2110,6 +2110,7 @@
     "error": "Ojoj. Pri získavaní vašej polohy sa vyskytla chyba"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} čakajúce",
     "receive": "Prijať",
     "send": "Odoslať",
     "title": "Domov",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2110,6 +2110,7 @@
     "error": "Упс. Нешто је пошло наопако приликом добијања ваше локације"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} на чекању",
     "receive": "Прими",
     "send": "Пошаљи",
     "title": "Почетна",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2110,6 +2110,7 @@
     "error": "Lo! Hitilafu fulani imetokea wakati wa kupata eneo lako"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} inasubiri",
     "receive": "Pokea",
     "send": "Tuma",
     "title": "Nyumbani",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2110,6 +2110,7 @@
     "error": "เกิดข้อผิดพลาดขณะรับตำแหน่งของคุณ"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} อยู่ระหว่างดำเนินการ",
     "receive": "รับเงิน",
     "send": "ส่ง",
     "title": "หน้าหลัก",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2110,6 +2110,7 @@
     "error": "Hay aksi. Konum bilgini alırken bir şeyler yanlış gitti."
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} beklemede",
     "receive": "Al",
     "send": "Gönder",
     "title": "Ev",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2110,6 +2110,7 @@
     "error": "Rất tiếc. Đã xảy ra lỗi khi lấy vị trí của bạn"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} Đang xử lí",
     "receive": "Nhận",
     "send": "Gửi",
     "title": "Nhà",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2110,7 +2110,7 @@
     "error": "Rất tiếc. Đã xảy ra lỗi khi lấy vị trí của bạn"
   },
   "HomeScreen": {
-    "pendingReceiveBadge": "+{amount: string} Đang xử lí",
+    "pendingReceiveBadge": "+{amount: string} đang chờ",
     "receive": "Nhận",
     "send": "Gửi",
     "title": "Nhà",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2110,6 +2110,7 @@
     "error": "Owu. Kukho into engahambanga kakuhle ngelixa sifumana indawo yakho"
   },
   "HomeScreen": {
+    "pendingReceiveBadge": "+{amount: string} pending",
     "receive": "Yamkela",
     "send": "Thumela",
     "title": "Ekhaya",

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -64,7 +64,10 @@ import {
   useTransferBlockedSync,
 } from "@app/hooks/use-transfer-blocked"
 import { useSelfCustodialNetworkMismatchToast } from "@app/self-custodial/hooks/use-network-mismatch-toast"
-import { useNonCustodialConversionLimits } from "@app/self-custodial/hooks"
+import {
+  useNonCustodialConversionLimits,
+  usePendingDeposits,
+} from "@app/self-custodial/hooks"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { ConvertDirection } from "@app/types/payment"
 import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
@@ -355,10 +358,15 @@ export const HomeScreen: React.FC = () => {
     dataAuthed?.me?.defaultAccount?.pendingIncomingTransactions
   const transactionsEdges = dataAuthed?.me?.defaultAccount?.transactions?.edges
 
+  /** Fetched once here and shared with the UnclaimedDepositBanner below, so the
+   *  pending pill and that banner can never disagree about the same deposits. */
+  const { deposits } = usePendingDeposits()
+
   /** Pending deposits stay visible beside the balance until confirmed —
    *  unlike the unseen-tx badge below, which auto-dismisses (blink-wip#937). */
   const { pendingReceiveAmountText } = usePendingReceiveAmount({
     pendingIncomingTransactions,
+    deposits,
   })
   const pendingStatusBadge = pendingReceiveAmountText
     ? {
@@ -864,7 +872,7 @@ export const HomeScreen: React.FC = () => {
             </React.Fragment>
           ))}
         </View>
-        {isSelfCustodial && <UnclaimedDepositBanner />}
+        {isSelfCustodial && <UnclaimedDepositBanner deposits={deposits} />}
         <NetworkStatusBanner />
         {shouldShowBanner && <BackupNudgeBanner onDismiss={dismissBanner} />}
         {offboardBulletin.isVisible && <OffboardOnlyBulletin />}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -565,6 +565,10 @@ export const HomeScreen: React.FC = () => {
     setIsPullRefreshing(true)
     try {
       await refetch()
+    } catch {
+      // A failed pull (e.g. offline) already surfaces through each query's
+      // error state; RefreshControl ignores the promise, so don't let the
+      // rejection escape as unhandled.
     } finally {
       setIsPullRefreshing(false)
     }

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -529,23 +529,22 @@ export const HomeScreen: React.FC = () => {
     openUpgradeModal,
   ])
 
-  const refetch = React.useCallback(() => {
+  const refetch = React.useCallback(async () => {
     if (isSelfCustodial) {
-      refreshSelfCustodialWallets()
+      await refreshSelfCustodialWallets()
       return
     }
 
     if (!isAuthed) return
 
-    Promise.all([
+    await Promise.all([
       refetchRealtimePrice(),
       refetchAuthed(),
       refetchUnauthed(),
       refetchBulletins(),
-    ]).then(() => {
-      // Triggers the upgrade trial account modal after refetch
-      triggerUpgradeModal()
-    })
+    ])
+    // Triggers the upgrade trial account modal after refetch
+    triggerUpgradeModal()
   }, [
     isAuthed,
     isSelfCustodial,
@@ -556,6 +555,20 @@ export const HomeScreen: React.FC = () => {
     refetchUnauthed,
     triggerUpgradeModal,
   ])
+
+  /** The refresh control reflects only user-initiated pulls: iOS renders a
+   *  programmatically-pinned UIRefreshControl as a frozen spinner, so binding
+   *  it to background query loading pinned a dead spinner on every mount (and
+   *  indefinitely while a self-custodial wallet connects). */
+  const [isPullRefreshing, setIsPullRefreshing] = React.useState(false)
+  const handlePullToRefresh = React.useCallback(async () => {
+    setIsPullRefreshing(true)
+    try {
+      await refetch()
+    } finally {
+      setIsPullRefreshing(false)
+    }
+  }, [refetch])
 
   const numberOfTxs = transactions.length
 
@@ -808,8 +821,8 @@ export const HomeScreen: React.FC = () => {
         contentContainerStyle={styles.scrollViewContainer}
         refreshControl={
           <RefreshControl
-            refreshing={loading && isFocused}
-            onRefresh={refetch}
+            refreshing={isPullRefreshing}
+            onRefresh={handlePullToRefresh}
             colors={[colors.primary]}
             tintColor={colors.primary}
           />

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -20,7 +20,11 @@ import { StableSatsModal } from "@app/components/stablesats-modal"
 import { DollarBalanceRestrictionModal } from "@app/components/dollar-balance-restriction-modal"
 import { UsdConvertToBtcModal } from "@app/components/usd-convert-to-btc-modal"
 import WalletOverview from "@app/components/wallet-overview/wallet-overview"
-import { BalanceHeader, useTotalBalance } from "@app/components/balance-header"
+import {
+  BalanceHeader,
+  usePendingReceiveAmount,
+  useTotalBalance,
+} from "@app/components/balance-header"
 import { BalanceMode, useBalanceMode } from "@app/hooks/use-balance-mode"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
@@ -350,6 +354,18 @@ export const HomeScreen: React.FC = () => {
   const pendingIncomingTransactions =
     dataAuthed?.me?.defaultAccount?.pendingIncomingTransactions
   const transactionsEdges = dataAuthed?.me?.defaultAccount?.transactions?.edges
+
+  /** Pending deposits stay visible beside the balance until confirmed —
+   *  unlike the unseen-tx badge below, which auto-dismisses (blink-wip#937). */
+  const { pendingReceiveAmountText } = usePendingReceiveAmount({
+    pendingIncomingTransactions,
+  })
+  const pendingStatusBadge = pendingReceiveAmountText
+    ? {
+        label: LL.HomeScreen.pendingReceiveBadge({ amount: pendingReceiveAmountText }),
+        status: "warning" as const,
+      }
+    : undefined
 
   const transactions = useMemo(() => {
     const txs: TransactionFragment[] = []
@@ -772,6 +788,7 @@ export const HomeScreen: React.FC = () => {
         showStableBalanceToggle={showStableBalanceToggle}
         mode={balanceMode}
         onModeChange={toggleBalanceMode}
+        statusBadge={pendingStatusBadge}
       />
       <View style={styles.badgeSlot}>
         <UnseenTxAmountBadge

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -360,7 +360,7 @@ export const HomeScreen: React.FC = () => {
 
   /** Fetched once here and shared with the UnclaimedDepositBanner below, so the
    *  pending pill and that banner can never disagree about the same deposits. */
-  const { deposits } = usePendingDeposits()
+  const { deposits, refetch: refetchPendingDeposits } = usePendingDeposits()
 
   /** Pending deposits stay visible beside the balance until confirmed —
    *  unlike the unseen-tx badge below, which auto-dismisses (blink-wip#937). */
@@ -539,7 +539,10 @@ export const HomeScreen: React.FC = () => {
 
   const refetch = React.useCallback(async () => {
     if (isSelfCustodial) {
-      await refreshSelfCustodialWallets()
+      // Both must land before the pull-to-refresh spinner retracts: the wallet
+      // snapshot feeds the balance, the deposit listing feeds the pending pill
+      // and the unclaimed-deposit banner.
+      await Promise.all([refreshSelfCustodialWallets(), refetchPendingDeposits()])
       return
     }
 
@@ -557,6 +560,7 @@ export const HomeScreen: React.FC = () => {
     isAuthed,
     isSelfCustodial,
     refreshSelfCustodialWallets,
+    refetchPendingDeposits,
     refetchAuthed,
     refetchBulletins,
     refetchRealtimePrice,

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -69,7 +69,7 @@ import {
   usePendingDeposits,
 } from "@app/self-custodial/hooks"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
-import { ConvertDirection } from "@app/types/payment"
+import { ConvertDirection, DepositStatus } from "@app/types/payment"
 import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
 import { useSelfCustodialInfoBulletinState } from "@app/hooks/use-self-custodial-info-bulletin-state"
 import { getErrorMessages } from "@app/graphql/utils"
@@ -368,10 +368,20 @@ export const HomeScreen: React.FC = () => {
     pendingIncomingTransactions,
     deposits,
   })
+  /** The banner below only counts actionable deposits, so the pill carries the
+   *  immature deposits' inspection path (txid / mempool link) to the
+   *  unclaimed-deposits screen. Custodial pending receives have no such
+   *  screen — their pill stays inert. */
+  const hasImmatureDeposits = deposits.some(
+    ({ status }) => status === DepositStatus.Immature,
+  )
   const pendingStatusBadge = pendingReceiveAmountText
     ? {
         label: LL.HomeScreen.pendingReceiveBadge({ amount: pendingReceiveAmountText }),
         status: "warning" as const,
+        onPress: hasImmatureDeposits
+          ? () => navigation.navigate("unclaimedDepositsScreen")
+          : undefined,
       }
     : undefined
 

--- a/app/self-custodial/hooks/index.ts
+++ b/app/self-custodial/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useNonCustodialConversionLimits } from "./use-non-custodial-conversion-limits"
 export { usePaymentRequest } from "./use-payment-request"
+export { usePendingDeposits } from "./use-pending-deposits"
 export { useSendDustWarning } from "./use-send-dust-warning"
 export { useTranslateSdkError } from "./use-translate-sdk-error"
 export type { SelfCustodialPaymentRequestState, InvoiceData } from "./types"

--- a/app/self-custodial/hooks/use-pending-deposits.ts
+++ b/app/self-custodial/hooks/use-pending-deposits.ts
@@ -32,8 +32,12 @@ export const usePendingDeposits = (): { deposits: PendingDeposit[] } => {
     if (!listPendingDeposits) return
     fetchGenerationRef.current += 1
     const generation = fetchGenerationRef.current
-    listPendingDeposits().then(({ deposits: fetched }) => {
+    listPendingDeposits().then(({ deposits: fetched, errors }) => {
       if (generation !== fetchGenerationRef.current) return
+      // A failed listing resolves with an empty array rather than rejecting.
+      // Committing it would read as "the deposit confirmed", so a listing we
+      // could not trust leaves the last known deposits on screen.
+      if (errors?.length) return
       if (sameDeposits(depositsRef.current, fetched)) return
       depositsRef.current = fetched
       setDeposits(fetched)

--- a/app/self-custodial/hooks/use-pending-deposits.ts
+++ b/app/self-custodial/hooks/use-pending-deposits.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useFocusEffect } from "@react-navigation/native"
 
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { usePayments } from "@app/hooks/use-payments"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { type PendingDeposit } from "@app/types/payment"
@@ -27,6 +28,8 @@ export const usePendingDeposits = (): {
   refetch: () => Promise<void>
 } => {
   const { listPendingDeposits } = usePayments()
+  const { activeAccount } = useAccountRegistry()
+  const activeAccountId = activeAccount?.id
   // Wallet refreshes proxy the SDK's deposit events (ClaimedDeposits /
   // NewDeposits land as wallet refreshes), so they drive the re-fetch below.
   const { wallets } = useSelfCustodialWallet()
@@ -34,31 +37,60 @@ export const usePendingDeposits = (): {
   // Coordinates concurrent fetches (focus + wallet-refresh + pull-to-refresh)
   // so only the latest in-flight resolution commits state.
   const fetchGenerationRef = useRef(0)
+  // The most recently issued listing; refetch converges on it so a caller
+  // resolves only after a listing nothing newer has superseded.
+  const latestFetchRef = useRef<Promise<void>>(Promise.resolve())
 
-  const fetchDeposits = useCallback(async (): Promise<void> => {
-    // Every call invalidates older in-flight listings — including one that is
-    // still resolving when the adapter has just vanished.
-    fetchGenerationRef.current += 1
+  const fetchDeposits = useCallback((): Promise<void> => {
+    const fetch = (async (): Promise<void> => {
+      // Every call invalidates older in-flight listings — including one that
+      // is still resolving when the adapter has just vanished.
+      fetchGenerationRef.current += 1
 
-    if (!listPendingDeposits) {
-      // The adapter disappears on account switch or SDK teardown: stale
-      // deposits must not linger beside another account's balance.
-      setDeposits((prev) => (prev.length === 0 ? prev : []))
-      return
-    }
+      // The adapter also vanishes on a same-account SDK teardown (spark-network
+      // change, reconnect): keep the last known deposits — clearing here made
+      // the pill and banner flash on every reconnect. The account-switch
+      // effect below owns the reset.
+      if (!listPendingDeposits) return
 
-    const generation = fetchGenerationRef.current
-    const { deposits: fetched, errors } = await listPendingDeposits()
-    if (generation !== fetchGenerationRef.current) return
-    // A failed listing resolves with an empty array plus `errors` rather than
-    // rejecting. Committing it would read as "the deposit confirmed", so an
-    // untrusted listing keeps the last known deposits. Tradeoff: nothing
-    // retries and no error surfaces — the stale list stands until the next
-    // focus / wallet-refresh / pull-to-refresh fetch, and only adapter loss
-    // (above) resets it.
-    if (errors?.length) return
-    setDeposits((prev) => (sameDeposits(prev, fetched) ? prev : fetched))
+      const generation = fetchGenerationRef.current
+      const { deposits: fetched, errors } = await listPendingDeposits()
+      if (generation !== fetchGenerationRef.current) return
+      // A failed listing resolves with an empty array plus `errors` rather
+      // than rejecting. Committing it would read as "the deposit confirmed",
+      // so an untrusted listing keeps the last known deposits. Tradeoff:
+      // nothing retries and no error surfaces — the stale list stands until
+      // the next focus / wallet-refresh / pull-to-refresh fetch, and only an
+      // account switch resets it.
+      if (errors?.length) return
+      setDeposits((prev) => (sameDeposits(prev, fetched) ? prev : fetched))
+    })()
+    latestFetchRef.current = fetch
+    return fetch
   }, [listPendingDeposits])
+
+  const refetch = useCallback(async (): Promise<void> => {
+    await fetchDeposits()
+    // A wallet refresh landing mid-listing supersedes it (generation bump), so
+    // the awaited listing may have been discarded. Settle only once the latest
+    // listing has run to completion, so pull-to-refresh retracts on the values
+    // that actually rendered.
+    for (;;) {
+      const latest = latestFetchRef.current
+      await latest
+      if (latestFetchRef.current === latest) return
+    }
+  }, [fetchDeposits])
+
+  // Stale deposits must not follow the user across accounts: reset state and
+  // invalidate anything in flight the moment the active account changes.
+  const lastAccountRef = useRef(activeAccountId)
+  useEffect(() => {
+    if (lastAccountRef.current === activeAccountId) return
+    lastAccountRef.current = activeAccountId
+    fetchGenerationRef.current += 1
+    setDeposits((prev) => (prev.length === 0 ? prev : []))
+  }, [activeAccountId])
 
   // The focus effect owns the mount fetch and re-fires when the adapter
   // changes; it also covers the user returning from the unclaimed-deposits
@@ -83,5 +115,5 @@ export const usePendingDeposits = (): {
     fetchDeposits()
   }, [fetchDeposits, wallets])
 
-  return { deposits, refetch: fetchDeposits }
+  return { deposits, refetch }
 }

--- a/app/self-custodial/hooks/use-pending-deposits.ts
+++ b/app/self-custodial/hooks/use-pending-deposits.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import { useFocusEffect } from "@react-navigation/native"
+
+import { usePayments } from "@app/hooks/use-payments"
+import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+import { type PendingDeposit } from "@app/types/payment"
+
+/** id (txid:vout) pins the deposit; status is its only field that changes. */
+const sameDeposits = (a: PendingDeposit[], b: PendingDeposit[]) =>
+  a.length === b.length &&
+  a.every((deposit, i) => deposit.id === b[i].id && deposit.status === b[i].status)
+
+/**
+ * Unclaimed onchain deposits for the active self-custodial wallet.
+ * Resolves to an empty list in custodial mode (the custodial adapter has no
+ * deposit concept), so callers need no account-type gate.
+ */
+export const usePendingDeposits = (): { deposits: PendingDeposit[] } => {
+  const { listPendingDeposits } = usePayments()
+  // Re-fetch whenever wallets refresh (e.g. ClaimedDeposits / NewDeposits SDK events).
+  const { wallets } = useSelfCustodialWallet()
+  const [deposits, setDeposits] = useState<PendingDeposit[]>([])
+  // Coordinates concurrent fetches (focus + wallet-refresh) so only the latest
+  // in-flight resolution commits state.
+  const fetchGenerationRef = useRef(0)
+  // Mirrors `deposits` so unchanged fetch results skip setState entirely —
+  // consumers and effects keyed on the array don't churn on background refresh.
+  const depositsRef = useRef<PendingDeposit[]>([])
+
+  const fetchDeposits = useCallback(() => {
+    if (!listPendingDeposits) return
+    fetchGenerationRef.current += 1
+    const generation = fetchGenerationRef.current
+    listPendingDeposits().then(({ deposits: fetched }) => {
+      if (generation !== fetchGenerationRef.current) return
+      if (sameDeposits(depositsRef.current, fetched)) return
+      depositsRef.current = fetched
+      setDeposits(fetched)
+    })
+    return () => {
+      fetchGenerationRef.current += 1
+    }
+  }, [listPendingDeposits])
+
+  // Re-fetch on SDK wallet refresh + every time the consumer comes back into
+  // focus (covers the user returning from the unclaimed-deposits screen).
+  useFocusEffect(fetchDeposits)
+  useEffect(fetchDeposits, [fetchDeposits, wallets])
+
+  return { deposits }
+}

--- a/app/self-custodial/hooks/use-pending-deposits.ts
+++ b/app/self-custodial/hooks/use-pending-deposits.ts
@@ -18,44 +18,70 @@ const sameDeposits = (a: PendingDeposit[], b: PendingDeposit[]) =>
 
 /**
  * Unclaimed onchain deposits for the active self-custodial wallet.
- * Resolves to an empty list in custodial mode (the custodial adapter has no
- * deposit concept), so callers need no account-type gate.
+ * In custodial mode the payment adapter stubs `listPendingDeposits` to resolve
+ * `{ deposits: [] }` (app/custodial/adapters/payment.ts), so callers need no
+ * account-type gate.
  */
-export const usePendingDeposits = (): { deposits: PendingDeposit[] } => {
+export const usePendingDeposits = (): {
+  deposits: PendingDeposit[]
+  refetch: () => Promise<void>
+} => {
   const { listPendingDeposits } = usePayments()
-  // Re-fetch whenever wallets refresh (e.g. ClaimedDeposits / NewDeposits SDK events).
+  // Wallet refreshes proxy the SDK's deposit events (ClaimedDeposits /
+  // NewDeposits land as wallet refreshes), so they drive the re-fetch below.
   const { wallets } = useSelfCustodialWallet()
   const [deposits, setDeposits] = useState<PendingDeposit[]>([])
-  // Coordinates concurrent fetches (focus + wallet-refresh) so only the latest
-  // in-flight resolution commits state.
+  // Coordinates concurrent fetches (focus + wallet-refresh + pull-to-refresh)
+  // so only the latest in-flight resolution commits state.
   const fetchGenerationRef = useRef(0)
-  // Mirrors `deposits` so unchanged fetch results skip setState entirely —
-  // consumers and effects keyed on the array don't churn on background refresh.
-  const depositsRef = useRef<PendingDeposit[]>([])
 
-  const fetchDeposits = useCallback(() => {
-    if (!listPendingDeposits) return
+  const fetchDeposits = useCallback(async (): Promise<void> => {
+    // Every call invalidates older in-flight listings — including one that is
+    // still resolving when the adapter has just vanished.
     fetchGenerationRef.current += 1
-    const generation = fetchGenerationRef.current
-    listPendingDeposits().then(({ deposits: fetched, errors }) => {
-      if (generation !== fetchGenerationRef.current) return
-      // A failed listing resolves with an empty array rather than rejecting.
-      // Committing it would read as "the deposit confirmed", so a listing we
-      // could not trust leaves the last known deposits on screen.
-      if (errors?.length) return
-      if (sameDeposits(depositsRef.current, fetched)) return
-      depositsRef.current = fetched
-      setDeposits(fetched)
-    })
-    return () => {
-      fetchGenerationRef.current += 1
+
+    if (!listPendingDeposits) {
+      // The adapter disappears on account switch or SDK teardown: stale
+      // deposits must not linger beside another account's balance.
+      setDeposits((prev) => (prev.length === 0 ? prev : []))
+      return
     }
+
+    const generation = fetchGenerationRef.current
+    const { deposits: fetched, errors } = await listPendingDeposits()
+    if (generation !== fetchGenerationRef.current) return
+    // A failed listing resolves with an empty array plus `errors` rather than
+    // rejecting. Committing it would read as "the deposit confirmed", so an
+    // untrusted listing keeps the last known deposits. Tradeoff: nothing
+    // retries and no error surfaces — the stale list stands until the next
+    // focus / wallet-refresh / pull-to-refresh fetch, and only adapter loss
+    // (above) resets it.
+    if (errors?.length) return
+    setDeposits((prev) => (sameDeposits(prev, fetched) ? prev : fetched))
   }, [listPendingDeposits])
 
-  // Re-fetch on SDK wallet refresh + every time the consumer comes back into
-  // focus (covers the user returning from the unclaimed-deposits screen).
-  useFocusEffect(fetchDeposits)
-  useEffect(fetchDeposits, [fetchDeposits, wallets])
+  // The focus effect owns the mount fetch and re-fires when the adapter
+  // changes; it also covers the user returning from the unclaimed-deposits
+  // screen.
+  useFocusEffect(
+    useCallback(() => {
+      fetchDeposits()
+      return () => {
+        // Losing focus invalidates whatever is still in flight.
+        fetchGenerationRef.current += 1
+      }
+    }, [fetchDeposits]),
+  )
 
-  return { deposits }
+  // Re-fetch only when the wallets identity actually changed (an SDK refresh
+  // landed). Mount and adapter changes are the focus effect's job — comparing
+  // identities here stops the two channels from double-firing the listing.
+  const lastWalletsRef = useRef(wallets)
+  useEffect(() => {
+    if (lastWalletsRef.current === wallets) return
+    lastWalletsRef.current = wallets
+    fetchDeposits()
+  }, [fetchDeposits, wallets])
+
+  return { deposits, refetch: fetchDeposits }
 }

--- a/app/self-custodial/hooks/use-pending-deposits.ts
+++ b/app/self-custodial/hooks/use-pending-deposits.ts
@@ -6,7 +6,12 @@ import { usePayments } from "@app/hooks/use-payments"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { type PendingDeposit } from "@app/types/payment"
 
-/** id (txid:vout) pins the deposit; status is its only field that changes. */
+/**
+ * Deposits are pinned by id (txid:vout) and compared on status, the only field
+ * the current consumers render. Fee and error details can therefore change
+ * without committing: the guard trades their freshness for a stable array
+ * identity, so widen it before rendering requiredFeeSats off this hook.
+ */
 const sameDeposits = (a: PendingDeposit[], b: PendingDeposit[]) =>
   a.length === b.length &&
   a.every((deposit, i) => deposit.id === b[i].id && deposit.status === b[i].status)

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -93,6 +93,7 @@ export const useSdkLifecycle = (
   const abortRef = useRef(false)
   const refreshingRef = useRef(false)
   const pendingRefreshRef = useRef(false)
+  const inflightRefreshRef = useRef<Promise<void> | null>(null)
   const rawTxOffsetRef = useRef(0)
   /**
    * The leeway only feeds the SDK config at connect time, so hold it in a ref:
@@ -105,14 +106,20 @@ export const useSdkLifecycle = (
 
   // `refreshingRef` linearizes concurrent refreshes (10s poll, AppState change,
   // SDK events): only one runOnce executes at a time, and any overlapping call
-  // sets `pendingRefreshRef` so the in-flight loop reruns once it returns. The
-  // two require-atomic-updates disables below (post-await ref writes) are safe
+  // sets `pendingRefreshRef` so the in-flight loop reruns once it returns —
+  // overlapping callers await that loop via `inflightRefreshRef`. The
+  // require-atomic-updates disables below (post-await ref writes) are safe
   // under that invariant.
   const refreshWallets = useCallback(async () => {
     const sdk = sdkRef.current
     if (!sdk) return
     if (refreshingRef.current) {
       pendingRefreshRef.current = true
+      // The in-flight do/while below reruns while pendingRefreshRef is set, so
+      // its completion also covers this queued refresh — hand the caller that
+      // promise instead of resolving before any data landed (pull-to-refresh
+      // would retract its spinner on stale values otherwise).
+      await inflightRefreshRef.current
       return
     }
     refreshingRef.current = true
@@ -164,14 +171,19 @@ export const useSdkLifecycle = (
       }
     }
 
-    try {
-      do {
-        pendingRefreshRef.current = false
-        await runOnce()
-      } while (pendingRefreshRef.current)
-    } finally {
-      refreshingRef.current = false // eslint-disable-line require-atomic-updates
-    }
+    const run = (async () => {
+      try {
+        do {
+          pendingRefreshRef.current = false
+          await runOnce()
+        } while (pendingRefreshRef.current)
+      } finally {
+        refreshingRef.current = false // eslint-disable-line require-atomic-updates
+        inflightRefreshRef.current = null // eslint-disable-line require-atomic-updates
+      }
+    })()
+    inflightRefreshRef.current = run
+    await run
   }, [resetBackoff, scheduleBackoffRetry])
 
   useEffect(() => {

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -182,7 +182,7 @@ export const useSdkLifecycle = (
     // everything); each iteration serves the waiters registered before it
     // started, and anyone arriving mid-iteration re-arms pendingRefreshRef to
     // be served by the next.
-    void (async () => {
+    ;(async () => {
       try {
         do {
           const waiters = refreshWaitersRef.current

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -93,7 +93,10 @@ export const useSdkLifecycle = (
   const abortRef = useRef(false)
   const refreshingRef = useRef(false)
   const pendingRefreshRef = useRef(false)
-  const inflightRefreshRef = useRef<Promise<void> | null>(null)
+  /** Callers waiting for the first refresh iteration that starts at or after
+   *  their call, resolved iteration by iteration — no caller adopts the whole
+   *  drain loop's lifetime (offline, the 10s poll can re-arm it indefinitely). */
+  const refreshWaitersRef = useRef<(() => void)[]>([])
   const rawTxOffsetRef = useRef(0)
   /**
    * The leeway only feeds the SDK config at connect time, so hold it in a ref:
@@ -106,20 +109,24 @@ export const useSdkLifecycle = (
 
   // `refreshingRef` linearizes concurrent refreshes (10s poll, AppState change,
   // SDK events): only one runOnce executes at a time, and any overlapping call
-  // sets `pendingRefreshRef` so the in-flight loop reruns once it returns —
-  // overlapping callers await that loop via `inflightRefreshRef`. The
-  // require-atomic-updates disables below (post-await ref writes) are safe
-  // under that invariant.
+  // sets `pendingRefreshRef` so the in-flight loop reruns once it returns.
+  // Every caller awaits only the iteration that serves it (refreshWaitersRef):
+  // fresh data before pull-to-refresh retracts, without waiting on the whole
+  // drain loop. The require-atomic-updates disables below (post-await ref
+  // writes) are safe under that invariant.
   const refreshWallets = useCallback(async () => {
     const sdk = sdkRef.current
     if (!sdk) return
+    const settled = new Promise<void>((resolve) => {
+      refreshWaitersRef.current.push(resolve)
+    })
     if (refreshingRef.current) {
+      // The in-flight do/while below reruns while pendingRefreshRef is set;
+      // this caller's waiter resolves when the rerun serving it completes —
+      // not before any data landed (the spinner would retract on stale
+      // values), and not after the loop's open-ended lifetime either.
       pendingRefreshRef.current = true
-      // The in-flight do/while below reruns while pendingRefreshRef is set, so
-      // its completion also covers this queued refresh — hand the caller that
-      // promise instead of resolving before any data landed (pull-to-refresh
-      // would retract its spinner on stale values otherwise).
-      await inflightRefreshRef.current
+      await settled
       return
     }
     refreshingRef.current = true
@@ -171,19 +178,29 @@ export const useSdkLifecycle = (
       }
     }
 
-    const run = (async () => {
+    // The drain loop runs detached (runOnce never rejects — its catch handles
+    // everything); each iteration serves the waiters registered before it
+    // started, and anyone arriving mid-iteration re-arms pendingRefreshRef to
+    // be served by the next.
+    void (async () => {
       try {
         do {
+          const waiters = refreshWaitersRef.current
+          refreshWaitersRef.current = []
           pendingRefreshRef.current = false
           await runOnce()
+          for (const resolve of waiters) resolve()
         } while (pendingRefreshRef.current)
       } finally {
         refreshingRef.current = false // eslint-disable-line require-atomic-updates
-        inflightRefreshRef.current = null // eslint-disable-line require-atomic-updates
+        // Belt and braces: a waiter can only be left behind if the loop exits
+        // abnormally; never strand its caller.
+        const leftover = refreshWaitersRef.current
+        refreshWaitersRef.current = [] // eslint-disable-line require-atomic-updates
+        for (const resolve of leftover) resolve()
       }
     })()
-    inflightRefreshRef.current = run
-    await run
+    await settled
   }, [resetBackoff, scheduleBackoffRetry])
 
   useEffect(() => {


### PR DESCRIPTION
Fixes https://github.com/blinkbitcoin/blink-wip/issues/937 (cross-repo — close the issue manually on merge).

## Problem

When an onchain deposit arrives, a green `+$X` flashes under the home balance for about a second and disappears, while the transaction list below keeps showing the pending deposit. That flash was never a pending indicator: it is the unseen-transaction badge, which auto-dismisses after ~5s by design (#3655), and its timer often starts before the screen is actually visible. Nothing in the balance area is pending-aware, so once it dismisses the top of the screen stops reflecting the unconfirmed deposit.

## Fix

A state-driven pending pill on `BalanceHeader`'s existing (previously unused) `statusBadge` slot: **+$X pending**, amber, visible exactly while pending incoming funds exist, independent of the seen/unseen mechanism.

- **Custodial**: sums the home query's `pendingIncomingTransactions` (each converted by its own settlement currency, so USD-wallet pending works too).
- **Self-custodial**: sums immature (unconfirmed) Spark deposits via a new `usePendingDeposits` hook extracted verbatim from `UnclaimedDepositBanner`. Claimable/errored deposits stay with the banner, which carries the action to resolve them — the header pill only covers "waiting for confirmations", so the two never double-signal.
- The unseen badge keeps its current behavior; hide-amounts mode already suppresses the pill via `BalanceHeader`'s existing guard.
- New i18n key `HomeScreen.pendingReceiveBadge` in EN + all 28 locales (each reusing its existing "pending" term).

## Rides along: frozen pull-to-refresh spinner

Surfaced while recording the demo: the refresh control was bound to background query loading, and iOS renders a programmatically-pinned `UIRefreshControl` as a frozen, non-spinning spinner — on every home mount until the first response, and indefinitely while a self-custodial wallet connects. It now reflects only user-initiated pulls (which the gesture animates natively), and a failed pull unpins the spinner without escaping as an unhandled rejection.

## Tests

- `use-pending-receive-amount.spec.tsx` — both modes, currency mix, empty/loading/zero/negative/outgoing edges, non-immature exclusion, conversion rounding to zero.
- `use-pending-deposits.spec.ts` — the setState identity guard (status-only changes commit; unchanged refetches keep array identity), stale-fetch coordination, custodial no-op.
- `home.spec.tsx` — pill visible with a pending deposit, **still visible past the 5s unseen-badge auto-dismiss** (the regression itself), absent when nothing is pending; self-custodial wiring (immature shows, claimable stays with the banner); refresh spinner not pinned while queries load, spins only during a user pull, recovers on a failed pull.
- `balance-header.spec.tsx` — pill hidden while amounts are hidden.
- `unclaimed-deposit-banner.spec.tsx` passes unchanged, proving the fetch extraction preserved banner behavior.

Screenshots and a video demo are in the comments below (simulated pending state, captioned as such).
