### PR TITLE
fix(migration): hand a locked migration with no resumable state to support

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -155,6 +155,73 @@ describe("useMigrationCheckpoint", () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(mockReportError).toHaveBeenCalledWith("Checkpoint load", expect.any(Error))
     expect(result.current.checkpoint).toBeNull()
+    /** Surfaced, not swallowed: an unreadable store must stay distinguishable from an
+     *  empty one, or the gate reads a transient failure as a wiped device. */
+    expect(result.current.hasError).toBe(true)
+  })
+
+  it("recovers through refetch after a failed load", async () => {
+    mockLoadCheckpoint.mockRejectedValueOnce(new Error("corrupt"))
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BackupAlerts,
+      savedAt: Date.now(),
+      accountId: "sc-account-2",
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.checkpoint).toBe(MigrationCheckpoint.BackupAlerts)
+    expect(result.current.hasResumableCheckpoint).toBe(true)
+  })
+
+  /** The error may only clear once the retry has SUCCEEDED: clearing it when the retry
+   *  starts would present the still-empty state as settled data for the length of the
+   *  read, and the gate would hand the user to support on it. */
+  it("keeps hasError raised while a refetch is still in flight", async () => {
+    mockLoadCheckpoint.mockRejectedValueOnce(new Error("corrupt"))
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    let resolveReload: (stored: unknown) => void = () => {}
+    mockLoadCheckpoint.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReload = resolve
+        }),
+    )
+
+    let refetchDone: Promise<void> | undefined
+    act(() => {
+      refetchDone = result.current.refetch()
+    })
+    expect(result.current.hasError).toBe(true)
+
+    await act(async () => {
+      resolveReload(null)
+      await refetchDone
+    })
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it("resolves instead of rejecting when the refetched load fails again", async () => {
+    mockLoadCheckpoint.mockRejectedValue(new Error("corrupt"))
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    /** The gate's retry Promise.alls every refetch; a rejection there would double-report
+     *  a failure that already traveled through reportError and hasError. */
+    await act(async () => {
+      await expect(result.current.refetch()).resolves.toBeUndefined()
+    })
+    expect(result.current.hasError).toBe(true)
   })
 
   it("resolves true when the storage write succeeds", async () => {

--- a/__tests__/screens/account-migration/hooks/use-migration-support-email.spec.tsx
+++ b/__tests__/screens/account-migration/hooks/use-migration-support-email.spec.tsx
@@ -146,6 +146,35 @@ describe("useMigrationSupportEmail", () => {
     expect(Linking.openURL).toHaveBeenCalledWith(expectedMailto(expectedBody))
   })
 
+  /** The gate handover's reason is what tells support this is the locked-without-state
+   *  cohort (#4070) — only the code string in the ticket identifies it, so it has to land
+   *  verbatim in both the on-screen details and the email body. */
+  it("carries the gate handover's locked-without-checkpoint reason verbatim", async () => {
+    const { result } = renderHook(
+      () => useMigrationSupportEmail(MigrationSupportReason.LockedWithoutCheckpoint),
+      { wrapper },
+    )
+
+    expect(result.current.cardDetails[0]).toEqual({
+      label: LLSupport.reasonLabel(),
+      value: "locked-without-checkpoint",
+      isIdentifier: false,
+    })
+    expect(result.current.supportDetailsText).toContain(
+      `${LLSupport.reasonLabel()}: locked-without-checkpoint`,
+    )
+
+    await act(async () => {
+      result.current.sendSupportEmail()
+    })
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      expect.stringContaining(
+        encodeURIComponent(`${LLSupport.reasonLabel()}: locked-without-checkpoint`),
+      ),
+    )
+  })
+
   /** The reason no longer travels with the account diagnostics, so it has to survive a
    *  device that can supply none of them. */
   it("carries the reason even when every account detail is missing", () => {

--- a/__tests__/screens/account-migration/hooks/use-pending-migration-accounts.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-pending-migration-accounts.spec.ts
@@ -170,6 +170,90 @@ describe("usePendingMigrationAccounts", () => {
       "Pending migration accounts load",
       expect.any(Error),
     )
+    /** Surfaced, not swallowed: an unreadable record must stay distinguishable from
+     *  "no pending wallet", or the gate reads a transient failure as a wiped device. */
+    expect(result.current.hasError).toBe(true)
+  })
+
+  it("recovers through refetch after a failed load", async () => {
+    mockLoadPendingProvisionedAccounts.mockRejectedValueOnce(new Error("read failed"))
+    mockLoadPendingProvisionedAccounts.mockResolvedValue({
+      "custodial-1": "sc-pending-1",
+    })
+
+    const { result } = renderHook(() => usePendingMigrationAccounts())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.pendingForActiveAccount).toBe("sc-pending-1")
+  })
+
+  /** The error may only clear once the retry has SUCCEEDED: clearing it when the retry
+   *  starts would present the still-empty map as settled data for the length of the
+   *  read, and the gate would hand the user to support on it. */
+  it("keeps hasError raised while a refetch is still in flight", async () => {
+    mockLoadPendingProvisionedAccounts.mockRejectedValueOnce(new Error("read failed"))
+
+    const { result } = renderHook(() => usePendingMigrationAccounts())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    let resolveReload: (pending: Record<string, string>) => void = () => {}
+    mockLoadPendingProvisionedAccounts.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveReload = resolve
+        }),
+    )
+
+    let refetchDone: Promise<void> | undefined
+    act(() => {
+      refetchDone = result.current.refetch()
+    })
+    expect(result.current.hasError).toBe(true)
+
+    await act(async () => {
+      resolveReload({})
+      await refetchDone
+    })
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it("resolves instead of rejecting when the refetched load fails again", async () => {
+    mockLoadPendingProvisionedAccounts.mockRejectedValue(new Error("read failed"))
+
+    const { result } = renderHook(() => usePendingMigrationAccounts())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    /** The gate's retry Promise.alls every refetch; a rejection there would double-report
+     *  a failure that already traveled through reportError and hasError. */
+    await act(async () => {
+      await expect(result.current.refetch()).resolves.toBeUndefined()
+    })
+    expect(result.current.hasError).toBe(true)
+  })
+
+  /** The record itself was read fine in the self-heal case, so it counts as a success
+   *  and clears a raised error rather than leaving the gate stuck on retry. */
+  it("clears hasError when a refetch lands on the self-heal path", async () => {
+    mockLoadPendingProvisionedAccounts.mockRejectedValueOnce(new Error("read failed"))
+    mockLoadPendingProvisionedAccounts.mockResolvedValue({
+      "custodial-1": "sc-wallet-1",
+    })
+    mockActiveAccount = { id: "sc-wallet-1", type: "selfCustodial" }
+
+    const { result } = renderHook(() => usePendingMigrationAccounts())
+    await waitFor(() => expect(result.current.hasError).toBe(true))
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.hasError).toBe(false)
+    expect(result.current.pendingForActiveAccount).toBeNull()
   })
 
   it("reports when the self-heal cleanup write fails", async () => {

--- a/__tests__/screens/account-migration/hooks/use-reusable-pending-wallet.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-reusable-pending-wallet.spec.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { useReusablePendingWallet } from "@app/screens/account-migration/hooks/use-reusable-pending-wallet"
+
+let mockPendingForActiveAccount: string | null = null
+let mockPendingLoading = false
+let mockRegistryAccounts: { id: string }[] = []
+let mockRegistryLoading = false
+
+jest.mock("@app/screens/account-migration/hooks/use-pending-migration-accounts", () => ({
+  usePendingMigrationAccounts: () => ({
+    pendingForActiveAccount: mockPendingForActiveAccount,
+    loading: mockPendingLoading,
+  }),
+}))
+
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({
+    accounts: mockRegistryAccounts,
+    loading: mockRegistryLoading,
+  }),
+}))
+
+describe("useReusablePendingWallet", () => {
+  beforeEach(() => {
+    mockPendingForActiveAccount = null
+    mockPendingLoading = false
+    mockRegistryAccounts = []
+    mockRegistryLoading = false
+  })
+
+  it("returns the pending wallet when it still exists on the device", () => {
+    mockPendingForActiveAccount = "sc-account-1"
+    mockRegistryAccounts = [{ id: "custodial-1" }, { id: "sc-account-1" }]
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.reusablePendingAccountId).toBe("sc-account-1")
+  })
+
+  it("returns null when the pending record survives but its wallet is gone", () => {
+    mockPendingForActiveAccount = "sc-account-1"
+    mockRegistryAccounts = [{ id: "custodial-1" }]
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.reusablePendingAccountId).toBeNull()
+  })
+
+  it("returns null when no wallet is pending for the active account", () => {
+    mockRegistryAccounts = [{ id: "custodial-1" }, { id: "sc-account-1" }]
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.reusablePendingAccountId).toBeNull()
+  })
+
+  it("reports loading while the pending record is still being read", () => {
+    mockPendingLoading = true
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it("reports loading while the account registry is still being read", () => {
+    mockRegistryLoading = true
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it("settles to not loading once both sources have read", () => {
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/__tests__/screens/account-migration/hooks/use-reusable-pending-wallet.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-reusable-pending-wallet.spec.ts
@@ -4,13 +4,18 @@ import { useReusablePendingWallet } from "@app/screens/account-migration/hooks/u
 
 let mockPendingForActiveAccount: string | null = null
 let mockPendingLoading = false
+let mockPendingHasError = false
+const mockRefetchPending = jest.fn()
 let mockRegistryAccounts: { id: string }[] = []
 let mockRegistryLoading = false
+const mockReloadSelfCustodialAccounts = jest.fn()
 
 jest.mock("@app/screens/account-migration/hooks/use-pending-migration-accounts", () => ({
   usePendingMigrationAccounts: () => ({
     pendingForActiveAccount: mockPendingForActiveAccount,
     loading: mockPendingLoading,
+    hasError: mockPendingHasError,
+    refetch: mockRefetchPending,
   }),
 }))
 
@@ -18,15 +23,20 @@ jest.mock("@app/hooks/use-account-registry", () => ({
   useAccountRegistry: () => ({
     accounts: mockRegistryAccounts,
     loading: mockRegistryLoading,
+    reloadSelfCustodialAccounts: mockReloadSelfCustodialAccounts,
   }),
 }))
 
 describe("useReusablePendingWallet", () => {
   beforeEach(() => {
+    jest.clearAllMocks()
     mockPendingForActiveAccount = null
     mockPendingLoading = false
+    mockPendingHasError = false
     mockRegistryAccounts = []
     mockRegistryLoading = false
+    mockRefetchPending.mockResolvedValue(undefined)
+    mockReloadSelfCustodialAccounts.mockResolvedValue(undefined)
   })
 
   it("returns the pending wallet when it still exists on the device", () => {
@@ -75,5 +85,24 @@ describe("useReusablePendingWallet", () => {
     const { result } = renderHook(() => useReusablePendingWallet())
 
     expect(result.current.loading).toBe(false)
+  })
+
+  /** The gate must not read a failed record read as "no wallet to reuse" — that is the
+   *  wiped-device signature, and it ends at terminal support. */
+  it("surfaces the pending record's read error", () => {
+    mockPendingHasError = true
+
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    expect(result.current.hasError).toBe(true)
+  })
+
+  it("reloads both halves of the predicate on refetch", async () => {
+    const { result } = renderHook(() => useReusablePendingWallet())
+
+    await result.current.refetch()
+
+    expect(mockRefetchPending).toHaveBeenCalledTimes(1)
+    expect(mockReloadSelfCustodialAccounts).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -198,6 +198,19 @@ describe("MigrationContactSupportScreen", () => {
     expect(options?.headerLeft?.()).toBeNull()
   })
 
+  /** A null headerLeft is not enough on native-stack: without headerBackVisible false the
+   *  navigator falls back to its native back button, which popped this cohort onto the
+   *  gate's spent spinner (caught on-device while demoing #4070). */
+  it("suppresses the native back button so null headerLeft cannot fall back to it", async () => {
+    mockOrigin = MigrationSupportOrigin.Gate
+    renderScreen()
+    await flushEffects()
+
+    const options = mockSetOptions.mock.calls.at(-1)?.[0]
+
+    expect(options?.headerBackVisible).toBe(false)
+  })
+
   it("renders the hero, every diagnostics row and the contact action", async () => {
     renderScreen()
     await flushEffects()

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -211,6 +211,20 @@ describe("MigrationContactSupportScreen", () => {
     expect(options?.headerBackVisible).toBe(false)
   })
 
+  /** The gate handover's ticket is identified by its code alone (support greps for it),
+   *  so the screen has to show `locked-without-checkpoint` verbatim for the cohort a
+   *  screenshot is the only diagnostic from. */
+  it("shows the gate handover's reason code verbatim", async () => {
+    mockReason = MigrationSupportReason.LockedWithoutCheckpoint
+    mockOrigin = MigrationSupportOrigin.Gate
+    renderScreen()
+    await flushEffects()
+
+    expect(screen.getByText(LLSupport.reasonLabel())).toBeTruthy()
+    expect(screen.getByText("locked-without-checkpoint")).toBeTruthy()
+    expect(mockUseMigrationSupportEmail).toHaveBeenCalledWith("locked-without-checkpoint")
+  })
+
   it("renders the hero, every diagnostics row and the contact action", async () => {
     renderScreen()
     await flushEffects()

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -169,6 +169,35 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
 
+  /** From the gate handover (a lock with nothing to resume, #4070) there is nothing behind
+   *  this screen: the gate underneath would only replay the handover, and the commit path
+   *  would fabricate a commit screen for an account with no provisioned wallet. Support is
+   *  terminal, so the hardware back is swallowed without navigating anywhere. */
+  it("swallows the hardware back when opened from the gate handover", async () => {
+    mockOrigin = MigrationSupportOrigin.Gate
+    const { BackHandler } =
+      jest.requireActual<typeof import("react-native")>("react-native")
+    const addListenerSpy = jest.spyOn(BackHandler, "addEventListener")
+    renderScreen()
+    await flushEffects()
+
+    const handler = addListenerSpy.mock.calls[0][1] as () => boolean
+
+    expect(handler()).toBe(true)
+    expect(mockGoBack).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("hides the header back control when opened from the gate handover", async () => {
+    mockOrigin = MigrationSupportOrigin.Gate
+    renderScreen()
+    await flushEffects()
+
+    const options = mockSetOptions.mock.calls.at(-1)?.[0]
+
+    expect(options?.headerLeft?.()).toBeNull()
+  })
+
   it("renders the hero, every diagnostics row and the contact action", async () => {
     renderScreen()
     await flushEffects()

--- a/__tests__/screens/account-migration/to-non-custodial/migration-gate.integration.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-gate.integration.spec.tsx
@@ -1,0 +1,237 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react-native"
+
+import { MigrationGate } from "@app/screens/account-migration/to-non-custodial/migration-gate"
+
+import { walletOverviewQueryResult } from "../helpers"
+
+/**
+ * Integration seam the unit specs cannot reach: the gate spec mocks
+ * useReusablePendingWallet wholesale and the hook specs mock each other, so nothing
+ * exercises the gate's resume-or-handover decision against the REAL pending-account
+ * logic. Here only storage and the unrelated gate inputs are mocked; the pending
+ * record chain (usePendingMigrationAccounts → useReusablePendingWallet → gate) runs
+ * for real, including the self-heal that drops a record pointing at the active account.
+ */
+
+const mockNavigate = jest.fn()
+const mockNavigateToCheckpoint = jest.fn()
+const mockLoadPendingProvisionedAccounts = jest.fn()
+const mockClearPendingProvisionedAccount = jest.fn()
+const mockReportError = jest.fn()
+let mockActiveAccount: { id: string; type: string } | undefined
+let mockRegistryAccounts: { id: string }[] = []
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
+  useIsFocused: () => true,
+  /** The real pending-accounts hook loads through useFocusEffect; outside a navigation
+   *  container it must run as a plain effect. */
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const { useEffect } = jest.requireActual("react")
+    useEffect(() => callback(), [callback])
+  },
+}))
+
+jest.mock("@rn-vui/themed", () => ({
+  ...jest.requireActual("@rn-vui/themed"),
+  useTheme: () => ({ theme: { colors: { primary: "#fb5607", warning: "#f0a202" } } }),
+}))
+
+jest.mock("@app/components/screen", () => ({
+  Screen: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+/** The barrel spread keeps usePendingMigrationAccounts real; the checkpoint hook is
+ *  stubbed to "nothing resumable" so the decision rides on the pending chain alone. */
+jest.mock("@app/screens/account-migration/hooks", () => ({
+  ...jest.requireActual("@app/screens/account-migration/hooks"),
+  useActiveApiKeys: () => ({
+    hasActiveApiKeys: false,
+    loading: false,
+    isReady: true,
+    hasError: false,
+    refetch: jest.fn(),
+  }),
+  useMigrationCheckpoint: () => ({
+    navigateToCheckpoint: mockNavigateToCheckpoint,
+    loading: false,
+    hasError: false,
+    refetch: jest.fn().mockResolvedValue(undefined),
+    hasResumableCheckpoint: false,
+  }),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-migration-lock", () => ({
+  useMigrationLock: () => ({
+    isLocked: true,
+    loading: false,
+    hasError: false,
+    refetch: jest.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+jest.mock("@app/screens/account-migration/utils/migration-checkpoint-storage", () => ({
+  ...jest.requireActual(
+    "@app/screens/account-migration/utils/migration-checkpoint-storage",
+  ),
+  loadPendingProvisionedAccounts: (...args: readonly unknown[]) =>
+    mockLoadPendingProvisionedAccounts(...args),
+  clearPendingProvisionedAccount: (...args: readonly unknown[]) =>
+    mockClearPendingProvisionedAccount(...args),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-custodial-owner-id", () => ({
+  useCustodialOwnerId: () => ({ ownerId: "custodial-1", loading: false }),
+}))
+
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({
+    accounts: mockRegistryAccounts,
+    activeAccount: mockActiveAccount,
+    loading: false,
+    reloadSelfCustodialAccounts: jest.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+jest.mock("@app/hooks/use-app-config", () => ({
+  useAppConfig: () => ({
+    appConfig: { galoyInstance: { name: "Main" } },
+  }),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-custodial-wind-down", () => ({
+  useCustodialWindDown: () => null,
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-self-custodial-disabled", () => ({
+  useSelfCustodialDisabled: () => false,
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-migration-conversion", () => ({
+  armMigrationConversion: jest.fn(),
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useWalletOverviewScreenQuery: () => walletOverviewQueryResult({ usdBalance: 0 }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  ...jest.requireActual("@app/graphql/is-authed-context"),
+  useIsAuthed: () => true,
+}))
+
+jest.mock("@app/hooks/use-transfer-blocked", () => ({
+  useTransferBlocked: () => false,
+}))
+
+jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
+  useDollarBalanceRestricted: () => false,
+}))
+
+jest.mock("@app/components/dollar-balance-migration-modal", () => ({
+  DollarBalanceMigrationModal: () => null,
+}))
+
+jest.mock("@app/screens/account-migration/to-non-custodial/api-service-screen", () => ({
+  MigrationApiServiceScreen: () => null,
+}))
+
+jest.mock(
+  "@app/screens/account-migration/to-non-custodial/migration-required-screen",
+  () => ({
+    MigrationRequiredScreen: () => null,
+  }),
+)
+
+jest.mock("@app/screens/feature-unavailable/temporarily-unavailable-screen", () => ({
+  TemporarilyUnavailableScreen: () => null,
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      errors: { generic: () => "generic error" },
+      common: { tryAgain: () => "Try Again" },
+    },
+  }),
+}))
+
+jest.mock("@app/components/atomic/galoy-primary-button", () => ({
+  GaloyPrimaryButton: () => null,
+}))
+
+jest.mock("@app/components/atomic/galoy-icon", () => ({
+  GaloyIcon: () => null,
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  ...jest.requireActual("@app/utils/error-logging"),
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
+describe("MigrationGate pending-wallet integration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockActiveAccount = { id: "custodial-1", type: "custodial" }
+    mockRegistryAccounts = [{ id: "custodial-1" }]
+    mockLoadPendingProvisionedAccounts.mockResolvedValue({})
+    mockClearPendingProvisionedAccount.mockResolvedValue(undefined)
+  })
+
+  /** A crash without a reinstall keeps the record and its wallet: the real chain must
+   *  read the stored record, find the wallet in the registry, and resume — the same
+   *  predicate ensureAccount will apply when the restarted flow reuses that wallet. */
+  it("resumes when the stored pending record's wallet still exists on the device", async () => {
+    mockLoadPendingProvisionedAccounts.mockResolvedValue({
+      "custodial-1": "sc-account-1",
+    })
+    mockRegistryAccounts = [{ id: "custodial-1" }, { id: "sc-account-1" }]
+
+    render(<MigrationGate />)
+
+    await waitFor(() => expect(mockNavigateToCheckpoint).toHaveBeenCalledTimes(1))
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /** A record pointing at the ACTIVE account is a completed migration whose cleanup
+   *  write was lost: the real hook self-heals it away, so nothing is reusable and the
+   *  locked gate hands over — instead of "resuming" onto the account already in use. */
+  it("hands over after the self-heal drops a record pointing at the active account", async () => {
+    mockLoadPendingProvisionedAccounts.mockResolvedValue({
+      "custodial-1": "sc-wallet-1",
+    })
+    mockActiveAccount = { id: "sc-wallet-1", type: "selfCustodial" }
+    mockRegistryAccounts = [{ id: "custodial-1" }, { id: "sc-wallet-1" }]
+
+    render(<MigrationGate />)
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+        reason: "locked-without-checkpoint",
+        origin: "gate",
+      }),
+    )
+    expect(mockClearPendingProvisionedAccount).toHaveBeenCalledWith(
+      "migrationPendingAccounts_main",
+      "custodial-1",
+    )
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+  })
+
+  /** The wiped-device signature end to end: an empty store (fresh reinstall) with the
+   *  lock still set must end at support, never at another provisioned orphan. */
+  it("hands over when the store holds no pending record at all", async () => {
+    render(<MigrationGate />)
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+        reason: "locked-without-checkpoint",
+        origin: "gate",
+      }),
+    )
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/screens/account-migration/to-non-custodial/migration-gate.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-gate.spec.tsx
@@ -16,10 +16,14 @@ let mockLockLoading = false
 let mockLockError = false
 const mockRefetchLock = jest.fn()
 let mockCheckpointLoading = false
+let mockCheckpointError = false
+const mockRefetchCheckpoint = jest.fn()
 let mockHasResumableCheckpoint = true
 const mockNavigateToCheckpoint = jest.fn()
 let mockReusablePendingAccountId: string | null = null
 let mockPendingWalletLoading = false
+let mockPendingWalletError = false
+const mockRefetchPendingWallet = jest.fn()
 const mockUseTransferBlocked = jest.fn()
 const mockUseDollarBalanceRestricted = jest.fn()
 const mockUseWalletOverviewScreenQuery = jest.fn()
@@ -120,6 +124,8 @@ jest.mock("@app/screens/account-migration/hooks", () => ({
   useMigrationCheckpoint: () => ({
     navigateToCheckpoint: mockNavigateToCheckpoint,
     loading: mockCheckpointLoading,
+    hasError: mockCheckpointError,
+    refetch: mockRefetchCheckpoint,
     hasResumableCheckpoint: mockHasResumableCheckpoint,
   }),
 }))
@@ -128,6 +134,8 @@ jest.mock("@app/screens/account-migration/hooks/use-reusable-pending-wallet", ()
   useReusablePendingWallet: () => ({
     reusablePendingAccountId: mockReusablePendingAccountId,
     loading: mockPendingWalletLoading,
+    hasError: mockPendingWalletError,
+    refetch: mockRefetchPendingWallet,
   }),
 }))
 
@@ -235,9 +243,11 @@ describe("MigrationGate", () => {
     mockLockLoading = false
     mockLockError = false
     mockCheckpointLoading = false
+    mockCheckpointError = false
     mockHasResumableCheckpoint = true
     mockReusablePendingAccountId = null
     mockPendingWalletLoading = false
+    mockPendingWalletError = false
     mockUseActiveApiKeys.mockReturnValue(apiKeysState())
     mockUseTransferBlocked.mockReturnValue(false)
     mockUseDollarBalanceRestricted.mockReturnValue(false)
@@ -701,6 +711,85 @@ describe("MigrationGate", () => {
     rerender(<MigrationGate />)
 
     expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  /** A failed checkpoint read is indistinguishable from a wiped device by its data alone,
+   *  and reading it as one would hand a resumable user to terminal support; the gate
+   *  blocks with a retry instead, the same treatment its network reads get. */
+  it("shows a retry instead of handing over when the checkpoint read fails while locked", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+    mockCheckpointError = true
+
+    const { getByTestId } = render(<MigrationGate />)
+
+    expect(getByTestId("gate-retry-button")).toBeTruthy()
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it("shows a retry instead of handing over when the pending-wallet read fails while locked", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+    mockPendingWalletError = true
+
+    const { getByTestId } = render(<MigrationGate />)
+
+    expect(getByTestId("gate-retry-button")).toBeTruthy()
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+  })
+
+  /** The once-per-mount claim must not be spent while the reads are in error: a retry that
+   *  then succeeds still owes the user its resume-or-handover decision. */
+  it("still decides after a retry recovers from a failed checkpoint read", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+    mockCheckpointError = true
+
+    const { rerender } = render(<MigrationGate />)
+    expect(mockNavigate).not.toHaveBeenCalled()
+
+    mockCheckpointError = false
+    rerender(<MigrationGate />)
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+      reason: "locked-without-checkpoint",
+      origin: "gate",
+    })
+  })
+
+  it("refetches the local reads too when the retry button is pressed", async () => {
+    mockIsMigrationLocked = true
+    mockCheckpointError = true
+    mockUseActiveApiKeys.mockReturnValue(
+      apiKeysState({ refetch: jest.fn().mockResolvedValue(undefined) }),
+    )
+    mockUseWalletOverviewScreenQuery.mockReturnValue({
+      ...walletOverviewQueryResult({ usdBalance: 0 }),
+      refetch: jest.fn().mockResolvedValue(undefined),
+    })
+
+    const { getByTestId } = render(<MigrationGate />)
+    fireEvent.press(getByTestId("gate-retry-button"))
+    await act(async () => {})
+
+    expect(mockRefetchCheckpoint).toHaveBeenCalledTimes(1)
+    expect(mockRefetchPendingWallet).toHaveBeenCalledTimes(1)
+  })
+
+  /** The local reads only feed the locked resume-or-handover decision, so their failure
+   *  must not block an unlocked entry the way a failed lock or balance read does. */
+  it("ignores a failed checkpoint read when nothing is locked", () => {
+    mockCheckpointError = true
+    mockPendingWalletError = true
+
+    render(<MigrationGate />)
+
+    expect(mockRequiredScreen).toHaveBeenCalled()
+    expect(mockPrimaryButton).not.toHaveBeenCalled()
   })
 
   it("does not resume an account the server has not locked", () => {

--- a/__tests__/screens/account-migration/to-non-custodial/migration-gate.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-gate.spec.tsx
@@ -16,7 +16,10 @@ let mockLockLoading = false
 let mockLockError = false
 const mockRefetchLock = jest.fn()
 let mockCheckpointLoading = false
+let mockHasResumableCheckpoint = true
 const mockNavigateToCheckpoint = jest.fn()
+let mockReusablePendingAccountId: string | null = null
+let mockPendingWalletLoading = false
 const mockUseTransferBlocked = jest.fn()
 const mockUseDollarBalanceRestricted = jest.fn()
 const mockUseWalletOverviewScreenQuery = jest.fn()
@@ -117,6 +120,14 @@ jest.mock("@app/screens/account-migration/hooks", () => ({
   useMigrationCheckpoint: () => ({
     navigateToCheckpoint: mockNavigateToCheckpoint,
     loading: mockCheckpointLoading,
+    hasResumableCheckpoint: mockHasResumableCheckpoint,
+  }),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-reusable-pending-wallet", () => ({
+  useReusablePendingWallet: () => ({
+    reusablePendingAccountId: mockReusablePendingAccountId,
+    loading: mockPendingWalletLoading,
   }),
 }))
 
@@ -208,7 +219,10 @@ jest.mock("@app/components/atomic/galoy-icon", () => ({
 
 jest.mock("@app/utils/error-logging", () => ({
   ...jest.requireActual("@app/utils/error-logging"),
-  reportError: (operation: string, err: unknown) => mockReportError(operation, err),
+  reportError: (operation: string, err: unknown, options?: unknown) =>
+    options === undefined
+      ? mockReportError(operation, err)
+      : mockReportError(operation, err, options),
 }))
 
 describe("MigrationGate", () => {
@@ -221,6 +235,9 @@ describe("MigrationGate", () => {
     mockLockLoading = false
     mockLockError = false
     mockCheckpointLoading = false
+    mockHasResumableCheckpoint = true
+    mockReusablePendingAccountId = null
+    mockPendingWalletLoading = false
     mockUseActiveApiKeys.mockReturnValue(apiKeysState())
     mockUseTransferBlocked.mockReturnValue(false)
     mockUseDollarBalanceRestricted.mockReturnValue(false)
@@ -615,6 +632,75 @@ describe("MigrationGate", () => {
     expect(mockRequiredScreen).toHaveBeenCalledWith(
       expect.objectContaining({ mode: "forcedPreDeadline", isExitBlocked: true }),
     )
+  })
+
+  /** A locked account with nothing to resume and no wallet to reuse would restart at the
+   *  explainer and provision a fresh orphan every crash-reinstall cycle (#4070); only
+   *  support can release the server-side lock, so the gate hands over instead. */
+  it("hands a locked migration with nothing to resume over to support", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+
+    render(<MigrationGate />)
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+      reason: "locked-without-checkpoint",
+      origin: "gate",
+    })
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+    expect(mockRequiredScreen).not.toHaveBeenCalled()
+  })
+
+  it("records the lockout once when handing over to support", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+
+    render(<MigrationGate />)
+
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Error),
+      expect.objectContaining({
+        dedupKey: "migration-locked-without-checkpoint",
+        alwaysRecord: true,
+      }),
+    )
+  })
+
+  /** A crash or 48h checkpoint expiry without a reinstall keeps the pending record and its
+   *  wallet: the restart at the explainer reuses that wallet, so no handover is needed. */
+  it("restarts a locked migration normally when a provisioned wallet is still reusable", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+    mockReusablePendingAccountId = "sc-account-1"
+
+    render(<MigrationGate />)
+
+    expect(mockNavigateToCheckpoint).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("waits for the pending-wallet read before deciding between resume and handover", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+    mockPendingWalletLoading = true
+
+    render(<MigrationGate />)
+
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("hands over to support only once per mount", () => {
+    mockIsMigrationLocked = true
+    mockHasResumableCheckpoint = false
+
+    const { rerender } = render(<MigrationGate />)
+    rerender(<MigrationGate />)
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
   })
 
   it("does not resume an account the server has not locked", () => {

--- a/app/screens/account-migration/hooks/use-migration-account.ts
+++ b/app/screens/account-migration/hooks/use-migration-account.ts
@@ -8,6 +8,7 @@ import { reportError } from "@app/utils/error-logging"
 import { toastShow } from "@app/utils/toast"
 
 import { MigrationCheckpoint } from "../utils/migration-checkpoint-storage"
+import { resolveReusablePendingAccount } from "../utils/migration-pending-account"
 
 import { useMigrationCheckpointState } from "./use-migration-checkpoint-state"
 import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
@@ -35,11 +36,10 @@ export const useMigrationAccount = () => {
   /** A wallet provisioned by an earlier abandoned run survives without expiry: reuse it
    *  so a phrase the user may have written down stays valid and no zombies pile up. It
    *  must still exist on the device, otherwise a fresh wallet replaces it. */
-  const reusableAccountId =
-    pendingForActiveAccount &&
-    accounts.some((account) => account.id === pendingForActiveAccount)
-      ? pendingForActiveAccount
-      : null
+  const reusableAccountId = resolveReusablePendingAccount(
+    pendingForActiveAccount,
+    accounts,
+  )
 
   const ensureAccount = useCallback(async (): Promise<string | null> => {
     if (accountId) return accountId

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -26,6 +26,7 @@ export const useMigrationCheckpointState = () => {
   const { ownerId, loading: ownerLoading } = useCustodialOwnerId()
   const [stored, setStored] = useState<StoredCheckpoint | null>(null)
   const [loading, setLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
   const isFocusedRef = useRef(true)
 
   const {
@@ -36,25 +37,38 @@ export const useMigrationCheckpointState = () => {
 
   const storageKey = getStorageKey(environment)
 
+  /** The error only clears on a read that succeeds, never at the start of one: a retry
+   *  that cleared it up front would hand consumers the still-empty state as settled data
+   *  for the length of the read, and the gate would act on it (the handover this flag
+   *  exists to hold back). Resolves instead of rejecting; the failure already traveled
+   *  through reportError and hasError. */
+  const load = useCallback(
+    (): Promise<void> =>
+      loadCheckpoint(storageKey)
+        .then((storedCheckpoint) => {
+          if (!isFocusedRef.current) return
+          setStored(storedCheckpoint ?? null)
+          setHasError(false)
+          setLoading(false)
+        })
+        .catch((err) => {
+          reportError("Checkpoint load", err)
+          if (!isFocusedRef.current) return
+          setHasError(true)
+          setLoading(false)
+        }),
+    [storageKey],
+  )
+
   const reloadCheckpoint = useCallback(() => {
     isFocusedRef.current = true
 
-    loadCheckpoint(storageKey)
-      .then((storedCheckpoint) => {
-        if (!isFocusedRef.current) return
-        setStored(storedCheckpoint ?? null)
-        setLoading(false)
-      })
-      .catch((err) => {
-        reportError("Checkpoint load", err)
-        if (!isFocusedRef.current) return
-        setLoading(false)
-      })
+    load()
 
     return () => {
       isFocusedRef.current = false
     }
-  }, [storageKey])
+  }, [load])
 
   /** Reloads on every focus: the root blocker and the settings entry stay mounted below
    *  the flow while it advances, so a mount-only read would keep offering a restart
@@ -111,6 +125,13 @@ export const useMigrationCheckpointState = () => {
     checkpoint,
     accountId,
     loading: loading || ownerLoading,
+    /** A read failure surfaced, not swallowed: without it an unreadable store is
+     *  indistinguishable from a wiped device, and the gate would hand a resumable user
+     *  to support (terminal for that origin) on a transient storage error. */
+    hasError,
+    /** Imperative reload for retry screens. Leaves the focus flag alone on purpose: a
+     *  retry resolving after blur still drops its update, same as the focus reload. */
+    refetch: load,
     saveCheckpoint,
     clearCheckpoint,
     hasResumableCheckpoint,

--- a/app/screens/account-migration/hooks/use-pending-migration-accounts.ts
+++ b/app/screens/account-migration/hooks/use-pending-migration-accounts.ts
@@ -28,6 +28,7 @@ export const usePendingMigrationAccounts = () => {
   const { ownerId, loading: ownerLoading } = useCustodialOwnerId()
   const [pendingByOwner, setPendingByOwner] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
   const isMountedRef = useRef(true)
 
   const activeAccountId = activeAccount?.id ?? null
@@ -40,39 +41,52 @@ export const usePendingMigrationAccounts = () => {
 
   const storageKey = getPendingAccountsStorageKey(environment)
 
+  /** The error only clears on a read that succeeds (the self-heal counts: the record
+   *  itself was read fine), never at the start of one, so a retry never presents the
+   *  still-empty map as settled data while the read is in flight. Resolves instead of
+   *  rejecting; the failure already traveled through reportError and hasError. */
+  const load = useCallback(
+    (): Promise<void> =>
+      loadPendingProvisionedAccounts(storageKey)
+        .then((pending) => {
+          if (!isMountedRef.current) return
+
+          const activatedOwner = Object.keys(pending).find(
+            (owner) => pending[owner] === activeAccountId,
+          )
+          if (activatedOwner) {
+            const { [activatedOwner]: activated, ...rest } = pending
+            setPendingByOwner(rest)
+            setHasError(false)
+            setLoading(false)
+            clearPendingProvisionedAccount(storageKey, activatedOwner).catch((err) => {
+              reportError("Pending migration account self-heal", err)
+            })
+            return
+          }
+
+          setPendingByOwner(pending)
+          setHasError(false)
+          setLoading(false)
+        })
+        .catch((err) => {
+          reportError("Pending migration accounts load", err)
+          if (!isMountedRef.current) return
+          setHasError(true)
+          setLoading(false)
+        }),
+    [storageKey, activeAccountId],
+  )
+
   const reloadPendingAccounts = useCallback(() => {
     isMountedRef.current = true
 
-    loadPendingProvisionedAccounts(storageKey)
-      .then((pending) => {
-        if (!isMountedRef.current) return
-
-        const activatedOwner = Object.keys(pending).find(
-          (owner) => pending[owner] === activeAccountId,
-        )
-        if (activatedOwner) {
-          const { [activatedOwner]: activated, ...rest } = pending
-          setPendingByOwner(rest)
-          setLoading(false)
-          clearPendingProvisionedAccount(storageKey, activatedOwner).catch((err) => {
-            reportError("Pending migration account self-heal", err)
-          })
-          return
-        }
-
-        setPendingByOwner(pending)
-        setLoading(false)
-      })
-      .catch((err) => {
-        reportError("Pending migration accounts load", err)
-        if (!isMountedRef.current) return
-        setLoading(false)
-      })
+    load()
 
     return () => {
       isMountedRef.current = false
     }
-  }, [storageKey, activeAccountId])
+  }, [load])
 
   useFocusEffect(reloadPendingAccounts)
 
@@ -122,5 +136,11 @@ export const usePendingMigrationAccounts = () => {
     savePendingAccount,
     clearPendingAccount,
     loading: loading || ownerLoading,
+    /** A read failure surfaced, not swallowed: an unreadable record read as "no pending
+     *  wallet" would tell the gate this device was wiped when it wasn't. */
+    hasError,
+    /** Imperative reload for retry screens; leaves the mount flag alone so a retry
+     *  resolving after unmount still drops its update. */
+    refetch: load,
   }
 }

--- a/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
+++ b/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react"
+
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 
 import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
@@ -12,10 +14,20 @@ import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
 export const useReusablePendingWallet = (): {
   reusablePendingAccountId: string | null
   loading: boolean
+  hasError: boolean
+  refetch: () => Promise<unknown>
 } => {
-  const { pendingForActiveAccount, loading: pendingLoading } =
-    usePendingMigrationAccounts()
-  const { accounts, loading: registryLoading } = useAccountRegistry()
+  const {
+    pendingForActiveAccount,
+    loading: pendingLoading,
+    hasError,
+    refetch: refetchPending,
+  } = usePendingMigrationAccounts()
+  const {
+    accounts,
+    loading: registryLoading,
+    reloadSelfCustodialAccounts,
+  } = useAccountRegistry()
 
   const reusablePendingAccountId =
     pendingForActiveAccount &&
@@ -23,5 +35,17 @@ export const useReusablePendingWallet = (): {
       ? pendingForActiveAccount
       : null
 
-  return { reusablePendingAccountId, loading: pendingLoading || registryLoading }
+  /** Both halves of the predicate reload together; the registry read never errors
+   *  (a failed read keeps its prior entries), so hasError is the pending record's alone. */
+  const refetch = useCallback(
+    () => Promise.all([refetchPending(), reloadSelfCustodialAccounts()]),
+    [refetchPending, reloadSelfCustodialAccounts],
+  )
+
+  return {
+    reusablePendingAccountId,
+    loading: pendingLoading || registryLoading,
+    hasError,
+    refetch,
+  }
 }

--- a/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
+++ b/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
@@ -1,0 +1,27 @@
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
+
+import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
+
+/**
+ * Whether a wallet provisioned by an earlier abandoned migration run is still usable on
+ * this device — the same predicate ensureAccount applies before reusing instead of
+ * provisioning (see use-migration-account). The gate reads it to tell a resumable restart
+ * (record and wallet both survived) from a wiped device (e.g. a reinstall), where a
+ * restart could only provision another orphan (#4070).
+ */
+export const useReusablePendingWallet = (): {
+  reusablePendingAccountId: string | null
+  loading: boolean
+} => {
+  const { pendingForActiveAccount, loading: pendingLoading } =
+    usePendingMigrationAccounts()
+  const { accounts, loading: registryLoading } = useAccountRegistry()
+
+  const reusablePendingAccountId =
+    pendingForActiveAccount &&
+    accounts.some((account) => account.id === pendingForActiveAccount)
+      ? pendingForActiveAccount
+      : null
+
+  return { reusablePendingAccountId, loading: pendingLoading || registryLoading }
+}

--- a/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
+++ b/app/screens/account-migration/hooks/use-reusable-pending-wallet.ts
@@ -2,14 +2,16 @@ import { useCallback } from "react"
 
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 
+import { resolveReusablePendingAccount } from "../utils/migration-pending-account"
+
 import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
 
 /**
  * Whether a wallet provisioned by an earlier abandoned migration run is still usable on
- * this device — the same predicate ensureAccount applies before reusing instead of
- * provisioning (see use-migration-account). The gate reads it to tell a resumable restart
- * (record and wallet both survived) from a wiped device (e.g. a reinstall), where a
- * restart could only provision another orphan (#4070).
+ * this device — the shared reuse rule (see migration-pending-account) ensureAccount also
+ * applies before reusing instead of provisioning. The gate reads it to tell a resumable
+ * restart (record and wallet both survived) from a wiped device (e.g. a reinstall),
+ * where a restart could only provision another orphan (#4070).
  */
 export const useReusablePendingWallet = (): {
   reusablePendingAccountId: string | null
@@ -29,11 +31,10 @@ export const useReusablePendingWallet = (): {
     reloadSelfCustodialAccounts,
   } = useAccountRegistry()
 
-  const reusablePendingAccountId =
-    pendingForActiveAccount &&
-    accounts.some((account) => account.id === pendingForActiveAccount)
-      ? pendingForActiveAccount
-      : null
+  const reusablePendingAccountId = resolveReusablePendingAccount(
+    pendingForActiveAccount,
+    accounts,
+  )
 
   /** Both halves of the predicate reload together; the registry read never errors
    *  (a failed read keeps its prior entries), so hasError is the pending record's alone. */

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -81,6 +81,7 @@ export const MigrationContactSupportScreen: React.FC = () => {
    *  transfer-time failure would land on the swallowing transfer screen. */
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerBackVisible: false,
       headerLeft: () =>
         isGateOrigin ? null : (
           <HeaderBackButton

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -58,16 +58,22 @@ export const MigrationContactSupportScreen: React.FC = () => {
    * blind goBack would land on. The resume handover is pushed from the root navigator with
    * no migration screens beneath it, so Back dismisses instead of fabricating a fresh commit
    * screen over an already-completed migration, which would re-arm the lock and re-hand the
-   * user to support with the wrong reason. A restore with no origin keeps the commit path.
+   * user to support with the wrong reason. The gate handover (a lock with nothing to
+   * resume, #4070) has nothing behind it either way: the gate underneath would only replay
+   * the handover, and the commit path would fabricate a commit screen for an account with
+   * no provisioned wallet, so support is terminal and Back goes nowhere. A restore with no
+   * origin keeps the commit path.
    */
   const isResumeOrigin = params?.origin === MigrationSupportOrigin.Resume
+  const isGateOrigin = params?.origin === MigrationSupportOrigin.Gate
   const handleBack = useCallback(() => {
+    if (isGateOrigin) return
     if (isResumeOrigin) {
       navigation.goBack()
       return
     }
     navigation.navigate("accountMigrationBalancesOverview")
-  }, [isResumeOrigin, navigation])
+  }, [isGateOrigin, isResumeOrigin, navigation])
   useHardwareBackGuard(handleBack)
 
   /** The back control lives in the navigator header, but its target is set from here so it
@@ -75,17 +81,18 @@ export const MigrationContactSupportScreen: React.FC = () => {
    *  transfer-time failure would land on the swallowing transfer screen. */
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerLeft: () => (
-        <HeaderBackButton
-          tintColor={colors.black}
-          pressColor={colors.grey5}
-          pressOpacity={1}
-          onPress={handleBack}
-          {...testProps("migration-contact-support-back")}
-        />
-      ),
+      headerLeft: () =>
+        isGateOrigin ? null : (
+          <HeaderBackButton
+            tintColor={colors.black}
+            pressColor={colors.grey5}
+            pressOpacity={1}
+            onPress={handleBack}
+            {...testProps("migration-contact-support-back")}
+          />
+        ),
     })
-  }, [navigation, handleBack, colors.black, colors.grey5])
+  }, [navigation, handleBack, isGateOrigin, colors.black, colors.grey5])
 
   const { supportEmailAddress } = useContactSupport()
   const { copyToClipboard } = useClipboard()

--- a/app/screens/account-migration/to-non-custodial/migration-gate.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-gate.tsx
@@ -12,6 +12,7 @@ import { Screen } from "@app/components/screen"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { TemporarilyUnavailableScreen } from "@app/screens/feature-unavailable/temporarily-unavailable-screen"
+import { MigrationSupportOrigin, MigrationSupportReason } from "@app/types/migration"
 import { WindDownStatus } from "@app/types/wind-down"
 import { reportError } from "@app/utils/error-logging"
 import { testProps } from "@app/utils/testProps"
@@ -24,6 +25,7 @@ import {
 import { useCustodialWindDown } from "@app/screens/account-migration/hooks/use-custodial-wind-down"
 import { useMigrationLock } from "@app/screens/account-migration/hooks/use-migration-lock"
 import { armMigrationConversion } from "@app/screens/account-migration/hooks/use-migration-conversion"
+import { useReusablePendingWallet } from "@app/screens/account-migration/hooks/use-reusable-pending-wallet"
 import { useSelfCustodialDisabled } from "@app/screens/account-migration/hooks/use-self-custodial-disabled"
 
 import { MigrationApiServiceScreen } from "./api-service-screen"
@@ -89,7 +91,13 @@ export const MigrationGate: React.FC = () => {
     hasError: balancesError,
     refetch: refetchBalances,
   } = useCustodialWalletBalances()
-  const { navigateToCheckpoint, loading: checkpointLoading } = useMigrationCheckpoint()
+  const {
+    navigateToCheckpoint,
+    loading: checkpointLoading,
+    hasResumableCheckpoint,
+  } = useMigrationCheckpoint()
+  const { reusablePendingAccountId, loading: pendingWalletLoading } =
+    useReusablePendingWallet()
 
   const acknowledgeApiWarning = useCallback(() => setIsApiWarningAcknowledged(true), [])
 
@@ -173,13 +181,44 @@ export const MigrationGate: React.FC = () => {
   const hasResumedRef = useRef(false)
 
   useEffect(() => {
-    if (!shouldResumeLockedMigration || checkpointLoading || hasResumedRef.current) return
+    if (
+      !shouldResumeLockedMigration ||
+      checkpointLoading ||
+      pendingWalletLoading ||
+      hasResumedRef.current
+    )
+      return
 
     /** Claimed once per mount: the checkpoint moves as the user advances, and a second
      *  run would yank them back from wherever they got to. */
     hasResumedRef.current = true
+
+    /** A locked account with nothing to resume and no wallet to reuse would restart at the
+     *  explainer and provision a fresh orphan every crash-reinstall cycle (#4070). No
+     *  client mutation can release the server-side lock, so support is the only way
+     *  forward; each cold start replays this handover until the lock is cleared. */
+    if (!hasResumableCheckpoint && !reusablePendingAccountId) {
+      reportError(
+        "Migration locked without resumable checkpoint",
+        new Error("Server lock present but no checkpoint or pending wallet on device"),
+        { dedupKey: "migration-locked-without-checkpoint", alwaysRecord: true },
+      )
+      navigation.navigate("accountMigrationContactSupport", {
+        reason: MigrationSupportReason.LockedWithoutCheckpoint,
+        origin: MigrationSupportOrigin.Gate,
+      })
+      return
+    }
     navigateToCheckpoint()
-  }, [shouldResumeLockedMigration, checkpointLoading, navigateToCheckpoint])
+  }, [
+    shouldResumeLockedMigration,
+    checkpointLoading,
+    pendingWalletLoading,
+    hasResumableCheckpoint,
+    reusablePendingAccountId,
+    navigateToCheckpoint,
+    navigation,
+  ])
 
   /** The emergency-disable net. Every entry funnels through the gate, so blocking here
    *  pauses the whole flow the moment ops disables the stack, whatever path the user

--- a/app/screens/account-migration/to-non-custodial/migration-gate.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-gate.tsx
@@ -94,10 +94,16 @@ export const MigrationGate: React.FC = () => {
   const {
     navigateToCheckpoint,
     loading: checkpointLoading,
+    hasError: checkpointError,
+    refetch: refetchCheckpoint,
     hasResumableCheckpoint,
   } = useMigrationCheckpoint()
-  const { reusablePendingAccountId, loading: pendingWalletLoading } =
-    useReusablePendingWallet()
+  const {
+    reusablePendingAccountId,
+    loading: pendingWalletLoading,
+    hasError: pendingWalletError,
+    refetch: refetchPendingWallet,
+  } = useReusablePendingWallet()
 
   const acknowledgeApiWarning = useCallback(() => setIsApiWarningAcknowledged(true), [])
 
@@ -119,13 +125,25 @@ export const MigrationGate: React.FC = () => {
   const retryGateData = useCallback(async () => {
     setIsRetrying(true)
     try {
-      await Promise.all([refetchApiKeys(), refetchBalances(), refetchLock()])
+      await Promise.all([
+        refetchApiKeys(),
+        refetchBalances(),
+        refetchLock(),
+        refetchCheckpoint(),
+        refetchPendingWallet(),
+      ])
     } catch (err) {
       reportError("Migration gate retry", err)
     } finally {
       setIsRetrying(false)
     }
-  }, [refetchApiKeys, refetchBalances, refetchLock])
+  }, [
+    refetchApiKeys,
+    refetchBalances,
+    refetchLock,
+    refetchCheckpoint,
+    refetchPendingWallet,
+  ])
 
   /** Returning from the dollar-transfer conversion, refetch so the balance reflects the
    *  now-empty dollars instead of the cached pre-transfer figure. */
@@ -147,8 +165,15 @@ export const MigrationGate: React.FC = () => {
 
   /** A failed query read as its empty default would wave a user with API keys or a live
    *  dollar balance straight in, or re-pitch the intro to a user a failed lock read makes
-   *  look unlocked, so a settled error blocks with a retry instead. */
-  const hasGateDataError = apiKeysError || balancesError || lockError
+   *  look unlocked, so a settled error blocks with a retry instead. The local reads join
+   *  only when locked — that is the only decision they feed, and an unreadable store there
+   *  would impersonate a wiped device and hand a resumable user to terminal support. */
+  const hasResumeDataError = checkpointError || pendingWalletError
+  const hasGateDataError =
+    apiKeysError ||
+    balancesError ||
+    lockError ||
+    (isMigrationLocked && hasResumeDataError)
 
   /** The API-key warning outranks the Dollar-Balance precondition in the entry order
    *  (entry, API-key check, Dollar Balance check, intro). */
@@ -181,10 +206,15 @@ export const MigrationGate: React.FC = () => {
   const hasResumedRef = useRef(false)
 
   useEffect(() => {
+    /** The error guard runs here, not only in render: the retry screen committing does
+     *  not stop this effect, and a read failure read as "nothing on device" would claim
+     *  the once-per-mount ref and navigate a resumable user to terminal support over it.
+     *  Unclaimed, a retry that succeeds re-runs this with real data. */
     if (
       !shouldResumeLockedMigration ||
       checkpointLoading ||
       pendingWalletLoading ||
+      hasResumeDataError ||
       hasResumedRef.current
     )
       return
@@ -214,6 +244,7 @@ export const MigrationGate: React.FC = () => {
     shouldResumeLockedMigration,
     checkpointLoading,
     pendingWalletLoading,
+    hasResumeDataError,
     hasResumableCheckpoint,
     reusablePendingAccountId,
     navigateToCheckpoint,

--- a/app/screens/account-migration/utils/migration-pending-account.ts
+++ b/app/screens/account-migration/utils/migration-pending-account.ts
@@ -1,0 +1,17 @@
+import { AccountDescriptor } from "@app/types/wallet"
+
+/**
+ * THE reuse rule for a wallet provisioned by an earlier abandoned migration run: the
+ * pending record must name a wallet that still exists on this device, otherwise nothing
+ * is reusable. ensureAccount applies it before provisioning (reuse over zombie) and the
+ * gate applies it to predict that choice (resume over handover, #4070) — one shared
+ * predicate, so the prediction can never drift from what the restart actually does.
+ */
+export const resolveReusablePendingAccount = (
+  pendingForActiveAccount: string | null,
+  accounts: readonly Pick<AccountDescriptor, "id">[],
+): string | null =>
+  pendingForActiveAccount &&
+  accounts.some((account) => account.id === pendingForActiveAccount)
+    ? pendingForActiveAccount
+    : null

--- a/app/types/migration.ts
+++ b/app/types/migration.ts
@@ -28,6 +28,10 @@ export const MigrationSupportReason = {
    *  longer on this device (its key is gone, e.g. after a reinstall), so the resume swap
    *  cannot run and no retry brings it back. */
   SelfCustodialAccountNotOnDevice: "self-custodial-account-not-on-device",
+  /** The server has this account locked mid-migration, but the device holds neither a
+   *  resumable checkpoint nor a reusable pending wallet (e.g. after a reinstall), so a
+   *  restart would only provision another orphan; support is the only way forward. */
+  LockedWithoutCheckpoint: "locked-without-checkpoint",
   /** The transfer itself failed or threw. */
   TransferFailed: "transfer-failed",
   /** The lightning-address re-point onto the migrated account failed. */
@@ -45,11 +49,14 @@ export type MigrationSupportReason =
  * has the commit point (Step 8) underneath, so Back returns there, skipping the
  * back-swallowing transfer screen. The resume handover is pushed from the root navigator
  * with no migration screens beneath it, so Back dismisses to where it came from rather than
- * fabricating a fresh commit screen over an already-completed migration.
+ * fabricating a fresh commit screen over an already-completed migration. The gate handover
+ * has nothing behind it at all — the gate underneath would only replay the handover — so
+ * support becomes the terminal screen with no Back.
  */
 export const MigrationSupportOrigin = {
   Commit: "commit",
   Resume: "resume",
+  Gate: "gate",
 } as const
 
 export type MigrationSupportOrigin =

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3259,7 +3259,7 @@ SPEC CHECKSUMS:
   GT3Captcha-iOS: aeb6fed2e8594099821430a89208679e5a55b740
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  hermes-engine: bbd6961e9f635999892e6d1e935fa272c050fec1
+  hermes-engine: 6653d25f5f43feaf527c53772e34e1e95b846caf
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroModules: 4b3ee576b2ee9967dfcdd4fe755832a0ab837556
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -3353,7 +3353,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 01edc8d202005315c06ca3826d1eaad2c619cae7
   ReactCommon: ced9cfa50957cb9e6b7a1a7cd4ee20f5da6fa3a4
   ReactNativeCameraKit: 1a06006322ddc7966a419df6217331e50236375d
-  ReactNativeDependencies: 1735688f7e6db23afb8058697a5e961b477886f3
+  ReactNativeDependencies: 4d94ba042d8f6b79854c9cb9e7fd62e6177e29b5
   RNBootSplash: 5e5bb0963e855048a8c51396756d4c772006b6e1
   RNCAsyncStorage: a455ed0edb854f0c8471b3049935680d5868796a
   RNCClipboard: ee9d1bdca545c481f20cd976b738da771c2ec63d
@@ -3371,7 +3371,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNKeychain: 1fdd8401d8c8d05da80a9e1843d837ccfb947ea2
   RNLocalize: 1d140ef314f96c5bb8ad47e13aaa6b34e27b8b35
-  RNPermissions: 4a06981d318437808d96bdb257b35a33dd1a8a7b
+  RNPermissions: ce2315bade79599eb39a12493293b76bbe31a4a6
   RNQrGenerator: b467624cdcb0e88108a8b4ca74c94b0978efa265
   RNReactNativeHapticFeedback: 71068ee2dd8b54feae784437353342c57c1cffa9
   RNReanimated: 669dcac7a77261e2c491333be34dd2eb9a5206c3

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3259,7 +3259,7 @@ SPEC CHECKSUMS:
   GT3Captcha-iOS: aeb6fed2e8594099821430a89208679e5a55b740
   GTMAppAuth: 217a876b249c3c585a54fd6f73e6b58c4f5c4238
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  hermes-engine: 6653d25f5f43feaf527c53772e34e1e95b846caf
+  hermes-engine: bbd6961e9f635999892e6d1e935fa272c050fec1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   NitroModules: 4b3ee576b2ee9967dfcdd4fe755832a0ab837556
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -3353,7 +3353,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 01edc8d202005315c06ca3826d1eaad2c619cae7
   ReactCommon: ced9cfa50957cb9e6b7a1a7cd4ee20f5da6fa3a4
   ReactNativeCameraKit: 1a06006322ddc7966a419df6217331e50236375d
-  ReactNativeDependencies: 4d94ba042d8f6b79854c9cb9e7fd62e6177e29b5
+  ReactNativeDependencies: 1735688f7e6db23afb8058697a5e961b477886f3
   RNBootSplash: 5e5bb0963e855048a8c51396756d4c772006b6e1
   RNCAsyncStorage: a455ed0edb854f0c8471b3049935680d5868796a
   RNCClipboard: ee9d1bdca545c481f20cd976b738da771c2ec63d
@@ -3371,7 +3371,7 @@ SPEC CHECKSUMS:
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNKeychain: 1fdd8401d8c8d05da80a9e1843d837ccfb947ea2
   RNLocalize: 1d140ef314f96c5bb8ad47e13aaa6b34e27b8b35
-  RNPermissions: ce2315bade79599eb39a12493293b76bbe31a4a6
+  RNPermissions: 4a06981d318437808d96bdb257b35a33dd1a8a7b
   RNQrGenerator: b467624cdcb0e88108a8b4ca74c94b0978efa265
   RNReactNativeHapticFeedback: 71068ee2dd8b54feae784437353342c57c1cffa9
   RNReanimated: 669dcac7a77261e2c491333be34dd2eb9a5206c3


### PR DESCRIPTION
Closes #4070 — this is the lockout fix. The crash hardening on the phrase screens ships separately in #4088.

> Note for support/ops: merging this closes the issue, but the affected user still needs the server-side `migrationStatus` reset — see the comment on the issue.

## The problem

When a user starts the custodial → self-custodial migration, the server marks the account as mid-migration (`migrationStatus`) and the app locks itself into the migration flow until the transfer completes. The record of *where* the user got to, however, lives only on the device (the AsyncStorage checkpoint and the `migrationPendingAccounts` record).

If the app dies mid-flow and the user **reinstalls**, the local records are wiped while the server lock survives (Android Auto Backup is disabled, so nothing on-device outlives an uninstall). On the next login the gate sees "locked, nothing to resume" and restarts the flow from the explainer — **provisioning a brand-new wallet and recovery phrase on every cycle**, orphaning the previous one each time. The user in #4070 crashed at phrase entry, reinstalled, and went around this loop with no way out: the client has no mutation that can release the lock (the migration API surface is `migrationStart` / `migrationLnAddressTransfer` / `migrationCommit` only).

## The fix

Before resuming a locked migration, the gate now distinguishes two cases:

- **A wallet from an earlier run is still on the device** (pending record + wallet both present): restart exactly as before — `ensureAccount` reuses that wallet, so a crash or a 48 h checkpoint expiry *without* a reinstall behaves the way it does today. No orphans, no support ticket.
- **Nothing to resume and no wallet to reuse** (the reinstall signature): navigate once to the existing contact-support screen with a new greppable reason code `locked-without-checkpoint`, and record a non-fatal (dedup key `migration-locked-without-checkpoint`, `alwaysRecord`) so the cohort is visible in Crashlytics.

For this origin the support screen is **terminal** — header back hidden, hardware back swallowed (swipe-back was already off for the route). There is genuinely nothing behind it: `goBack()` would land on the gate's spent spinner, and the commit-path fallback would fabricate a commit screen for an account with no provisioned wallet. Every cold start replays the handover until the lock is released server-side, so the user cannot fall back into the loop.

## What this deliberately does not do

- **It cannot release the lock.** A backend cancel/rollback mutation would make this self-serve; until then support resets `migrationStatus` (safe for this cohort — the custodial balance never moved).
- The affected user from the report still needs that support-side reset.
- Support tooling should learn the new reason code `locked-without-checkpoint` (it appears verbatim in the ticket email, like the existing reason codes).

## Changes

- `app/screens/account-migration/hooks/use-reusable-pending-wallet.ts` (new): "is the pending wallet still on this device" — the same predicate `use-migration-account` already applies before reusing instead of provisioning, extracted so the gate can read it.
- `app/screens/account-migration/to-non-custodial/migration-gate.tsx`: the resume effect decides handover vs restart, and waits for the pending-wallet read the same way it already waited for the checkpoint.
- `app/screens/account-migration/to-non-custodial/contact-support-screen.tsx`: terminal back handling for the new `gate` origin; `resume` and commit origins unchanged.
- `app/types/migration.ts`: `MigrationSupportReason.LockedWithoutCheckpoint`, `MigrationSupportOrigin.Gate`.

No i18n changes: reason codes are deliberately untranslated (greppable in tickets), and the existing support-screen copy fits this cohort. The screen already tolerates the missing local wallet — the pubkey row just drops out, and the account id comes from the intact custodial session.

## Testing

All test-first (each watched fail before the fix):

- Gate: hands over only for locked + no checkpoint + no reusable wallet; still resumes when a reusable wallet exists; waits for the pending-wallet read; navigates once per mount; records the non-fatal exactly once with the dedup key.
- Support screen: `gate` origin swallows hardware back and renders no header back; `resume`/commit behavior unchanged.
- New hook: reuse matrix (record+wallet / record only / neither) and loading composition.

Full suite green on this branch (6,446 tests), `tsc`, ESLint and `check:translations` clean.
