### PR TITLE
fix(migration): wait for confirmed Spark receive before redirecting after migration

### DIFF
--- a/__tests__/config/feature-flags-default-blocks.spec.ts
+++ b/__tests__/config/feature-flags-default-blocks.spec.ts
@@ -108,4 +108,14 @@ describe("defaultRemoteConfig: compliance country lists", () => {
       "MM",
     ])
   })
+
+  /** The registered default is what runs before the first fetch lands and on every fetch
+   *  that fails; releasing the swap on the server's COMPLETED alone is the #4102 report. */
+  it("migrationDelayedRedirectEnabled defaults to holding the swap", () => {
+    expect(defaultRemoteConfig.migrationDelayedRedirectEnabled).toBe(false)
+  })
+
+  it("migrationReceiveDelayedNoticeMs defaults to the one minute product asked for", () => {
+    expect(defaultRemoteConfig.migrationReceiveDelayedNoticeMs).toBe(60_000)
+  })
 })

--- a/__tests__/screens/account-migration/hooks/use-complete-migration.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-complete-migration.spec.ts
@@ -6,11 +6,13 @@ const mockDiscardCustodialSession = jest.fn()
 
 let mockAccountId: string | undefined
 let mockCheckpoint: string | null
+let mockExpectedReceiveSats: number | null
 
 jest.mock("@app/screens/account-migration/hooks/use-migration-checkpoint-state", () => ({
   useMigrationCheckpointState: () => ({
     checkpoint: mockCheckpoint,
     accountId: mockAccountId,
+    expectedReceiveSats: mockExpectedReceiveSats,
     clearCheckpoint: mockClearCheckpoint,
   }),
 }))
@@ -62,6 +64,7 @@ describe("useCompleteMigration", () => {
     mockAccounts = [{ id: "sc-account-1" }]
     mockRegistryLoading = false
     mockCheckpoint = "backupAlerts"
+    mockExpectedReceiveSats = 21000
     mockDiscardCustodialSession.mockResolvedValue(undefined)
   })
 
@@ -116,6 +119,7 @@ describe("useCompleteMigration", () => {
 
     expect(result.current.migrationCheckpoint).toBe("backupAlerts")
     expect(result.current.migrationAccountId).toBe("sc-account-1")
+    expect(result.current.migrationExpectedReceiveSats).toBe(21000)
   })
 
   /** The account check reads the registry's accounts, which start empty and fill after an

--- a/__tests__/screens/account-migration/hooks/use-migration-account.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-account.spec.ts
@@ -107,7 +107,7 @@ describe("useMigrationAccount", () => {
     expect(ensured).toBe("sc-account-1")
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.TermsAndConditions,
-      "sc-account-1",
+      { provisionedAccountId: "sc-account-1" },
     )
   })
 
@@ -192,7 +192,7 @@ describe("useMigrationAccount", () => {
     expect(mockSavePendingAccount).not.toHaveBeenCalled()
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.TermsAndConditions,
-      "sc-pending-1",
+      { provisionedAccountId: "sc-pending-1" },
     )
   })
 

--- a/__tests__/screens/account-migration/hooks/use-migration-balances-preview.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-balances-preview.spec.ts
@@ -1,0 +1,107 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { useMigrationBalancesPreview } from "@app/screens/account-migration/hooks/use-migration-balances-preview"
+import { AccountMigrationPreview } from "@app/types/migration"
+
+loadLocale("en")
+const mockLL = i18nObject("en")
+
+const mockUseMigrationPreview = jest.fn()
+const mockUseCustodialWalletBalances = jest.fn()
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: mockLL }),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-migration-preview", () => ({
+  useMigrationPreview: () => mockUseMigrationPreview(),
+}))
+
+jest.mock("@app/screens/account-migration/hooks/use-custodial-wallet-balances", () => ({
+  useCustodialWalletBalances: (options: unknown) =>
+    mockUseCustodialWalletBalances(options),
+}))
+
+jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
+  useDollarBalanceRestricted: () => false,
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: ({ moneyAmount }: { moneyAmount: { amount: number } }) =>
+      `${moneyAmount.amount} sats`,
+    moneyAmountToDisplayCurrencyString: () => "$1.00",
+  }),
+}))
+
+const previewOf = (receiveSats: number): AccountMigrationPreview => ({
+  balanceSats: receiveSats + 10,
+  feeSats: 10,
+  feeCoveredByBlink: false,
+  receiveSats,
+})
+
+const previewSource = (preview: AccountMigrationPreview | null) => ({
+  preview,
+  loading: false,
+  isSkipped: false,
+  hasConnectionIssue: false,
+  refetch: jest.fn(),
+})
+
+const balancesSource = (isReady: boolean) => ({
+  usdBalanceCents: 0,
+  isReady,
+  loading: !isReady,
+  isSkipped: false,
+  hasConnectionIssue: false,
+  refetch: jest.fn(),
+})
+
+describe("useMigrationBalancesPreview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseMigrationPreview.mockReturnValue(previewSource(previewOf(990)))
+    mockUseCustodialWalletBalances.mockReturnValue(balancesSource(true))
+  })
+
+  it("reports the server's raw receive figure once both sources are ready", () => {
+    const { result } = renderHook(() => useMigrationBalancesPreview())
+
+    expect(result.current.isReady).toBe(true)
+    expect(result.current.expectedReceiveSats).toBe(990)
+  })
+
+  /** The receive gate reads a zero as "nothing will ever arrive" and opens without waiting,
+   *  so the placeholder preview's own zero must never reach a caller as a figure. */
+  it("reports no expectation while the server has not answered with a preview", () => {
+    mockUseMigrationPreview.mockReturnValue(previewSource(null))
+
+    const { result } = renderHook(() => useMigrationBalancesPreview())
+
+    expect(result.current.isReady).toBe(false)
+    expect(result.current.expectedReceiveSats).toBeNull()
+  })
+
+  it("reports no expectation while the custodial balances are still loading", () => {
+    mockUseCustodialWalletBalances.mockReturnValue(balancesSource(false))
+
+    const { result } = renderHook(() => useMigrationBalancesPreview())
+
+    expect(result.current.isReady).toBe(false)
+    expect(result.current.expectedReceiveSats).toBeNull()
+  })
+
+  /** A zero the server actually answered is a real zero-receive migration, not the unknown
+   *  the placeholder stands for, and the two must stay distinguishable. */
+  it("reports a server-answered zero as a figure, not as unknown", () => {
+    mockUseMigrationPreview.mockReturnValue(previewSource(previewOf(0)))
+
+    const { result } = renderHook(() => useMigrationBalancesPreview())
+
+    expect(result.current.isReady).toBe(true)
+    expect(result.current.expectedReceiveSats).toBe(0)
+  })
+})

--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -147,6 +147,66 @@ describe("useMigrationCheckpoint", () => {
     expect(result.current.accountId).toBe("sc-account-2")
   })
 
+  it("persists and exposes the expected receive figure", async () => {
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.saveCheckpoint(MigrationCheckpoint.BalancesOverview, "sc-1", 21000)
+    })
+
+    expect(result.current.expectedReceiveSats).toBe(21000)
+    expect(mockSaveCheckpointToStorage).toHaveBeenCalledWith("migrationCheckpoint_main", {
+      step: MigrationCheckpoint.BalancesOverview,
+      accountId: "sc-1",
+      custodialAccountId: "custodial-1",
+      expectedReceiveSats: 21000,
+    })
+  })
+
+  it("loads the expected receive figure from storage", async () => {
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: Date.now(),
+      accountId: "sc-account-2",
+      expectedReceiveSats: 500,
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.expectedReceiveSats).toBe(500)
+  })
+
+  /** A zero must survive the save: the receive gate reads absent as "unknown" and would
+   *  wait on a receive that a zero-figure migration will never get. */
+  it("re-sends a known zero expected figure on step saves", async () => {
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: Date.now(),
+      accountId: "sc-account-2",
+      custodialAccountId: "custodial-1",
+      expectedReceiveSats: 0,
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    act(() => {
+      result.current.saveCheckpoint(MigrationCheckpoint.BalancesOverview)
+    })
+
+    expect(mockSaveCheckpointToStorage).toHaveBeenCalledWith("migrationCheckpoint_main", {
+      step: MigrationCheckpoint.BalancesOverview,
+      accountId: "sc-account-2",
+      custodialAccountId: "custodial-1",
+      expectedReceiveSats: 0,
+    })
+  })
+
   it("reports the error and finishes loading when loadCheckpoint rejects", async () => {
     mockLoadCheckpoint.mockRejectedValue(new Error("corrupt"))
 

--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -122,7 +122,9 @@ describe("useMigrationCheckpoint", () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
-      result.current.saveCheckpoint(MigrationCheckpoint.BackupMethod, "sc-account-1")
+      result.current.saveCheckpoint(MigrationCheckpoint.BackupMethod, {
+        provisionedAccountId: "sc-account-1",
+      })
     })
 
     expect(result.current.accountId).toBe("sc-account-1")
@@ -153,7 +155,10 @@ describe("useMigrationCheckpoint", () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     act(() => {
-      result.current.saveCheckpoint(MigrationCheckpoint.BalancesOverview, "sc-1", 21000)
+      result.current.saveCheckpoint(MigrationCheckpoint.BalancesOverview, {
+        provisionedAccountId: "sc-1",
+        expectedReceiveSats: 21000,
+      })
     })
 
     expect(result.current.expectedReceiveSats).toBe(21000)

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -16,6 +16,8 @@ jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
 }))
 
 const DELAYED_NOTICE_MS = 60_000
+const RECEIVE_CHECK_RETRY_MS = 5000
+const DELAYED_RETRY_MS = 30_000
 
 const defaultRemoteConfig = {
   selfCustodialDepositClaimLeewayVbyte: 1,
@@ -125,7 +127,7 @@ describe("useMigrationReceiveConfirmation", () => {
     expect(result.current.isReceiveDelayed).toBe(true)
 
     mockCheckReceiveLanded.mockResolvedValue(ok(landed))
-    await advance(5000)
+    await advance(DELAYED_RETRY_MS)
 
     expect(result.current).toEqual({
       isReceiveConfirmed: true,
@@ -150,6 +152,56 @@ describe("useMigrationReceiveConfirmation", () => {
       isReceiveDelayed: false,
     })
     expect(mockCheckReceiveLanded.mock.calls).toHaveLength(checksSoFar)
+  })
+
+  /** Both callers recompute `skip` from inputs that hydrate and flap; a window re-armed
+   *  from zero on each flap would never elapse and the notice would never appear. */
+  it("reaches the notice across a caller whose skip flaps", async () => {
+    const { result, rerender } = renderGate()
+    await flushCheck()
+
+    await advance(DELAYED_NOTICE_MS / 2)
+    expect(result.current.isReceiveDelayed).toBe(false)
+
+    rerender({ skip: true })
+    rerender({ skip: false })
+    await flushCheck()
+
+    await advance(DELAYED_NOTICE_MS / 2)
+    expect(result.current.isReceiveDelayed).toBe(true)
+  })
+
+  /** The gate never gives up, so past the notice window the checks back off rather than
+   *  opening an SDK connection every 5s for the rest of the session. */
+  it("backs the checks off once the wait passes the notice window", async () => {
+    const { result } = renderGate()
+    await flushCheck()
+
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+    const checksAtNotice = mockCheckReceiveLanded.mock.calls.length
+
+    await advance(RECEIVE_CHECK_RETRY_MS)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(checksAtNotice)
+
+    await advance(DELAYED_RETRY_MS - RECEIVE_CHECK_RETRY_MS)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(checksAtNotice + 1)
+  })
+
+  /** The wait belongs to one migration's receive: a gate re-pointed at another wallet must
+   *  not inherit a notice minted for a payment it never waited on. */
+  it("measures a fresh window when the gate is pointed at another wallet", async () => {
+    const { result, rerender } = renderGate()
+    await flushCheck()
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+
+    rerender({ selfCustodialAccountId: "sc-account-2" })
+    await flushCheck()
+    expect(result.current.isReceiveDelayed).toBe(false)
+
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
   })
 
   /** Nothing will ever arrive for a zero-receive migration, so waiting on the wallet
@@ -282,7 +334,7 @@ describe("useMigrationReceiveConfirmation", () => {
     expect(result.current.isReceiveConfirmed).toBe(false)
 
     const checksSoFar = mockCheckReceiveLanded.mock.calls.length
-    await advance(5000)
+    await advance(DELAYED_RETRY_MS)
     expect(mockCheckReceiveLanded.mock.calls.length).toBeGreaterThan(checksSoFar)
   })
 

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -17,12 +17,16 @@ jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
 
 const DELAYED_NOTICE_MS = 60_000
 
+const defaultRemoteConfig = {
+  selfCustodialDepositClaimLeewayVbyte: 1,
+  migrationReceiveDelayedNoticeMs: DELAYED_NOTICE_MS,
+  migrationDelayedRedirectEnabled: false,
+}
+let mockRemoteConfig = { ...defaultRemoteConfig }
+
 jest.mock("@app/config/feature-flags-context", () => ({
   ...jest.requireActual("@app/config/feature-flags-context"),
-  useRemoteConfig: () => ({
-    selfCustodialDepositClaimLeewayVbyte: 1,
-    migrationReceiveDelayedNoticeMs: 60_000,
-  }),
+  useRemoteConfig: () => mockRemoteConfig,
 }))
 
 jest.mock("@app/utils/error-logging", () => ({
@@ -64,6 +68,7 @@ describe("useMigrationReceiveConfirmation", () => {
   beforeEach(() => {
     jest.useFakeTimers()
     jest.clearAllMocks()
+    mockRemoteConfig = { ...defaultRemoteConfig }
     mockCheckReceiveLanded.mockResolvedValue(ok(stillEmpty))
   })
 
@@ -217,10 +222,50 @@ describe("useMigrationReceiveConfirmation", () => {
 
     await advance(DELAYED_NOTICE_MS)
     expect(result.current.isReceiveDelayed).toBe(true)
+    expect(result.current.isReceiveConfirmed).toBe(false)
 
     const checksSoFar = mockCheckReceiveLanded.mock.calls.length
     await advance(5000)
     expect(mockCheckReceiveLanded.mock.calls.length).toBeGreaterThan(checksSoFar)
+  })
+
+  /** The escape hatch, off by default: with the flag on, the elapsed window opens the
+   *  gate — no notice, straight to the swap, as the flow behaved before the gate. */
+  it("releases the redirect after the window when the delayed-redirect flag is on", async () => {
+    mockRemoteConfig.migrationDelayedRedirectEnabled = true
+
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(DELAYED_NOTICE_MS)
+
+    expect(result.current.isReceiveConfirmed).toBe(true)
+    expect(result.current.isReceiveDelayed).toBe(false)
+  })
+
+  it("stops checking once the timeout releases the gate", async () => {
+    mockRemoteConfig.migrationDelayedRedirectEnabled = true
+
+    renderGate()
+    await flushCheck()
+    await advance(DELAYED_NOTICE_MS)
+    const checksSoFar = mockCheckReceiveLanded.mock.calls.length
+
+    await advance(60_000)
+
+    expect(mockCheckReceiveLanded.mock.calls).toHaveLength(checksSoFar)
+  })
+
+  it("still confirms through a landed receive before the window with the flag on", async () => {
+    mockRemoteConfig.migrationDelayedRedirectEnabled = true
+    mockCheckReceiveLanded.mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+
+    expect(result.current.isReceiveConfirmed).toBe(true)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
   })
 
   it("keeps the delayed notice down when the receive confirms in time", async () => {

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -301,15 +301,47 @@ describe("useMigrationReceiveConfirmation", () => {
     )
   })
 
-  /** The swap path already reads a missing wallet key and routes it to support; a gate
-   *  that held the swap back would only hide that handover. */
-  it("passes a missing mnemonic through as confirmed", async () => {
+  /**
+   * The swap this would release checks the account index, not the keystore, so it would
+   * discard the working custodial session for a wallet whose key is unrecoverable and
+   * leave the user with neither. Not confirming keeps the working session, and the
+   * delayed notice is what routes the user to support.
+   */
+  it("does not confirm when the wallet's key is gone from the device", async () => {
     mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
 
     const { result } = renderGate()
     await flushCheck()
 
+    expect(result.current.isReceiveConfirmed).toBe(false)
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Migration receive check",
+      expect.objectContaining({ message: "No mnemonic for the provisioned account" }),
+    )
+  })
+
+  it("keeps checking after a missing mnemonic, in case the keystore reads again", async () => {
+    mockCheckReceiveLanded
+      .mockResolvedValueOnce({ status: MigrationSdkStatus.NoMnemonic })
+      .mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(RECEIVE_CHECK_RETRY_MS)
     expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  it("reports a missing mnemonic once, however many checks find it", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    renderGate()
+    await flushCheck()
+    await advance(RECEIVE_CHECK_RETRY_MS)
+    await advance(RECEIVE_CHECK_RETRY_MS)
+
+    expect(mockReportError).toHaveBeenCalledTimes(1)
   })
 
   /** The retry waits for the previous check to settle: checks serialize on the wallet's

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -1,0 +1,274 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { useMigrationReceiveConfirmation } from "@app/screens/account-migration/hooks/use-migration-receive-confirmation"
+import { MigrationSdkStatus } from "@app/self-custodial/migration-transfer-request"
+
+const mockCheckReceiveLanded = jest.fn()
+const mockReportError = jest.fn()
+
+jest.mock("@app/self-custodial/migration-transfer-request", () => ({
+  ...jest.requireActual("@app/self-custodial/migration-transfer-request"),
+  checkMigrationReceiveLanded: (args: unknown) => mockCheckReceiveLanded(args),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
+  useSparkNetwork: () => "regtest",
+}))
+
+const DELAYED_NOTICE_MS = 60_000
+
+jest.mock("@app/config/feature-flags-context", () => ({
+  ...jest.requireActual("@app/config/feature-flags-context"),
+  useRemoteConfig: () => ({
+    selfCustodialDepositClaimLeewayVbyte: 1,
+    migrationReceiveDelayedNoticeMs: 60_000,
+  }),
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  ...jest.requireActual("@app/utils/error-logging"),
+  reportError: (operation: string, err: unknown) => mockReportError(operation, err),
+}))
+
+const landed = { hasReceived: true, balanceSats: 21000 }
+const stillEmpty = { hasReceived: false, balanceSats: 0 }
+
+const ok = (value: typeof landed) => ({ status: MigrationSdkStatus.Ok, value })
+
+const renderGate = (
+  overrides: Partial<Parameters<typeof useMigrationReceiveConfirmation>[0]> = {},
+) =>
+  renderHook(() =>
+    useMigrationReceiveConfirmation({
+      selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
+      skip: false,
+      ...overrides,
+    }),
+  )
+
+/** Lets the pending check's promise chain settle without moving the fake clock. */
+const flushCheck = () =>
+  act(async () => {
+    await Promise.resolve()
+  })
+
+/** Moves the clock and lets whatever it released settle. */
+const advance = (ms: number) =>
+  act(async () => {
+    jest.advanceTimersByTime(ms)
+    await Promise.resolve()
+  })
+
+describe("useMigrationReceiveConfirmation", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+    mockCheckReceiveLanded.mockResolvedValue(ok(stillEmpty))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("does not touch the SDK while skipped", async () => {
+    const { result } = renderGate({ skip: true })
+    await flushCheck()
+
+    expect(mockCheckReceiveLanded).not.toHaveBeenCalled()
+    expect(result.current).toEqual({
+      isReceiveConfirmed: false,
+      isReceiveDelayed: false,
+    })
+  })
+
+  it("does not touch the SDK without a provisioned account id", async () => {
+    const { result } = renderGate({ selfCustodialAccountId: null })
+    await flushCheck()
+
+    expect(mockCheckReceiveLanded).not.toHaveBeenCalled()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+  })
+
+  /** Nothing will ever arrive for a zero-receive migration, so waiting on the wallet
+   *  would strand the user forever. */
+  it("confirms a zero-receive migration at once, without the SDK", async () => {
+    const { result } = renderGate({ expectedReceiveSats: 0 })
+    await flushCheck()
+
+    expect(mockCheckReceiveLanded).not.toHaveBeenCalled()
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  it("confirms once the first check finds the funds landed", async () => {
+    mockCheckReceiveLanded.mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledWith({
+      accountId: "sc-account-1",
+      network: "regtest",
+      leewaySatPerVbyte: 1,
+    })
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  it("keeps checking until the funds land", async () => {
+    mockCheckReceiveLanded
+      .mockResolvedValueOnce(ok(stillEmpty))
+      .mockResolvedValueOnce(ok(stillEmpty))
+      .mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(5000)
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(5000)
+    expect(result.current.isReceiveConfirmed).toBe(true)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(3)
+  })
+
+  /** An unknown expectation (a checkpoint saved before the field existed) waits like a
+   *  funded one: it cannot be told apart from real funds in transit. */
+  it("keeps waiting on a legacy checkpoint with no expected figure", async () => {
+    const { result } = renderGate({ expectedReceiveSats: null })
+    await flushCheck()
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(5000)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(2)
+    expect(result.current.isReceiveConfirmed).toBe(false)
+  })
+
+  it("retries a dropped connection instead of surfacing it", async () => {
+    mockCheckReceiveLanded
+      .mockResolvedValueOnce({
+        status: MigrationSdkStatus.ConnectionError,
+        error: new Error("offline"),
+      })
+      .mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(5000)
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  it("reports a settled failure once and keeps checking", async () => {
+    mockCheckReceiveLanded
+      .mockResolvedValueOnce({
+        status: MigrationSdkStatus.Failed,
+        error: new Error("info unavailable"),
+      })
+      .mockResolvedValueOnce({
+        status: MigrationSdkStatus.Failed,
+        error: new Error("info unavailable"),
+      })
+      .mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+    await advance(5000)
+    await advance(5000)
+
+    expect(result.current.isReceiveConfirmed).toBe(true)
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Migration receive check",
+      expect.objectContaining({ message: "info unavailable" }),
+    )
+  })
+
+  /** The swap path already reads a missing wallet key and routes it to support; a gate
+   *  that held the swap back would only hide that handover. */
+  it("passes a missing mnemonic through as confirmed", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    const { result } = renderGate()
+    await flushCheck()
+
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  /** The retry waits for the previous check to settle: checks serialize on the wallet's
+   *  storage directory anyway, so stacking would only queue. */
+  it("never overlaps checks while one is still in flight", async () => {
+    mockCheckReceiveLanded.mockReturnValue(new Promise(() => {}))
+
+    renderGate()
+    await flushCheck()
+    await advance(20_000)
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+  })
+
+  it("raises the delayed notice after the configured wait, still checking", async () => {
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveDelayed).toBe(false)
+
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+
+    const checksSoFar = mockCheckReceiveLanded.mock.calls.length
+    await advance(5000)
+    expect(mockCheckReceiveLanded.mock.calls.length).toBeGreaterThan(checksSoFar)
+  })
+
+  it("keeps the delayed notice down when the receive confirms in time", async () => {
+    mockCheckReceiveLanded.mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(false)
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+
+  it("stops checking for good once confirmed", async () => {
+    mockCheckReceiveLanded.mockResolvedValue(ok(landed))
+
+    renderGate()
+    await flushCheck()
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+
+    await advance(60_000)
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops checking when unmounted mid-wait", async () => {
+    const { unmount } = renderGate()
+    await flushCheck()
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+
+    unmount()
+    await advance(60_000)
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+  })
+
+  /** The keystore read sits before the SDK result shape exists, so it can reject rather
+   *  than settle; the gate treats that like any other transient miss. */
+  it("retries when the check itself rejects", async () => {
+    mockCheckReceiveLanded
+      .mockRejectedValueOnce(new Error("keystore locked"))
+      .mockResolvedValue(ok(landed))
+
+    const { result } = renderGate()
+    await flushCheck()
+    expect(result.current.isReceiveConfirmed).toBe(false)
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+
+    await advance(5000)
+    expect(result.current.isReceiveConfirmed).toBe(true)
+  })
+})

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -39,16 +39,20 @@ const stillEmpty = { hasReceived: false, balanceSats: 0 }
 
 const ok = (value: typeof landed) => ({ status: MigrationSdkStatus.Ok, value })
 
-const renderGate = (
-  overrides: Partial<Parameters<typeof useMigrationReceiveConfirmation>[0]> = {},
-) =>
-  renderHook(() =>
-    useMigrationReceiveConfirmation({
-      selfCustodialAccountId: "sc-account-1",
-      expectedReceiveSats: 21000,
-      skip: false,
-      ...overrides,
-    }),
+type GateOverrides = Partial<Parameters<typeof useMigrationReceiveConfirmation>[0]>
+
+/** Prop-driven so a test can rerender through the transitions production actually
+ *  takes: mounted skipped, armed later, possibly re-skipped after a failure. */
+const renderGate = (overrides: GateOverrides = {}) =>
+  renderHook(
+    (props: GateOverrides) =>
+      useMigrationReceiveConfirmation({
+        selfCustodialAccountId: "sc-account-1",
+        expectedReceiveSats: 21000,
+        skip: false,
+        ...props,
+      }),
+    { initialProps: overrides },
   )
 
 /** Lets the pending check's promise chain settle without moving the fake clock. */
@@ -93,6 +97,59 @@ describe("useMigrationReceiveConfirmation", () => {
 
     expect(mockCheckReceiveLanded).not.toHaveBeenCalled()
     expect(result.current.isReceiveConfirmed).toBe(false)
+  })
+
+  /** The sequence production always takes: the gate mounts skipped (server still
+   *  TRANSFERRING) and arms only when COMPLETED arrives. The first check and the notice
+   *  window must both start from that moment, not from mount. */
+  it("starts checking and arms the notice once the caller stops skipping", async () => {
+    const { result, rerender } = renderGate({ skip: true })
+    await flushCheck()
+    expect(mockCheckReceiveLanded).not.toHaveBeenCalled()
+
+    rerender({ skip: false })
+    await flushCheck()
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+    expect(result.current.isReceiveConfirmed).toBe(false)
+
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+  })
+
+  /** The reverse ordering of "confirms in time": the notice has already fired when the
+   *  funds land. The screen must swap at once, not keep the "taking longer" copy up. */
+  it("withdraws the delayed notice when the receive lands after it fired", async () => {
+    const { result } = renderGate()
+    await flushCheck()
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+
+    mockCheckReceiveLanded.mockResolvedValue(ok(landed))
+    await advance(5000)
+
+    expect(result.current).toEqual({
+      isReceiveConfirmed: true,
+      isReceiveDelayed: false,
+    })
+  })
+
+  /** A caller that re-skips (a late failure handed the user to support) must get an
+   *  inert gate, not a notice minted for a swap that is no longer allowed. */
+  it("goes inert when the caller re-skips after the notice fired", async () => {
+    const { result, rerender } = renderGate()
+    await flushCheck()
+    await advance(DELAYED_NOTICE_MS)
+    expect(result.current.isReceiveDelayed).toBe(true)
+    const checksSoFar = mockCheckReceiveLanded.mock.calls.length
+
+    rerender({ skip: true })
+    await advance(60_000)
+
+    expect(result.current).toEqual({
+      isReceiveConfirmed: false,
+      isReceiveDelayed: false,
+    })
+    expect(mockCheckReceiveLanded.mock.calls).toHaveLength(checksSoFar)
   })
 
   /** Nothing will ever arrive for a zero-receive migration, so waiting on the wallet
@@ -299,6 +356,45 @@ describe("useMigrationReceiveConfirmation", () => {
     await advance(60_000)
 
     expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+  })
+
+  /** A check in flight at unmount settles into a torn-down hook: its result must be
+   *  dropped, not turned into a state update or another scheduled check. */
+  it("drops a check that settles after unmount", async () => {
+    let settle: (value: unknown) => void = () => {}
+    mockCheckReceiveLanded.mockReturnValue(
+      new Promise((resolve) => {
+        settle = resolve
+      }),
+    )
+
+    const { unmount } = renderGate()
+    await flushCheck()
+    unmount()
+
+    settle(ok(stillEmpty))
+    await advance(60_000)
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+  })
+
+  it("drops a check that rejects after unmount, without reporting", async () => {
+    let fail: (err: unknown) => void = () => {}
+    mockCheckReceiveLanded.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        fail = reject
+      }),
+    )
+
+    const { unmount } = renderGate()
+    await flushCheck()
+    unmount()
+
+    fail(new Error("keystore locked"))
+    await advance(60_000)
+
+    expect(mockCheckReceiveLanded).toHaveBeenCalledTimes(1)
+    expect(mockReportError).not.toHaveBeenCalled()
   })
 
   /** The keystore read sits before the SDK result shape exists, so it can reject rather

--- a/__tests__/screens/account-migration/hooks/use-migration-transfer.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-transfer.spec.ts
@@ -42,6 +42,21 @@ jest.mock("@app/self-custodial/migration-transfer-request", () => ({
   buildMigrationTransferRequest: (args: unknown) => mockBuildTransferRequest(args),
 }))
 
+/** Confirmed by default so the server phase stays the deciding voice in the existing
+ *  cases; the receive-gate cases below flip it. */
+let mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+const mockUseReceiveConfirmation = jest.fn()
+
+jest.mock(
+  "@app/screens/account-migration/hooks/use-migration-receive-confirmation",
+  () => ({
+    useMigrationReceiveConfirmation: (args: unknown) => {
+      mockUseReceiveConfirmation(args)
+      return mockReceiveConfirmation
+    },
+  }),
+)
+
 jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
   useSparkNetwork: () => "regtest",
 }))
@@ -83,6 +98,7 @@ const renderTransfer = (
     useMigrationTransfer({
       custodialAccountId: "custodial-1",
       selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
       skip: false,
       ...overrides,
     }),
@@ -101,6 +117,7 @@ describe("useMigrationTransfer", () => {
     mockCommitMigration.mockResolvedValue({ data: { migrationCommit: { errors: [] } } })
     mockIsDeviceClockSkewed.mockReturnValue(false)
     mockCurrentProofTimestamp.mockReturnValue(1_700_000_000)
+    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
   })
 
   it("commits the collected destination while the server awaits one", async () => {
@@ -205,6 +222,7 @@ describe("useMigrationTransfer", () => {
         useMigrationTransfer({
           custodialAccountId,
           selfCustodialAccountId: "sc-account-1",
+          expectedReceiveSats: 21000,
           skip: false,
         }),
       { initialProps: { custodialAccountId: null as string | null } },
@@ -242,6 +260,7 @@ describe("useMigrationTransfer", () => {
         useMigrationTransfer({
           custodialAccountId,
           selfCustodialAccountId: "sc-account-1",
+          expectedReceiveSats: 21000,
           skip: false,
         }),
       { initialProps: { custodialAccountId: null as string | null } },
@@ -344,6 +363,98 @@ describe("useMigrationTransfer", () => {
 
     expect(result.current.isTransferred).toBe(true)
     expect(result.current.failureReason).toBeNull()
+  })
+
+  /** The fix for #4102: COMPLETED is the sender's word only. Until the receive into the
+   *  new wallet is confirmed, the swap must not fire — the funds are still in transit. */
+  it("holds the swap while the receive is unconfirmed", async () => {
+    mockStatus = MigrationStatus.Completed
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    const { result } = renderTransfer()
+    await flushEffects()
+
+    expect(result.current.isTransferred).toBe(false)
+    expect(result.current.failureReason).toBeNull()
+  })
+
+  it("reports done once the receive confirms after the server completed", async () => {
+    mockStatus = MigrationStatus.Completed
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    const { result, rerender } = renderTransfer()
+    await flushEffects()
+    expect(result.current.isTransferred).toBe(false)
+
+    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+    rerender({})
+    await flushEffects()
+
+    expect(result.current.isTransferred).toBe(true)
+  })
+
+  /** The phase can no longer change once the server settled COMPLETED, so the status
+   *  poll stops even while the receive gate is still waiting on the wallet. */
+  it("stops watching the phase while the receive gate waits", async () => {
+    mockStatus = MigrationStatus.Completed
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    renderTransfer()
+    await flushEffects()
+
+    expect(mockUseMigrationStatus).toHaveBeenLastCalledWith({
+      skip: false,
+      pollInterval: 0,
+    })
+  })
+
+  /** Each look at the wallet opens a whole SDK connection, so the gate stays off until
+   *  the server has actually paid the drain out. */
+  it("keeps the receive gate off until the server completes", async () => {
+    mockStatus = MigrationStatus.Transferring
+    renderTransfer({ expectedReceiveSats: 21000 })
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
+      selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
+      skip: true,
+    })
+
+    mockStatus = MigrationStatus.Completed
+    renderTransfer({ expectedReceiveSats: 21000 })
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
+      selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
+      skip: false,
+    })
+  })
+
+  /** A failure already handed the user to support; the gate must not keep polling the
+   *  wallet for a swap that is never allowed to happen. */
+  it("keeps the receive gate off once a failure has handed over", async () => {
+    mockStatus = MigrationStatus.InProgress
+    mockCommitMigration.mockResolvedValue({
+      data: { migrationCommit: { errors: [{ message: "refused" }] } },
+    })
+    const { rerender } = renderTransfer()
+    await flushEffects()
+
+    mockStatus = MigrationStatus.Completed
+    rerender({})
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith(
+      expect.objectContaining({ skip: true }),
+    )
+  })
+
+  it("passes the delayed notice through for the screen to show", async () => {
+    mockStatus = MigrationStatus.Completed
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: true }
+    const { result } = renderTransfer()
+    await flushEffects()
+
+    expect(result.current.isReceiveDelayed).toBe(true)
   })
 
   /** FAILED has no client-side way back: the phase machine only leaves it when a late

--- a/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
@@ -163,6 +163,38 @@ describe("useResumeCompletedMigration", () => {
     expect(mockCompleteMigration).not.toHaveBeenCalled()
   })
 
+  /** This path has no screen of its own to say the wait is unusual, so the crossing is at
+   *  least reported rather than leaving a stuck receive invisible. */
+  it("reports a receive that has not landed within the notice window", async () => {
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: true }
+    renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Migration resume receive delayed",
+      expect.any(Error),
+    )
+  })
+
+  it("reports the delayed receive once, however often it re-renders", async () => {
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: true }
+    const { rerender } = renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+    rerender({})
+    rerender({})
+    await flushEffects()
+
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+  })
+
+  it("stays quiet while the wait is still inside the notice window", async () => {
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
   /** Nobody who cannot act on the answer should be asking for it on every launch. */
   it("does not ask the server when no checkpoint says a migration is unfinished", async () => {
     mockMigrationAccountId = null

--- a/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
@@ -32,10 +32,26 @@ let mockCompleteMigrationRef: () => Promise<boolean> = mockCompleteMigration
 jest.mock("@app/screens/account-migration/hooks/use-complete-migration", () => ({
   useCompleteMigration: () => ({
     migrationAccountId: mockMigrationAccountId,
+    migrationExpectedReceiveSats: 21000,
     migrationLoading: mockMigrationLoading,
     completeMigration: mockCompleteMigrationRef,
   }),
 }))
+
+/** Confirmed by default so the server phase stays the deciding voice in the existing
+ *  cases; the receive-gate cases below flip it. */
+let mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+const mockUseReceiveConfirmation = jest.fn()
+
+jest.mock(
+  "@app/screens/account-migration/hooks/use-migration-receive-confirmation",
+  () => ({
+    useMigrationReceiveConfirmation: (args: unknown) => {
+      mockUseReceiveConfirmation(args)
+      return mockReceiveConfirmation
+    },
+  }),
+)
 
 jest.mock("@app/screens/account-migration/hooks/use-migration-status", () => ({
   useMigrationStatus: (options: unknown) => {
@@ -57,6 +73,7 @@ describe("useResumeCompletedMigration", () => {
     mockMigrationLoading = false
     mockCompleteMigrationRef = mockCompleteMigration
     mockCompleteMigration.mockResolvedValue(true)
+    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
   })
 
   /**
@@ -87,6 +104,55 @@ describe("useResumeCompletedMigration", () => {
     await flushEffects()
 
     expect(mockCompleteMigration).not.toHaveBeenCalled()
+  })
+
+  /** The fix for #4102 covers the relaunch path too: a COMPLETED found at launch must
+   *  not swap into a wallet whose funds are still in transit. No swap this session is
+   *  fine — the custodial session stays intact and the gate keeps checking. */
+  it("holds the swap while the receive is unconfirmed", async () => {
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+
+    expect(mockCompleteMigration).not.toHaveBeenCalled()
+  })
+
+  it("finishes the swap once the receive confirms", async () => {
+    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    const { rerender } = renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+    expect(mockCompleteMigration).not.toHaveBeenCalled()
+
+    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+    rerender({})
+    await flushEffects()
+
+    expect(mockCompleteMigration).toHaveBeenCalledTimes(1)
+  })
+
+  /** Each look at the wallet opens a whole SDK connection, so the gate stays off until
+   *  the server reports the drain paid out. */
+  it("keeps the receive gate off until the server completes", async () => {
+    mockStatus = MigrationStatus.Transferring
+    renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
+      selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
+      skip: true,
+    })
+  })
+
+  it("arms the receive gate once the server has completed", async () => {
+    renderHook(() => useResumeCompletedMigration())
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
+      selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
+      skip: false,
+    })
   })
 
   it("waits for the checkpoint before deciding there is a swap to finish", async () => {

--- a/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
@@ -668,8 +668,9 @@ describe("MigrationBalancesOverviewScreen", () => {
 
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.BalancesOverview,
-      undefined,
-      990,
+      {
+        expectedReceiveSats: 990,
+      },
     )
   })
 
@@ -689,8 +690,9 @@ describe("MigrationBalancesOverviewScreen", () => {
 
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.BalancesOverview,
-      undefined,
-      0,
+      {
+        expectedReceiveSats: 0,
+      },
     )
   })
 

--- a/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
@@ -662,11 +662,36 @@ describe("MigrationBalancesOverviewScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it("persists the commit-point checkpoint on landing", async () => {
+  it("persists the commit-point checkpoint with the preview's receive figure", async () => {
     renderScreen()
     await flushEffects()
 
-    expect(mockSaveCheckpoint).toHaveBeenCalledWith(MigrationCheckpoint.BalancesOverview)
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+      MigrationCheckpoint.BalancesOverview,
+      undefined,
+      990,
+    )
+  })
+
+  /** A zero must be recorded as a zero: the receive gate reads an absent figure as
+   *  "expectation unknown" and would wait on funds that will never come. */
+  it("persists a zero receive figure rather than dropping it", async () => {
+    mockUseMigrationQuery.mockReturnValue(
+      migrationQueryResult({
+        balanceSats: 10,
+        feeSats: 10,
+        feeCoveredByBlink: false,
+        receiveSats: 0,
+      }),
+    )
+    renderScreen()
+    await flushEffects()
+
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+      MigrationCheckpoint.BalancesOverview,
+      undefined,
+      0,
+    )
   })
 
   it("waits for the checkpoint to load before persisting the commit point", async () => {

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -30,6 +30,11 @@ let mockHasParams = true
 const mockNavigate = jest.fn()
 const mockGoBack = jest.fn()
 const mockSetOptions = jest.fn()
+const mockRemoveListener = jest.fn()
+type BeforeRemoveListener = (event: { preventDefault: () => void }) => void
+const mockAddListener = jest.fn(
+  (_event: string, _listener: BeforeRemoveListener) => mockRemoveListener,
+)
 let mockOrigin: MigrationSupportOrigin | undefined
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
@@ -37,6 +42,7 @@ jest.mock("@react-navigation/native", () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
     setOptions: mockSetOptions,
+    addListener: mockAddListener,
   }),
   useRoute: () => ({
     params: mockHasParams ? { reason: mockReason, origin: mockOrigin } : undefined,
@@ -127,16 +133,57 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
 
-  /** The back control lives in the navigator header, set from this screen so it reuses the
-   *  return path to the commit point rather than a blind goBack. */
-  it("returns to the commit point from the header back control", async () => {
+  /** The navigator's back control pops, which from a commit-time failure would land on the
+   *  back-swallowing transfer screen, so the removal is intercepted and redirected. */
+  it("redirects a removal to the commit point when opened mid-migration", async () => {
+    renderScreen()
+    await flushEffects()
+
+    const [event, listener] = mockAddListener.mock.calls.at(-1) ?? []
+    const preventDefault = jest.fn()
+    listener?.({ preventDefault })
+
+    expect(event).toBe("beforeRemove")
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationBalancesOverview")
+  })
+
+  /** The redirect removes this screen too; intercepting that second pass as well would
+   *  loop on it instead of ending the handover. */
+  it("lets the redirect's own removal through instead of looping", async () => {
+    renderScreen()
+    await flushEffects()
+
+    const listener = mockAddListener.mock.calls.at(-1)?.[1]
+    listener?.({ preventDefault: jest.fn() })
+
+    const preventDefault = jest.fn()
+    listener?.({ preventDefault })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  /** Replacing headerLeft through setOptions re-renders the native stack header with a
+   *  different hook count on Android and crashes the screen outright, so the control is
+   *  left to the navigator and only plain option values are set from here. */
+  it("never sets a headerLeft through setOptions", async () => {
+    renderScreen()
+    await flushEffects()
+
+    for (const [options] of mockSetOptions.mock.calls) {
+      expect(options).not.toHaveProperty("headerLeft")
+    }
+  })
+
+  it("hides the native back control so the navigator's own is not doubled", async () => {
     renderScreen()
     await flushEffects()
 
     const options = mockSetOptions.mock.calls.at(-1)?.[0]
-    options?.headerLeft?.().props.onPress()
 
-    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationBalancesOverview")
+    expect(options?.headerBackVisible).toBe(false)
+    expect(options?.headerShown).toBe(true)
   })
 
   /** From the resume handover there is no commit screen underneath, so the hardware back
@@ -157,16 +204,12 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
 
-  it("dismisses the header back when opened from the resume handover", async () => {
+  it("leaves a removal alone when opened from the resume handover", async () => {
     mockOrigin = MigrationSupportOrigin.Resume
     renderScreen()
     await flushEffects()
 
-    const options = mockSetOptions.mock.calls.at(-1)?.[0]
-    options?.headerLeft?.().props.onPress()
-
-    expect(mockGoBack).toHaveBeenCalledTimes(1)
-    expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
+    expect(mockAddListener).not.toHaveBeenCalled()
   })
 
   /** The delayed handover is opened over a transfer that is still running: navigating to
@@ -187,16 +230,12 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
 
-  it("dismisses the header back when opened from the delayed-receive handover", async () => {
+  it("leaves a removal alone when opened from the delayed-receive handover", async () => {
     mockOrigin = MigrationSupportOrigin.ReceiveDelayed
     renderScreen()
     await flushEffects()
 
-    const options = mockSetOptions.mock.calls.at(-1)?.[0]
-    options?.headerLeft?.().props.onPress()
-
-    expect(mockGoBack).toHaveBeenCalledTimes(1)
-    expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
+    expect(mockAddListener).not.toHaveBeenCalled()
   })
 
   /** From the gate handover (a lock with nothing to resume, #4070) there is nothing behind
@@ -218,27 +257,25 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it("hides the header back control when opened from the gate handover", async () => {
+  /** The header holds nothing else on this screen, so hiding it is what leaves the gate
+   *  handover without any back control. */
+  it("hides the header entirely when opened from the gate handover", async () => {
     mockOrigin = MigrationSupportOrigin.Gate
     renderScreen()
     await flushEffects()
 
     const options = mockSetOptions.mock.calls.at(-1)?.[0]
 
-    expect(options?.headerLeft?.()).toBeNull()
+    expect(options?.headerShown).toBe(false)
+    expect(options?.headerBackVisible).toBe(false)
   })
 
-  /** A null headerLeft is not enough on native-stack: without headerBackVisible false the
-   *  navigator falls back to its native back button, which popped this cohort onto the
-   *  gate's spent spinner (caught on-device while demoing #4070). */
-  it("suppresses the native back button so null headerLeft cannot fall back to it", async () => {
+  it("leaves a removal alone when opened from the gate handover", async () => {
     mockOrigin = MigrationSupportOrigin.Gate
     renderScreen()
     await flushEffects()
 
-    const options = mockSetOptions.mock.calls.at(-1)?.[0]
-
-    expect(options?.headerBackVisible).toBe(false)
+    expect(mockAddListener).not.toHaveBeenCalled()
   })
 
   /** The gate handover's ticket is identified by its code alone (support greps for it),

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -169,6 +169,36 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
 
+  /** The delayed handover is opened over a transfer that is still running: navigating to
+   *  the commit screen would pop the transfer screen off the stack and unmount the receive
+   *  gate the user is waiting on, so this Back dismisses instead. */
+  it("dismisses the hardware back when opened from the delayed-receive handover", async () => {
+    mockOrigin = MigrationSupportOrigin.ReceiveDelayed
+    const { BackHandler } =
+      jest.requireActual<typeof import("react-native")>("react-native")
+    const addListenerSpy = jest.spyOn(BackHandler, "addEventListener")
+    renderScreen()
+    await flushEffects()
+
+    const handler = addListenerSpy.mock.calls[0][1] as () => boolean
+
+    expect(handler()).toBe(true)
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
+  })
+
+  it("dismisses the header back when opened from the delayed-receive handover", async () => {
+    mockOrigin = MigrationSupportOrigin.ReceiveDelayed
+    renderScreen()
+    await flushEffects()
+
+    const options = mockSetOptions.mock.calls.at(-1)?.[0]
+    options?.headerLeft?.().props.onPress()
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationBalancesOverview")
+  })
+
   /** From the gate handover (a lock with nothing to resume, #4070) there is nothing behind
    *  this screen: the gate underneath would only replay the handover, and the commit path
    *  would fabricate a commit screen for an account with no provisioned wallet. Support is

--- a/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
@@ -27,6 +27,7 @@ jest.mock("@app/screens/account-migration/hooks", () => ({
   ...jest.requireActual("@app/screens/account-migration/hooks"),
   useCompleteMigration: () => ({
     migrationAccountId: mockMigrationAccountId,
+    migrationExpectedReceiveSats: 21000,
     migrationLoading: mockMigrationLoading,
     completeMigration: mockCompleteMigration,
   }),
@@ -35,6 +36,7 @@ jest.mock("@app/screens/account-migration/hooks", () => ({
 
 const mockUseMigrationTransfer = jest.fn()
 let mockIsTransferred = false
+let mockIsReceiveDelayed = false
 let mockFailureReason: MigrationSupportReason | null = null
 let mockIsClockOutOfSync = false
 let mockHasConnectionIssue = false
@@ -45,6 +47,7 @@ jest.mock("@app/screens/account-migration/hooks/use-migration-transfer", () => (
     mockUseMigrationTransfer(args)
     return {
       isTransferred: mockIsTransferred,
+      isReceiveDelayed: mockIsReceiveDelayed,
       failureReason: mockFailureReason,
       isClockOutOfSync: mockIsClockOutOfSync,
       hasConnectionIssue: mockHasConnectionIssue,
@@ -102,6 +105,7 @@ describe("MigrationTransferringFundsScreen", () => {
     mockMigrationAccountId = "sc-account-1"
     mockMigrationLoading = false
     mockIsTransferred = false
+    mockIsReceiveDelayed = false
     mockFailureReason = null
     mockIsClockOutOfSync = false
     mockHasConnectionIssue = false
@@ -135,6 +139,7 @@ describe("MigrationTransferringFundsScreen", () => {
     expect(mockUseMigrationTransfer).toHaveBeenCalledWith({
       custodialAccountId: "custodial-1",
       selfCustodialAccountId: "sc-account-1",
+      expectedReceiveSats: 21000,
       skip: false,
     })
   })
@@ -327,5 +332,65 @@ describe("MigrationTransferringFundsScreen", () => {
     fireEvent.press(screen.getByTestId("migration-connection-issue-retry"))
 
     expect(mockRetry).toHaveBeenCalledTimes(1)
+  })
+
+  /** The receive gate held the swap past the notice window (#4102): the screen keeps
+   *  waiting — the swap still fires by itself — but says so and offers support. */
+  it("explains the wait and offers support once the receive is delayed", async () => {
+    mockIsReceiveDelayed = true
+    renderScreen()
+    await flushEffects()
+
+    expect(
+      screen.getByText(
+        "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      ),
+    ).toBeTruthy()
+    expect(
+      screen.queryByText("Transferring your funds. It should be done in a few seconds."),
+    ).toBeNull()
+    expect(mockCompleteMigration).not.toHaveBeenCalled()
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("navigates to support with the delayed-receive reason when asked", async () => {
+    mockIsReceiveDelayed = true
+    renderScreen()
+    await flushEffects()
+
+    fireEvent.press(screen.getByTestId("migration-receive-delayed-contact-support"))
+
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+      reason: MigrationSupportReason.ReceiveDelayed,
+      origin: "commit",
+    })
+  })
+
+  /** A lost connection explains the wait better than the wait itself, and its retry is
+   *  the more useful footer, so the recoverable state wins over the delayed notice. */
+  it("lets a recoverable issue take over from the delayed notice", async () => {
+    mockIsReceiveDelayed = true
+    mockHasConnectionIssue = true
+    renderScreen()
+    await flushEffects()
+
+    expect(
+      screen.getByText("Connection issue.\nVerify your internet connection"),
+    ).toBeTruthy()
+    expect(screen.queryByTestId("migration-receive-delayed-contact-support")).toBeNull()
+    expect(screen.getByTestId("migration-connection-issue-retry")).toBeTruthy()
+  })
+
+  it("still swaps and resets to success when the receive lands after the notice", async () => {
+    mockIsReceiveDelayed = true
+    mockIsTransferred = true
+    renderScreen()
+    await flushEffects()
+
+    expect(mockCompleteMigration).toHaveBeenCalledTimes(1)
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: "selfCustodialBackupSuccess", params: { reBackup: false } }],
+    })
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
@@ -353,7 +353,9 @@ describe("MigrationTransferringFundsScreen", () => {
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("navigates to support with the delayed-receive reason when asked", async () => {
+  /** Its own origin, not the failure handovers': the receive is still being watched here,
+   *  and the commit-screen Back would pop this screen off the stack along with the gate. */
+  it("navigates to support with the delayed-receive reason and its own origin", async () => {
     mockIsReceiveDelayed = true
     renderScreen()
     await flushEffects()
@@ -362,7 +364,7 @@ describe("MigrationTransferringFundsScreen", () => {
 
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
       reason: MigrationSupportReason.ReceiveDelayed,
-      origin: "commit",
+      origin: "receive-delayed",
     })
   })
 

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -134,14 +134,34 @@ describe("migration-checkpoint-storage", () => {
       expect(result?.expectedReceiveSats).toBe(21000)
     })
 
-    it("rejects a non-number value", () => {
-      expect(
-        validateStoredCheckpoint({
-          step: MigrationCheckpoint.BalancesOverview,
-          savedAt: 1000,
-          expectedReceiveSats: "21000",
-        }),
-      ).toBeNull()
+    it("drops a non-number value but keeps the rest of the record", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: "21000",
+      })
+
+      expect(result).toEqual({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: undefined,
+      })
+    })
+
+    it("drops a non-finite value but keeps the rest of the record", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+        expectedReceiveSats: Number.NaN,
+      })
+
+      expect(result?.accountId).toBe("sc-1")
+      expect(result?.expectedReceiveSats).toBeUndefined()
     })
 
     /** Checkpoints saved by app versions before the field existed must stay valid: their
@@ -395,6 +415,77 @@ describe("migration-checkpoint-storage", () => {
         custodialAccountId: "cust-1",
         expectedReceiveSats: 21000,
       })
+    })
+
+    /** The #4102 regression: the commit screen is re-enterable after the drain, and the
+     *  preview it re-reads then answers 0 for an already emptied balance. */
+    it("keeps the stored expected receive amount when a later save carries a post-drain zero", async () => {
+      mockLoadJson.mockResolvedValue({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now(),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 0,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: expect.any(Number),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+    })
+
+    it("keeps the stored expected receive amount when a later save carries a different figure", async () => {
+      mockLoadJson.mockResolvedValue({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now(),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 500,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ expectedReceiveSats: 21000 }),
+      )
+    })
+
+    it("takes the new owner's expected receive amount over the previous owner's", async () => {
+      mockLoadJson.mockResolvedValue({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now(),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-2",
+        expectedReceiveSats: 700,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({
+          custodialAccountId: "cust-2",
+          expectedReceiveSats: 700,
+        }),
+      )
     })
 
     it("drops the previous owner's expected amount when another account starts a flow", async () => {

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -124,6 +124,42 @@ describe("migration-checkpoint-storage", () => {
     })
   })
 
+  describe("validateStoredCheckpoint expectedReceiveSats", () => {
+    it("keeps a stored number", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        expectedReceiveSats: 21000,
+      })
+      expect(result?.expectedReceiveSats).toBe(21000)
+    })
+
+    it("rejects a non-number value", () => {
+      expect(
+        validateStoredCheckpoint({
+          step: MigrationCheckpoint.BalancesOverview,
+          savedAt: 1000,
+          expectedReceiveSats: "21000",
+        }),
+      ).toBeNull()
+    })
+
+    /** Checkpoints saved by app versions before the field existed must stay valid: their
+     *  absence is what the receive gate reads as "expectation unknown". */
+    it("accepts a legacy record without the field", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+      })
+      expect(result).toEqual({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+      })
+    })
+  })
+
   describe("resolveCheckpointRoute", () => {
     it("returns the default destination for a null checkpoint", () => {
       expect(resolveCheckpointRoute(null)).toEqual({
@@ -317,6 +353,70 @@ describe("migration-checkpoint-storage", () => {
         savedAt: expect.any(Number),
         accountId: "sc-1",
         custodialAccountId: "cust-2",
+      })
+    })
+
+    it("stores the expected receive amount alongside the step", async () => {
+      mockLoadJson.mockResolvedValue(null)
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: expect.any(Number),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+    })
+
+    it("preserves the expected receive amount across step updates by the same owner", async () => {
+      mockLoadJson.mockResolvedValue({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now(),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-1",
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: expect.any(Number),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+    })
+
+    it("drops the previous owner's expected amount when another account starts a flow", async () => {
+      mockLoadJson.mockResolvedValue({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now(),
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 21000,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.TermsAndConditions,
+        custodialAccountId: "cust-2",
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith("test-key", {
+        step: MigrationCheckpoint.TermsAndConditions,
+        savedAt: expect.any(Number),
+        accountId: undefined,
+        custodialAccountId: "cust-2",
+        expectedReceiveSats: undefined,
       })
     })
 

--- a/__tests__/self-custodial/migration-transfer-request.spec.ts
+++ b/__tests__/self-custodial/migration-transfer-request.spec.ts
@@ -3,6 +3,7 @@ import { Network } from "@breeztech/breez-sdk-spark-react-native"
 import {
   buildMigrationLnAddressProof,
   buildMigrationTransferRequest,
+  checkMigrationReceiveLanded,
   MigrationSdkStatus,
 } from "@app/self-custodial/migration-transfer-request"
 import { SelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
@@ -294,6 +295,117 @@ describe("buildMigrationTransferRequest", () => {
     await Promise.all([first, second])
 
     expect(mockInitSdk).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("checkMigrationReceiveLanded", () => {
+  const mockGetInfo = jest.fn()
+
+  const check = () =>
+    checkMigrationReceiveLanded({
+      accountId: "sc-account-1",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetMnemonic.mockResolvedValue("abandon abandon ability")
+    mockInitSdk.mockResolvedValue({ getInfo: mockGetInfo })
+    mockDisconnectSdk.mockResolvedValue(undefined)
+    mockGetInfo.mockResolvedValue({ balanceSats: 0 })
+    mockClassifySdkError.mockReturnValue(SelfCustodialErrorCode.Generic)
+  })
+
+  /** The forced sync is the point of the call: it is what claims a payment Spark held
+   *  for the offline wallet, so the read is detector and actuator in one. */
+  it("confirms the receive once the synced wallet shows a balance", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(21000) })
+
+    const result = await check()
+
+    expect(mockGetInfo).toHaveBeenCalledWith({ ensureSynced: true })
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: true, balanceSats: 21000 },
+    })
+  })
+
+  it("reports a still-empty wallet as not received", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(0) })
+
+    const result = await check()
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  it("reports a device with no mnemonic for the provisioned account", async () => {
+    mockGetMnemonic.mockResolvedValue(null)
+
+    const result = await check()
+
+    expect(result).toEqual({ status: MigrationSdkStatus.NoMnemonic })
+    expect(mockInitSdk).not.toHaveBeenCalled()
+  })
+
+  it("keeps a network-tagged connect failure retryable", async () => {
+    mockClassifySdkError.mockReturnValue(SelfCustodialErrorCode.NetworkError)
+    mockInitSdk.mockRejectedValue(new Error("connection reset"))
+
+    const result = await check()
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.ConnectionError,
+      error: expect.objectContaining({ message: "connection reset" }),
+    })
+  })
+
+  it("disconnects even when the balance read fails", async () => {
+    mockGetInfo.mockRejectedValue(new Error("info unavailable"))
+
+    const result = await check()
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Failed,
+      error: expect.objectContaining({ message: "info unavailable" }),
+    })
+    expect(mockDisconnectSdk).toHaveBeenCalledTimes(1)
+  })
+
+  /** The check and the invoice builder open SDKs on the same storage directory, so a
+   *  check fired while a commit retry is mid-connect must wait its turn. */
+  it("serializes behind a transfer request on the same storage directory", async () => {
+    let releaseFirstConnect: () => void = () => {}
+    const connectedSdk = sdkWith(jest.fn().mockResolvedValue({ signature: "deadbeef" }))
+    mockGetWalletInfo.mockResolvedValue({ identityPubkey: SPARK_PUBKEY })
+    mockReceivePayment.mockResolvedValue({ paymentRequest: "lnbcrt1invoice" })
+    mockInitSdk.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseFirstConnect = () => resolve(connectedSdk)
+        }),
+    )
+    mockInitSdk.mockResolvedValue({ getInfo: mockGetInfo })
+
+    const request = buildMigrationTransferRequest({
+      accountId: "sc-account-1",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+      signChallenge: () => "migrate:challenge",
+    })
+    const landed = check()
+    await flushMicrotasks()
+    expect(mockInitSdk).toHaveBeenCalledTimes(1)
+    expect(mockGetInfo).not.toHaveBeenCalled()
+
+    releaseFirstConnect()
+    await Promise.all([request, landed])
+
+    expect(mockInitSdk).toHaveBeenCalledTimes(2)
+    expect(mockGetInfo).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/__tests__/utils/remote-config.spec.ts
+++ b/__tests__/utils/remote-config.spec.ts
@@ -2,13 +2,18 @@ import {
   getRemoteConfigList,
   getRemoteConfigNumericObject,
   getRemoteConfigObject,
+  getRemoteConfigPositiveNumber,
   getRemoteConfigStringList,
   serializeRemoteConfigDefault,
 } from "@app/utils/remote-config"
 
 const mockLogError = jest.fn()
 const mockAsString = jest.fn()
-const mockGetValue = jest.fn(() => ({ asString: mockAsString }))
+const mockAsNumber = jest.fn()
+const mockGetValue = jest.fn(() => ({
+  asString: mockAsString,
+  asNumber: mockAsNumber,
+}))
 
 jest.mock("@app/utils/log-error", () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
@@ -297,5 +302,60 @@ describe("getRemoteConfigNumericObject", () => {
         context: expect.objectContaining({ actualShape: "array" }),
       }),
     )
+  })
+})
+
+describe("getRemoteConfigPositiveNumber", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns a finite positive remote value", () => {
+    mockAsNumber.mockReturnValue(30_000)
+    mockAsString.mockReturnValue("30000")
+
+    expect(getRemoteConfigPositiveNumber("duration-key", 60_000)).toBe(30_000)
+    expect(mockGetValue).toHaveBeenCalledWith("duration-key")
+    expect(mockLogError).not.toHaveBeenCalled()
+  })
+
+  /** asNumber() answers 0 for anything it cannot parse, and for a duration a real zero
+   *  means "no wait at all" — the opposite of what a caller asking for one wants. */
+  it("keeps the fallback and reports a value that was set but does not parse", () => {
+    mockAsNumber.mockReturnValue(0)
+    mockAsString.mockReturnValue("60s")
+
+    expect(getRemoteConfigPositiveNumber("duration-key", 60_000)).toBe(60_000)
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({ rawSnippet: "60s" }),
+      }),
+    )
+  })
+
+  it("keeps the fallback and reports a negative value", () => {
+    mockAsNumber.mockReturnValue(-1)
+    mockAsString.mockReturnValue("-1")
+
+    expect(getRemoteConfigPositiveNumber("duration-key", 60_000)).toBe(60_000)
+    expect(mockLogError).toHaveBeenCalled()
+  })
+
+  it("keeps the fallback and reports a non-finite value", () => {
+    mockAsNumber.mockReturnValue(Number.NaN)
+    mockAsString.mockReturnValue("not-a-number")
+
+    expect(getRemoteConfigPositiveNumber("duration-key", 60_000)).toBe(60_000)
+    expect(mockLogError).toHaveBeenCalled()
+  })
+
+  /** A key that was never set answers with its registered default; that is not an ops
+   *  mistake, so it must not file one on every launch. */
+  it("keeps the fallback silently when the key was never set", () => {
+    mockAsNumber.mockReturnValue(0)
+    mockAsString.mockReturnValue("")
+
+    expect(getRemoteConfigPositiveNumber("missing-key", 60_000)).toBe(60_000)
+    expect(mockLogError).not.toHaveBeenCalled()
   })
 })

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -55,6 +55,7 @@ const SelfCustodialCreationBlockedCountriesKey = "selfCustodialCreationBlockedCo
 const OffboardOnlyCountriesKey = "offboardOnlyCountries"
 const SelfCustodialDepositClaimLeewayVbyteKey = "selfCustodialDepositClaimLeewayVbyte"
 const MigrationReceiveDelayedNoticeMsKey = "migrationReceiveDelayedNoticeMs"
+const MigrationDelayedRedirectEnabledKey = "migrationDelayedRedirectEnabled"
 const FeeRatesConfigKey = "feeRatesConfig"
 
 type DeliveryOptionConfig = {
@@ -123,6 +124,7 @@ type RemoteConfig = {
   [OffboardOnlyCountriesKey]: string[]
   [SelfCustodialDepositClaimLeewayVbyteKey]: number
   [MigrationReceiveDelayedNoticeMsKey]: number
+  [MigrationDelayedRedirectEnabledKey]: boolean
   [FeeRatesConfigKey]: FeeRatesConfig
 }
 
@@ -229,6 +231,10 @@ export const defaultRemoteConfig: RemoteConfig = {
    *  payment is taking longer than usual and offering support. Product call on #4102:
    *  a minute after the confirmed send is more than enough for a healthy receive. */
   migrationReceiveDelayedNoticeMs: 60 * 1000,
+  /** Escape hatch should requirements change: when on, the migration's receive gate
+   *  releases the redirect once the notice window elapses instead of holding the swap
+   *  until the receive confirms. Off by default — waiting is the product decision. */
+  migrationDelayedRedirectEnabled: false,
   feeRatesConfig: defaultFeeRatesConfig,
 }
 
@@ -474,6 +480,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .getValue(MigrationReceiveDelayedNoticeMsKey)
           .asNumber()
 
+        const migrationDelayedRedirectEnabled = remoteConfigInstance()
+          .getValue(MigrationDelayedRedirectEnabledKey)
+          .asBoolean()
+
         const feeRatesConfig = getRemoteConfigNumericObject(
           FeeRatesConfigKey,
           defaultFeeRatesConfig,
@@ -521,6 +531,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           offboardOnlyCountries,
           selfCustodialDepositClaimLeewayVbyte,
           migrationReceiveDelayedNoticeMs,
+          migrationDelayedRedirectEnabled,
           feeRatesConfig,
         })
       } catch (err) {

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -54,6 +54,7 @@ const CustodialCreationBlockedCountriesKey = "custodialCreationBlockedCountries"
 const SelfCustodialCreationBlockedCountriesKey = "selfCustodialCreationBlockedCountries"
 const OffboardOnlyCountriesKey = "offboardOnlyCountries"
 const SelfCustodialDepositClaimLeewayVbyteKey = "selfCustodialDepositClaimLeewayVbyte"
+const MigrationReceiveDelayedNoticeMsKey = "migrationReceiveDelayedNoticeMs"
 const FeeRatesConfigKey = "feeRatesConfig"
 
 type DeliveryOptionConfig = {
@@ -121,6 +122,7 @@ type RemoteConfig = {
   [SelfCustodialCreationBlockedCountriesKey]: string[]
   [OffboardOnlyCountriesKey]: string[]
   [SelfCustodialDepositClaimLeewayVbyteKey]: number
+  [MigrationReceiveDelayedNoticeMsKey]: number
   [FeeRatesConfigKey]: FeeRatesConfig
 }
 
@@ -223,6 +225,9 @@ export const defaultRemoteConfig: RemoteConfig = {
   selfCustodialCreationBlockedCountries: creationBlockedDefault,
   offboardOnlyCountries: offboardOnlyDefault,
   selfCustodialDepositClaimLeewayVbyte: 1,
+  /** How long the migration's receive gate waits before telling the user the incoming
+   *  payment is taking longer than usual. Generous until real transit times are known. */
+  migrationReceiveDelayedNoticeMs: 10 * 60 * 1000,
   feeRatesConfig: defaultFeeRatesConfig,
 }
 
@@ -464,6 +469,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .getValue(SelfCustodialDepositClaimLeewayVbyteKey)
           .asNumber()
 
+        const migrationReceiveDelayedNoticeMs = remoteConfigInstance()
+          .getValue(MigrationReceiveDelayedNoticeMsKey)
+          .asNumber()
+
         const feeRatesConfig = getRemoteConfigNumericObject(
           FeeRatesConfigKey,
           defaultFeeRatesConfig,
@@ -510,6 +519,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           selfCustodialCreationBlockedCountries,
           offboardOnlyCountries,
           selfCustodialDepositClaimLeewayVbyte,
+          migrationReceiveDelayedNoticeMs,
           feeRatesConfig,
         })
       } catch (err) {

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -9,6 +9,7 @@ import { logError } from "@app/utils/log-error"
 import {
   getRemoteConfigNumericObject,
   getRemoteConfigObject,
+  getRemoteConfigPositiveNumber,
   getRemoteConfigStringList,
   serializeRemoteConfigDefault,
 } from "@app/utils/remote-config"
@@ -476,9 +477,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .getValue(SelfCustodialDepositClaimLeewayVbyteKey)
           .asNumber()
 
-        const migrationReceiveDelayedNoticeMs = remoteConfigInstance()
-          .getValue(MigrationReceiveDelayedNoticeMsKey)
-          .asNumber()
+        const migrationReceiveDelayedNoticeMs = getRemoteConfigPositiveNumber(
+          MigrationReceiveDelayedNoticeMsKey,
+          defaultRemoteConfig.migrationReceiveDelayedNoticeMs,
+        )
 
         const migrationDelayedRedirectEnabled = remoteConfigInstance()
           .getValue(MigrationDelayedRedirectEnabledKey)

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -226,8 +226,9 @@ export const defaultRemoteConfig: RemoteConfig = {
   offboardOnlyCountries: offboardOnlyDefault,
   selfCustodialDepositClaimLeewayVbyte: 1,
   /** How long the migration's receive gate waits before telling the user the incoming
-   *  payment is taking longer than usual. Generous until real transit times are known. */
-  migrationReceiveDelayedNoticeMs: 10 * 60 * 1000,
+   *  payment is taking longer than usual and offering support. Product call on #4102:
+   *  a minute after the confirmed send is more than enough for a healthy receive. */
+  migrationReceiveDelayedNoticeMs: 60 * 1000,
   feeRatesConfig: defaultFeeRatesConfig,
 }
 

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -3894,6 +3894,10 @@ const en: BaseTranslation = {
     explainerCta: "I understand",
     transferringFunds:
       "Transferring your funds. It should be done in a few seconds.",
+    transferDelayed: {
+      body: "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      contactSupportCta: "Contact support",
+    },
     clockOutOfSync: {
       body: "Your device's date and time are out of sync. Set them to automatic to continue.",
       retryCta: "Try again",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -12356,6 +12356,16 @@ type RootTranslation = {
 		 * T​r​a​n​s​f​e​r​r​i​n​g​ ​y​o​u​r​ ​f​u​n​d​s​.​ ​I​t​ ​s​h​o​u​l​d​ ​b​e​ ​d​o​n​e​ ​i​n​ ​a​ ​f​e​w​ ​s​e​c​o​n​d​s​.
 		 */
 		transferringFunds: string
+		transferDelayed: {
+			/**
+			 * Y​o​u​r​ ​f​u​n​d​s​ ​a​r​e​ ​o​n​ ​t​h​e​i​r​ ​w​a​y​ ​t​o​ ​y​o​u​r​ ​n​e​w​ ​a​c​c​o​u​n​t​.​ ​T​h​i​s​ ​i​s​ ​t​a​k​i​n​g​ ​l​o​n​g​e​r​ ​t​h​a​n​ ​u​s​u​a​l​ ​—​ ​k​e​e​p​ ​t​h​e​ ​a​p​p​ ​o​p​e​n​ ​a​n​d​ ​w​e​'​l​l​ ​f​i​n​i​s​h​ ​u​p​ ​a​u​t​o​m​a​t​i​c​a​l​l​y​.
+			 */
+			body: string
+			/**
+			 * C​o​n​t​a​c​t​ ​s​u​p​p​o​r​t
+			 */
+			contactSupportCta: string
+		}
 		clockOutOfSync: {
 			/**
 			 * Y​o​u​r​ ​d​e​v​i​c​e​'​s​ ​d​a​t​e​ ​a​n​d​ ​t​i​m​e​ ​a​r​e​ ​o​u​t​ ​o​f​ ​s​y​n​c​.​ ​S​e​t​ ​t​h​e​m​ ​t​o​ ​a​u​t​o​m​a​t​i​c​ ​t​o​ ​c​o​n​t​i​n​u​e​.
@@ -25384,6 +25394,16 @@ export type TranslationFunctions = {
 		 * Transferring your funds. It should be done in a few seconds.
 		 */
 		transferringFunds: () => LocalizedString
+		transferDelayed: {
+			/**
+			 * Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.
+			 */
+			body: () => LocalizedString
+			/**
+			 * Contact support
+			 */
+			contactSupportCta: () => LocalizedString
+		}
 		clockOutOfSync: {
 			/**
 			 * Your device's date and time are out of sync. Set them to automatic to continue.

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -3730,6 +3730,10 @@
         "explainerCheck5": "Your account will be deducted with a Spark network fee",
         "explainerCta": "I understand",
         "transferringFunds": "Transferring your funds. It should be done in a few seconds.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "Your device's date and time are out of sync. Set them to automatic to continue.",
             "retryCta": "Try again"

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Ek verstaan",
     "transferringFunds": "Jou fondse word oorgedra. Dit behoort binne 'n paar sekondes klaar te wees.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Jou fondse is op pad na jou nuwe rekening. Dit neem langer as gewoonlik — hou die app oop en ons handel dit outomaties af.",
+      "contactSupportCta": "Kontak ondersteuning"
     },
     "clockOutOfSync": {
       "body": "Die datum en tyd van jou toestel is nie in sinkronisasie nie. Stel dit op outomaties om voort te gaan.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Jou rekening sal met 'n Spark-netwerkfooi belas word",
     "explainerCta": "Ek verstaan",
     "transferringFunds": "Jou fondse word oorgedra. Dit behoort binne 'n paar sekondes klaar te wees.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Die datum en tyd van jou toestel is nie in sinkronisasie nie. Stel dit op outomaties om voort te gaan.",
       "retryCta": "Probeer weer"

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "فهمت",
     "transferringFunds": "جارٍ تحويل أموالك. سيتم الانتهاء في غضون ثوانٍ قليلة.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "أموالك في طريقها إلى حسابك الجديد. يستغرق الأمر وقتًا أطول من المعتاد — أبقِ التطبيق مفتوحًا وسننهي العملية تلقائيًا.",
+      "contactSupportCta": "التواصل مع الدعم"
     },
     "clockOutOfSync": {
       "body": "تاريخ ووقت جهازك غير متزامنين. اضبطهما على الوضع التلقائي للمتابعة.",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "سيتم خصم رسوم شبكة Spark من حسابك",
     "explainerCta": "فهمت",
     "transferringFunds": "جارٍ تحويل أموالك. سيتم الانتهاء في غضون ثوانٍ قليلة.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "تاريخ ووقت جهازك غير متزامنين. اضبطهما على الوضع التلقائي للمتابعة.",
       "retryCta": "حاول مرة أخرى"

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Es descomptarà una comissió de xarxa de Spark del teu compte",
     "explainerCta": "Ho entenc",
     "transferringFunds": "Transferint els teus fons. Hauria d'estar llest en uns segons.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "La data i l'hora del teu dispositiu no estan sincronitzades. Configura-les en automàtic per continuar.",
       "retryCta": "Torna-ho a provar"

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Ho entenc",
     "transferringFunds": "Transferint els teus fons. Hauria d'estar llest en uns segons.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Els teus fons estan de camí al teu nou compte. Està trigant més de l'habitual — mantén l'aplicació oberta i ho acabarem automàticament.",
+      "contactSupportCta": "Contacta amb suport"
     },
     "clockOutOfSync": {
       "body": "La data i l'hora del teu dispositiu no estan sincronitzades. Configura-les en automàtic per continuar.",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Z tvého účtu bude stržen síťový poplatek Spark",
     "explainerCta": "Rozumím",
     "transferringFunds": "Převádíme vaše prostředky. Mělo by to být hotové za několik sekund.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Datum a čas vašeho zařízení nejsou synchronizované. Nastavte je na automatické, abyste mohli pokračovat.",
       "retryCta": "Zkusit znovu"

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Rozumím",
     "transferringFunds": "Převádíme vaše prostředky. Mělo by to být hotové za několik sekund.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Vaše prostředky jsou na cestě do vašeho nového účtu. Trvá to déle než obvykle — nechte aplikaci otevřenou a dokončíme to automaticky.",
+      "contactSupportCta": "Kontaktovat podporu"
     },
     "clockOutOfSync": {
       "body": "Datum a čas vašeho zařízení nejsou synchronizované. Nastavte je na automatické, abyste mohli pokračovat.",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Din konto vil blive trukket et Spark-netværksgebyr",
     "explainerCta": "Jeg forstår",
     "transferringFunds": "Overfører dine midler. Det skulle være færdigt om få sekunder.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Din enheds dato og klokkeslæt er ude af synkronisering. Indstil dem til automatisk for at fortsætte.",
       "retryCta": "Prøv igen"

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Jeg forstår",
     "transferringFunds": "Overfører dine midler. Det skulle være færdigt om få sekunder.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Dine midler er på vej til din nye konto. Det tager længere tid end normalt — hold appen åben, så afslutter vi automatisk.",
+      "contactSupportCta": "Kontakt support"
     },
     "clockOutOfSync": {
       "body": "Din enheds dato og klokkeslæt er ude af synkronisering. Indstil dem til automatisk for at fortsætte.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "Deinem Konto wird eine Spark-Netzwerkgebühr abgezogen",
         "explainerCta": "Ich verstehe",
         "transferringFunds": "Deine Guthaben werden übertragen. Es sollte in wenigen Sekunden abgeschlossen sein.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "Datum und Uhrzeit deines Geräts sind nicht synchron. Stelle sie auf automatisch, um fortzufahren.",
             "retryCta": "Erneut versuchen"

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "Ich verstehe",
         "transferringFunds": "Deine Guthaben werden übertragen. Es sollte in wenigen Sekunden abgeschlossen sein.",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "Deine Guthaben sind auf dem Weg zu deinem neuen Konto. Es dauert länger als üblich — lass die App geöffnet, wir schließen es automatisch ab.",
+            "contactSupportCta": "Support kontaktieren"
         },
         "clockOutOfSync": {
             "body": "Datum und Uhrzeit deines Geräts sind nicht synchron. Stelle sie auf automatisch, um fortzufahren.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Θα χρεωθεί στον λογαριασμό σας ένα τέλος δικτύου Spark",
     "explainerCta": "Καταλαβαίνω",
     "transferringFunds": "Μεταφορά των κεφαλαίων σας. Θα ολοκληρωθεί σε λίγα δευτερόλεπτα.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Η ημερομηνία και η ώρα της συσκευής σου δεν είναι συγχρονισμένες. Ρύθμισέ τες σε αυτόματες για να συνεχίσεις.",
       "retryCta": "Δοκίμασε ξανά"

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Καταλαβαίνω",
     "transferringFunds": "Μεταφορά των κεφαλαίων σας. Θα ολοκληρωθεί σε λίγα δευτερόλεπτα.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Τα κεφάλαιά σας βρίσκονται καθ' οδόν προς τον νέο σας λογαριασμό. Διαρκεί περισσότερο από το συνηθισμένο — κρατήστε την εφαρμογή ανοιχτή και θα ολοκληρώσουμε αυτόματα.",
+      "contactSupportCta": "Επικοινωνία με την υποστήριξη"
     },
     "clockOutOfSync": {
       "body": "Η ημερομηνία και η ώρα της συσκευής σου δεν είναι συγχρονισμένες. Ρύθμισέ τες σε αυτόματες για να συνεχίσεις.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "Entiendo",
         "transferringFunds": "Transfiriendo tus fondos. Debería completarse en unos segundos.",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "Tus fondos están en camino a tu nueva cuenta. Está tardando más de lo habitual — mantén la aplicación abierta y terminaremos automáticamente.",
+            "contactSupportCta": "Contactar a soporte"
         },
         "clockOutOfSync": {
             "body": "La fecha y la hora de tu dispositivo están desincronizadas. Ponlas en automático para continuar.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "Se descontará una comisión de red de Spark de tu cuenta",
         "explainerCta": "Entiendo",
         "transferringFunds": "Transfiriendo tus fondos. Debería completarse en unos segundos.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "La fecha y la hora de tu dispositivo están desincronizadas. Ponlas en automático para continuar.",
             "retryCta": "Reintentar"

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "Je comprends",
         "transferringFunds": "Transfert de vos fonds en cours. Cela devrait être terminé en quelques secondes.",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "Vos fonds sont en route vers votre nouveau compte. Cela prend plus de temps que d'habitude — gardez l'application ouverte et nous terminerons automatiquement.",
+            "contactSupportCta": "Contacter le support"
         },
         "clockOutOfSync": {
             "body": "La date et l'heure de votre appareil sont désynchronisées. Réglez-les sur automatique pour continuer.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "Des frais de réseau Spark seront déduits de votre compte",
         "explainerCta": "Je comprends",
         "transferringFunds": "Transfert de vos fonds en cours. Cela devrait être terminé en quelques secondes.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "La date et l'heure de votre appareil sont désynchronisées. Réglez-les sur automatique pour continuer.",
             "retryCta": "Réessayer"

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Razumijem",
     "transferringFunds": "Prebacujemo vaša sredstva. Trebalo bi biti gotovo za nekoliko sekundi.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Vaša sredstva su na putu prema vašem novom računu. Traje duže nego inače — držite aplikaciju otvorenom i automatski ćemo dovršiti.",
+      "contactSupportCta": "Kontaktirajte podršku"
     },
     "clockOutOfSync": {
       "body": "Datum i vrijeme vašeg uređaja nisu usklađeni. Postavite ih na automatski način rada za nastavak.",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "S tvog računa bit će naplaćena mrežna naknada Spark",
     "explainerCta": "Razumijem",
     "transferringFunds": "Prebacujemo vaša sredstva. Trebalo bi biti gotovo za nekoliko sekundi.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Datum i vrijeme vašeg uređaja nisu usklađeni. Postavite ih na automatski način rada za nastavak.",
       "retryCta": "Pokušaj ponovno"

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Megértettem",
     "transferringFunds": "Átutalás folyamatban. Néhány másodperc alatt befejeződik.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "A pénzed úton van az új számládra. A szokásosnál tovább tart — hagyd nyitva az alkalmazást, és automatikusan befejezzük.",
+      "contactSupportCta": "Kapcsolatfelvétel az ügyfélszolgálattal"
     },
     "clockOutOfSync": {
       "body": "Az eszközöd dátuma és ideje nincs szinkronban. Állítsd automatikusra a folytatáshoz.",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "A fiókodból levonásra kerül egy Spark hálózati díj",
     "explainerCta": "Megértettem",
     "transferringFunds": "Átutalás folyamatban. Néhány másodperc alatt befejeződik.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Az eszközöd dátuma és ideje nincs szinkronban. Állítsd automatikusra a folytatáshoz.",
       "retryCta": "Próbáld újra"

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Ձեր հաշվից կպահվի Spark ցանցի վճար",
     "explainerCta": "Հասկանում եմ",
     "transferringFunds": "Ձեր միջոցները փոխանցվում են։ Դա պետք է ավարտվի մի քանի վայրկյանի ընթացքում։",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Ձեր սարքի ամսաթիվն ու ժամը համաժամացված չեն։ Դրանք ավտոմատ դարձրեք՝ շարունակելու համար։",
       "retryCta": "Կրկին փորձել"

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Հասկանում եմ",
     "transferringFunds": "Ձեր միջոցները փոխանցվում են։ Դա պետք է ավարտվի մի քանի վայրկյանի ընթացքում։",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Ձեր միջոցները ձեր նոր հաշվի ճանապարհին են։ Դա տևում է սովորականից երկար — պահեք հավելվածը բաց, և մենք ավտոմատ կավարտենք։",
+      "contactSupportCta": "Կապվել աջակցության հետ"
     },
     "clockOutOfSync": {
       "body": "Ձեր սարքի ամսաթիվն ու ժամը համաժամացված չեն։ Դրանք ավտոմատ դարձրեք՝ շարունակելու համար։",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Akun Anda akan dikenakan biaya jaringan Spark",
     "explainerCta": "Saya mengerti",
     "transferringFunds": "Mentransfer dana Anda. Seharusnya selesai dalam beberapa detik.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Tanggal dan waktu perangkat Anda tidak sinkron. Atur ke otomatis untuk melanjutkan.",
       "retryCta": "Coba lagi"

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Saya mengerti",
     "transferringFunds": "Mentransfer dana Anda. Seharusnya selesai dalam beberapa detik.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Dana Anda sedang dalam perjalanan ke akun baru Anda. Ini memakan waktu lebih lama dari biasanya — biarkan aplikasi tetap terbuka dan kami akan menyelesaikannya secara otomatis.",
+      "contactSupportCta": "Hubungi dukungan"
     },
     "clockOutOfSync": {
       "body": "Tanggal dan waktu perangkat Anda tidak sinkron. Atur ke otomatis untuk melanjutkan.",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "Ho capito",
         "transferringFunds": "Trasferimento dei tuoi fondi in corso. Dovrebbe completarsi in pochi secondi.",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "I tuoi fondi sono in viaggio verso il tuo nuovo conto. Sta richiedendo più tempo del solito — tieni l'app aperta e completeremo automaticamente.",
+            "contactSupportCta": "Contatta l'assistenza"
         },
         "clockOutOfSync": {
             "body": "La data e l'ora del tuo dispositivo non sono sincronizzate. Impostale su automatico per continuare.",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "Verrà addebitata una commissione di rete Spark sul tuo account",
         "explainerCta": "Ho capito",
         "transferringFunds": "Trasferimento dei tuoi fondi in corso. Dovrebbe completarsi in pochi secondi.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "La data e l'ora del tuo dispositivo non sono sincronizzate. Impostale su automatico per continuare.",
             "retryCta": "Riprova"

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "理解しました",
         "transferringFunds": "資金を転送中です。数秒で完了するはずです。",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "資金は新しいアカウントへ送金中です。通常より時間がかかっています。アプリを開いたままにしていただければ、自動的に完了します。",
+            "contactSupportCta": "サポートに問い合わせる"
         },
         "clockOutOfSync": {
             "body": "デバイスの日付と時刻がずれています。続けるには自動設定にしてください。",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "アカウントからSparkネットワーク手数料が差し引かれます",
         "explainerCta": "理解しました",
         "transferringFunds": "資金を転送中です。数秒で完了するはずです。",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "デバイスの日付と時刻がずれています。続けるには自動設定にしてください。",
             "retryCta": "再試行"

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Ku kawunti yo kujja kusalibwako ssente z'omukutu gwa Spark",
     "explainerCta": "Ntegedde",
     "transferringFunds": "Tutwala ssente zo. Kijja kuggwa mu sikonda ntono.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Ennaku n'obudde bw'ekyuma kyo tebituukagana. Bisseeko ku otomatiki osobole okweyongerayo.",
       "retryCta": "Ddamu ogezaako"

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Ntegedde",
     "transferringFunds": "Tutwala ssente zo. Kijja kuggwa mu sikonda ntono.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Ssente zo ziri mu kkubo okutuuka ku akaawunti yo empya. Kino kitwala ebbanga okusinga bulijjo — leka app ng'eggule, tujja kukimaliriza kyokka.",
+      "contactSupportCta": "Tuukirira abayambi"
     },
     "clockOutOfSync": {
       "body": "Ennaku n'obudde bw'ekyuma kyo tebituukagana. Bisseeko ku otomatiki osobole okweyongerayo.",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Saya faham",
     "transferringFunds": "Memindahkan dana anda. Ia sepatutnya siap dalam beberapa saat.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Dana anda sedang dalam perjalanan ke akaun baharu anda. Ia mengambil masa lebih lama daripada biasa — biarkan aplikasi terbuka dan kami akan menyelesaikannya secara automatik.",
+      "contactSupportCta": "Hubungi sokongan"
     },
     "clockOutOfSync": {
       "body": "Tarikh dan masa peranti anda tidak segerak. Tetapkan kepada automatik untuk meneruskan.",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Akaun anda akan dikenakan yuran rangkaian Spark",
     "explainerCta": "Saya faham",
     "transferringFunds": "Memindahkan dana anda. Ia sepatutnya siap dalam beberapa saat.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Tarikh dan masa peranti anda tidak segerak. Tetapkan kepada automatik untuk meneruskan.",
       "retryCta": "Cuba lagi"

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Ik begrijp het",
     "transferringFunds": "Je saldo wordt overgedragen. Het zou binnen enkele seconden klaar moeten zijn.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Je saldo is onderweg naar je nieuwe account. Het duurt langer dan gebruikelijk — houd de app open, dan ronden we het automatisch af.",
+      "contactSupportCta": "Contact opnemen met support"
     },
     "clockOutOfSync": {
       "body": "De datum en tijd van je apparaat lopen niet gelijk. Zet ze op automatisch om door te gaan.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Er worden Spark-netwerkkosten van je account afgeschreven",
     "explainerCta": "Ik begrijp het",
     "transferringFunds": "Je saldo wordt overgedragen. Het zou binnen enkele seconden klaar moeten zijn.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "De datum en tijd van je apparaat lopen niet gelijk. Zet ze op automatisch om door te gaan.",
       "retryCta": "Opnieuw proberen"

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -3788,8 +3788,8 @@
         "explainerCta": "Entendi",
         "transferringFunds": "Transferindo seus fundos. Deve ser concluído em poucos segundos.",
         "transferDelayed": {
-            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-            "contactSupportCta": "Contact support"
+            "body": "Seus fundos estão a caminho da sua nova conta. Está demorando mais que o normal — mantenha o aplicativo aberto e concluiremos automaticamente.",
+            "contactSupportCta": "Falar com o suporte"
         },
         "clockOutOfSync": {
             "body": "A data e a hora do teu dispositivo estão dessincronizadas. Define-as como automáticas para continuar.",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -3787,6 +3787,10 @@
         "explainerCheck5": "Uma taxa de rede Spark será descontada da sua conta",
         "explainerCta": "Entendi",
         "transferringFunds": "Transferindo seus fundos. Deve ser concluído em poucos segundos.",
+        "transferDelayed": {
+            "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+            "contactSupportCta": "Contact support"
+        },
         "clockOutOfSync": {
             "body": "A data e a hora do teu dispositivo estão dessincronizadas. Define-as como automáticas para continuar.",
             "retryCta": "Tentar novamente"

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Akawuntiykimanta Spark red pagota qichunqaku",
     "explainerCta": "Entiendini",
     "transferringFunds": "Qullqiykita apachkaniku. Iskay kinsa sikundullapi tukurunqa.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Dispositivoykipa p'unchawnin hinaspa horan mana huñusqachu. Automáticoman churay qatinaykipaq.",
       "retryCta": "Kutiy yapamuy"

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Entiendini",
     "transferringFunds": "Qullqiykita apachkaniku. Iskay kinsa sikundullapi tukurunqa.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Qullqiykiqa musuq cuentaykiman chayachkanña. Aswan unayta ruwakuchkan — app kichasqata saqiy, ñuqayku kikillanmanta tukuchisaqku.",
+      "contactSupportCta": "Yanapakuqkunawan rimanakuy"
     },
     "clockOutOfSync": {
       "body": "Dispositivoykipa p'unchawnin hinaspa horan mana huñusqachu. Automáticoman churay qatinaykipaq.",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Din contul tău se va deduce un comision de rețea Spark",
     "explainerCta": "Am înțeles",
     "transferringFunds": "Se transferă fondurile tale. Ar trebui să fie gata în câteva secunde.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Data și ora dispozitivului tău nu sunt sincronizate. Setează-le pe automat pentru a continua.",
       "retryCta": "Încearcă din nou"

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Am înțeles",
     "transferringFunds": "Se transferă fondurile tale. Ar trebui să fie gata în câteva secunde.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Fondurile tale sunt în drum spre noul tău cont. Durează mai mult decât de obicei — ține aplicația deschisă și vom finaliza automat.",
+      "contactSupportCta": "Contactează asistența"
     },
     "clockOutOfSync": {
       "body": "Data și ora dispozitivului tău nu sunt sincronizate. Setează-le pe automat pentru a continua.",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Z tvojho účtu bude stiahnutý sieťový poplatok Spark",
     "explainerCta": "Rozumiem",
     "transferringFunds": "Prevádzame vaše prostriedky. Malo by to byť hotové za niekoľko sekúnd.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Dátum a čas vášho zariadenia nie sú synchronizované. Nastavte ich na automatické, aby ste mohli pokračovať.",
       "retryCta": "Skúsiť znova"

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Rozumiem",
     "transferringFunds": "Prevádzame vaše prostriedky. Malo by to byť hotové za niekoľko sekúnd.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Vaše prostriedky sú na ceste do vášho nového účtu. Trvá to dlhšie než zvyčajne — nechajte aplikáciu otvorenú a dokončíme to automaticky.",
+      "contactSupportCta": "Kontaktovať podporu"
     },
     "clockOutOfSync": {
       "body": "Dátum a čas vášho zariadenia nie sú synchronizované. Nastavte ich na automatické, aby ste mohli pokračovať.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Са твог налога биће наплаћена мрежна накнада Spark",
     "explainerCta": "Разумем",
     "transferringFunds": "Пребацујемо ваша средства. Требало би да буде готово за неколико секунди.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Датум и време вашег уређаја нису усклађени. Подесите их на аутоматски да бисте наставили.",
       "retryCta": "Покушај поново"

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Разумем",
     "transferringFunds": "Пребацујемо ваша средства. Требало би да буде готово за неколико секунди.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Ваша средства су на путу ка вашем новом налогу. Траје дуже него обично — држите апликацију отвореном и аутоматски ћемо завршити.",
+      "contactSupportCta": "Контактирајте подршку"
     },
     "clockOutOfSync": {
       "body": "Датум и време вашег уређаја нису усклађени. Подесите их на аутоматски да бисте наставили.",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Akaunti yako itakatwa ada ya mtandao wa Spark",
     "explainerCta": "Naelewa",
     "transferringFunds": "Tunahamisha fedha zako. Inapaswa kukamilika ndani ya sekunde chache.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Tarehe na saa za kifaa chako hazijaoanishwa. Ziweke kwa kiotomatiki ili kuendelea.",
       "retryCta": "Jaribu tena"

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Naelewa",
     "transferringFunds": "Tunahamisha fedha zako. Inapaswa kukamilika ndani ya sekunde chache.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Fedha zako ziko njiani kuelekea kwenye akaunti yako mpya. Inachukua muda mrefu kuliko kawaida — acha programu ikiwa wazi na tutakamilisha kiotomatiki.",
+      "contactSupportCta": "Wasiliana na usaidizi"
     },
     "clockOutOfSync": {
       "body": "Tarehe na saa za kifaa chako hazijaoanishwa. Ziweke kwa kiotomatiki ili kuendelea.",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "บัญชีของคุณจะถูกหักค่าธรรมเนียมเครือข่าย Spark",
     "explainerCta": "เข้าใจแล้ว",
     "transferringFunds": "กำลังโอนเงินของคุณ จะเสร็จสิ้นภายในไม่กี่วินาที",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "วันที่และเวลาของอุปกรณ์ของคุณไม่ตรงกัน ตั้งค่าเป็นอัตโนมัติเพื่อดำเนินการต่อ",
       "retryCta": "ลองอีกครั้ง"

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "เข้าใจแล้ว",
     "transferringFunds": "กำลังโอนเงินของคุณ จะเสร็จสิ้นภายในไม่กี่วินาที",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "เงินของคุณกำลังอยู่ระหว่างการโอนไปยังบัญชีใหม่ของคุณ ใช้เวลานานกว่าปกติ — เปิดแอปทิ้งไว้ แล้วเราจะดำเนินการให้เสร็จโดยอัตโนมัติ",
+      "contactSupportCta": "ติดต่อฝ่ายสนับสนุน"
     },
     "clockOutOfSync": {
       "body": "วันที่และเวลาของอุปกรณ์ของคุณไม่ตรงกัน ตั้งค่าเป็นอัตโนมัติเพื่อดำเนินการต่อ",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Hesabından bir Spark ağ ücreti düşülecek",
     "explainerCta": "Anladım",
     "transferringFunds": "Bakiyeniz aktarılıyor. Birkaç saniye içinde tamamlanacaktır.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Cihazının tarih ve saati eşitlenmemiş. Devam etmek için otomatik olarak ayarla.",
       "retryCta": "Tekrar dene"

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Anladım",
     "transferringFunds": "Bakiyeniz aktarılıyor. Birkaç saniye içinde tamamlanacaktır.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Bakiyeniz yeni hesabınıza aktarılıyor. Bu, normalden uzun sürüyor — uygulamayı açık tutun, işlemi otomatik olarak tamamlayacağız.",
+      "contactSupportCta": "Destek ile iletişime geçin"
     },
     "clockOutOfSync": {
       "body": "Cihazının tarih ve saati eşitlenmemiş. Devam etmek için otomatik olarak ayarla.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Tôi hiểu",
     "transferringFunds": "Đang chuyển tiền của bạn. Sẽ hoàn tất trong vài giây.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Tiền của bạn đang trên đường chuyển đến tài khoản mới. Quá trình này lâu hơn bình thường — hãy giữ ứng dụng mở và chúng tôi sẽ tự động hoàn tất.",
+      "contactSupportCta": "Liên hệ hỗ trợ"
     },
     "clockOutOfSync": {
       "body": "Ngày và giờ trên thiết bị của bạn không đồng bộ. Đặt về tự động để tiếp tục.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "Tài khoản của bạn sẽ bị trừ phí mạng Spark",
     "explainerCta": "Tôi hiểu",
     "transferringFunds": "Đang chuyển tiền của bạn. Sẽ hoàn tất trong vài giây.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Ngày và giờ trên thiết bị của bạn không đồng bộ. Đặt về tự động để tiếp tục.",
       "retryCta": "Thử lại"

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -3787,6 +3787,10 @@
     "explainerCheck5": "I-akhawunti yakho iya kukhutshelwa intlawulo yothungelwano lwe-Spark",
     "explainerCta": "Ndiyaqonda",
     "transferringFunds": "Sidlulisela imali yakho. Kufanele kugqitywe ngomzuzwana nje.",
+    "transferDelayed": {
+      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
+      "contactSupportCta": "Contact support"
+    },
     "clockOutOfSync": {
       "body": "Umhla nexesha lesixhobo sakho azihambelani. Zimisele ukuba zizenzekele ukuze uqhubeke.",
       "retryCta": "Zama kwakhona"

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -3788,8 +3788,8 @@
     "explainerCta": "Ndiyaqonda",
     "transferringFunds": "Sidlulisela imali yakho. Kufanele kugqitywe ngomzuzwana nje.",
     "transferDelayed": {
-      "body": "Your funds are on their way to your new account. This is taking longer than usual — keep the app open and we'll finish up automatically.",
-      "contactSupportCta": "Contact support"
+      "body": "Imali yakho isendleleni eya kwiakhawunti yakho entsha. Kuthatha ixesha elide kunesiqhelo — gcina i-app ivulekile, siza kugqibezela ngokuzenzekelayo.",
+      "contactSupportCta": "Qhagamshelana nenkxaso"
     },
     "clockOutOfSync": {
       "body": "Umhla nexesha lesixhobo sakho azihambelani. Zimisele ukuba zizenzekele ukuze uqhubeke.",

--- a/app/screens/account-migration/hooks/use-complete-migration.ts
+++ b/app/screens/account-migration/hooks/use-complete-migration.ts
@@ -14,7 +14,7 @@ import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
  *  with the checkpoint intact, never stranded on an empty self-custodial account. Also
  *  surfaces the migration's checkpoint and account id from a single source of truth. */
 export const useCompleteMigration = () => {
-  const { checkpoint, accountId, loading, clearCheckpoint } =
+  const { checkpoint, accountId, expectedReceiveSats, loading, clearCheckpoint } =
     useMigrationCheckpointState()
   const { clearPendingAccount } = usePendingMigrationAccounts()
   const { setActiveAccountId, accounts, loading: accountsLoading } = useAccountRegistry()
@@ -55,6 +55,8 @@ export const useCompleteMigration = () => {
   return {
     migrationCheckpoint: checkpoint,
     migrationAccountId: accountId,
+    /** What the receive gate waits for; null on checkpoints saved before the field existed. */
+    migrationExpectedReceiveSats: expectedReceiveSats,
     migrationLoading: isMigrationDataLoading,
     completeMigration,
   }

--- a/app/screens/account-migration/hooks/use-migration-account.ts
+++ b/app/screens/account-migration/hooks/use-migration-account.ts
@@ -50,10 +50,9 @@ export const useMigrationAccount = () => {
         /** The step is the terms screen: resuming may never skip past an unaccepted T&C.
          *  A failed write stops the flow here; the provisioned id survives in the hook's
          *  local state, so retrying resumes it instead of provisioning a second account. */
-        const isSaved = await saveCheckpoint(
-          MigrationCheckpoint.TermsAndConditions,
-          newAccountId,
-        )
+        const isSaved = await saveCheckpoint(MigrationCheckpoint.TermsAndConditions, {
+          provisionedAccountId: newAccountId,
+        })
         if (!isSaved) throw new Error("Migration checkpoint save failed")
         return newAccountId
       })

--- a/app/screens/account-migration/hooks/use-migration-balances-preview.ts
+++ b/app/screens/account-migration/hooks/use-migration-balances-preview.ts
@@ -135,6 +135,10 @@ export const useMigrationBalancesPreview = () => {
 
   return {
     isReady,
+    /** The raw figure for persisting into the checkpoint, unlike the formatted strings
+     *  below; null until the preview is ready so a placeholder zero is never mistaken
+     *  for a real zero-receive migration. */
+    receiveSats: isReady ? receiveSats : null,
     isRetryable,
     isUnavailable,
     unavailableReason,

--- a/app/screens/account-migration/hooks/use-migration-balances-preview.ts
+++ b/app/screens/account-migration/hooks/use-migration-balances-preview.ts
@@ -135,10 +135,10 @@ export const useMigrationBalancesPreview = () => {
 
   return {
     isReady,
-    /** The raw figure for persisting into the checkpoint, unlike the formatted strings
-     *  below; null until the preview is ready so a placeholder zero is never mistaken
-     *  for a real zero-receive migration. */
-    receiveSats: isReady ? receiveSats : null,
+    /** The raw figure for the checkpoint, named for what the checkpoint calls it rather
+     *  than shadowing the preview field whose type it does not share. Null until ready, so
+     *  a placeholder zero is never mistaken for a real zero-receive migration. */
+    expectedReceiveSats: isReady ? receiveSats : null,
     isRetryable,
     isUnavailable,
     unavailableReason,

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -17,6 +17,13 @@ import {
 
 import { useCustodialOwnerId } from "./use-custodial-owner-id"
 
+/** Named rather than positional so a caller setting only one field does not pass a
+ *  placeholder for the other. */
+type SaveCheckpointOptions = {
+  provisionedAccountId?: string
+  expectedReceiveSats?: number
+}
+
 /**
  * The persisted migration checkpoint's state and writes, free of any navigation
  * coupling so pure-logic consumers (backup routing, the session swap) can read the
@@ -86,13 +93,16 @@ export const useMigrationCheckpointState = () => {
     : null
 
   /** Resolves false when the write fails, so callers can stop the flow instead of
-   *  advancing on a checkpoint that only exists in memory. Re-sending the known
-   *  accountId lets a later successful save heal a write that failed. */
+   *  advancing on a checkpoint that only exists in memory. Re-sending what this hook
+   *  already knows heals a failed write: mergeCheckpoint preserves what reached storage,
+   *  this covers what never did. */
   const saveCheckpoint = useCallback(
     async (
       step: MigrationCheckpoint,
-      provisionedAccountId?: string,
-      expectedReceiveSatsUpdate?: number,
+      {
+        provisionedAccountId,
+        expectedReceiveSats: expectedReceiveSatsUpdate,
+      }: SaveCheckpointOptions = {},
     ): Promise<boolean> => {
       /** Without a resolved owner the checkpoint cannot be keyed, and saving would erase the
        *  stored owner + account id via mergeCheckpoint; refuse so a null-owner window (an

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -81,6 +81,9 @@ export const useMigrationCheckpointState = () => {
     !stored?.custodialAccountId || stored.custodialAccountId === ownerId
   const checkpoint = isOwnedByActiveAccount ? stored?.step ?? null : null
   const accountId = isOwnedByActiveAccount ? stored?.accountId ?? null : null
+  const expectedReceiveSats = isOwnedByActiveAccount
+    ? stored?.expectedReceiveSats ?? null
+    : null
 
   /** Resolves false when the write fails, so callers can stop the flow instead of
    *  advancing on a checkpoint that only exists in memory. Re-sending the known
@@ -89,6 +92,7 @@ export const useMigrationCheckpointState = () => {
     async (
       step: MigrationCheckpoint,
       provisionedAccountId?: string,
+      expectedReceiveSatsUpdate?: number,
     ): Promise<boolean> => {
       /** Without a resolved owner the checkpoint cannot be keyed, and saving would erase the
        *  stored owner + account id via mergeCheckpoint; refuse so a null-owner window (an
@@ -98,6 +102,8 @@ export const useMigrationCheckpointState = () => {
         step,
         accountId: provisionedAccountId ?? accountId ?? undefined,
         custodialAccountId: ownerId,
+        expectedReceiveSats:
+          expectedReceiveSatsUpdate ?? expectedReceiveSats ?? undefined,
       }
       setStored((existing) => mergeCheckpoint(existing, update))
       try {
@@ -108,7 +114,7 @@ export const useMigrationCheckpointState = () => {
         return false
       }
     },
-    [storageKey, ownerId, accountId],
+    [storageKey, ownerId, accountId, expectedReceiveSats],
   )
 
   const clearCheckpoint = useCallback(() => {
@@ -124,6 +130,7 @@ export const useMigrationCheckpointState = () => {
   return {
     checkpoint,
     accountId,
+    expectedReceiveSats,
     loading: loading || ownerLoading,
     /** A read failure surfaced, not swallowed: without it an unreadable store is
      *  indistinguishable from a wiped device, and the gate would hand a resumable user

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -13,6 +13,11 @@ import { reportError } from "@app/utils/error-logging"
  *  per-directory serialization for nothing. */
 const RECEIVE_CHECK_RETRY_MS = 5000
 
+/** Past the notice window the wait is no longer a matter of seconds, and the gate never
+ *  gives up, so the checks back off rather than opening an SDK connection every 5s for the
+ *  rest of the session. */
+const DELAYED_RECEIVE_CHECK_RETRY_MS = 30_000
+
 type UseMigrationReceiveConfirmationArgs = {
   selfCustodialAccountId: string | null
   /**
@@ -76,6 +81,10 @@ export const useMigrationReceiveConfirmation = ({
    *  file the same story. */
   const hasReportedFailureRef = useRef(false)
 
+  /** Mirrors the state for the polling effect, which outlives the flip and must read the
+   *  current cadence without re-arming (a re-armed effect fires an extra check at once). */
+  const isReceiveDelayedRef = useRef(false)
+
   useEffect(() => {
     if (!isWatching || selfCustodialAccountId === null) return
 
@@ -84,7 +93,10 @@ export const useMigrationReceiveConfirmation = ({
     const accountId = selfCustodialAccountId
 
     const scheduleNextCheck = () => {
-      timer = setTimeout(runCheck, RECEIVE_CHECK_RETRY_MS)
+      const retryMs = isReceiveDelayedRef.current
+        ? DELAYED_RECEIVE_CHECK_RETRY_MS
+        : RECEIVE_CHECK_RETRY_MS
+      timer = setTimeout(runCheck, retryMs)
     }
 
     const reportOnce = (err: unknown) => {
@@ -139,16 +151,33 @@ export const useMigrationReceiveConfirmation = ({
     }
   }, [isWatching, selfCustodialAccountId, network, selfCustodialDepositClaimLeewayVbyte])
 
-  /** The notice measures the wait for the receive, not the whole transfer: it starts when
-   *  the watching starts (server COMPLETED, nothing landed) and is withdrawn if a check
-   *  confirms before it fires. */
+  /** The notice measures the wait for the receive, not the whole transfer: it runs from a
+   *  timestamp rather than the effect's own lifetime because both callers recompute `skip`
+   *  from inputs that flap, and a window re-armed on each flap would never elapse. */
+  const watchStartedAtRef = useRef(0)
+  const watchedAccountIdRef = useRef<string | null>(null)
+
   useEffect(() => {
     if (!isWatching) return
+
+    /** Only a different wallet starts a fresh window: the wait belongs to one migration's
+     *  receive. A caller merely re-skipping deliberately does not reset it. */
+    if (watchedAccountIdRef.current !== selfCustodialAccountId) {
+      watchedAccountIdRef.current = selfCustodialAccountId
+      watchStartedAtRef.current = Date.now()
+      isReceiveDelayedRef.current = false
+      setIsReceiveDelayed(false)
+    }
+
+    const elapsed = Date.now() - watchStartedAtRef.current
+    const remaining = Math.max(migrationReceiveDelayedNoticeMs - elapsed, 0)
+
     const timer = setTimeout(() => {
+      isReceiveDelayedRef.current = true
       setIsReceiveDelayed(true)
-    }, migrationReceiveDelayedNoticeMs)
+    }, remaining)
     return () => clearTimeout(timer)
-  }, [isWatching, migrationReceiveDelayedNoticeMs])
+  }, [isWatching, selfCustodialAccountId, migrationReceiveDelayedNoticeMs])
 
   /** A skipped gate is inert, whatever it remembers: a caller that re-skips after a
    *  late failure must not keep receiving a notice (or a confirmation) minted for a

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -39,7 +39,9 @@ type UseMigrationReceiveConfirmation = {
  * claims a payment Spark held for the offline wallet — and never gives up: an unconfirmed
  * receive keeps the user on the working custodial session, which is strictly better than
  * an empty new one. After the remote-configured notice window it raises `isReceiveDelayed`
- * so the screen can say the wait is unusual and offer support, while still polling.
+ * so the screen can say the wait is unusual and offer support, while still polling —
+ * unless the delayed-redirect flag is on, in which case the elapsed window releases the
+ * gate instead (the pre-#4102 behavior, kept reachable without an app release).
  */
 export const useMigrationReceiveConfirmation = ({
   selfCustodialAccountId,
@@ -47,17 +49,26 @@ export const useMigrationReceiveConfirmation = ({
   skip,
 }: UseMigrationReceiveConfirmationArgs): UseMigrationReceiveConfirmation => {
   const network = useSparkNetwork()
-  const { selfCustodialDepositClaimLeewayVbyte, migrationReceiveDelayedNoticeMs } =
-    useRemoteConfig()
+  const {
+    selfCustodialDepositClaimLeewayVbyte,
+    migrationReceiveDelayedNoticeMs,
+    migrationDelayedRedirectEnabled,
+  } = useRemoteConfig()
   const [isReceiveConfirmed, setIsReceiveConfirmed] = useState(false)
   const [isReceiveDelayed, setIsReceiveDelayed] = useState(false)
 
   /** A zero-receive migration (balance at or under an uncovered fee) gets no payment, so
    *  the gate opens without ever touching the SDK; waiting would strand the user forever. */
   const isConfirmedWithoutWaiting = !skip && expectedReceiveSats === 0
+
+  /** The escape hatch: with the flag on, the elapsed notice window opens the gate rather
+   *  than raising the notice, so the swap proceeds as it did before the gate existed. */
+  const isReleasedByTimeout = isReceiveDelayed && migrationDelayedRedirectEnabled
+
   const isWatching =
     !skip &&
     !isConfirmedWithoutWaiting &&
+    !isReleasedByTimeout &&
     !isReceiveConfirmed &&
     selfCustodialAccountId !== null
 
@@ -140,8 +151,14 @@ export const useMigrationReceiveConfirmation = ({
   }, [isWatching, migrationReceiveDelayedNoticeMs])
 
   return {
-    isReceiveConfirmed: isReceiveConfirmed || isConfirmedWithoutWaiting,
+    isReceiveConfirmed:
+      isReceiveConfirmed || isConfirmedWithoutWaiting || isReleasedByTimeout,
+    /** Masked once anything confirms — including the timeout release, which must swap
+     *  at once rather than flash the "taking longer" copy it just made moot. */
     isReceiveDelayed:
-      isReceiveDelayed && !isReceiveConfirmed && !isConfirmedWithoutWaiting,
+      isReceiveDelayed &&
+      !isReceiveConfirmed &&
+      !isConfirmedWithoutWaiting &&
+      !isReleasedByTimeout,
   }
 }

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react"
+
+import { useRemoteConfig } from "@app/config/feature-flags-context"
+import { useSparkNetwork } from "@app/self-custodial/hooks/use-spark-network"
+import {
+  checkMigrationReceiveLanded,
+  MigrationSdkStatus,
+} from "@app/self-custodial/migration-transfer-request"
+import { reportError } from "@app/utils/error-logging"
+
+/** Between settled checks, not between starts: a check itself takes seconds (a connect
+ *  plus a forced sync), and stacking a second one would only queue behind the
+ *  per-directory serialization for nothing. */
+const RECEIVE_CHECK_RETRY_MS = 5000
+
+type UseMigrationReceiveConfirmationArgs = {
+  selfCustodialAccountId: string | null
+  /**
+   * What the commit-point preview said the wallet will receive. Zero means nothing will
+   * ever arrive, so the gate opens at once; null means the checkpoint predates the field,
+   * and an unknown expectation waits like a funded one — the delayed notice is its way out.
+   */
+  expectedReceiveSats: number | null
+  /** True until the server phase is COMPLETED: before the drain is even paid there is
+   *  nothing to look for, and each look opens a whole SDK connection. */
+  skip: boolean
+}
+
+type UseMigrationReceiveConfirmation = {
+  isReceiveConfirmed: boolean
+  isReceiveDelayed: boolean
+}
+
+/**
+ * Whether the migration's payment has landed in the provisioned Spark wallet. The server's
+ * COMPLETED is the sender's word only; swapping the session on it alone can land the user
+ * in a zero-balance wallet while the funds are still in transit (#4102), so both swap
+ * paths wait for this gate. It polls the wallet's synced balance — the sync itself is what
+ * claims a payment Spark held for the offline wallet — and never gives up: an unconfirmed
+ * receive keeps the user on the working custodial session, which is strictly better than
+ * an empty new one. After the remote-configured notice window it raises `isReceiveDelayed`
+ * so the screen can say the wait is unusual and offer support, while still polling.
+ */
+export const useMigrationReceiveConfirmation = ({
+  selfCustodialAccountId,
+  expectedReceiveSats,
+  skip,
+}: UseMigrationReceiveConfirmationArgs): UseMigrationReceiveConfirmation => {
+  const network = useSparkNetwork()
+  const { selfCustodialDepositClaimLeewayVbyte, migrationReceiveDelayedNoticeMs } =
+    useRemoteConfig()
+  const [isReceiveConfirmed, setIsReceiveConfirmed] = useState(false)
+  const [isReceiveDelayed, setIsReceiveDelayed] = useState(false)
+
+  /** A zero-receive migration (balance at or under an uncovered fee) gets no payment, so
+   *  the gate opens without ever touching the SDK; waiting would strand the user forever. */
+  const isConfirmedWithoutWaiting = !skip && expectedReceiveSats === 0
+  const isWatching =
+    !skip &&
+    !isConfirmedWithoutWaiting &&
+    !isReceiveConfirmed &&
+    selfCustodialAccountId !== null
+
+  /** One report however long the polling runs; every retry after the first failure would
+   *  file the same story. */
+  const hasReportedFailureRef = useRef(false)
+
+  useEffect(() => {
+    if (!isWatching || selfCustodialAccountId === null) return
+
+    let isActive = true
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const accountId = selfCustodialAccountId
+
+    const scheduleNextCheck = () => {
+      timer = setTimeout(runCheck, RECEIVE_CHECK_RETRY_MS)
+    }
+
+    const reportOnce = (err: unknown) => {
+      if (hasReportedFailureRef.current) return
+      hasReportedFailureRef.current = true
+      reportError("Migration receive check", err)
+    }
+
+    const runCheck = async () => {
+      let result: Awaited<ReturnType<typeof checkMigrationReceiveLanded>>
+      try {
+        result = await checkMigrationReceiveLanded({
+          accountId,
+          network,
+          leewaySatPerVbyte: selfCustodialDepositClaimLeewayVbyte,
+        })
+      } catch (err) {
+        /** A keystore read that threw before the SDK result shape existed: transient as
+         *  far as this gate can tell, so it is retried like a lost connection. */
+        if (!isActive) return
+        reportOnce(err)
+        scheduleNextCheck()
+        return
+      }
+      if (!isActive) return
+
+      /** The wallet's key is gone from the device. The gate must not invent its own
+       *  handover: it opens, and the swap it releases already reads the same absence and
+       *  routes to support (SelfCustodialAccountMissing / NotOnDevice). */
+      if (result.status === MigrationSdkStatus.NoMnemonic) {
+        setIsReceiveConfirmed(true)
+        return
+      }
+
+      if (result.status === MigrationSdkStatus.Ok && result.value.hasReceived) {
+        setIsReceiveConfirmed(true)
+        return
+      }
+
+      /** Not landed yet, or the check itself failed: either way the funds may still be in
+       *  transit, so the only wrong move is to stop looking. A settled failure is reported
+       *  (once) rather than surfaced — the user can do nothing with it mid-wait. */
+      if (result.status === MigrationSdkStatus.Failed) reportOnce(result.error)
+      scheduleNextCheck()
+    }
+
+    runCheck()
+
+    return () => {
+      isActive = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [isWatching, selfCustodialAccountId, network, selfCustodialDepositClaimLeewayVbyte])
+
+  /** The notice measures the wait for the receive, not the whole transfer: it starts when
+   *  the watching starts (server COMPLETED, nothing landed) and is withdrawn if a check
+   *  confirms before it fires. */
+  useEffect(() => {
+    if (!isWatching) return
+    const timer = setTimeout(() => {
+      setIsReceiveDelayed(true)
+    }, migrationReceiveDelayedNoticeMs)
+    return () => clearTimeout(timer)
+  }, [isWatching, migrationReceiveDelayedNoticeMs])
+
+  return {
+    isReceiveConfirmed: isReceiveConfirmed || isConfirmedWithoutWaiting,
+    isReceiveDelayed:
+      isReceiveDelayed && !isReceiveConfirmed && !isConfirmedWithoutWaiting,
+  }
+}

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -59,7 +59,7 @@ export const useMigrationReceiveConfirmation = ({
 
   /** A zero-receive migration (balance at or under an uncovered fee) gets no payment, so
    *  the gate opens without ever touching the SDK; waiting would strand the user forever. */
-  const isConfirmedWithoutWaiting = !skip && expectedReceiveSats === 0
+  const isConfirmedWithoutWaiting = expectedReceiveSats === 0
 
   /** The escape hatch: with the flag on, the elapsed notice window opens the gate rather
    *  than raising the notice, so the swap proceeds as it did before the gate existed. */
@@ -150,12 +150,16 @@ export const useMigrationReceiveConfirmation = ({
     return () => clearTimeout(timer)
   }, [isWatching, migrationReceiveDelayedNoticeMs])
 
+  /** A skipped gate is inert, whatever it remembers: a caller that re-skips after a
+   *  late failure must not keep receiving a notice (or a confirmation) minted for a
+   *  swap that is no longer allowed to happen. */
   return {
     isReceiveConfirmed:
-      isReceiveConfirmed || isConfirmedWithoutWaiting || isReleasedByTimeout,
-    /** Masked once anything confirms — including the timeout release, which must swap
-     *  at once rather than flash the "taking longer" copy it just made moot. */
+      !skip && (isReceiveConfirmed || isConfirmedWithoutWaiting || isReleasedByTimeout),
+    /** Also masked once anything confirms — including the timeout release, which must
+     *  swap at once rather than flash the "taking longer" copy it just made moot. */
     isReceiveDelayed:
+      !skip &&
       isReceiveDelayed &&
       !isReceiveConfirmed &&
       !isConfirmedWithoutWaiting &&

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -123,11 +123,17 @@ export const useMigrationReceiveConfirmation = ({
       }
       if (!isActive) return
 
-      /** The wallet's key is gone from the device. The gate must not invent its own
-       *  handover: it opens, and the swap it releases already reads the same absence and
-       *  routes to support (SelfCustodialAccountMissing / NotOnDevice). */
+      /**
+       * The wallet's key is gone from the device, and the gate must not answer that with a
+       * confirmation: the swap it would release checks the account index rather than the
+       * keystore, so it would discard the working custodial session for a wallet whose key
+       * is unrecoverable, leaving the user with neither. Treated as not-landed instead,
+       * which keeps the working session and lets the delayed notice route to support. The
+       * re-read is cheap — it settles before any SDK connection is opened.
+       */
       if (result.status === MigrationSdkStatus.NoMnemonic) {
-        setIsReceiveConfirmed(true)
+        reportOnce(new Error("No mnemonic for the provisioned account"))
+        scheduleNextCheck()
         return
       }
 

--- a/app/screens/account-migration/hooks/use-migration-transfer.ts
+++ b/app/screens/account-migration/hooks/use-migration-transfer.ts
@@ -19,6 +19,7 @@ import {
   currentProofTimestamp,
 } from "../utils/migration-proof"
 
+import { useMigrationReceiveConfirmation } from "./use-migration-receive-confirmation"
 import { useMigrationStatus } from "./use-migration-status"
 
 gql`
@@ -75,11 +76,14 @@ export const resetMigrationCommitGuard = (): void => {
 type UseMigrationTransferArgs = {
   custodialAccountId: string | null
   selfCustodialAccountId: string | null
+  /** From the checkpoint; null on records saved before the field existed. */
+  expectedReceiveSats: number | null
   skip: boolean
 }
 
 type UseMigrationTransfer = {
   isTransferred: boolean
+  isReceiveDelayed: boolean
   failureReason: MigrationSupportReason | null
   isClockOutOfSync: boolean
   hasConnectionIssue: boolean
@@ -96,6 +100,7 @@ type UseMigrationTransfer = {
 export const useMigrationTransfer = ({
   custodialAccountId,
   selfCustodialAccountId,
+  expectedReceiveSats,
   skip,
 }: UseMigrationTransferArgs): UseMigrationTransfer => {
   const network = useSparkNetwork()
@@ -129,13 +134,26 @@ export const useMigrationTransfer = ({
 
   const hasServerFailed = status === MigrationStatus.Failed
 
+  /** COMPLETED is the sender's word only; the swap must also wait for the receiver's,
+   *  or the user lands in a wallet whose funds are still in transit (#4102). */
+  const { isReceiveConfirmed, isReceiveDelayed } = useMigrationReceiveConfirmation({
+    selfCustodialAccountId,
+    expectedReceiveSats,
+    skip: skip || status !== MigrationStatus.Completed || failureReason !== null,
+  })
+
   /** A failure already handed the user to support, so a later COMPLETED from a stray poll
    *  must not also swap the session out from under that screen. */
-  const isTransferred = status === MigrationStatus.Completed && failureReason === null
+  const isTransferred =
+    status === MigrationStatus.Completed && failureReason === null && isReceiveConfirmed
 
+  /** Stops on the server's terminal phase, not on isTransferred: the phase can no longer
+   *  change while the receive gate waits, so polling on would only re-run the server's
+   *  resume routine for the length of the wait. */
   useEffect(() => {
-    if (isTransferred || hasServerFailed || failureReason !== null) setHasStopped(true)
-  }, [isTransferred, hasServerFailed, failureReason])
+    const hasServerSettled = status === MigrationStatus.Completed || hasServerFailed
+    if (hasServerSettled || failureReason !== null) setHasStopped(true)
+  }, [status, hasServerFailed, failureReason])
 
   /** A phase past IN_PROGRESS means the commit did land (the drop hit the response, not the
    *  request): the transfer is under way, so the notice clears and the screen watches it. */
@@ -302,6 +320,7 @@ export const useMigrationTransfer = ({
 
   return {
     isTransferred,
+    isReceiveDelayed,
     failureReason: activeFailureReason,
     isClockOutOfSync,
     hasConnectionIssue,

--- a/app/screens/account-migration/hooks/use-migration-transfer.ts
+++ b/app/screens/account-migration/hooks/use-migration-transfer.ts
@@ -133,27 +133,29 @@ export const useMigrationTransfer = ({
   })
 
   const hasServerFailed = status === MigrationStatus.Failed
+  const isServerCompleted = status === MigrationStatus.Completed
+  const hasFailed = failureReason !== null
 
   /** COMPLETED is the sender's word only; the swap must also wait for the receiver's,
    *  or the user lands in a wallet whose funds are still in transit (#4102). */
+  const isReceiveGateSkipped = skip || !isServerCompleted || hasFailed
   const { isReceiveConfirmed, isReceiveDelayed } = useMigrationReceiveConfirmation({
     selfCustodialAccountId,
     expectedReceiveSats,
-    skip: skip || status !== MigrationStatus.Completed || failureReason !== null,
+    skip: isReceiveGateSkipped,
   })
 
   /** A failure already handed the user to support, so a later COMPLETED from a stray poll
    *  must not also swap the session out from under that screen. */
-  const isTransferred =
-    status === MigrationStatus.Completed && failureReason === null && isReceiveConfirmed
+  const isTransferred = isServerCompleted && !hasFailed && isReceiveConfirmed
 
   /** Stops on the server's terminal phase, not on isTransferred: the phase can no longer
    *  change while the receive gate waits, so polling on would only re-run the server's
    *  resume routine for the length of the wait. */
   useEffect(() => {
-    const hasServerSettled = status === MigrationStatus.Completed || hasServerFailed
-    if (hasServerSettled || failureReason !== null) setHasStopped(true)
-  }, [status, hasServerFailed, failureReason])
+    const hasServerSettled = isServerCompleted || hasServerFailed
+    if (hasServerSettled || hasFailed) setHasStopped(true)
+  }, [isServerCompleted, hasServerFailed, hasFailed])
 
   /** A phase past IN_PROGRESS means the commit did land (the drop hit the response, not the
    *  request): the transfer is under way, so the notice clears and the screen watches it. */
@@ -176,10 +178,10 @@ export const useMigrationTransfer = ({
   /** The owner id can resolve a tick after mount; once it does, restore any failure the
    *  guard already remembers so a re-entered screen routes to support rather than spinning. */
   useEffect(() => {
-    if (!custodialAccountId || failureReason !== null) return
+    if (!custodialAccountId || hasFailed) return
     const rememberedFailure = settledCommitFailures.get(custodialAccountId)
     if (rememberedFailure) setFailureReason(rememberedFailure)
-  }, [custodialAccountId, failureReason])
+  }, [custodialAccountId, hasFailed])
 
   const commit = useCallback(
     async (custodialId: string, selfCustodialId: string) => {
@@ -247,7 +249,6 @@ export const useMigrationTransfer = ({
   /** The server is waiting for a destination only while IN_PROGRESS: TRANSFERRING already
    *  has one, and committing a second invoice is refused as a state conflict. */
   const isAwaitingDestination = status === MigrationStatus.InProgress
-  const hasFailed = failureReason !== null
   /** A recoverable issue (skewed clock or lost connection) pauses the commit; clearing the
    *  flag on retry flips canCommit back to true and re-fires the effect. */
   const hasRecoverableIssue = isClockOutOfSync || hasConnectionIssue

--- a/app/screens/account-migration/hooks/use-resume-completed-migration.ts
+++ b/app/screens/account-migration/hooks/use-resume-completed-migration.ts
@@ -9,6 +9,7 @@ import { MigrationSupportOrigin, MigrationSupportReason } from "@app/types/migra
 import { reportError } from "@app/utils/error-logging"
 
 import { useCompleteMigration } from "./use-complete-migration"
+import { useMigrationReceiveConfirmation } from "./use-migration-receive-confirmation"
 import { useMigrationStatus } from "./use-migration-status"
 
 /** A transient swap failure (a briefly locked keystore) can clear on a retry, so a few
@@ -26,8 +27,12 @@ const MAX_SWAP_ATTEMPTS = 3
  */
 export const useResumeCompletedMigration = (): void => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
-  const { migrationAccountId, migrationLoading, completeMigration } =
-    useCompleteMigration()
+  const {
+    migrationAccountId,
+    migrationExpectedReceiveSats,
+    migrationLoading,
+    completeMigration,
+  } = useCompleteMigration()
 
   const hasUnfinishedMigration = Boolean(migrationAccountId)
   const { status } = useMigrationStatus({ skip: !hasUnfinishedMigration })
@@ -35,12 +40,24 @@ export const useResumeCompletedMigration = (): void => {
   const [attempts, setAttempts] = useState(0)
   const isSwapInFlightRef = useRef(false)
 
+  const isServerCompleted =
+    status === MigrationStatus.Completed && hasUnfinishedMigration && !migrationLoading
+
+  /** The same receive gate as the transfer screen: a relaunch mid-transfer must not swap
+   *  into a wallet whose funds are still in transit either (#4102). Unconfirmed simply
+   *  means no swap this session — the custodial session stays intact and the next launch
+   *  (or this one, once a check lands) picks the swap back up. */
+  const { isReceiveConfirmed } = useMigrationReceiveConfirmation({
+    selfCustodialAccountId: migrationAccountId,
+    expectedReceiveSats: migrationExpectedReceiveSats,
+    skip: !isServerCompleted,
+  })
+
   /** A swap that resolves false is terminal, not transient: the destination account is
    *  gone from the device, so no retry brings it back. Blocks the effect from re-entering
    *  once the user has been handed to support, so the handover happens exactly once. */
   const hasHandedOverRef = useRef(false)
-  const isSwapPending =
-    status === MigrationStatus.Completed && hasUnfinishedMigration && !migrationLoading
+  const isSwapPending = isServerCompleted && isReceiveConfirmed
 
   useEffect(() => {
     const canAttempt =

--- a/app/screens/account-migration/hooks/use-resume-completed-migration.ts
+++ b/app/screens/account-migration/hooks/use-resume-completed-migration.ts
@@ -47,11 +47,24 @@ export const useResumeCompletedMigration = (): void => {
    *  into a wallet whose funds are still in transit either (#4102). Unconfirmed simply
    *  means no swap this session — the custodial session stays intact and the next launch
    *  (or this one, once a check lands) picks the swap back up. */
-  const { isReceiveConfirmed } = useMigrationReceiveConfirmation({
+  const { isReceiveConfirmed, isReceiveDelayed } = useMigrationReceiveConfirmation({
     selfCustodialAccountId: migrationAccountId,
     expectedReceiveSats: migrationExpectedReceiveSats,
     skip: !isServerCompleted,
   })
+
+  /** This path has no screen of its own to say the wait is unusual, so the crossing is at
+   *  least reported: a receive that never lands would otherwise be invisible, the user
+   *  sitting on a normal home with nothing pending anywhere. */
+  const hasReportedDelayRef = useRef(false)
+  useEffect(() => {
+    if (!isReceiveDelayed || hasReportedDelayRef.current) return
+    hasReportedDelayRef.current = true
+    reportError(
+      "Migration resume receive delayed",
+      new Error("Receive has not landed within the notice window"),
+    )
+  }, [isReceiveDelayed])
 
   /** A swap that resolves false is terminal, not transient: the destination account is
    *  gone from the device, so no retry brings it back. Blocks the effect from re-entering

--- a/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
@@ -97,14 +97,21 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
     skip: isLnRepointBlocked,
   })
 
-  /** The checkpoint only remembers which screen to resume on. Gated on focus so a
+  /** The checkpoint only remembers which screen to resume on — plus the preview's
+   *  receive figure, which the transfer's receive gate needs and which is knowable only
+   *  here, before the drain empties the balance the preview reads. Gated on focus so a
    *  background instance (this screen stays mounted under the completion screen) never
    *  re-saves the checkpoint the migration just cleared, and on ready figures so it is
    *  never recorded before the commit point exists. */
+  const expectedReceiveSats = preview.receiveSats
   useEffect(() => {
     if (!isFocused || checkpointLoading || !preview.isReady) return
-    saveCheckpoint(MigrationCheckpoint.BalancesOverview)
-  }, [isFocused, checkpointLoading, preview.isReady, saveCheckpoint])
+    saveCheckpoint(
+      MigrationCheckpoint.BalancesOverview,
+      undefined,
+      expectedReceiveSats ?? undefined,
+    )
+  }, [isFocused, checkpointLoading, preview.isReady, expectedReceiveSats, saveCheckpoint])
 
   /**
    * The ways this screen ends without an Approve to offer, as one value: the preview

--- a/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
@@ -103,15 +103,11 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
    *  background instance (this screen stays mounted under the completion screen) never
    *  re-saves the checkpoint the migration just cleared, and on ready figures so it is
    *  never recorded before the commit point exists. */
-  const expectedReceiveSats = preview.receiveSats
+  const expectedReceiveSats = preview.expectedReceiveSats
   useEffect(() => {
-    if (!isFocused || checkpointLoading || !preview.isReady) return
-    saveCheckpoint(
-      MigrationCheckpoint.BalancesOverview,
-      undefined,
-      expectedReceiveSats ?? undefined,
-    )
-  }, [isFocused, checkpointLoading, preview.isReady, expectedReceiveSats, saveCheckpoint])
+    if (!isFocused || checkpointLoading || expectedReceiveSats === null) return
+    saveCheckpoint(MigrationCheckpoint.BalancesOverview, { expectedReceiveSats })
+  }, [isFocused, checkpointLoading, expectedReceiveSats, saveCheckpoint])
 
   /**
    * The ways this screen ends without an Approve to offer, as one value: the preview

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -5,7 +5,6 @@ import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { GaloySecondaryButton } from "@app/components/atomic/galoy-secondary-button"
-import { HeaderBackButton } from "@react-navigation/elements"
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect } from "react"
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from "react"
 import { ScrollView, View } from "react-native"
 
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
@@ -71,6 +71,7 @@ export const MigrationContactSupportScreen: React.FC = () => {
    *  would pop it off the stack, taking the gate the user is waiting on with it. */
   const isReceiveDelayedOrigin = params?.origin === MigrationSupportOrigin.ReceiveDelayed
   const isBackToScreenBeneath = isResumeOrigin || isReceiveDelayedOrigin
+  const isBackToCommitScreen = !isGateOrigin && !isBackToScreenBeneath
   const handleBack = useCallback(() => {
     if (isGateOrigin) return
     if (isBackToScreenBeneath) {
@@ -81,24 +82,38 @@ export const MigrationContactSupportScreen: React.FC = () => {
   }, [isGateOrigin, isBackToScreenBeneath, navigation])
   useHardwareBackGuard(handleBack)
 
-  /** The back control lives in the navigator header, but its target is set from here so it
-   *  reuses this screen's origin-aware back path rather than a blind goBack, which from a
-   *  transfer-time failure would land on the swallowing transfer screen. */
+  /** The navigator already supplies the back control, so the native one stays hidden or the
+   *  header shows two. The gate handover is terminal and keeps no control at all: the header
+   *  holds nothing else here, so hiding it outright leaves the same screen without one. */
   useLayoutEffect(() => {
     navigation.setOptions({
+      headerShown: !isGateOrigin,
       headerBackVisible: false,
-      headerLeft: () =>
-        isGateOrigin ? null : (
-          <HeaderBackButton
-            tintColor={colors.black}
-            pressColor={colors.grey5}
-            pressOpacity={1}
-            onPress={handleBack}
-            {...testProps("migration-contact-support-back")}
-          />
-        ),
     })
-  }, [navigation, handleBack, isGateOrigin, colors.black, colors.grey5])
+  }, [navigation, isGateOrigin])
+
+  /**
+   * The commit-time handover is the only origin whose back must not simply pop: the screen
+   * beneath it swallows back, so the press is intercepted and redirected to the commit
+   * point instead. Every other origin pops, which is already what the header control does.
+   *
+   * Intercepting through the navigator rather than replacing `headerLeft` is deliberate: a
+   * `headerLeft` render function passed through `setOptions` makes the native stack header
+   * re-render with a different hook count on Android, which crashes the screen outright
+   * ("Rendered fewer hooks than expected") before any of this is reachable.
+   */
+  const isRedirectingBackRef = useRef(false)
+  useEffect(() => {
+    if (!isBackToCommitScreen) return
+    return navigation.addListener("beforeRemove", (event) => {
+      /** The redirect removes this screen too; letting that second pass through is what
+       *  ends the interception instead of looping on it. */
+      if (isRedirectingBackRef.current) return
+      event.preventDefault()
+      isRedirectingBackRef.current = true
+      navigation.navigate("accountMigrationBalancesOverview")
+    })
+  }, [navigation, isBackToCommitScreen])
 
   const { supportEmailAddress } = useContactSupport()
   const { copyToClipboard } = useClipboard()

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -66,14 +66,19 @@ export const MigrationContactSupportScreen: React.FC = () => {
    */
   const isResumeOrigin = params?.origin === MigrationSupportOrigin.Resume
   const isGateOrigin = params?.origin === MigrationSupportOrigin.Gate
+  /** The delayed handover shares the resume path's Back: the transfer screen is still
+   *  mounted underneath watching for the receive, and navigating to the commit screen
+   *  would pop it off the stack, taking the gate the user is waiting on with it. */
+  const isReceiveDelayedOrigin = params?.origin === MigrationSupportOrigin.ReceiveDelayed
+  const isBackToScreenBeneath = isResumeOrigin || isReceiveDelayedOrigin
   const handleBack = useCallback(() => {
     if (isGateOrigin) return
-    if (isResumeOrigin) {
+    if (isBackToScreenBeneath) {
       navigation.goBack()
       return
     }
     navigation.navigate("accountMigrationBalancesOverview")
-  }, [isGateOrigin, isResumeOrigin, navigation])
+  }, [isGateOrigin, isBackToScreenBeneath, navigation])
   useHardwareBackGuard(handleBack)
 
   /** The back control lives in the navigator header, but its target is set from here so it

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
+import { GaloySecondaryButton } from "@app/components/atomic/galoy-secondary-button"
 import { Screen } from "@app/components/screen"
 import { StatusScreenLayout } from "@app/components/status-screen-layout"
 import { useCustodialOwnerId } from "@app/screens/account-migration/hooks/use-custodial-owner-id"
@@ -29,8 +30,12 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   } = useTheme()
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const { ownerId } = useCustodialOwnerId()
-  const { migrationAccountId, migrationLoading, completeMigration } =
-    useCompleteMigration()
+  const {
+    migrationAccountId,
+    migrationExpectedReceiveSats,
+    migrationLoading,
+    completeMigration,
+  } = useCompleteMigration()
 
   /** No navigation at all while the funds move. */
   useHardwareBackGuard()
@@ -54,12 +59,19 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
     !migrationLoading && !hasProvisionedAccount && !hasSwappedRef.current
 
   const isTransferSkipped = migrationLoading || isAccountMissing
-  const { isTransferred, failureReason, isClockOutOfSync, hasConnectionIssue, retry } =
-    useMigrationTransfer({
-      custodialAccountId: ownerId,
-      selfCustodialAccountId: migrationAccountId,
-      skip: isTransferSkipped,
-    })
+  const {
+    isTransferred,
+    isReceiveDelayed,
+    failureReason,
+    isClockOutOfSync,
+    hasConnectionIssue,
+    retry,
+  } = useMigrationTransfer({
+    custodialAccountId: ownerId,
+    selfCustodialAccountId: migrationAccountId,
+    expectedReceiveSats: migrationExpectedReceiveSats,
+    skip: isTransferSkipped,
+  })
 
   useEffect(() => {
     if (!isAccountMissing) return
@@ -109,7 +121,12 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   const recoverableMessage = isClockOutOfSync
     ? LLMigration.clockOutOfSync.body()
     : LL.errors.network.connection()
-  const message = isRecoverable ? recoverableMessage : LLMigration.transferringFunds()
+  /** The delayed notice yields to a recoverable issue: a lost connection explains the
+   *  wait better than the wait itself, and its retry is the more useful footer. */
+  const delayedMessage = isReceiveDelayed ? LLMigration.transferDelayed.body() : null
+  const message =
+    (isRecoverable ? recoverableMessage : delayedMessage) ??
+    LLMigration.transferringFunds()
 
   const retryTitle = isClockOutOfSync
     ? LLMigration.clockOutOfSync.retryCta()
@@ -118,8 +135,21 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
     ? "migration-clock-out-of-sync-retry"
     : "migration-connection-issue-retry"
 
+  /** Secondary, not primary: waiting stays the recommended path — the swap still fires
+   *  the moment the receive lands, including while the support screen sits on top (this
+   *  screen stays mounted beneath it, exactly like the failure handover). */
+  const delayedFooter = (
+    <GaloySecondaryButton
+      title={LLMigration.transferDelayed.contactSupportCta()}
+      onPress={() => goToContactSupport(MigrationSupportReason.ReceiveDelayed)}
+      {...testProps("migration-receive-delayed-contact-support")}
+    />
+  )
+
   const retryFooter = isRecoverable ? (
     <GaloyPrimaryButton title={retryTitle} onPress={retry} {...testProps(retryTestId)} />
+  ) : isReceiveDelayed ? (
+    delayedFooter
   ) : undefined
 
   return (

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -40,6 +40,8 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   /** No navigation at all while the funds move. */
   useHardwareBackGuard()
 
+  /** Every failure handover leaves this screen for good, so Back belongs on the commit
+   *  screen: the transfer is over and this one has nothing left to offer. */
   const goToContactSupport = useCallback(
     (reason: MigrationSupportReason) => {
       navigation.navigate("accountMigrationContactSupport", {
@@ -49,6 +51,16 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
     },
     [navigation],
   )
+
+  /** The delayed handover is the one the user comes back from: the receive is still being
+   *  watched here, so its Back returns to this screen rather than popping it off the stack
+   *  along with the gate that is still waiting. */
+  const goToDelayedSupport = useCallback(() => {
+    navigation.navigate("accountMigrationContactSupport", {
+      reason: MigrationSupportReason.ReceiveDelayed,
+      origin: MigrationSupportOrigin.ReceiveDelayed,
+    })
+  }, [navigation])
 
   /** Completing the transfer clears the checkpoint and swaps the session, so once it
    *  succeeds a missing provisioned account is the expected outcome, not the fault this
@@ -147,7 +159,7 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   const delayedFooter = (
     <GaloySecondaryButton
       title={LLMigration.transferDelayed.contactSupportCta()}
-      onPress={() => goToContactSupport(MigrationSupportReason.ReceiveDelayed)}
+      onPress={goToDelayedSupport}
       {...testProps("migration-receive-delayed-contact-support")}
     />
   )

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -118,15 +118,17 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
    *  Each keeps its own message; only a real failure leaves this screen for support. */
   const isRecoverable = isClockOutOfSync || hasConnectionIssue
 
+  /** The delayed notice yields to a recoverable issue: a lost connection explains the
+   *  wait better than the wait itself, and its retry is the more useful footer. */
+  const isDelayedNoticeShown = isReceiveDelayed && !isRecoverable
+
   const recoverableMessage = isClockOutOfSync
     ? LLMigration.clockOutOfSync.body()
     : LL.errors.network.connection()
-  /** The delayed notice yields to a recoverable issue: a lost connection explains the
-   *  wait better than the wait itself, and its retry is the more useful footer. */
-  const delayedMessage = isReceiveDelayed ? LLMigration.transferDelayed.body() : null
-  const message =
-    (isRecoverable ? recoverableMessage : delayedMessage) ??
-    LLMigration.transferringFunds()
+  const waitingMessage = isDelayedNoticeShown
+    ? LLMigration.transferDelayed.body()
+    : LLMigration.transferringFunds()
+  const message = isRecoverable ? recoverableMessage : waitingMessage
 
   const retryTitle = isClockOutOfSync
     ? LLMigration.clockOutOfSync.retryCta()
@@ -134,6 +136,10 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   const retryTestId = isClockOutOfSync
     ? "migration-clock-out-of-sync-retry"
     : "migration-connection-issue-retry"
+
+  const recoverableFooter = (
+    <GaloyPrimaryButton title={retryTitle} onPress={retry} {...testProps(retryTestId)} />
+  )
 
   /** Secondary, not primary: waiting stays the recommended path — the swap still fires
    *  the moment the receive lands, including while the support screen sits on top (this
@@ -146,11 +152,8 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
     />
   )
 
-  const retryFooter = isRecoverable ? (
-    <GaloyPrimaryButton title={retryTitle} onPress={retry} {...testProps(retryTestId)} />
-  ) : isReceiveDelayed ? (
-    delayedFooter
-  ) : undefined
+  const waitingFooter = isDelayedNoticeShown ? delayedFooter : undefined
+  const screenFooter = isRecoverable ? recoverableFooter : waitingFooter
 
   return (
     <Screen preset="fixed">
@@ -158,7 +161,7 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
         icon="clock"
         iconColor={colors.warning}
         iconBackgroundColor={colors._warningLight}
-        footer={retryFooter}
+        footer={screenFooter}
       >
         <Text style={styles.message}>{message}</Text>
       </StatusScreenLayout>

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -73,11 +73,18 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
   if (custodialAccountId !== undefined && typeof custodialAccountId !== "string") {
     return null
   }
-  if (expectedReceiveSats !== undefined && typeof expectedReceiveSats !== "number") {
-    return null
-  }
+  /** Advisory, unlike the fields above: dropping a malformed one on its own keeps the step
+   *  and ids a locked account resumes from, which discarding the record would strip. */
+  const hasUsableExpectedReceiveSats =
+    typeof expectedReceiveSats === "number" && Number.isFinite(expectedReceiveSats)
 
-  return { step, savedAt, accountId, custodialAccountId, expectedReceiveSats }
+  return {
+    step,
+    savedAt,
+    accountId,
+    custodialAccountId,
+    expectedReceiveSats: hasUsableExpectedReceiveSats ? expectedReceiveSats : undefined,
+  }
 }
 
 export const resolveCheckpointRoute = (
@@ -129,14 +136,20 @@ export const mergeCheckpoint = (
   const hasSameOwner =
     existing?.custodialAccountId === undefined ||
     existing.custodialAccountId === update.custodialAccountId
+
+  /** Write-once for one owner's flow: the figure is only knowable before the drain, so a
+   *  re-entered commit screen would carry the post-drain zero the gate reads as "nothing
+   *  will ever arrive" and swap while the funds are still in transit (#4102). */
+  const inheritedExpectedReceiveSats = hasSameOwner
+    ? existing?.expectedReceiveSats
+    : undefined
+
   return {
     step: update.step,
     savedAt: Date.now(),
     accountId: update.accountId ?? (hasSameOwner ? existing?.accountId : undefined),
     custodialAccountId: update.custodialAccountId,
-    expectedReceiveSats:
-      update.expectedReceiveSats ??
-      (hasSameOwner ? existing?.expectedReceiveSats : undefined),
+    expectedReceiveSats: inheritedExpectedReceiveSats ?? update.expectedReceiveSats,
   }
 }
 

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -14,6 +14,10 @@ export type StoredCheckpoint = {
   savedAt: number
   accountId?: string
   custodialAccountId?: string
+  /** What the server's preview said the new wallet will receive, captured at the commit
+   *  point — the only moment it is knowable (after the drain the preview reads an already
+   *  emptied balance). Absent on records saved by app versions before the field existed. */
+  expectedReceiveSats?: number
 }
 
 /**
@@ -60,7 +64,8 @@ export const isExpired = (
 export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null => {
   if (!raw || typeof raw !== "object") return null
 
-  const { step, savedAt, accountId, custodialAccountId } = raw as StoredCheckpoint
+  const { step, savedAt, accountId, custodialAccountId, expectedReceiveSats } =
+    raw as StoredCheckpoint
 
   if (!Object.values(MigrationCheckpoint).includes(step)) return null
   if (typeof savedAt !== "number") return null
@@ -68,8 +73,11 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
   if (custodialAccountId !== undefined && typeof custodialAccountId !== "string") {
     return null
   }
+  if (expectedReceiveSats !== undefined && typeof expectedReceiveSats !== "number") {
+    return null
+  }
 
-  return { step, savedAt, accountId, custodialAccountId }
+  return { step, savedAt, accountId, custodialAccountId, expectedReceiveSats }
 }
 
 export const resolveCheckpointRoute = (
@@ -105,6 +113,7 @@ export type CheckpointUpdate = {
   step: MigrationCheckpoint
   accountId?: string
   custodialAccountId?: string
+  expectedReceiveSats?: number
 }
 
 /**
@@ -125,6 +134,9 @@ export const mergeCheckpoint = (
     savedAt: Date.now(),
     accountId: update.accountId ?? (hasSameOwner ? existing?.accountId : undefined),
     custodialAccountId: update.custodialAccountId,
+    expectedReceiveSats:
+      update.expectedReceiveSats ??
+      (hasSameOwner ? existing?.expectedReceiveSats : undefined),
   }
 }
 

--- a/app/self-custodial/migration-transfer-request.ts
+++ b/app/self-custodial/migration-transfer-request.ts
@@ -22,16 +22,19 @@ export const MigrationSdkStatus = {
 export type MigrationSdkStatus =
   (typeof MigrationSdkStatus)[keyof typeof MigrationSdkStatus]
 
-type MigrationSdkResult<T> =
+export type MigrationSdkResult<T> =
   | { status: typeof MigrationSdkStatus.Ok; value: T }
   | { status: typeof MigrationSdkStatus.NoMnemonic }
   | { status: typeof MigrationSdkStatus.ConnectionError; error: Error }
   | { status: typeof MigrationSdkStatus.Failed; error: Error }
 
-type WithMigrationSdkArgs = {
+export type MigrationSdkConnectionArgs = {
   accountId: string
   network: Network
   leewaySatPerVbyte: number
+}
+
+type WithMigrationSdkArgs = MigrationSdkConnectionArgs & {
   /** Built by the caller, which owns the backend's challenge format, from the pubkey the
    *  wallet hands back. */
   signChallenge: (sparkPubkey: string) => string
@@ -92,7 +95,7 @@ const runExclusivePerStorageDir = <T>(
  * route; a network-tagged failure is a retryable ConnectionError; any other failure is Failed.
  */
 const withMigrationSdk = async <T>(
-  { accountId, network, leewaySatPerVbyte }: WithMigrationSdkArgs,
+  { accountId, network, leewaySatPerVbyte }: MigrationSdkConnectionArgs,
   use: (sdk: BreezSdkInterface) => Promise<T>,
 ): Promise<MigrationSdkResult<T>> => {
   const mnemonic = await KeyStoreWrapper.getMnemonicForAccount(accountId)
@@ -188,6 +191,27 @@ export const buildMigrationTransferRequest = (
       args.signChallenge,
     )
     return { sparkInvoice: invoice, sparkPubkey: identityPubkey, proofSignature }
+  })
+
+export type MigrationReceiveCheck = {
+  hasReceived: boolean
+  balanceSats: number
+}
+
+/**
+ * Whether the migration payment has landed in the provisioned wallet. Any positive
+ * balance is the receive: the wallet is provisioned by this flow and never used before
+ * the session swap, so nothing else can have funded it. The forced sync is the point of
+ * the call — Spark holds an incoming payment for an offline wallet and claims it on
+ * sync, so this read is the detector and the actuator in one.
+ */
+export const checkMigrationReceiveLanded = (
+  args: MigrationSdkConnectionArgs,
+): Promise<MigrationSdkResult<MigrationReceiveCheck>> =>
+  withMigrationSdk(args, async (sdk) => {
+    const info = await sdk.getInfo({ ensureSynced: true })
+    const balanceSats = Number(info.balanceSats)
+    return { hasReceived: balanceSats > 0, balanceSats }
   })
 
 /** The two proof fields `migrationLnAddressTransfer` takes; it re-points the lightning

--- a/app/self-custodial/migration-transfer-request.ts
+++ b/app/self-custodial/migration-transfer-request.ts
@@ -22,13 +22,13 @@ export const MigrationSdkStatus = {
 export type MigrationSdkStatus =
   (typeof MigrationSdkStatus)[keyof typeof MigrationSdkStatus]
 
-export type MigrationSdkResult<T> =
+type MigrationSdkResult<T> =
   | { status: typeof MigrationSdkStatus.Ok; value: T }
   | { status: typeof MigrationSdkStatus.NoMnemonic }
   | { status: typeof MigrationSdkStatus.ConnectionError; error: Error }
   | { status: typeof MigrationSdkStatus.Failed; error: Error }
 
-export type MigrationSdkConnectionArgs = {
+type MigrationSdkConnectionArgs = {
   accountId: string
   network: Network
   leewaySatPerVbyte: number
@@ -193,7 +193,7 @@ export const buildMigrationTransferRequest = (
     return { sparkInvoice: invoice, sparkPubkey: identityPubkey, proofSignature }
   })
 
-export type MigrationReceiveCheck = {
+type MigrationReceiveCheck = {
   hasReceived: boolean
   balanceSats: number
 }

--- a/app/types/migration.ts
+++ b/app/types/migration.ts
@@ -34,6 +34,9 @@ export const MigrationSupportReason = {
   LockedWithoutCheckpoint: "locked-without-checkpoint",
   /** The transfer itself failed or threw. */
   TransferFailed: "transfer-failed",
+  /** The server paid the migration out, but the receive into the new self-custodial
+   *  wallet stayed unconfirmed past the notice window — the funds look stuck in transit. */
+  ReceiveDelayed: "receive-delayed",
   /** The lightning-address re-point onto the migrated account failed. */
   LnAddressTransferFailed: "ln-address-transfer-failed",
   /** The support screen was reached without a reason, e.g. after a navigation-state

--- a/app/types/migration.ts
+++ b/app/types/migration.ts
@@ -60,6 +60,10 @@ export const MigrationSupportOrigin = {
   Commit: "commit",
   Resume: "resume",
   Gate: "gate",
+  /** The only handover the transfer is expected to survive: the receive is still being
+   *  watched underneath, so backing out returns to the screen watching it rather than
+   *  popping to the commit screen, which would unmount the gate with it. */
+  ReceiveDelayed: "receive-delayed",
 } as const
 
 export type MigrationSupportOrigin =

--- a/app/utils/remote-config.ts
+++ b/app/utils/remote-config.ts
@@ -77,6 +77,28 @@ export const getRemoteConfigStringList = (key: string, fallback: string[]): stri
   return strings
 }
 
+/**
+ * Reads a scalar number, keeping `fallback` when the remote value is not usable.
+ * `asNumber()` answers 0 for anything it cannot parse, and for a duration a real zero
+ * means "no wait at all". A key that was never set answers with its registered default,
+ * which is not a misconfiguration, so only a set-but-unusable value is reported.
+ */
+export const getRemoteConfigPositiveNumber = (key: string, fallback: number): number => {
+  const value = remoteConfigInstance().getValue(key)
+  const parsed = value.asNumber()
+  if (Number.isFinite(parsed) && parsed > 0) return parsed
+
+  const raw = value.asString()
+  if (raw) {
+    logError({
+      scope: SCOPE,
+      error: new Error(`Expected a positive number for "${key}"`),
+      context: { key, rawSnippet: raw.slice(0, 100) },
+    })
+  }
+  return fallback
+}
+
 export const getRemoteConfigObject = <T extends object>(key: string, fallback: T): T => {
   const parsed = tryParseJson<unknown>(
     remoteConfigInstance().getValue(key).asString(),


### PR DESCRIPTION
Fixes #4102

## Problem

The migration flow swapped the user into the new Spark account as soon as the backend reported `MigrationStatus === COMPLETED`. That status is the **sender's** word: the lightning payment into the new Spark wallet can still be in transit at that moment (Spark holds an incoming payment for an offline wallet and only claims it on the next sync — and the migration wallet's SDK is disconnected right then). Users landed in a zero-balance account that looked like lost funds.

There were two ungated swap paths: the transferring-funds screen, and the launch-time resume hook (`useResumeCompletedMigration`) that finishes a migration completed server-side but never swapped locally.

## What this does

- **New shared gate** `useMigrationReceiveConfirmation`, composed by **both** swap paths: after the server reports COMPLETED, it polls the provisioned wallet's synced balance until the receive is confirmed. The check runs through the existing serialized migration-SDK helper (`withMigrationSdk`), so it can never race the invoice-building connection, and the forced sync (`ensureSynced: true`) is itself what claims the pending payment — the first check typically claims and confirms in one shot. Any positive balance is the receive: the wallet is provisioned by this flow and never used before the swap.
- **Zero-receive migrations don't wait**: the commit-point preview's `receiveSats` is now persisted into the migration checkpoint (the only moment it is knowable — after the drain the preview reads an already-emptied balance). An expected receive of 0 opens the gate at once. Checkpoints saved by app versions before the field existed wait like funded ones; the delayed notice below is their escape hatch.
- **Delayed notice**: after a remote-configured window (`migrationReceiveDelayedNoticeMs`, default 1 minute — per product on the Slack thread, a minute after the confirmed send is more than enough) the transferring screen switches to "taking longer than usual — keep the app open" and offers a secondary Contact Support button (reason code `receive-delayed`). Polling never stops (while the escape hatch below is off), and the swap still fires by itself the moment the receive lands — including while the support screen sits on top, since the transfer screen stays mounted beneath it.
- **Delayed-redirect escape hatch**: a second remote-config flag, `migrationDelayedRedirectEnabled` (default **false**), releases the swap once the notice window elapses instead of holding it until the receive confirms — the pre-gate behavior, reachable without an app release should requirements change. While off (the product decision), nothing changes.
- The resume path simply doesn't swap while unconfirmed: the user stays on the working custodial session (strictly better than an empty new wallet) and the gate keeps checking, this session and the next.
- The migration-status poll now stops on the server's terminal phase rather than on the swap condition, so it doesn't hammer the server's resume routine during the receive wait.

## Notes

- `NoMnemonic` from the check passes through as confirmed on purpose: `completeMigration()` already reads the same absence and routes to support (`self-custodial-account-missing` / `not-on-device`); the gate must not invent a second handover path.
- Old checkpoints without `expectedReceiveSats` stay valid — the field is optional and validated like `accountId`, carried across step saves under the same owner rule.
- The `transferDelayed` strings are translated in all 28 locale files (AI-translated, register matched to each locale's existing migration strings), satisfying the locale-parity check on CI.
- The gate is fully inert while its caller skips it — a late failure that re-skips the gate cannot keep surfacing a stale delayed notice.
- Firebase: the `migrationReceiveDelayedNoticeMs` and `migrationDelayedRedirectEnabled` parameters can be created in the console later; the in-app defaults (1 min, off) cover until then.

## Tests

296 tests across the 10 affected suites, including a 23-case spec for the gate hook (polling cadence, no overlapping checks, the mount-skipped→armed transition, delayed-notice timing and withdrawal, escape-hatch release, legacy-checkpoint behavior, re-skip inertness, unmount races) and a new serialization case proving the balance check queues behind a transfer request on the same storage directory. The changed source files sit at 100% statement/branch coverage. `tsc`, `eslint`, and `check:translations` clean.

Before/after GIFs are in the PR comments (assets on branch `assets/pr-4103-demo`).
