### PR TITLE
fix(android): drop multitouch events hitting AOSP ScrollView pointerIndex crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,8 @@ jobs:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - run: yarn install --frozen-lockfile
-      - run: cd android && ./gradlew :app:testDebugUnitTest
+      # Caches ~/.gradle/caches and the wrapper between runs.
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :app:testDebugUnitTest
+        working-directory: android
         timeout-minutes: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,21 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=4096
         timeout-minutes: 20
+  android-unit-test:
+    name: Android unit tests
+    # GH-hosted: ships the Android SDK and JDK toolchains the Gradle build
+    # auto-detects, unlike the self-hosted small runners.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .nvmrc
+      # Gradle needs node_modules for the RN gradle plugins and autolinking.
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+      - run: cd android && ./gradlew :app:testDebugUnitTest
+        timeout-minutes: 30

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -170,6 +170,11 @@ dependencies {
     androidTestImplementation('com.wix:detox:+')
     implementation 'androidx.appcompat:appcompat:1.1.0'
 
+    // Keep the BoM in sync with @react-native-firebase/app's pinned version
+    // (node_modules/@react-native-firebase/app/package.json -> sdkVersions.android.firebase)
+    implementation platform('com.google.firebase:firebase-bom:34.2.0')
+    implementation 'com.google.firebase:firebase-crashlytics'
+
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.test:core:1.6.0")
     testImplementation("org.robolectric:robolectric:4.16")

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -170,9 +170,14 @@ dependencies {
     androidTestImplementation('com.wix:detox:+')
     implementation 'androidx.appcompat:appcompat:1.1.0'
 
-    // Keep the BoM in sync with @react-native-firebase/app's pinned version
-    // (node_modules/@react-native-firebase/app/package.json -> sdkVersions.android.firebase)
-    implementation platform('com.google.firebase:firebase-bom:34.2.0')
+    // BoM version read from the same source @react-native-firebase's own gradle
+    // scripts resolve it from, so an RNFB upgrade moves both in lockstep. The
+    // explicit crashlytics artifact is needed because RNFB declares its Firebase
+    // deps as `implementation`, keeping them off the app's compile classpath.
+    def rnfbSdkVersions = new groovy.json.JsonSlurper().parseText(
+        file("$rootDir/../node_modules/@react-native-firebase/app/package.json").text
+    ).sdkVersions
+    implementation platform("com.google.firebase:firebase-bom:${rnfbSdkVersions.android.firebase}")
     implementation 'com.google.firebase:firebase-crashlytics'
 
     testImplementation("junit:junit:4.13.2")

--- a/android/app/src/main/java/com/galoyapp/MainActivity.kt
+++ b/android/app/src/main/java/com/galoyapp/MainActivity.kt
@@ -6,6 +6,8 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnable
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 import android.os.Bundle
+import android.view.MotionEvent
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.zoontek.rnbootsplash.RNBootSplash
 
 class MainActivity : ReactActivity() {
@@ -26,4 +28,11 @@ class MainActivity : ReactActivity() {
     RNBootSplash.init(this, R.style.BootTheme) // ⬅️ initialize the splash screen
     super.onCreate(null)
   }
+
+  override fun dispatchTouchEvent(ev: MotionEvent): Boolean =
+      SafeTouchDispatch.dispatch(
+          onFrameworkBug = { FirebaseCrashlytics.getInstance().recordException(it) },
+      ) {
+        super.dispatchTouchEvent(ev)
+      }
 }

--- a/android/app/src/main/java/com/galoyapp/MainActivity.kt
+++ b/android/app/src/main/java/com/galoyapp/MainActivity.kt
@@ -29,8 +29,10 @@ class MainActivity : ReactActivity() {
     super.onCreate(null)
   }
 
+  private val safeTouchDispatch = SafeTouchDispatch()
+
   override fun dispatchTouchEvent(ev: MotionEvent): Boolean =
-      SafeTouchDispatch.dispatch(
+      safeTouchDispatch.dispatch(
           onFrameworkBug = { FirebaseCrashlytics.getInstance().recordException(it) },
       ) {
         super.dispatchTouchEvent(ev)

--- a/android/app/src/main/java/com/galoyapp/SafeTouchDispatch.kt
+++ b/android/app/src/main/java/com/galoyapp/SafeTouchDispatch.kt
@@ -1,12 +1,22 @@
 package com.galoyapp
 
-object SafeTouchDispatch {
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SafeTouchDispatch {
+  private val reported = AtomicBoolean(false)
+
   /**
    * Guards against a long-standing AOSP bug: ScrollView.onTouchEvent throws
-   * IllegalArgumentException ("invalid pointerIndex -1") when a multitouch
+   * IllegalArgumentException from MotionEvent.getY ("invalid pointerIndex -1",
+   * or "pointerIndex out of range" on some releases) when a multitouch
    * POINTER_UP arrives for a gesture it didn't fully observe (e.g. after
    * react-native-gesture-handler intercepted part of the stream).
    * By then the gesture is already inconsistent, so dropping the event is safe.
+   *
+   * Only IllegalArgumentExceptions whose message names a pointerIndex are
+   * swallowed — any other exception is a real bug and propagates. The
+   * framework bug is reported at most once per process: every occurrence has
+   * the identical stack, so repeats add no signal and would flood Crashlytics.
    */
   fun dispatch(
     onFrameworkBug: (IllegalArgumentException) -> Unit,
@@ -15,7 +25,8 @@ object SafeTouchDispatch {
     try {
       superDispatch()
     } catch (e: IllegalArgumentException) {
-      onFrameworkBug(e)
+      if (e.message?.contains("pointerIndex") != true) throw e
+      if (reported.compareAndSet(false, true)) onFrameworkBug(e)
       false
     }
 }

--- a/android/app/src/main/java/com/galoyapp/SafeTouchDispatch.kt
+++ b/android/app/src/main/java/com/galoyapp/SafeTouchDispatch.kt
@@ -1,0 +1,21 @@
+package com.galoyapp
+
+object SafeTouchDispatch {
+  /**
+   * Guards against a long-standing AOSP bug: ScrollView.onTouchEvent throws
+   * IllegalArgumentException ("invalid pointerIndex -1") when a multitouch
+   * POINTER_UP arrives for a gesture it didn't fully observe (e.g. after
+   * react-native-gesture-handler intercepted part of the stream).
+   * By then the gesture is already inconsistent, so dropping the event is safe.
+   */
+  fun dispatch(
+    onFrameworkBug: (IllegalArgumentException) -> Unit,
+    superDispatch: () -> Boolean,
+  ): Boolean =
+    try {
+      superDispatch()
+    } catch (e: IllegalArgumentException) {
+      onFrameworkBug(e)
+      false
+    }
+}

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -29,7 +29,10 @@ import com.galoyapp.R
 
 @RunWith(RobolectricTestRunner::class)
 @Config(
-    application = TestApplication::class
+    application = TestApplication::class,
+    // Robolectric needs Java 21 to emulate SDK 36 (the default from targetSdk),
+    // but the RN Gradle plugin pins the test toolchain to Java 17.
+    sdk = [35]
 )
 class BitcoinPriceWidgetTest {
     private var context: Context? = null

--- a/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
+++ b/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
@@ -46,6 +46,32 @@ class SafeTouchDispatchTest {
   }
 
   @Test
+  fun `swallows the out-of-range pointerIndex variant and reports it`() {
+    val frameworkBug = IllegalArgumentException("pointerIndex out of range")
+    var reported: Throwable? = null
+
+    val handled = safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) {
+      throw frameworkBug
+    }
+
+    assertFalse(handled)
+    assertSame(frameworkBug, reported)
+  }
+
+  @Test
+  fun `propagates IllegalArgumentException without a message without reporting`() {
+    val messageless = IllegalArgumentException()
+    var reported: Throwable? = null
+
+    val thrown = assertThrows(IllegalArgumentException::class.java) {
+      safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { throw messageless }
+    }
+
+    assertSame(messageless, thrown)
+    assertNull(reported)
+  }
+
+  @Test
   fun `propagates IllegalArgumentException with an unrelated message without reporting`() {
     val realBug = IllegalArgumentException("span index out of bounds")
     var reported: Throwable? = null

--- a/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
+++ b/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
@@ -10,11 +10,13 @@ import org.junit.Test
 
 class SafeTouchDispatchTest {
 
+  private val safeTouchDispatch = SafeTouchDispatch()
+
   @Test
   fun `returns true when superDispatch handles the event`() {
     var reported: Throwable? = null
 
-    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { true }
+    val handled = safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { true }
 
     assertTrue(handled)
     assertNull(reported)
@@ -24,18 +26,18 @@ class SafeTouchDispatchTest {
   fun `returns false when superDispatch does not handle the event`() {
     var reported: Throwable? = null
 
-    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { false }
+    val handled = safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { false }
 
     assertFalse(handled)
     assertNull(reported)
   }
 
   @Test
-  fun `swallows IllegalArgumentException and reports it`() {
+  fun `swallows the pointerIndex IllegalArgumentException and reports it`() {
     val frameworkBug = IllegalArgumentException("invalid pointerIndex -1")
     var reported: Throwable? = null
 
-    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) {
+    val handled = safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) {
       throw frameworkBug
     }
 
@@ -44,15 +46,42 @@ class SafeTouchDispatchTest {
   }
 
   @Test
+  fun `propagates IllegalArgumentException with an unrelated message without reporting`() {
+    val realBug = IllegalArgumentException("span index out of bounds")
+    var reported: Throwable? = null
+
+    val thrown = assertThrows(IllegalArgumentException::class.java) {
+      safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { throw realBug }
+    }
+
+    assertSame(realBug, thrown)
+    assertNull(reported)
+  }
+
+  @Test
   fun `propagates other exceptions without reporting`() {
     val unrelated = IllegalStateException("not the framework bug")
     var reported: Throwable? = null
 
     val thrown = assertThrows(IllegalStateException::class.java) {
-      SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { throw unrelated }
+      safeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { throw unrelated }
     }
 
     assertSame(unrelated, thrown)
     assertNull(reported)
+  }
+
+  @Test
+  fun `swallows repeated framework bugs but reports only the first`() {
+    var reportCount = 0
+
+    repeat(3) {
+      val handled = safeTouchDispatch.dispatch(onFrameworkBug = { reportCount++ }) {
+        throw IllegalArgumentException("invalid pointerIndex -1")
+      }
+      assertFalse(handled)
+    }
+
+    assertEquals(1, reportCount)
   }
 }

--- a/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
+++ b/android/app/src/test/java/com/galoyapp/SafeTouchDispatchTest.kt
@@ -1,0 +1,58 @@
+package com.galoyapp
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SafeTouchDispatchTest {
+
+  @Test
+  fun `returns true when superDispatch handles the event`() {
+    var reported: Throwable? = null
+
+    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { true }
+
+    assertTrue(handled)
+    assertNull(reported)
+  }
+
+  @Test
+  fun `returns false when superDispatch does not handle the event`() {
+    var reported: Throwable? = null
+
+    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { false }
+
+    assertFalse(handled)
+    assertNull(reported)
+  }
+
+  @Test
+  fun `swallows IllegalArgumentException and reports it`() {
+    val frameworkBug = IllegalArgumentException("invalid pointerIndex -1")
+    var reported: Throwable? = null
+
+    val handled = SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) {
+      throw frameworkBug
+    }
+
+    assertFalse(handled)
+    assertSame(frameworkBug, reported)
+  }
+
+  @Test
+  fun `propagates other exceptions without reporting`() {
+    val unrelated = IllegalStateException("not the framework bug")
+    var reported: Throwable? = null
+
+    val thrown = assertThrows(IllegalStateException::class.java) {
+      SafeTouchDispatch.dispatch(onFrameworkBug = { reported = it }) { throw unrelated }
+    }
+
+    assertSame(unrelated, thrown)
+    assertNull(reported)
+  }
+}


### PR DESCRIPTION
Closes #4093

## What

Fixes the Crashlytics fatal `IllegalArgumentException: invalid pointerIndex -1` thrown by the Android framework's `ScrollView.onTouchEvent` during multitouch (second finger lifting on a scrollable screen).

## Why this shape

The throw is an AOSP bug: on `ACTION_POINTER_UP`, `ScrollView` calls `ev.getY(ev.findPointerIndex(mActivePointerId))` with a stale pointer id when it didn't observe the full gesture stream — which happens when react-native-gesture-handler intercepts part of it (`RNGestureHandlerRootView` is in the crash's dispatch chain). It's not fixable in app or RN code: RN 0.85 ships prebuilt Android artifacts and `ReactScrollView.onTouchEvent` just calls `super`. Upgrading RN/RNGH doesn't help — the bug is in current Android releases.

The standard production mitigation is a narrow catch at the activity's touch-dispatch boundary:

- `SafeTouchDispatch` — a tiny pure-Kotlin helper (unit-testable without Robolectric) that swallows **only** `IllegalArgumentException`s whose message names a `pointerIndex` (both AOSP variants: `invalid pointerIndex -1`, `pointerIndex out of range`) and drops the event; anything else — other exceptions, other IAE messages, messageless IAEs — propagates, so genuine bugs still crash visibly. By the time the framework throws, the gesture is already inconsistent, so dropping is safe.
- The framework bug is reported as a **Crashlytics non-fatal at most once per process** — every occurrence carries the identical stack, so repeats add no signal and would flood the dashboard on an affected device.
- `MainActivity.dispatchTouchEvent` wires the helper around `super.dispatchTouchEvent`.
- `firebase-bom` + `firebase-crashlytics` added to the app module — RNFB declares its Firebase deps as `implementation`, so `FirebaseCrashlytics` wasn't on the app's compile classpath. The BoM version is read from `@react-native-firebase/app/package.json` (`sdkVersions.android.firebase`) — the same source RNFB's own gradle scripts resolve it from — so an RNFB upgrade moves both in lockstep instead of drifting against a hand-pinned literal.

## Also in this PR

- **`BitcoinPriceWidgetTest` was failing on `main`**: without an explicit `sdk`, Robolectric emulates targetSdk 36, which requires Java 21 — but the RN Gradle plugin pins the test toolchain to Java 17. Broken since the API 36 bump, unnoticed because no workflow ran these tests. Pinned to `sdk = [35]`.
- **New CI job** `android-unit-test` in `test.yml` running `./gradlew :app:testDebugUnitTest` on ubuntu-latest (the self-hosted small runners ship no Android SDK), with Gradle caching via `gradle/actions/setup-gradle`, so the Android unit tests actually gate PRs.

## Test coverage

`SafeTouchDispatchTest` (plain JUnit, 8 cases) pins every branch of the guard: passes through `true`/`false` from `superDispatch`; swallows and reports both AOSP message variants; rethrows unreported an IAE with an unrelated message, an IAE with no message, and non-IAE exceptions; and reports repeated framework throws exactly once while dropping each.

The 5-line `MainActivity` override is deliberately untested — a `ReactActivity` cannot be constructed on the JVM without faking the entire RN host, which would test the fakes rather than the wiring.

## Verification

```
$ cd android && ./gradlew :app:testDebugUnitTest
BUILD SUCCESSFUL
com.galoyapp.BitcoinPriceWidgetTest  tests="8" failures="0" errors="0"
com.galoyapp.SafeTouchDispatchTest   tests="8" failures="0" errors="0"
```

Resolved BoM confirmed unchanged after the package.json-derived version: `./gradlew :app:dependencies --configuration debugRuntimeClasspath` still resolves `firebase-bom:34.2.0`.

Manual repro of the framework bug is not reliably possible (requires a mangled multitouch stream); see the [before/after demo](https://github.com/blinkbitcoin/blink-mobile/pull/4096#issuecomment-5220544448) for a simulated repro of the crash-site behavior on both builds.