### PR TITLE
perf(agents): speed up simulator demo capture between PRs

### DIFF
--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -56,6 +56,16 @@ Fastest first:
 - **Copy/i18n swaps:** `git checkout origin/main -- app/i18n` → `reload-app.sh` (still JS-only), shoot, restore
 - **Whole branch:** build native once from the pre-change tree, then `git checkout --detach <branch>` for the JS side. Needs `git checkout -- ios/Podfile.lock` first, since pod install dirties it
 
+**Never a simulator per side.** Running "before" on one device and "after" on
+another halves wall-clock on paper and was explicitly rejected (issue #4092):
+two simulators are two devices — different app data, account state,
+remote-config fetches, timing — and anything that differs between the sides
+other than the code is a way for the comparison to lie. A worktree per side
+against one simulator is honest but slower than it sounds: each worktree pays
+its own `node_modules` install and every side-switch is a Metro swap, while
+the in-place flip above is a file checkout plus a ~5s reload. One worktree,
+one device, flip the code.
+
 Then crop both sides with one box:
 
 ```bash
@@ -131,7 +141,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 46 assertions, ~5s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 47 assertions, ~5s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -52,8 +52,8 @@ looping illustration).
 
 Fastest first:
 
-- **One file changed:** `git checkout <main-sha> -- <file>` → fast refresh (~12s, no relaunch) → shoot → `git checkout HEAD -- <file>`
-- **Copy/i18n swaps:** `git checkout origin/main -- app/i18n`, cold relaunch, shoot, restore
+- **One file changed:** `git checkout <main-sha> -- <file>` → `reload-app.sh` from the simulator skill (~5s, no relaunch; a full reload also applies TEMP `initialRouteName` edits, which fast refresh does not) → shoot → `git checkout HEAD -- <file>` → reload again
+- **Copy/i18n swaps:** `git checkout origin/main -- app/i18n` → `reload-app.sh` (still JS-only), shoot, restore
 - **Whole branch:** build native once from the pre-change tree, then `git checkout --detach <branch>` for the JS side. Needs `git checkout -- ios/Podfile.lock` first, since pod install dirties it
 
 Then crop both sides with one box:
@@ -131,7 +131,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 45 assertions, ~5s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 46 assertions, ~5s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -185,6 +185,8 @@ check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md pairs section uses the reload flip, not a blind fast refresh" "yes" \
   "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md rejects a simulator per side, with the honesty rationale" "yes" \
+  "$(grep -qi "simulator per side" "$SKILL_MD" && echo yes || echo no)"
 
 echo
 echo "-------------------------------------"

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -183,6 +183,8 @@ echo "documented behavior matches the scripts"
 SKILL_MD="$TESTS_DIR/../SKILL.md"
 check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md pairs section uses the reload flip, not a blind fast refresh" "yes" \
+  "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
 
 echo
 echo "-------------------------------------"

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -226,8 +226,11 @@ prove nothing — the difference has to come from the code, not from how you
 tapped. (A content *wait* may target per-side text when the two sides land on
 different screens by design; the taps stay identical.)
 
-For a JS-only change, a file checkout plus fast refresh (~12s) is enough. A
-branch detach is only needed when native code differs.
+For a JS-only change, a file checkout plus the simulator skill's
+`reload-app.sh` (~5s; it confirms via Metro that the bundle was actually
+re-served) is enough — no relaunch between sides, and TEMP `initialRouteName`
+edits are re-applied, which fast refresh alone would miss. A branch detach is
+only needed when native code differs.
 
 Consider whether the `before` is worth recording at all: for a crash or a
 missing screen, a single still plus a sentence is often clearer than a video of
@@ -260,7 +263,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 87 assertions, ~30s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 88 assertions, ~30s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -357,6 +357,8 @@ check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md warns clearState wipes the persisted redirect" "yes" \
   "$(grep -i "clearState" "$SKILL_MD" | grep -qi "redirect\|RCT_jsLocation\|8081" && echo yes || echo no)"
+check "SKILL.md before/after section uses the reload flip for JS-only changes" "yes" \
+  "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md teaches the launchApp arguments form" "yes" \
   "$(grep -q "RCT_jsLocation" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md requires eyeballing extracted frames before publishing" "yes" \

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -157,7 +157,30 @@ simulate "the user reinstalled the app": `clearState` wipes the persisted
 silently loads the user's 8081 bundler (see the `react-native-demo-videos`
 gotcha table).
 
-### 7. Release and verify
+### 7. Flip JS with a reload, not a relaunch
+
+Before/after pairs flip a file and shoot again. When the diff is JS-only,
+reload the running app instead of terminate + launch + splash (~35s → ~5s per
+flip, several flips per PR):
+
+```bash
+git checkout <main-sha> -- path/to/changed-screen.tsx
+"$SKILL/scripts/reload-app.sh"      # uses $DEMO_PORT; same as pressing r in Metro
+# shoot the "before", then restore and reload again
+git checkout HEAD -- path/to/changed-screen.tsx
+"$SKILL/scripts/reload-app.sh"
+```
+
+A full reload re-runs the JS entry point, so TEMP `initialRouteName` edits take
+effect — the case Fast Refresh cannot cover and the reason flips used to need a
+relaunch. The script broadcasts on Metro's `/message` websocket and then
+**waits for Metro to report the re-served bundle** on `/events`: a broadcast
+with no app connected succeeds silently, and an unconfirmed flip produces a
+before/after pair whose sides are quietly identical. Non-zero exit means no
+bundle request followed — fall back to `simctl terminate` + launch. Native
+diffs still need a rebuild, not a reload.
+
+### 8. Release and verify
 
 ```bash
 "$SKILL/scripts/release-session.sh" 3712            # shut down, keep for 24h (default)
@@ -184,7 +207,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 84 assertions, ~30s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 99 assertions, ~45s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -255,7 +255,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 135 assertions, ~60s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 137 assertions, ~60s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -67,9 +67,11 @@ Re-running is idempotent — same sim, same port. Sessions created before the
 
 When a **golden simulator** exists (see below), claiming clones it instead of
 creating a blank device — app already installed, account already logged in —
-and prints the golden's stamp as `# golden` comment lines. Anything that makes
-the clone dishonest (golden booted, different device type, explicit runtime
-mismatch) falls back to a blank create with a note on stderr, never silently.
+and prints the golden's stamp as `# golden` comment lines, plus (when run from
+an app worktree root) an instant `# golden verdict:` on whether the golden's
+native build still matches `ios/Podfile.lock`. Anything that makes the clone
+dishonest (golden booted, different device type, explicit runtime mismatch)
+falls back to a blank create with a note on stderr, never silently.
 
 ### 2. Work in a scratchpad worktree
 
@@ -103,7 +105,18 @@ xcrun simctl install "$DEMO_UDID" <path>/<YourApp>.app
 ```
 
 Reuse is safe for pure-JS diffs and even dep removals (a native superset is
-harmless). Confirm nothing added or updated a native module since the build:
+harmless) — while the native closure is unchanged. `Podfile.lock` is that
+closure's fingerprint, so the verdict is a hash comparison, not git
+archaeology (a wrong guess costs a ~14 min locked rebuild discovered as a
+crash at launch):
+
+```bash
+"$SKILL/scripts/native-stamp.sh" check <dir-of-the-.app>/demo-native-stamp   # instant verdict
+```
+
+After any native build you make, stamp it so the next agent gets that verdict
+too: `native-stamp.sh write <dir-of-the-.app>/demo-native-stamp`. For an
+unstamped build (made outside this workflow), fall back to git:
 
 ```bash
 git -C /path/to/your-app log origin/main --since=<build-date> -- ios/ package.json yarn.lock
@@ -241,17 +254,22 @@ golden — exactly one device ever carries the name), writes a stamp
 manifest gone, nothing left to release. Both the swap and claim's clone run
 under a shared lock, so a clone can never race a re-bless.
 
-**Staleness is judged, not guessed.** The clone carries the app build the
-golden was blessed with; before trusting it, diff native paths against the
-stamp's SHA (same rule as reusing a DerivedData build):
+**Staleness is judged, not guessed — and mechanically.** Bless hashes the
+build's `ios/Podfile.lock` into the stamp (`--lockfile` overrides the default
+cwd-relative path), and every claim run from an app worktree root prints the
+verdict as a `# golden verdict:` line: `native build matches` or
+`NATIVE BUILD STALE`. Stale means a native module changed since the bless (a
+`Podfile.lock` change, like the geetest module rename) — install a fresh build
+onto the clone or re-bless; do not trust the cloned install. For a stamp
+without a hash (blessed before lockfile stamping, or blessed without a
+lockfile), fall back to diffing native paths against the stamp's SHA:
 
 ```bash
 git -C /path/to/your-app log <stamp-sha>..origin/main -- ios/ package.json yarn.lock
 ```
 
-Anything listed → the golden's native build is stale: set up a fresh session
-and re-bless. A clone that comes up logged out (staging sessions do expire)
-means the same thing — re-bless with a fresh login. Opt out of cloning with
+A clone that comes up logged out (staging sessions do expire) means the same
+thing — re-bless with a fresh login. Opt out of cloning with
 `DEMO_SIM_GOLDEN=none`, or point at a differently named golden with
 `DEMO_SIM_GOLDEN=<device name>`. The reaper never touches the golden: it has
 no session, and the name gate refuses it like any foreign device.
@@ -262,7 +280,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 137 assertions, ~60s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 150 assertions, ~60s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -183,8 +183,15 @@ relaunch. The script broadcasts on Metro's `/message` websocket and then
 **waits for Metro to report the re-served bundle** on `/events`: a broadcast
 with no app connected succeeds silently, and an unconfirmed flip produces a
 before/after pair whose sides are quietly identical. Non-zero exit means no
-bundle request followed — fall back to `simctl terminate` + launch. Native
-diffs still need a rebuild, not a reload.
+bundle request followed — fall back to `simctl terminate` + launch. That
+fallback is not hypothetical: an app's dev-server connection dies after a few
+reload cycles, and from then on every broadcast lands nowhere until the next
+cold launch. Native diffs still need a rebuild, not a reload.
+
+Exit 0 confirms the bundle was *served*, not that JS finished re-rendering —
+the app takes a few more seconds to execute it, and capture's settle-wait will
+happily lock onto the stable white teardown screen. Poll with throwaway
+screenshots until content is visible before shooting the real frame.
 
 ### 8. Release and verify
 

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -37,6 +37,7 @@ this workflow that needs any of them:
 | Metro on 8081, or `--port` you picked by eye | 8081 is the user's; eyeballed ports collide with other agents |
 | Booting/shutting a sim you did not create | Other agents' demo sims may be booted and mid-run |
 | `simctl openurl` for deep links | Pops a SpringBoard confirm that simctl cannot dismiss and that survives relaunch — use TEMP `initialRouteName` |
+| `--reset-cache` with the demo Metro config | Clears the *shared* `~/.cache/metro-demo` store — every other agent's warm cache dies with yours. Point `DEMO_METRO_CACHE_ROOT` at a fresh dir instead |
 
 ## Workflow
 
@@ -114,14 +115,23 @@ If you genuinely must build (~14 min cold), take the lock and pin the device:
 ### 4. Start your bundler and record its PID
 
 The PID is what lets release-session stop *your* Metro without a `pkill`.
+Run from the worktree root — the demo config resolves the app's own
+`metro.config.js` from the working directory.
 
 ```bash
-node node_modules/react-native/cli.js start --port "$DEMO_PORT" &
+node node_modules/react-native/cli.js start --port "$DEMO_PORT" \
+  --config "$SKILL/scripts/metro-demo.config.js" &
 echo $! > "$DEMO_SESSION_DIR/metro.pid"
 ```
 
-First bundle on a cold worktree is ~90s–2.5 min. Poll with screenshots rather
-than assuming failure at 40s.
+`metro-demo.config.js` is the app's own config plus a transform cache shared
+across demo worktrees (`~/.cache/metro-demo`, override:
+`DEMO_METRO_CACHE_ROOT`). Metro's cache keys are content- and
+relative-path-based, so worktrees hit each other's entries: the first bundle
+after a dependency bump is cold (~90s–2.5 min — poll with screenshots rather
+than assuming failure at 40s), every later worktree's is warm (~15–30s, only
+the diff's files re-transform). Never `--reset-cache` here — the store is
+shared machine-wide.
 
 ### 5. Launch and shoot
 
@@ -174,7 +184,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 69 assertions, ~30s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 84 assertions, ~30s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -73,6 +73,13 @@ native build still matches `ios/Podfile.lock`. Anything that makes the clone
 dishonest (golden booted, different device type, explicit runtime mismatch)
 falls back to a blank create with a note on stderr, never silently.
 
+Claim also reports missing credentials up front: set `DEMO_REQUIRED_ENV` to
+the names of env vars real-account flows need (this repo lists it in
+`AGENTS.md`), and any that are unset appear as a `# note: missing credentials`
+line — the signal to plan the stub-harness route immediately instead of
+hitting the wall mid-session. The claim itself never blocks on it; most demos
+need no account at all.
+
 ### 2. Work in a scratchpad worktree
 
 Never the shared checkout: the user keeps their own branch checked out and
@@ -280,7 +287,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 150 assertions, ~60s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 155 assertions, ~60s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -65,6 +65,12 @@ Re-running is idempotent — same sim, same port. Sessions created before the
 2026-08 rename keep their old device prefix; release them by setting
 `DEMO_SIM_PREFIX=<old prefix>` for that one call.
 
+When a **golden simulator** exists (see below), claiming clones it instead of
+creating a blank device — app already installed, account already logged in —
+and prints the golden's stamp as `# golden` comment lines. Anything that makes
+the clone dishonest (golden booted, different device type, explicit runtime
+mismatch) falls back to a blank create with a note on stderr, never silently.
+
 ### 2. Work in a scratchpad worktree
 
 Never the shared checkout: the user keeps their own branch checked out and
@@ -201,13 +207,55 @@ dead). Use `--delete` only when you know no more shots are coming and want the
 disk back now. A re-claim inside the window un-stamps the session, and the
 reaper never touches a booted device or one named for another session prefix.
 
+## The Golden Simulator: Skip Install + Login
+
+A video session used to pay a fresh staging login (OTP, coordinate taps,
+keyboard overlays) on every new simulator, and every session paid the app
+install. The golden simulator pays both **once**: a blessed, shutdown device
+with the app installed and an account logged in, which `claim-session.sh`
+clones in seconds for each session. Clones are immutable copies — sessions can
+never contaminate the golden or each other, which is what the rejected
+warm-sim-reuse idea could not guarantee.
+
+Create or refresh it by promoting a session you set up once:
+
+```bash
+eval "$("$SKILL/scripts/claim-session.sh" 3712)"
+# install the app, log in to staging once (Maestro or by hand), verify the
+# home screen, then promote - bless REPLACES release for this session:
+"$SKILL/scripts/bless-golden.sh" 3712 --sha "$(git rev-parse HEAD)"
+```
+
+`bless-golden.sh` verifies the device is this session's (same ownership gate as
+release), stops the session's Metro, shuts the device down, renames it to
+`${DEMO_SIM_PREFIX:-rn-demo}-golden` (swapping out and deleting any previous
+golden — exactly one device ever carries the name), writes a stamp
+(`sha`/`date`/`device-type`/`runtime`), and adopts the session: port freed,
+manifest gone, nothing left to release. Both the swap and claim's clone run
+under a shared lock, so a clone can never race a re-bless.
+
+**Staleness is judged, not guessed.** The clone carries the app build the
+golden was blessed with; before trusting it, diff native paths against the
+stamp's SHA (same rule as reusing a DerivedData build):
+
+```bash
+git -C /path/to/your-app log <stamp-sha>..origin/main -- ios/ package.json yarn.lock
+```
+
+Anything listed → the golden's native build is stale: set up a fresh session
+and re-bless. A clone that comes up logged out (staging sessions do expire)
+means the same thing — re-bless with a fresh login. Opt out of cloning with
+`DEMO_SIM_GOLDEN=none`, or point at a differently named golden with
+`DEMO_SIM_GOLDEN=<device name>`. The reaper never touches the golden: it has
+no session, and the name gate refuses it like any foreign device.
+
 ## After Editing the Scripts
 
 The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 99 assertions, ~45s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 130 assertions, ~60s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -189,7 +189,7 @@ diffs still need a rebuild, not a reload.
 ### 8. Release and verify
 
 ```bash
-"$SKILL/scripts/release-session.sh" 3712            # shut down, keep for 24h (default)
+"$SKILL/scripts/release-session.sh" 3712            # shut down, keep for 72h (default)
 "$SKILL/scripts/release-session.sh" 3712 --delete   # remove immediately
 ```
 
@@ -199,7 +199,7 @@ at claim time is still booted. **A non-zero exit here means you damaged someone
 else's session — report it, don't ignore it.**
 
 The default release keeps the simulator (with its app install and account) for
-`DEMO_SIM_TTL_HOURS` (24h) so retakes cost ~3 min instead of a full rebuild;
+`DEMO_SIM_TTL_HOURS` (72h) so retakes cost ~3 min instead of a full rebuild;
 `reap-stale.sh` — run automatically by every claim and release — deletes it
 once the stamp expires, so kept sims cannot accumulate the way they did before
 this skill existed (eight piled up once, one still booted from a session a week
@@ -255,7 +255,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 130 assertions, ~60s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 135 assertions, ~60s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
@@ -18,11 +18,16 @@
 # the claim-side clone) run under the shared `golden` lock, because a clone of
 # a golden that is being swapped mid-flight is a real race.
 #
-# Usage: bless-golden.sh <pr-number> [--sha <sha>]
+# Usage: bless-golden.sh <pr-number> [--sha <sha>] [--lockfile <path>]
 #   <pr-number>  the claimed session whose simulator becomes the golden
 #   --sha        build SHA recorded in the stamp (default: HEAD of the cwd's
 #                git repo, or "unknown") - the agent compares it against
 #                native-path changes before trusting a clone's app install
+#   --lockfile   Podfile.lock of the build the golden carries (default:
+#                ios/Podfile.lock in the cwd). Its hash goes into the stamp so
+#                claim-session.sh can give an instant stale/fresh verdict
+#                instead of git archaeology; without a lockfile the stamp
+#                carries no hash and native-stamp.sh check demands a re-bless
 #
 # Workflow: claim a session, install the app, log in once, then bless.
 # If a later clone comes up logged out, the fix is to re-bless a fresh login.
@@ -39,10 +44,12 @@ case "$PR" in
 esac
 
 SHA=""
+LOCKFILE="ios/Podfile.lock"
 while [ $# -gt 0 ]; do
   case "$1" in
     --sha) SHA="${2:?--sha needs a value}"; shift 2 ;;
-    *) die "unknown argument '$1' (usage: bless-golden.sh <pr-number> [--sha <sha>])" ;;
+    --lockfile) LOCKFILE="${2:?--lockfile needs a value}"; shift 2 ;;
+    *) die "unknown argument '$1' (usage: bless-golden.sh <pr-number> [--sha <sha>] [--lockfile <path>])" ;;
   esac
 done
 [ -n "$SHA" ] || SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
@@ -129,6 +136,13 @@ date=$(date +%Y-%m-%dT%H:%M:%S)
 device-type=$DEVICE_TYPE
 runtime=$RUNTIME
 EOF
+# The lockfile hash is what turns "is this golden's native build stale?" from
+# git archaeology into an instant claim-time comparison.
+if [ -f "$LOCKFILE" ]; then
+  "$(dirname "${BASH_SOURCE[0]}")/native-stamp.sh" write "$GOLDEN_DIR/stamp" --lockfile "$LOCKFILE" >/dev/null
+else
+  echo "note: no Podfile.lock at $LOCKFILE - the stamp carries no native hash, so staleness checks will demand a re-bless; pass --lockfile to fix" >&2
+fi
 
 # --- Collateral-damage assertion ---------------------------------------------
 # Same exit guarantee as release-session.sh: every device booted before this

--- a/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Promote this session's simulator into the golden slot - the device that
+# claim-session.sh clones for every later session instead of creating a blank
+# one and paying app install + staging login again.
+#
+# Bless INSTEAD of release, never after it: this script terminates the session
+# it promotes. Merely renaming the device would leave the session manifest
+# pointing at a UDID whose name no longer matches, and the next
+# release-session.sh would exit FATAL through its ownership gate - the signal
+# reserved for real collateral damage, degraded into a false alarm. So bless
+# verifies ownership, shuts the device down, renames it into the golden slot,
+# writes the staleness stamp, and then adopts the session: manifest removed,
+# port freed. There is nothing left to release.
+#
+# Simulator names are not unique, so replacing an existing golden is a swap
+# that must end with exactly one device carrying the name: rename the old
+# golden aside, rename the new one into place, delete the old. The swap (and
+# the claim-side clone) run under the shared `golden` lock, because a clone of
+# a golden that is being swapped mid-flight is a real race.
+#
+# Usage: bless-golden.sh <pr-number> [--sha <sha>]
+#   <pr-number>  the claimed session whose simulator becomes the golden
+#   --sha        build SHA recorded in the stamp (default: HEAD of the cwd's
+#                git repo, or "unknown") - the agent compares it against
+#                native-path changes before trusting a clone's app install
+#
+# Workflow: claim a session, install the app, log in once, then bless.
+# If a later clone comes up logged out, the fix is to re-bless a fresh login.
+
+set -euo pipefail
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+PR="${1:?usage: bless-golden.sh <pr-number> [--sha <sha>]}"
+shift
+
+case "$PR" in
+  ''|*[!0-9]*) die "pr-number must be numeric, got '$PR'" ;;
+esac
+
+SHA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sha) SHA="${2:?--sha needs a value}"; shift 2 ;;
+    *) die "unknown argument '$1' (usage: bless-golden.sh <pr-number> [--sha <sha>])" ;;
+  esac
+done
+[ -n "$SHA" ] || SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+
+REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
+PREFIX="${DEMO_SIM_PREFIX:-rn-demo}"
+SIM_NAME="${PREFIX}-pr${PR}"
+SESSION_DIR="$REGISTRY/$SIM_NAME"
+GOLDEN_NAME="${DEMO_SIM_GOLDEN:-${PREFIX}-golden}"
+[ "$GOLDEN_NAME" != "none" ] || die "DEMO_SIM_GOLDEN=none disables the golden slot; unset it to bless"
+GOLDEN_DIR="$REGISTRY/golden/$GOLDEN_NAME"
+
+[ -d "$SESSION_DIR" ] || die "no claimed session for PR #$PR"
+UDID=$(cat "$SESSION_DIR/udid" 2>/dev/null || echo "")
+[ -n "$UDID" ] || die "session for PR #$PR has no recorded device"
+PORT=$(cat "$SESSION_DIR/port" 2>/dev/null || echo "")
+
+# --- Ownership gate ----------------------------------------------------------
+# Same rule as release-session.sh: never touch a device this skill did not name
+# for this exact session, even if the manifest points at it.
+ACTUAL_NAME=$(xcrun simctl list devices -j | python3 -c "
+import json,sys
+udid=sys.argv[1]
+for _, devices in json.load(sys.stdin)['devices'].items():
+    for d in devices:
+        if d['udid'] == udid:
+            print(d['name']); sys.exit(0)
+" "$UDID" || true)
+[ -n "$ACTUAL_NAME" ] || die "device $UDID no longer exists"
+[ "$ACTUAL_NAME" = "$SIM_NAME" ] || die "refusing to bless $UDID - named '$ACTUAL_NAME', expected '$SIM_NAME'"
+
+DEVICE_TYPE=$(cat "$SESSION_DIR/device-type" 2>/dev/null || echo "")
+RUNTIME=$(cat "$SESSION_DIR/runtime" 2>/dev/null || echo "default")
+[ -n "$DEVICE_TYPE" ] || die "session for PR #$PR recorded no device type (claimed before the golden-clone feature?) - re-claim and retry"
+
+# --- Stop this session's Metro, by recorded PID only -------------------------
+# Bless replaces release, so it inherits release's cleanup duties: without this
+# the bundler would keep listening on a port the registry just freed.
+METRO_PID=$(cat "$SESSION_DIR/metro.pid" 2>/dev/null || echo "")
+if [ -n "$METRO_PID" ] && kill -0 "$METRO_PID" 2>/dev/null; then
+  kill "$METRO_PID" 2>/dev/null || true
+  sleep 1
+  kill -0 "$METRO_PID" 2>/dev/null && kill -9 "$METRO_PID" 2>/dev/null || true
+  echo "stopped Metro pid $METRO_PID (port $PORT)"
+fi
+
+# Ours by the gate above, so shutting it down is as safe as release doing it.
+xcrun simctl shutdown "$UDID" 2>/dev/null || true
+
+# --- The swap, under the golden lock -----------------------------------------
+SWAP="$(mktemp -d "${TMPDIR:-/tmp}/bless-golden.XXXXXX")"
+trap 'rm -rf "$SWAP"' EXIT
+cat > "$SWAP/swap.sh" <<'SWAPEOF'
+set -euo pipefail
+UDID="$1"; GOLDEN_NAME="$2"
+OLD=$(xcrun simctl list devices -j | python3 -c "
+import json,sys
+name=sys.argv[1]
+for _, devices in json.load(sys.stdin)['devices'].items():
+    for d in devices:
+        if d['name'] == name:
+            print(d['udid']); sys.exit(0)
+" "$GOLDEN_NAME" || true)
+if [ -n "$OLD" ]; then
+  xcrun simctl shutdown "$OLD" 2>/dev/null || true
+  xcrun simctl rename "$OLD" "$GOLDEN_NAME-retired"
+fi
+xcrun simctl rename "$UDID" "$GOLDEN_NAME"
+if [ -n "$OLD" ]; then
+  xcrun simctl delete "$OLD"
+fi
+SWAPEOF
+"$(dirname "${BASH_SOURCE[0]}")/with-lock.sh" golden 300 \
+  bash "$SWAP/swap.sh" "$UDID" "$GOLDEN_NAME"
+
+# --- Stamp -------------------------------------------------------------------
+# What a later claim needs to judge a clone: which hardware this is (device
+# type/runtime gate the clone) and which build it carries (the agent diffs
+# native paths against this SHA before trusting the install).
+mkdir -p "$GOLDEN_DIR"
+cat > "$GOLDEN_DIR/stamp" <<EOF
+sha=$SHA
+date=$(date +%Y-%m-%dT%H:%M:%S)
+device-type=$DEVICE_TYPE
+runtime=$RUNTIME
+EOF
+
+# --- Collateral-damage assertion ---------------------------------------------
+# Same exit guarantee as release-session.sh: every device booted before this
+# session began must still be booted (our own was never in that snapshot - the
+# preflight is taken before claim boots it).
+PRE="$SESSION_DIR/preflight-booted.json"
+if [ -f "$PRE" ]; then
+  NOW="$SESSION_DIR/postflight-booted.json"
+  xcrun simctl list devices booted -j > "$NOW"
+  MISSING=$(python3 -c "
+import json, sys
+pre_path, now_path, ours = sys.argv[1], sys.argv[2], sys.argv[3]
+def udids(path):
+    with open(path) as f:
+        doc = json.load(f)
+    return {d['udid']: d['name'] for _, ds in doc['devices'].items() for d in ds}
+before, after = udids(pre_path), udids(now_path)
+for u, n in before.items():
+    if u not in after and u != ours:
+        print('%s (%s)' % (n, u))
+" "$PRE" "$NOW" "$UDID")
+  if [ -n "$MISSING" ]; then
+    echo "COLLATERAL DAMAGE - these were booted before this session and are not now:" >&2
+    echo "$MISSING" >&2
+    exit 1
+  fi
+fi
+
+# --- Adopt the session -------------------------------------------------------
+# The device left the session's namespace, so the session must not survive it.
+if [ -n "$PORT" ] && [ "$(cat "$REGISTRY/ports/$PORT/owner" 2>/dev/null)" = "$SIM_NAME" ]; then
+  rm -rf "$REGISTRY/ports/$PORT"
+fi
+rm -rf "$SESSION_DIR"
+
+echo "blessed $GOLDEN_NAME ($UDID) - stamp: $GOLDEN_DIR/stamp"
+sed 's/^/  /' "$GOLDEN_DIR/stamp"

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -91,6 +91,59 @@ for runtime, devices in json.load(sys.stdin)['devices'].items():
             print(d['udid']); sys.exit(0)
 " "$SIM_NAME" || true)
 
+# --- Golden clone fast path --------------------------------------------------
+# A blessed "golden" simulator (app installed, account logged in - see
+# bless-golden.sh) turns device setup from install + login minutes into a
+# seconds-long clone. The clone never mutates the golden, and the new device is
+# named for this PR like any other, so every ownership guard works unchanged.
+# Any ineligibility falls through to a blank create with a note - a demo on the
+# wrong device type or a booted golden must never be silent.
+if [ -z "$UDID" ]; then
+  GOLDEN_NAME="${DEMO_SIM_GOLDEN:-${DEMO_SIM_PREFIX:-rn-demo}-golden}"
+  GOLDEN_DIR="$REGISTRY/golden/$GOLDEN_NAME"
+  if [ "$GOLDEN_NAME" != "none" ]; then
+    GOLDEN=$(xcrun simctl list devices -j \
+      | python3 -c "
+import json,sys
+name=sys.argv[1]
+for _, devices in json.load(sys.stdin)['devices'].items():
+    for d in devices:
+        if d['name'] == name and d.get('isAvailable', True):
+            print('%s|%s' % (d['udid'], d.get('state', ''))); sys.exit(0)
+" "$GOLDEN_NAME" || true)
+    if [ -n "$GOLDEN" ]; then
+      GOLDEN_UDID="${GOLDEN%|*}"; GOLDEN_STATE="${GOLDEN#*|}"
+      STAMP_TYPE=$(grep '^device-type=' "$GOLDEN_DIR/stamp" 2>/dev/null | cut -d= -f2- || true)
+      STAMP_RUNTIME=$(grep '^runtime=' "$GOLDEN_DIR/stamp" 2>/dev/null | cut -d= -f2- || true)
+      if [ ! -f "$GOLDEN_DIR/stamp" ]; then
+        echo "note: golden $GOLDEN_NAME has no stamp (not blessed by bless-golden.sh); creating a blank device" >&2
+      elif [ "$GOLDEN_STATE" != "Shutdown" ]; then
+        echo "note: golden $GOLDEN_NAME is $GOLDEN_STATE, clone needs Shutdown; creating a blank device" >&2
+      elif [ "$DEVICE_TYPE" != "$STAMP_TYPE" ]; then
+        # A clone inherits the golden's hardware; shipping a pair shot on a
+        # silently different device type would make the demo dishonest.
+        echo "note: golden $GOLDEN_NAME is a '$STAMP_TYPE', requested '$DEVICE_TYPE'; creating a blank device" >&2
+      elif [ -n "$RUNTIME" ] && [ "$RUNTIME" != "$STAMP_RUNTIME" ]; then
+        echo "note: golden $GOLDEN_NAME runs '$STAMP_RUNTIME', requested '$RUNTIME'; creating a blank device" >&2
+      else
+        # Under the golden lock: a concurrent re-bless swaps the golden device
+        # mid-flight. If the clone still fails, fall through to a blank create.
+        UDID=$("$(dirname "${BASH_SOURCE[0]}")/with-lock.sh" golden 300 \
+          xcrun simctl clone "$GOLDEN_UDID" "$SIM_NAME" 2>/dev/null || true)
+        if [ -n "$UDID" ]; then
+          echo "cloned-from-golden" > "$SESSION_DIR/origin"
+          echo "$GOLDEN_NAME" > "$SESSION_DIR/golden-source"
+          cp "$GOLDEN_DIR/stamp" "$SESSION_DIR/golden-stamp" 2>/dev/null || true
+          echo "$STAMP_TYPE" > "$SESSION_DIR/device-type"
+          echo "${STAMP_RUNTIME:-default}" > "$SESSION_DIR/runtime"
+        else
+          echo "note: cloning golden $GOLDEN_NAME failed; creating a blank device" >&2
+        fi
+      fi
+    fi
+  fi
+fi
+
 if [ -z "$UDID" ]; then
   if [ -z "$RUNTIME" ]; then
     RUNTIME_ID=$(xcrun simctl list runtimes -j \
@@ -112,6 +165,10 @@ sys.exit('runtime not available: ' + name)
   fi
   UDID=$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE" "$RUNTIME_ID")
   echo "created" > "$SESSION_DIR/origin"
+  # Recorded so bless-golden.sh can stamp what hardware the golden actually is,
+  # which is what lets a later claim refuse a device-type-mismatched clone.
+  echo "$DEVICE_TYPE" > "$SESSION_DIR/device-type"
+  echo "${RUNTIME:-default}" > "$SESSION_DIR/runtime"
 fi
 
 echo "$UDID" > "$SESSION_DIR/udid"
@@ -137,3 +194,10 @@ export DEMO_PORT=$PORT
 export DEMO_SESSION_DIR="$SESSION_DIR"
 # Devices booted before this session: $PREFLIGHT_COUNT (recorded for the release check)
 EOF
+
+# Stamp comments (sha/date/device-type) let the agent judge whether the golden's
+# native build is stale before trusting the cloned install - see SKILL.md.
+if [ -f "$SESSION_DIR/golden-stamp" ]; then
+  echo "# golden: this device is a clone of $(cat "$SESSION_DIR/golden-source" 2>/dev/null || echo "the golden sim")"
+  sed 's/^/# golden /' "$SESSION_DIR/golden-stamp"
+fi

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -200,4 +200,16 @@ EOF
 if [ -f "$SESSION_DIR/golden-stamp" ]; then
   echo "# golden: this device is a clone of $(cat "$SESSION_DIR/golden-source" 2>/dev/null || echo "the golden sim")"
   sed 's/^/# golden /' "$SESSION_DIR/golden-stamp"
+  # Instant staleness verdict when the cwd is an app worktree: hash comparison
+  # against the blessed Podfile.lock instead of git archaeology. A wrong guess
+  # here used to cost a ~14 min rebuild discovered as a crash at launch.
+  RECORDED_LOCK=$(grep '^podfile-lock-hash=' "$SESSION_DIR/golden-stamp" 2>/dev/null | cut -d= -f2- || true)
+  if [ -n "$RECORDED_LOCK" ] && [ -f "ios/Podfile.lock" ]; then
+    CURRENT_LOCK=$(shasum -a 256 ios/Podfile.lock | cut -d' ' -f1)
+    if [ "$CURRENT_LOCK" = "$RECORDED_LOCK" ]; then
+      echo "# golden verdict: native build matches this worktree's ios/Podfile.lock"
+    else
+      echo "# golden verdict: NATIVE BUILD STALE - ios/Podfile.lock changed since the bless; install a fresh build onto this clone, or re-bless the golden"
+    fi
+  fi
 fi

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -20,6 +20,18 @@ case "$PR" in
   ''|*[!0-9]*) echo "FATAL: pr-number must be numeric, got '$PR'" >&2; exit 1 ;;
 esac
 
+# DEMO_REQUIRED_ENV lists the names (space-separated) of credentials this
+# repo's real-account flows need; each one that is unset gets reported in the
+# claim output. The skill stays app-agnostic - it checks presence, nothing more.
+MISSING_CREDS=""
+for CRED_NAME in ${DEMO_REQUIRED_ENV:-}; do
+  [ -n "$CRED_NAME" ] || continue
+  if [ -z "${!CRED_NAME:-}" ]; then
+    MISSING_CREDS="$MISSING_CREDS $CRED_NAME"
+  fi
+done
+MISSING_CREDS="${MISSING_CREDS# }"
+
 REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
 SIM_NAME="${DEMO_SIM_PREFIX:-rn-demo}-pr${PR}"
 # Keyed by the full device name, not the bare PR number: the registry is shared
@@ -212,4 +224,14 @@ if [ -f "$SESSION_DIR/golden-stamp" ]; then
       echo "# golden verdict: NATIVE BUILD STALE - ios/Podfile.lock changed since the bless; install a fresh build onto this clone, or re-bless the golden"
     fi
   fi
+fi
+
+# Fail-fast credential report: flows that need a real account (a staging login
+# for the golden, an OTP) dead-end mid-session when a credential is absent.
+# Naming the gap at claim time lets the agent plan the stub-harness route up
+# front instead of discovering the wall forty minutes in. Repo-specific names
+# come from DEMO_REQUIRED_ENV (see AGENTS.md); this never blocks the claim -
+# plenty of demos need no account at all.
+if [ -n "$MISSING_CREDS" ]; then
+  echo "# note: missing credentials: $MISSING_CREDS - real-account flows are unavailable this session; plan the stub-harness route now, not mid-flow"
 fi

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -27,7 +27,7 @@ SIM_NAME="${DEMO_SIM_PREFIX:-rn-demo}-pr${PR}"
 # once. The prefix is what keeps their sessions apart.
 SESSION_DIR="$REGISTRY/${SIM_NAME}"
 
-# Sweep simulators from sessions released more than the TTL ago (default 24h),
+# Sweep simulators from sessions released more than the TTL ago (default 72h),
 # then un-mark our own session: an active claim is never reaped.
 "$(dirname "${BASH_SOURCE[0]}")/reap-stale.sh" >/dev/null 2>&1 || true
 mkdir -p "$REGISTRY/ports" "$SESSION_DIR"

--- a/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
+++ b/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
@@ -49,6 +49,18 @@ if (typeof appConfig !== "object" || appConfig === null || typeof appConfig.then
 
 module.exports = {
   ...appConfig,
+  transformer: {
+    ...appConfig.transformer,
+    // @react-native/metro-config require.resolve()s this to an ABSOLUTE path,
+    // and unlike babelTransformerPath (which metro-transform-worker excludes
+    // from its cache key) it is hashed into the global key - one per-worktree
+    // path in here and no worktree ever hits another's entries. Metro's own
+    // default is the bare specifier, resolved per-worktree at use time, so
+    // pinning it restores sharing without changing behavior. Verified live:
+    // this one field was the difference between 0% and full cross-worktree
+    // cache reuse.
+    asyncRequireModulePath: "metro-runtime/src/modules/asyncRequire",
+  },
   // AutoCleanFileStore, not FileStore: nothing ever purges ~/.cache the way
   // macOS purges $TMPDIR (where Metro's default cache lives), and this store
   // sweeps stale entries by mtime while a long-lived `start` process runs.

--- a/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
+++ b/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
@@ -1,0 +1,60 @@
+// Demo-only Metro config: the worktree's own config plus a transform cache
+// shared across worktrees.
+//
+// Metro's transform-cache keys are worktree-portable — the per-file key uses
+// the path relative to projectRoot and the global key hashes transformer file
+// *contents* — so successive PRs' demo worktrees can share one cache and only
+// pay transform cost for files their diffs actually change. Pass this file to
+// the bundler you start for a demo session:
+//
+//   node node_modules/react-native/cli.js start --port "$DEMO_PORT" \
+//     --config "$SKILL/scripts/metro-demo.config.js"
+//
+// (The flag's help text says "CLI configuration file", but the CLI forwards it
+// to metro-config's resolveConfig — it is the Metro config override.)
+//
+// Sharing one store between concurrently running Metros is safe: entries are
+// JSON keyed by content hash, a torn read is treated as a miss, and two
+// writers of the same key write identical bytes. Never `--reset-cache` with
+// this config, though — that clears the shared store for every agent at once.
+//
+// This file lives outside any node_modules, so it must not require anything
+// that isn't part of Node itself; the function-form `cacheStores` below is
+// what lets Metro hand us its own metro-cache module instead.
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+// The app's own config comes from the working directory, which the skill's
+// workflow already fixes to the demo worktree root (step 4 starts the bundler
+// with a node_modules-relative path). Fail loudly on a wrong cwd: silently
+// dropping the app config would "work" and then misrender every asset.
+const appConfigPath = path.join(process.cwd(), "metro.config.js")
+if (!fs.existsSync(appConfigPath)) {
+  throw new Error(
+    `metro-demo.config.js: no metro.config.js at ${appConfigPath} - ` +
+      "start Metro from the worktree root (step 4 of the skill workflow)",
+  )
+}
+const appConfig = require(appConfigPath)
+
+// Metro configs may also export a function or a promise; spreading either
+// silently loses every app field, so support the object form only.
+if (typeof appConfig !== "object" || appConfig === null || typeof appConfig.then === "function") {
+  throw new Error(
+    "metro-demo.config.js: the app's metro.config.js does not export a plain object - " +
+      "this wrapper supports object-form configs only; start Metro without --config",
+  )
+}
+
+module.exports = {
+  ...appConfig,
+  // AutoCleanFileStore, not FileStore: nothing ever purges ~/.cache the way
+  // macOS purges $TMPDIR (where Metro's default cache lives), and this store
+  // sweeps stale entries by mtime while a long-lived `start` process runs.
+  cacheStores: ({ AutoCleanFileStore }) => [
+    new AutoCleanFileStore({
+      root: process.env.DEMO_METRO_CACHE_ROOT || path.join(os.homedir(), ".cache", "metro-demo"),
+    }),
+  ],
+}

--- a/.claude/skills/react-native-ios-simulator/scripts/native-stamp.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/native-stamp.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Instant verdict on whether a native build still matches the app's
+# ios/Podfile.lock - replacing git archaeology with a hash comparison.
+#
+# Why this exists: reusing a DerivedData build (SKILL.md step 3) or a golden
+# simulator's app install is safe only while no native module changed since
+# that build was made. Deciding that by reading git history is slow and
+# error-prone, and a wrong guess costs a ~14 min locked rebuild discovered
+# only when the app crashes at launch (a renamed native module - the geetest
+# rename - did exactly this). Podfile.lock is the native closure's fingerprint:
+# same hash, same native build inputs.
+#
+# Usage:
+#   native-stamp.sh write <stamp-file> [--lockfile <path>]
+#   native-stamp.sh check <stamp-file> [--lockfile <path>]
+#
+#   write   records podfile-lock-hash=<sha256> into the stamp file, replacing
+#           any previous hash line and preserving every other key - so it works
+#           on the golden stamp (bless-golden.sh calls this) and on a plain
+#           build stamp you drop next to a DerivedData .app after building.
+#   check   compares the current lockfile against the recorded hash.
+#           Exit 0: match. Exit 1: STALE (or no hash recorded - a stamp that
+#           cannot vouch for its build must fail, not pass silently).
+#
+#   --lockfile defaults to ios/Podfile.lock relative to the cwd, which is the
+#   app worktree root in every workflow this skill documents.
+
+set -euo pipefail
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+MODE="${1:?usage: native-stamp.sh <write|check> <stamp-file> [--lockfile <path>]}"
+STAMP="${2:?missing stamp-file (usage: native-stamp.sh <write|check> <stamp-file> [--lockfile <path>])}"
+shift 2
+
+LOCKFILE="ios/Podfile.lock"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --lockfile) LOCKFILE="${2:?--lockfile needs a value}"; shift 2 ;;
+    *) die "unknown argument '$1'" ;;
+  esac
+done
+
+[ -f "$LOCKFILE" ] || die "no lockfile at $LOCKFILE - run from the app worktree root or pass --lockfile"
+HASH=$(shasum -a 256 "$LOCKFILE" | cut -d' ' -f1)
+
+case "$MODE" in
+  write)
+    touch "$STAMP"
+    if grep -q '^podfile-lock-hash=' "$STAMP"; then
+      sed -i '' "s|^podfile-lock-hash=.*|podfile-lock-hash=$HASH|" "$STAMP"
+    else
+      echo "podfile-lock-hash=$HASH" >> "$STAMP"
+    fi
+    echo "stamped $STAMP (podfile-lock-hash=$HASH)"
+    ;;
+  check)
+    [ -f "$STAMP" ] || die "no stamp at $STAMP - nothing vouches for this build; rebuild or write a stamp at build time"
+    RECORDED=$(grep '^podfile-lock-hash=' "$STAMP" 2>/dev/null | cut -d= -f2- || true)
+    [ -n "$RECORDED" ] || die "stamp $STAMP has no podfile-lock-hash - it predates lockfile stamping and cannot vouch for the build; re-bless (or re-stamp after a fresh build)"
+    if [ "$RECORDED" = "$HASH" ]; then
+      echo "native build matches $LOCKFILE (podfile-lock-hash $HASH)"
+    else
+      die "native build is STALE: $LOCKFILE hashes to $HASH but the stamp recorded $RECORDED.
+       A native module changed since this build was stamped (a Podfile.lock change,
+       like the geetest module rename) - rebuild, or re-bless the golden, before
+       trusting this install"
+    fi
+    ;;
+  *) die "mode must be 'write' or 'check', got '$MODE'" ;;
+esac

--- a/.claude/skills/react-native-ios-simulator/scripts/reap-stale.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/reap-stale.sh
@@ -11,7 +11,7 @@
 # <prefix>-pr<N> name, and never while it is booted (someone is using it).
 #
 # Usage: reap-stale.sh
-#   DEMO_SIM_TTL_HOURS  retention window, default 24
+#   DEMO_SIM_TTL_HOURS  retention window, default 72
 #   DEMO_SIM_REGISTRY   session registry, default ~/.claude/rn-sim-sessions
 #   DEMO_SIM_PREFIX     device-name prefix, default rn-demo
 
@@ -19,7 +19,7 @@ set -uo pipefail
 
 REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
 PREFIX="${DEMO_SIM_PREFIX:-rn-demo}"
-TTL_HOURS="${DEMO_SIM_TTL_HOURS:-24}"
+TTL_HOURS="${DEMO_SIM_TTL_HOURS:-72}"
 NOW=$(date +%s)
 TTL_SECONDS=$((TTL_HOURS * 3600))
 

--- a/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
@@ -9,7 +9,7 @@
 # Usage: release-session.sh <pr-number> [--delete]
 #   default leaves the simulator shut down but present (cheap to re-use for
 #           retakes); reap-stale.sh removes it automatically once it has sat
-#           released for DEMO_SIM_TTL_HOURS (default 24h)
+#           released for DEMO_SIM_TTL_HOURS (default 72h)
 #   --delete removes it immediately
 
 set -euo pipefail
@@ -73,10 +73,10 @@ if [ -n "$UDID" ]; then
     xcrun simctl delete "$UDID"
     echo "deleted $EXPECTED_NAME ($UDID)"
   else
-    # Stamp for the reaper: kept for DEMO_SIM_TTL_HOURS (default 24h) so
+    # Stamp for the reaper: kept for DEMO_SIM_TTL_HOURS (default 72h) so
     # retakes are cheap, then reap-stale.sh removes it on a later claim/release.
     date +%s > "$SESSION_DIR/released-at"
-    echo "shut down $EXPECTED_NAME ($UDID), kept for ${DEMO_SIM_TTL_HOURS:-24}h"
+    echo "shut down $EXPECTED_NAME ($UDID), kept for ${DEMO_SIM_TTL_HOURS:-72}h"
   fi
 fi
 

--- a/.claude/skills/react-native-ios-simulator/scripts/reload-app.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/reload-app.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# Reload the JS of the app(s) connected to this session's Metro - the fast
+# before/after flip.
+#
+# A checkout-flip changes only JS, so a dev-server reload (what pressing `r`
+# in Metro's terminal does) replaces terminate + launch + splash: ~35s saved
+# per flip. Unlike Fast Refresh, a full reload re-runs the JS entry point, so
+# TEMP `initialRouteName` edits take effect - the exact case that used to
+# force a cold relaunch.
+#
+# The mechanism is the dev server's /message websocket: a broadcast frame
+# `{"version":2,"method":"reload"}` reaches every connected app. That
+# broadcast *succeeds silently when no app is connected* (the "No apps
+# connected" warning lands in Metro's stdout, not here), and a flip that
+# silently didn't happen produces a before/after pair whose sides are
+# identical - indistinguishable from "no visual change". So this script
+# only trusts what it can observe: it watches the sibling /events websocket
+# and exits 0 only after Metro reports the re-requested bundle was served
+# (`bundle_build_done` - emitted for cache-hit serves too). Waiting for that
+# event also closes the race where a screenshot's settle-wait declares the
+# screen "settled" before the reload has torn it down.
+#
+# Talks to Metro only - platform-neutral, no simctl, works for Android flips
+# unchanged. Dependency-free: the websocket client is python3 stdlib.
+#
+# Usage: reload-app.sh [--port P] [--timeout S] [--no-wait]
+#   --port     defaults to $DEMO_PORT (from claim-session.sh); REQUIRED one
+#              way or the other - a guessed port would reload the user's app
+#   --timeout  seconds to wait for bundle confirmation (default 30,
+#              env: RELOAD_TIMEOUT)
+#   --no-wait  fire the broadcast and exit 0 without confirmation
+
+set -euo pipefail
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+PORT="${DEMO_PORT:-}"
+TIMEOUT="${RELOAD_TIMEOUT:-30}"
+NO_WAIT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port)    PORT="${2:?--port needs a value}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:?--timeout needs a value}"; shift 2 ;;
+    --no-wait) NO_WAIT=1; shift ;;
+    *) die "unknown argument '$1' (usage: reload-app.sh [--port P] [--timeout S] [--no-wait])" ;;
+  esac
+done
+
+# No default port, ever: 8081 is the user's Metro, and reloading whatever is
+# connected there would yank the app out from under their live session.
+[ -n "$PORT" ] || die "no port: eval claim-session.sh first (sets DEMO_PORT) or pass --port explicitly (a guessed port would reload the user's app on their 8081 bundler)"
+case "$PORT" in
+  ''|*[!0-9]*) die "port must be numeric, got '$PORT'" ;;
+esac
+
+python3 - "$PORT" "$TIMEOUT" "${NO_WAIT:-0}" <<'PYEOF'
+import base64, hashlib, json, os, socket, struct, sys, time
+
+port, timeout, no_wait = int(sys.argv[1]), float(sys.argv[2]), sys.argv[3] == "1"
+
+
+def ws_connect(path):
+    """Minimal RFC 6455 client handshake; returns (socket, leftover bytes)."""
+    s = socket.create_connection(("127.0.0.1", port), timeout=5)
+    key = base64.b64encode(os.urandom(16)).decode()
+    s.sendall((
+        "GET %s HTTP/1.1\r\n"
+        "Host: 127.0.0.1:%d\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: %s\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n" % (path, port, key)
+    ).encode())
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise ConnectionError("server closed during handshake on " + path)
+        buf += chunk
+    head, leftover = buf.split(b"\r\n\r\n", 1)
+    status = head.split(b"\r\n", 1)[0]
+    if b" 101" not in status:
+        raise ConnectionError("handshake refused on %s: %s" % (path, status.decode(errors="replace")))
+    return s, leftover
+
+
+def masked_frame(opcode, payload):
+    # Clients MUST mask (RFC 6455 5.1); a compliant server drops unmasked frames.
+    mask = os.urandom(4)
+    n = len(payload)
+    if n < 126:
+        head = bytes([0x80 | opcode, 0x80 | n])
+    elif n < 65536:
+        head = bytes([0x80 | opcode, 0x80 | 126]) + struct.pack(">H", n)
+    else:
+        head = bytes([0x80 | opcode, 0x80 | 127]) + struct.pack(">Q", n)
+    return head + mask + bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+
+
+def send_text(s, text):
+    s.sendall(masked_frame(0x1, text.encode()))
+
+
+def send_close(s):
+    try:
+        s.sendall(masked_frame(0x8, struct.pack(">H", 1000)))
+        s.close()
+    except OSError:
+        pass
+
+
+def parse_frame(buf):
+    """One frame from buf -> (opcode, payload, rest), or None if incomplete."""
+    if len(buf) < 2:
+        return None
+    opcode = buf[0] & 0x0F
+    b2 = buf[1]
+    n, off = b2 & 0x7F, 2
+    if n == 126:
+        if len(buf) < 4:
+            return None
+        n, off = struct.unpack(">H", buf[2:4])[0], 4
+    elif n == 127:
+        if len(buf) < 10:
+            return None
+        n, off = struct.unpack(">Q", buf[2:10])[0], 10
+    if b2 & 0x80:  # a server frame should not be masked, but tolerate it
+        if len(buf) < off + 4 + n:
+            return None
+        mask, payload = buf[off:off + 4], buf[off + 4:off + 4 + n]
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        rest = buf[off + 4 + n:]
+    else:
+        if len(buf) < off + n:
+            return None
+        payload, rest = buf[off:off + n], buf[off + n:]
+    return opcode, payload, rest
+
+
+def text_frames(s, leftover, deadline):
+    """Yield text payloads from server frames until close, EOF or deadline."""
+    buf = leftover
+    s.settimeout(0.5)
+    while time.time() < deadline:
+        frame = parse_frame(buf)
+        while frame:
+            opcode, payload, buf = frame
+            if opcode == 0x8:  # close
+                return
+            if opcode == 0x9:  # ping -> masked pong keeps the connection alive
+                s.sendall(masked_frame(0xA, payload))
+            elif opcode == 0x1:
+                yield payload
+            frame = parse_frame(buf)
+        try:
+            chunk = s.recv(4096)
+        except socket.timeout:
+            continue
+        if not chunk:
+            return
+        buf += chunk
+
+
+# Listener first: an event fired between "reload sent" and "listener open"
+# would otherwise be missed and turn a successful flip into a timeout.
+try:
+    ev_sock, ev_leftover = ws_connect("/events")
+    msg_sock, _ = ws_connect("/message")
+except OSError as e:
+    sys.stderr.write("FATAL: no Metro dev server on 127.0.0.1:%d (%s)\n" % (port, e))
+    sys.exit(1)
+
+# No "id", no "target": that is what makes the message socket treat this as a
+# broadcast to every connected app (createMessageSocketEndpoint.isBroadcast).
+send_text(msg_sock, json.dumps({"version": 2, "method": "reload"}))
+send_close(msg_sock)
+
+if no_wait:
+    print("reload broadcast sent (unconfirmed: --no-wait)")
+    send_close(ev_sock)
+    sys.exit(0)
+
+deadline = time.time() + timeout
+for payload in text_frames(ev_sock, ev_leftover, deadline):
+    try:
+        event = json.loads(payload)
+    except ValueError:
+        continue
+    etype = event.get("type", "")
+    if etype == "bundle_build_done":
+        print("reload confirmed: Metro served the bundle again")
+        send_close(ev_sock)
+        sys.exit(0)
+    if etype == "bundle_build_failed":
+        sys.stderr.write("FATAL: the reloaded bundle failed to build - fix the JS error and rerun\n")
+        send_close(ev_sock)
+        sys.exit(1)
+
+sys.stderr.write(
+    "FATAL: reload sent but no bundle request observed within %gs - "
+    "no app may be connected to this Metro; fall back to terminate + launch\n" % timeout
+)
+send_close(ev_sock)
+sys.exit(1)
+PYEOF

--- a/.claude/skills/react-native-ios-simulator/tests/fixtures/bin/xcrun
+++ b/.claude/skills/react-native-ios-simulator/tests/fixtures/bin/xcrun
@@ -105,6 +105,40 @@ with open(db, "w") as f:
 ' "$DB" "$udid"
     ;;
 
+  # Real `simctl clone` refuses a booted source and copies the device's whole
+  # data directory. Both semantics are modelled so the tests that depend on
+  # them (fallback-when-booted, login-state fidelity) cannot pass vacuously.
+  clone)
+    src="${2:?}"; newname="${3:?}"
+    state=$(awk -F'|' -v u="$src" '$1==u {print $3}' "$DB")
+    [ -n "$state" ] || { echo "fake xcrun: no such device $src" >&2; exit 1; }
+    [ "$state" = "Booted" ] && { echo "fake xcrun: unable to clone a booted device" >&2; exit 1; }
+    udid="FAKE-CLONE-$(date +%s)-$RANDOM"
+    printf '%s|%s|Shutdown\n' "$udid" "$newname" >> "$DB"
+    if [ -n "${FAKE_APP_ROOT:-}" ] && [ -d "$FAKE_APP_ROOT/$src" ]; then
+      mkdir -p "$FAKE_APP_ROOT"
+      cp -R "$FAKE_APP_ROOT/$src" "$FAKE_APP_ROOT/$udid"
+    fi
+    echo "$udid"
+    ;;
+
+  rename)
+    udid="${2:?}"; newname="${3:?}"
+    python3 -c '
+import sys
+db, udid, newname = sys.argv[1], sys.argv[2], sys.argv[3]
+rows = [l.strip().split("|") for l in open(db) if l.strip()]
+found = False
+with open(db, "w") as f:
+    for u, n, s in rows:
+        if u == udid:
+            found = True
+            n = newname
+        f.write("%s|%s|%s\n" % (u, n, s))
+sys.exit(0 if found else 1)
+' "$DB" "$udid" "$newname" || { echo "fake xcrun: no such device $udid" >&2; exit 1; }
+    ;;
+
   spawn) exit 0 ;;  # `defaults write` on the device — recorded in the args log above
 
   terminate) exit 0 ;;  # app process kill — nothing to model beyond the log entry

--- a/.claude/skills/react-native-ios-simulator/tests/fixtures/ws-fake.py
+++ b/.claude/skills/react-native-ios-simulator/tests/fixtures/ws-fake.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Fake Metro dev-server websocket endpoints for reload-app.sh tests.
+
+Serves /message and /events like @react-native-community/cli-server-api does,
+records what the client actually sent, and emits events per FAKE_WS_MODE:
+
+  bundle-done   after a reload broadcast arrives on /message, emit
+                bundle_build_started then bundle_build_done on /events
+  silent        never emit anything on /events (models "no app connected")
+  bundle-fail   emit bundle_build_failed instead
+
+Env:
+  FAKE_WS_PORT_FILE  where to write the chosen port (bound on 127.0.0.1:0)
+  FAKE_WS_LOG        append-only observation log the assertions read:
+                       connect <path>
+                       frame path=<path> masked=<0|1> payload=<raw json>
+  FAKE_WS_MODE       see above (default bundle-done)
+
+Enforces what the real `ws` server enforces where it matters for the tests:
+frame contents and mask bits are *recorded* rather than rejected, so a
+non-compliant client shows up as a red assertion instead of a hang.
+"""
+import base64
+import hashlib
+import json
+import os
+import socket
+import struct
+import sys
+import threading
+import time
+
+GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+MODE = os.environ.get("FAKE_WS_MODE", "bundle-done")
+LOG = os.environ["FAKE_WS_LOG"]
+PORT_FILE = os.environ["FAKE_WS_PORT_FILE"]
+
+log_lock = threading.Lock()
+reload_seen = threading.Event()
+
+
+def log(line):
+    with log_lock:
+        with open(LOG, "a") as f:
+            f.write(line + "\n")
+
+
+def text_frame(payload_text):
+    data = payload_text.encode()
+    n = len(data)
+    if n < 126:
+        head = bytes([0x81, n])
+    else:
+        head = bytes([0x81, 126]) + struct.pack(">H", n)
+    return head + data
+
+
+def read_exact(conn, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = conn.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("client closed")
+        buf += chunk
+    return buf
+
+
+def read_frame(conn):
+    head = read_exact(conn, 2)
+    opcode = head[0] & 0x0F
+    masked = bool(head[1] & 0x80)
+    n = head[1] & 0x7F
+    if n == 126:
+        n = struct.unpack(">H", read_exact(conn, 2))[0]
+    elif n == 127:
+        n = struct.unpack(">Q", read_exact(conn, 8))[0]
+    mask = read_exact(conn, 4) if masked else b""
+    payload = read_exact(conn, n)
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, masked, payload
+
+
+def handshake(conn):
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = conn.recv(4096)
+        if not chunk:
+            raise ConnectionError("client closed during handshake")
+        buf += chunk
+    head = buf.split(b"\r\n\r\n", 1)[0].decode(errors="replace")
+    request_line = head.split("\r\n")[0]
+    path = request_line.split(" ")[1]
+    key = ""
+    for line in head.split("\r\n")[1:]:
+        if line.lower().startswith("sec-websocket-key:"):
+            key = line.split(":", 1)[1].strip()
+    accept = base64.b64encode(hashlib.sha1((key + GUID).encode()).digest()).decode()
+    conn.sendall(
+        (
+            "HTTP/1.1 101 Switching Protocols\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            "Sec-WebSocket-Accept: %s\r\n\r\n" % accept
+        ).encode()
+    )
+    return path
+
+
+def handle(conn):
+    try:
+        path = handshake(conn)
+        log("connect %s" % path)
+        if path == "/events":
+            # The real events socket pushes reporter events; it never needs to
+            # read. Emit per mode once a reload broadcast has been observed.
+            if MODE in ("bundle-done", "bundle-fail"):
+                if reload_seen.wait(timeout=20):
+                    time.sleep(0.1)
+                    conn.sendall(text_frame(json.dumps({"type": "bundle_build_started"})))
+                    if MODE == "bundle-done":
+                        conn.sendall(text_frame(json.dumps({"type": "bundle_build_done"})))
+                    else:
+                        conn.sendall(text_frame(json.dumps({"type": "bundle_build_failed"})))
+            # silent mode: hold the connection open, send nothing
+            while True:
+                opcode, _, _ = read_frame(conn)
+                if opcode == 0x8:
+                    break
+        else:
+            while True:
+                opcode, masked, payload = read_frame(conn)
+                if opcode == 0x8:
+                    break
+                if opcode == 0x1:
+                    log("frame path=%s masked=%d payload=%s" % (path, int(masked), payload.decode(errors="replace")))
+                    try:
+                        if json.loads(payload.decode()).get("method") == "reload":
+                            reload_seen.set()
+                    except ValueError:
+                        pass
+    except (ConnectionError, OSError):
+        pass
+    finally:
+        conn.close()
+
+
+def main():
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(("127.0.0.1", 0))
+    server.listen(8)
+    with open(PORT_FILE, "w") as f:
+        f.write(str(server.getsockname()[1]))
+    while True:
+        conn, _ = server.accept()
+        threading.Thread(target=handle, args=(conn,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -363,6 +363,124 @@ check "reset without a port writes no defaults" "no" \
 "$SCRIPTS/release-session.sh" 622 --delete >/dev/null 2>&1
 
 echo
+echo "golden simulator (bless + clone)"
+
+# One world for the whole section: a golden is long-lived state by design.
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 700)" >/dev/null 2>&1
+BLESS_UDID="$DEMO_UDID"; BLESS_PORT="$DEMO_PORT"
+mkdir -p "$FAKE_APP_ROOT/$BLESS_UDID"
+cp -R "$APP_SRC" "$FAKE_APP_ROOT/$BLESS_UDID/com.example.demoapp.app"
+"$SCRIPTS/bless-golden.sh" 700 --sha abc123 >/dev/null 2>&1
+check "bless exits zero" "0" "$?"
+check "the blessed device carries the golden name" "rn-demo-golden" \
+  "$(awk -F'|' -v u="$BLESS_UDID" '$1==u {print $2}' "$FAKE_DEVICES")"
+check "the golden is left shutdown (clone requires it)" "Shutdown" \
+  "$(device_state "$BLESS_UDID")"
+GOLDEN_STAMP="$DEMO_SIM_REGISTRY/golden/rn-demo-golden/stamp"
+check "the stamp records the build sha" "yes" \
+  "$(grep -q '^sha=abc123' "$GOLDEN_STAMP" && echo yes || echo no)"
+check "the stamp records the device type" "yes" \
+  "$(grep -q '^device-type=iPhone 16 Pro' "$GOLDEN_STAMP" && echo yes || echo no)"
+check "bless adopts the session - a later release finds nothing" "1" \
+  "$("$SCRIPTS/release-session.sh" 700 >/dev/null 2>&1; echo $?)"
+check "bless freed the session's port" "absent" \
+  "$([ -d "$DEMO_SIM_REGISTRY/ports/$BLESS_PORT" ] && echo present || echo absent)"
+
+# --- claim clones the golden instead of creating blank -----------------------
+out=$("$SCRIPTS/claim-session.sh" 701) && eval "$out"
+check "claim clones the golden's udid" "yes" \
+  "$(grep -q "clone $BLESS_UDID rn-demo-pr701" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+check "the clone is named for the PR like any other session device" "Booted" \
+  "$(device_state "$DEMO_UDID")"
+check "the clone carries the golden's app container" "present" \
+  "$([ -d "$FAKE_APP_ROOT/$DEMO_UDID/com.example.demoapp.app" ] && echo present || echo absent)"
+check "claim output surfaces the golden stamp for staleness judgment" "yes" \
+  "$(echo "$out" | grep -q "sha=abc123" && echo yes || echo no)"
+"$SCRIPTS/release-session.sh" 701 --delete >/dev/null 2>&1
+check "a cloned session releases cleanly" "0" "$?"
+check "releasing the clone leaves the golden alone" "Shutdown" \
+  "$(device_state "$BLESS_UDID")"
+
+# --- the Metro redirect is persisted on clones too ---------------------------
+: > "$FAKE_ARGS_LOG"
+eval "$(DEMO_APP_ID_IOS=com.example.demoapp "$SCRIPTS/claim-session.sh" 702)" >/dev/null 2>&1
+check "a cloned claim still persists the Metro redirect" "yes" \
+  "$(grep -q "spawn $DEMO_UDID defaults write com.example.demoapp RCT_jsLocation localhost:$DEMO_PORT" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+"$SCRIPTS/release-session.sh" 702 --delete >/dev/null 2>&1
+
+# --- every ineligibility falls back to a blank create ------------------------
+# The fake's clone verb errors on a booted source, so this cannot pass against
+# a clone that "succeeded" anyway.
+xcrun simctl boot "$BLESS_UDID"
+eval "$("$SCRIPTS/claim-session.sh" 703)" >/dev/null 2>&1
+check "a booted golden falls back to create" "created" \
+  "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr703/origin")"
+"$SCRIPTS/release-session.sh" 703 --delete >/dev/null 2>&1
+xcrun simctl shutdown "$BLESS_UDID"
+
+eval "$("$SCRIPTS/claim-session.sh" 704 "iPhone SE (3rd generation)")" >/dev/null 2>&1
+check "a device-type mismatch falls back to create (a clone would lie about hardware)" "created" \
+  "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr704/origin")"
+"$SCRIPTS/release-session.sh" 704 --delete >/dev/null 2>&1
+
+eval "$("$SCRIPTS/claim-session.sh" 705 "iPhone 16 Pro" "iOS 18.6")" >/dev/null 2>&1
+check "an explicit runtime mismatch falls back to create" "created" \
+  "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr705/origin")"
+"$SCRIPTS/release-session.sh" 705 --delete >/dev/null 2>&1
+
+eval "$(DEMO_SIM_GOLDEN=none "$SCRIPTS/claim-session.sh" 706)" >/dev/null 2>&1
+check "DEMO_SIM_GOLDEN=none disables cloning" "created" \
+  "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr706/origin")"
+"$SCRIPTS/release-session.sh" 706 --delete >/dev/null 2>&1
+
+# --- the reaper never touches the golden -------------------------------------
+# Including via a hostile session manifest pointing at the golden's udid: the
+# reaper's name gate must hold for the golden exactly as for the user's sim.
+eval "$("$SCRIPTS/claim-session.sh" 707)" >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 707 >/dev/null 2>&1
+echo 1 > "$DEMO_SIM_REGISTRY/rn-demo-pr707/released-at"
+echo "$BLESS_UDID" > "$DEMO_SIM_REGISTRY/rn-demo-pr707/udid"
+"$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "the reaper refuses a manifest pointing at the golden" "Shutdown" \
+  "$(device_state "$BLESS_UDID")"
+rm -rf "$DEMO_SIM_REGISTRY/rn-demo-pr707"
+
+# --- re-bless swaps atomically: exactly one golden survives ------------------
+out=$("$SCRIPTS/claim-session.sh" 708) && eval "$out"
+NEW_UDID="$DEMO_UDID"
+"$SCRIPTS/bless-golden.sh" 708 --sha def456 >/dev/null 2>&1
+check "re-bless exits zero" "0" "$?"
+check "exactly one device carries the golden name after a re-bless" "1" \
+  "$(awk -F'|' '$2=="rn-demo-golden"' "$FAKE_DEVICES" | wc -l | tr -d ' ')"
+check "the new device is the golden now" "rn-demo-golden" \
+  "$(awk -F'|' -v u="$NEW_UDID" '$1==u {print $2}' "$FAKE_DEVICES")"
+check "the retired golden is deleted, not orphaned" "" \
+  "$(device_state "$BLESS_UDID")"
+check "the stamp now describes the new golden" "yes" \
+  "$(grep -q '^sha=def456' "$GOLDEN_STAMP" && echo yes || echo no)"
+
+# --- bless safety gates ------------------------------------------------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 710)" >/dev/null 2>&1
+echo "OTHER-AGENT" > "$DEMO_SESSION_DIR/udid"      # manifest points at someone else
+"$SCRIPTS/bless-golden.sh" 710 >/dev/null 2>&1
+check "bless refuses a device not named for the session" "1" "$?"
+check "the foreign device survives the refused bless" "Booted" \
+  "$(device_state OTHER-AGENT)"
+rm -rf "$DEMO_SIM_REGISTRY/rn-demo-pr710"
+
+"$SCRIPTS/bless-golden.sh" 9999 >/dev/null 2>&1
+check "bless without a claimed session fails loudly" "1" "$?"
+
+# The golden race window (a clone of a golden being swapped mid-bless) is
+# closed by the shared lock; these go red if either side sheds it.
+check "claim's clone step runs under the golden lock" "yes" \
+  "$(grep -q 'with-lock.sh" golden' "$SCRIPTS/claim-session.sh" && echo yes || echo no)"
+check "bless's swap runs under the golden lock" "yes" \
+  "$(grep -q 'with-lock.sh" golden' "$SCRIPTS/bless-golden.sh" && echo yes || echo no)"
+
+echo
 echo "shared metro transform cache (metro-demo.config.js)"
 
 DEMO_CFG="$SCRIPTS/metro-demo.config.js"
@@ -499,6 +617,10 @@ echo "documented behavior matches the scripts"
 SKILL_MD="$TESTS_DIR/../SKILL.md"
 check "SKILL.md documents the reload flip" "yes" \
   "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents the golden bless workflow" "yes" \
+  "$(grep -q "bless-golden.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md ties golden staleness to the stamp sha" "yes" \
+  "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md step 4 starts Metro with the demo cache config" "yes" \
   "$(grep -q "metro-demo.config.js" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md forbids --reset-cache against the shared store" "yes" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -387,6 +387,42 @@ check "reset without a port writes no defaults" "no" \
 "$SCRIPTS/release-session.sh" 622 --delete >/dev/null 2>&1
 
 echo
+echo "native-build staleness stamp (native-stamp.sh)"
+
+NS="$SCRIPTS/native-stamp.sh"
+NS_APP="$WORK/lock-app"; mkdir -p "$NS_APP/ios"
+echo "PODS v1" > "$NS_APP/ios/Podfile.lock"
+NS_STAMP="$WORK/native-stamp"
+echo "sha=abc" > "$NS_STAMP"
+
+(cd "$NS_APP" && "$NS" write "$NS_STAMP") >/dev/null 2>&1
+check "write records a podfile-lock-hash" "yes" \
+  "$(grep -q '^podfile-lock-hash=' "$NS_STAMP" && echo yes || echo no)"
+check "write preserves the stamp's other keys" "yes" \
+  "$(grep -q '^sha=abc' "$NS_STAMP" && echo yes || echo no)"
+
+(cd "$NS_APP" && "$NS" check "$NS_STAMP") >/dev/null 2>&1
+check "check passes while the lockfile is unchanged" "0" "$?"
+
+echo "PODS v2 - a native module renamed" > "$NS_APP/ios/Podfile.lock"
+out=$(cd "$NS_APP" && "$NS" check "$NS_STAMP" 2>&1); rc=$?
+check "check fails once the lockfile changed" "1" "$rc"
+check "the failure says STALE and names Podfile.lock" "yes" \
+  "$(echo "$out" | grep -q "STALE" && echo "$out" | grep -q "Podfile.lock" && echo yes || echo no)"
+
+(cd "$NS_APP" && "$NS" write "$NS_STAMP") >/dev/null 2>&1
+check "re-write replaces the hash line instead of stacking a second one" "1" \
+  "$(grep -c '^podfile-lock-hash=' "$NS_STAMP" | tr -d ' ')"
+
+# A stamp that cannot vouch for its build must fail, never pass vacuously.
+echo "sha=abc" > "$NS_STAMP"
+(cd "$NS_APP" && "$NS" check "$NS_STAMP") >/dev/null 2>&1
+check "a stamp without a hash demands a re-stamp" "1" "$?"
+
+"$NS" check "$NS_STAMP" --lockfile "$WORK/does-not-exist.lock" >/dev/null 2>&1
+check "a missing lockfile is a loud failure, not a pass" "1" "$?"
+
+echo
 echo "golden simulator (bless + clone)"
 
 # One world for the whole section: a golden is long-lived state by design.
@@ -483,6 +519,28 @@ check "the retired golden is deleted, not orphaned" "" \
   "$(device_state "$BLESS_UDID")"
 check "the stamp now describes the new golden" "yes" \
   "$(grep -q '^sha=def456' "$GOLDEN_STAMP" && echo yes || echo no)"
+
+# --- the stamp's lockfile hash gives claim an instant staleness verdict ------
+VERDICT_APP="$WORK/verdict-app"; mkdir -p "$VERDICT_APP/ios"
+echo "PODS blessed" > "$VERDICT_APP/ios/Podfile.lock"
+"$NS" write "$GOLDEN_STAMP" --lockfile "$VERDICT_APP/ios/Podfile.lock" >/dev/null 2>&1
+out=$(cd "$VERDICT_APP" && "$SCRIPTS/claim-session.sh" 709)
+check "claim reports a matching native build from the worktree root" "yes" \
+  "$(echo "$out" | grep -q "native build matches" && echo yes || echo no)"
+(cd "$VERDICT_APP" && "$SCRIPTS/release-session.sh" 709 --delete) >/dev/null 2>&1
+
+echo "PODS newer - native module changed" > "$VERDICT_APP/ios/Podfile.lock"
+out=$(cd "$VERDICT_APP" && "$SCRIPTS/claim-session.sh" 712)
+check "claim warns NATIVE BUILD STALE when the lockfile moved on" "yes" \
+  "$(echo "$out" | grep -q "NATIVE BUILD STALE" && echo yes || echo no)"
+(cd "$VERDICT_APP" && "$SCRIPTS/release-session.sh" 712 --delete) >/dev/null 2>&1
+
+# --- bless records the lockfile hash in the stamp ----------------------------
+out=$("$SCRIPTS/claim-session.sh" 713) && eval "$out"
+"$SCRIPTS/bless-golden.sh" 713 --sha bbb222 --lockfile "$VERDICT_APP/ios/Podfile.lock" >/dev/null 2>&1
+check "bless with a lockfile exits zero" "0" "$?"
+check "the blessed stamp carries the lockfile hash" "yes" \
+  "$(grep -q '^podfile-lock-hash=' "$GOLDEN_STAMP" && echo yes || echo no)"
 
 # --- bless safety gates ------------------------------------------------------
 reset_world
@@ -661,6 +719,8 @@ check "SKILL.md documents the golden bless workflow" "yes" \
   "$(grep -q "bless-golden.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md ties golden staleness to the stamp sha" "yes" \
   "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents the native-stamp verdict" "yes" \
+  "$(grep -q "native-stamp.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the 72h retention default" "yes" \
   "$(grep -q "72h" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md carries no stale 24h default" "no" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -542,6 +542,28 @@ check "bless with a lockfile exits zero" "0" "$?"
 check "the blessed stamp carries the lockfile hash" "yes" \
   "$(grep -q '^podfile-lock-hash=' "$GOLDEN_STAMP" && echo yes || echo no)"
 
+echo
+echo "credential precheck"
+
+# The wall this removes: an agent discovering forty minutes into a session
+# that the staging OTP was never set on this machine. Claim reports the gap
+# up front - and never blocks, because most demos need no account at all.
+reset_world
+export FAKE_CRED_PRESENT=some-value
+out=$(DEMO_REQUIRED_ENV="FAKE_CRED_PRESENT FAKE_CRED_ABSENT" "$SCRIPTS/claim-session.sh" 720); rc=$?
+check "a claim with missing credentials still succeeds" "0" "$rc"
+check "claim names each missing credential up front" "yes" \
+  "$(echo "$out" | grep "missing credentials" | grep -q "FAKE_CRED_ABSENT" && echo yes || echo no)"
+check "a present credential is not reported missing" "no" \
+  "$(echo "$out" | grep "missing credentials" | grep -q "FAKE_CRED_PRESENT" && echo yes || echo no)"
+"$SCRIPTS/release-session.sh" 720 --delete >/dev/null 2>&1
+
+out=$(DEMO_REQUIRED_ENV="FAKE_CRED_PRESENT" "$SCRIPTS/claim-session.sh" 721)
+check "no note when every required credential is present" "no" \
+  "$(echo "$out" | grep -q "missing credentials" && echo yes || echo no)"
+"$SCRIPTS/release-session.sh" 721 --delete >/dev/null 2>&1
+unset FAKE_CRED_PRESENT
+
 # --- bless safety gates ------------------------------------------------------
 reset_world
 eval "$("$SCRIPTS/claim-session.sh" 710)" >/dev/null 2>&1
@@ -721,6 +743,8 @@ check "SKILL.md ties golden staleness to the stamp sha" "yes" \
   "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the native-stamp verdict" "yes" \
   "$(grep -q "native-stamp.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents the credential precheck" "yes" \
+  "$(grep -q "DEMO_REQUIRED_ENV" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the 72h retention default" "yes" \
   "$(grep -q "72h" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md carries no stale 24h default" "no" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -148,7 +148,7 @@ check "leaves another agent's process alone" "alive" \
 check "release without a claim fails loudly" "1" "$?"
 
 echo
-echo "24h retention"
+echo "72h retention"
 
 # --- default release keeps the device and stamps it for the reaper ----------
 reset_world
@@ -163,6 +163,30 @@ eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
 check "re-claim clears the released-at stamp" "absent" \
   "$([ -f "$DEMO_SESSION_DIR/released-at" ] && echo present || echo absent)"
 check "re-claim within the TTL reuses the kept device" "Booted" "$(device_state "$DEMO_UDID")"
+
+# --- the 72h default is real, not just documented ----------------------------
+# Every other retention test ages a stamp with `echo 1` (expired under ANY
+# ttl), so these two are the only assertions that notice the default silently
+# reverting to 24h (48h-old must survive) or drifting to forever (73h-old
+# must not).
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 3712 >/dev/null 2>&1
+echo $(( $(date +%s) - 48 * 3600 )) > "$DEMO_SESSION_DIR/released-at"
+"$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "a session released 48h ago survives the default TTL" "Shutdown" \
+  "$(device_state "$DEMO_UDID")"
+echo $(( $(date +%s) - 73 * 3600 )) > "$DEMO_SESSION_DIR/released-at"
+"$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "a session released 73h ago is reaped" "" "$(device_state "$DEMO_UDID")"
+
+# --- DEMO_SIM_TTL_HOURS still overrides the default --------------------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 3712 >/dev/null 2>&1
+echo $(( $(date +%s) - 2 * 3600 )) > "$DEMO_SESSION_DIR/released-at"
+DEMO_SIM_TTL_HOURS=1 "$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "DEMO_SIM_TTL_HOURS=1 reaps a 2h-old session" "" "$(device_state "$DEMO_UDID")"
 
 # --- reaper removes only expired sessions -----------------------------------
 reset_world
@@ -621,6 +645,10 @@ check "SKILL.md documents the golden bless workflow" "yes" \
   "$(grep -q "bless-golden.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md ties golden staleness to the stamp sha" "yes" \
   "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents the 72h retention default" "yes" \
+  "$(grep -q "72h" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md carries no stale 24h default" "no" \
+  "$(grep -q "24h" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md step 4 starts Metro with the demo cache config" "yes" \
   "$(grep -q "metro-demo.config.js" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md forbids --reset-cache against the shared store" "yes" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -520,6 +520,8 @@ const stores = typeof cfg.cacheStores === "function"
   : []
 console.log(JSON.stringify({
   sourceExts: (cfg.resolver || {}).sourceExts || [],
+  transformerSentinel: (cfg.transformer || {}).sentinelField || "",
+  asyncRequireModulePath: (cfg.transformer || {}).asyncRequireModulePath || "",
   storeCount: stores.length,
   root: stores.length ? stores[0].root : "",
 }))
@@ -530,6 +532,13 @@ mkdir -p "$FAKE_APP"
 cat > "$FAKE_APP/metro.config.js" <<'EOF'
 module.exports = {
   resolver: { sourceExts: ["ts", "tsx", "svg-sentinel"] },
+  transformer: {
+    sentinelField: "transformer-sentinel",
+    // Models what @react-native/metro-config really does: a require.resolve()d
+    // per-worktree ABSOLUTE path. Hashed into the global transform-cache key,
+    // it silently reduces cross-worktree sharing to zero.
+    asyncRequireModulePath: "/private/tmp/some-worktree/node_modules/metro-runtime/src/modules/asyncRequire",
+  },
 }
 EOF
 
@@ -540,6 +549,13 @@ check "wrapper installs exactly one shared cache store" "yes" \
   "$(echo "$out" | grep -q '"storeCount":1' && echo yes || echo no)"
 check "cache root honors DEMO_METRO_CACHE_ROOT" "yes" \
   "$(echo "$out" | grep -qF "\"root\":\"$WORK/cache-root\"" && echo yes || echo no)"
+check "app transformer fields survive the wrapper" "yes" \
+  "$(echo "$out" | grep -q "transformer-sentinel" && echo yes || echo no)"
+# Verified live: with the app's absolute asyncRequireModulePath in the hashed
+# transformer config, cross-worktree sharing was exactly 0%; pinned to the bare
+# specifier, a second worktree's first bundle went from 39s to 4s.
+check "asyncRequireModulePath is pinned to the worktree-independent specifier" "yes" \
+  "$(echo "$out" | grep -q '"asyncRequireModulePath":"metro-runtime/src/modules/asyncRequire"' && echo yes || echo no)"
 
 # The fixture app deliberately has no node_modules: together with the loads
 # above this is what fails if anyone turns the function-form cacheStores into

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -363,9 +363,79 @@ check "reset without a port writes no defaults" "no" \
 "$SCRIPTS/release-session.sh" 622 --delete >/dev/null 2>&1
 
 echo
+echo "shared metro transform cache (metro-demo.config.js)"
+
+DEMO_CFG="$SCRIPTS/metro-demo.config.js"
+
+# The probe loads the wrapper the way Metro would and reports what came out.
+# The stub store classes stand in for metro-cache, which the wrapper must only
+# ever receive through the function-form cacheStores - never require itself.
+cat > "$WORK/metro-probe.js" <<'EOF'
+const cfg = require(process.argv[2])
+const Stub = class { constructor(o) { this.root = o.root } }
+const stores = typeof cfg.cacheStores === "function"
+  ? cfg.cacheStores({ AutoCleanFileStore: Stub, FileStore: Stub })
+  : []
+console.log(JSON.stringify({
+  sourceExts: (cfg.resolver || {}).sourceExts || [],
+  storeCount: stores.length,
+  root: stores.length ? stores[0].root : "",
+}))
+EOF
+
+FAKE_APP="$WORK/fake-app"
+mkdir -p "$FAKE_APP"
+cat > "$FAKE_APP/metro.config.js" <<'EOF'
+module.exports = {
+  resolver: { sourceExts: ["ts", "tsx", "svg-sentinel"] },
+}
+EOF
+
+out=$(cd "$FAKE_APP" && DEMO_METRO_CACHE_ROOT="$WORK/cache-root" node "$WORK/metro-probe.js" "$DEMO_CFG" 2>&1)
+check "app config fields survive the demo wrapper" "yes" \
+  "$(echo "$out" | grep -q "svg-sentinel" && echo yes || echo no)"
+check "wrapper installs exactly one shared cache store" "yes" \
+  "$(echo "$out" | grep -q '"storeCount":1' && echo yes || echo no)"
+check "cache root honors DEMO_METRO_CACHE_ROOT" "yes" \
+  "$(echo "$out" | grep -qF "\"root\":\"$WORK/cache-root\"" && echo yes || echo no)"
+
+# The fixture app deliberately has no node_modules: together with the loads
+# above this is what fails if anyone turns the function-form cacheStores into
+# a top-level require of metro-cache.
+check "fixture app carries no node_modules for the wrapper to lean on" "absent" \
+  "$([ -d "$FAKE_APP/node_modules" ] && echo present || echo absent)"
+
+out=$(cd "$FAKE_APP" && env -u DEMO_METRO_CACHE_ROOT node "$WORK/metro-probe.js" "$DEMO_CFG" 2>&1)
+check "default cache root expands to an absolute path under \$HOME" "yes" \
+  "$(echo "$out" | grep -qF "\"root\":\"$HOME/" && echo yes || echo no)"
+
+EMPTY_APP="$WORK/empty-app"
+mkdir -p "$EMPTY_APP"
+out=$(cd "$EMPTY_APP" && node "$WORK/metro-probe.js" "$DEMO_CFG" 2>&1); rc=$?
+check "wrapper fails loudly when cwd has no metro.config.js" "nonzero" \
+  "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)"
+# Suffix match: node reports the symlink-resolved cwd (/private/var/...) while
+# bash's $WORK keeps the /var/... spelling on macOS.
+check "the failure names the missing config path" "yes" \
+  "$(echo "$out" | grep -qF "empty-app/metro.config.js" && echo yes || echo no)"
+
+FN_APP="$WORK/fn-app"
+mkdir -p "$FN_APP"
+echo "module.exports = () => ({})" > "$FN_APP/metro.config.js"
+out=$(cd "$FN_APP" && node "$WORK/metro-probe.js" "$DEMO_CFG" 2>&1); rc=$?
+check "wrapper refuses a function-form app config rather than dropping it" "nonzero" \
+  "$([ "$rc" -ne 0 ] && echo nonzero || echo zero)"
+check "the refusal says object-form only" "yes" \
+  "$(echo "$out" | grep -qi "object" && echo yes || echo no)"
+
+echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md step 4 starts Metro with the demo cache config" "yes" \
+  "$(grep -q "metro-demo.config.js" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md forbids --reset-cache against the shared store" "yes" \
+  "$(grep -q -- "--reset-cache" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents reset-app.sh for reinstall state" "yes" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -429,9 +429,76 @@ check "the refusal says object-form only" "yes" \
   "$(echo "$out" | grep -qi "object" && echo yes || echo no)"
 
 echo
+echo "js reload flip (reload-app.sh)"
+
+# One fake dev server per scenario: fresh port, fresh observation log.
+start_ws_fake() { # start_ws_fake <mode>; sets WS_PORT, WS_LOG, WS_PID
+  WS_LOG="$WORK/ws-$1.log"; : > "$WS_LOG"
+  rm -f "$WORK/ws-port"
+  FAKE_WS_MODE="$1" FAKE_WS_LOG="$WS_LOG" FAKE_WS_PORT_FILE="$WORK/ws-port" \
+    python3 "$TESTS_DIR/fixtures/ws-fake.py" &
+  WS_PID=$!; STRAYS+=($WS_PID); disown $WS_PID 2>/dev/null
+  for _ in $(seq 50); do [ -s "$WORK/ws-port" ] && break; sleep 0.1; done
+  WS_PORT=$(cat "$WORK/ws-port" 2>/dev/null || echo "")
+}
+
+# --- happy path: broadcast on /message, confirmation via /events -------------
+start_ws_fake bundle-done
+"$SCRIPTS/reload-app.sh" --port "$WS_PORT" --timeout 10 >/dev/null 2>&1
+check "reload exits zero once bundle activity is observed" "0" "$?"
+check "the broadcast lands on /message after a real handshake" "yes" \
+  "$(grep -q "^connect /message" "$WS_LOG" && echo yes || echo no)"
+check "the confirmation listener opens /events" "yes" \
+  "$(grep -q "^connect /events" "$WS_LOG" && echo yes || echo no)"
+FRAME=$(grep "^frame path=/message" "$WS_LOG" | head -1)
+check "payload is the version-2 reload method" "yes" \
+  "$(echo "$FRAME" | grep -q '"method": "reload"' && echo "$FRAME" | grep -q '"version": 2' && echo yes || echo no)"
+check "payload carries no id/target (broadcast, not a directed request)" "yes" \
+  "$(echo "$FRAME" | grep -qv '"id"' && echo "$FRAME" | grep -qv '"target"' && echo yes || echo no)"
+check "the client frame is masked as RFC 6455 requires" "yes" \
+  "$(echo "$FRAME" | grep -q "masked=1" && echo yes || echo no)"
+kill "$WS_PID" 2>/dev/null
+
+# --- no app connected: the silent-no-op broadcast must not report success ----
+# This is the assertion that dies if the /events wait is ever skipped: a
+# fire-and-forget mutant exits 0 here and ships identical before/after pairs.
+start_ws_fake silent
+out=$("$SCRIPTS/reload-app.sh" --port "$WS_PORT" --timeout 3 2>&1); rc=$?
+check "no bundle activity within the timeout fails the reload" "1" "$rc"
+check "the failure points at the terminate+launch fallback" "yes" \
+  "$(echo "$out" | grep -qi "terminate" && echo yes || echo no)"
+kill "$WS_PID" 2>/dev/null
+
+# --- a broken bundle is a failure, not a confirmed flip ----------------------
+start_ws_fake bundle-fail
+out=$("$SCRIPTS/reload-app.sh" --port "$WS_PORT" --timeout 10 2>&1); rc=$?
+check "a failed bundle build fails the reload" "1" "$rc"
+kill "$WS_PID" 2>/dev/null
+
+# --- --no-wait is explicit fire-and-forget -----------------------------------
+start_ws_fake silent
+"$SCRIPTS/reload-app.sh" --port "$WS_PORT" --no-wait >/dev/null 2>&1
+check "--no-wait fires the broadcast and exits zero unconfirmed" "0" "$?"
+check "--no-wait still delivered the reload frame" "yes" \
+  "$(for _ in $(seq 20); do grep -q "reload" "$WS_LOG" && break; sleep 0.1; done; grep -q "reload" "$WS_LOG" && echo yes || echo no)"
+kill "$WS_PID" 2>/dev/null
+
+# --- dead port and missing port fail fast, never hang ------------------------
+FREE_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+"$SCRIPTS/reload-app.sh" --port "$FREE_PORT" --timeout 3 >/dev/null 2>&1
+check "nothing listening on the port is an immediate failure" "1" "$?"
+
+out=$(DEMO_PORT= "$SCRIPTS/reload-app.sh" 2>&1); rc=$?
+check "reload refuses to run without a port" "1" "$rc"
+check "the refusal names the 8081 hazard" "yes" \
+  "$(echo "$out" | grep -q "8081" && echo yes || echo no)"
+
+echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md documents the reload flip" "yes" \
+  "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md step 4 starts Metro with the demo cache config" "yes" \
   "$(grep -q "metro-demo.config.js" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md forbids --reset-cache against the shared store" "yes" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,19 @@ configuration are:
 export DEMO_APP_ID_IOS=io.galoy.bitcoinbeach
 export DEMO_APP_ID_ANDROID=com.galoyapp
 export DEMO_SIM_PREFIX=blink-demo
+export DEMO_REQUIRED_ENV="GALOY_STAGING_GLOBAL_OTP"
 ```
 
 Set them before claiming a simulator session or recording a flow — the
 scripts refuse to guess an app id. `DEMO_SIM_PREFIX` names this repo's
 simulators (`blink-demo-pr<N>`) and scopes their session state, so other
 repos using the same skills on one machine can never collide with ours.
+
+`DEMO_REQUIRED_ENV` lists the credentials this repo's real-account demo flows
+need; claim-session.sh reports any that are unset at claim time, so a session
+knows from the start whether staging login is possible or the stub-harness
+route is the plan. The OTP value itself belongs in the machine's `.env.local`
+(loaded by `.envrc` via direnv), never in the repo.
 
 ## Critical Rules (Always Apply)
 - `app/graphql/generated.ts` is AUTO-GENERATED - never modify manually


### PR DESCRIPTION
Fixes #4092. Stacked on #4085 (`chore/commit-claude-skills`) — only the last six commits are this PR.

Per-PR demo capture paid a repeated setup tax: ~2 min cold Metro bundle per worktree, ~40 s per before/after flip, ~45 s sim setup, and minutes of staging login for video sessions. Each cost now lands as its own tested patch, in the issue's payoff order. All guarantees follow the suites' mutation-check rule — every one has an assertion that goes red without it (303 assertions across the 4 suites, up from 237).

## 1. Shared Metro transform cache (`metro-demo.config.js`)

A demo-only Metro config wraps the worktree's own `metro.config.js` and points `cacheStores` at a shared `AutoCleanFileStore` in `~/.cache/metro-demo` (override: `DEMO_METRO_CACHE_ROOT`). Metro's cache keys are content- and relative-path-based, so worktrees hit each other's entries.

One field poisoned that on the first live run: `@react-native/metro-config` resolves `asyncRequireModulePath` to an absolute per-worktree path, and unlike `babelTransformerPath` it is hashed into the global cache key — measured cross-worktree reuse was exactly 0%. Pinned to Metro's own bare-specifier default, **a second worktree's first bundle went from 39 s to 4.3 s** (cold seed: 23.4 s). `--reset-cache` with this config is now a Never-Do row (it clears the shared store machine-wide).

## 2. `reload-app.sh` — JS reload instead of cold relaunch

A checkout-flip changes only JS, so the flip now reloads the running app (the `/message` websocket broadcast behind Metro's `r` key; dependency-free python3-stdlib client) instead of terminate + launch + splash. A full reload re-runs the entry point, so TEMP `initialRouteName` edits apply — the case Fast Refresh can't cover.

The broadcast succeeds silently with zero apps connected, and an unnoticed no-op flip ships a before/after pair whose sides are quietly identical — so the script watches the sibling `/events` socket and exits 0 only after Metro reports the re-served bundle (verified live: `bundle_build_done` fires on cache-warm serves too). Verified end-to-end on-device: confirmed reload in **0.35–0.9 s** vs the ~40 s relaunch; the honest-failure path is real too (an app's dev connection dies after a few reload cycles — the script says so and the documented terminate+launch fallback recovers).

## 3. Golden logged-in simulator, cloned per session

`bless-golden.sh` promotes a session's device — app installed, account logged in — into a shutdown golden; `claim-session.sh` then clones it in seconds instead of creating a blank device. Clones are immutable per-PR copies, so every existing ownership/release/reaper guard applies unchanged.

Bless replaces release, terminally: ownership gate, Metro stopped by recorded PID, swap under the shared `golden` lock (names aren't unique — exactly one golden ever exists), `sha/date/device-type/runtime` stamp, collateral-damage assertion, session adopted. Claim clones only on a shutdown, type-matching golden and surfaces the stamp so the agent can diff native paths against the blessed SHA; every ineligibility falls back to a blank create with a note.

Verified live on this Mac: blessed a real device into `blink-demo-golden`, re-claimed → clone came up in seconds with the app install, the full 1.2 GB data directory, and a planted data-container marker intact; the cloned app boots normally. *Caveat, stated honestly: the blessed golden carries app state but not a real staging login — keychain content rides in the same cloned data directory, but "login survives a clone" gets its definitive confirmation the first time someone blesses a logged-in device (SKILL.md says to re-bless if a clone ever comes up logged out).*

## 4. Retention TTL 24 h → 72 h

Retakes routinely arrive a day or two later; 72 h keeps them cheap across that window while the reaper still bounds accumulation. The existing suite aged stamps with `echo 1` — expired under *any* TTL — so the bump alone would have had zero failing-without-it coverage; new assertions pin the default itself (48 h-old kept, 73 h-old reaped, override honored).

The issue's opt-in **repo-scoped sim reuse is closed as superseded** by the golden clone: same economy, immutable source, no cross-PR shared mutable state.

## Notes

- The pre-repo skills copy at `~/Dev/blink/.claude/skills/` predates this branch's session-keying fix and these patches; once this lands it should be retired or synced (not done here).
- Verification left a useful artifact on this Mac: `blink-demo-golden` (iPhone 16 Pro, app installed from the Jul 27 DerivedData build, stamp `2a3c3d8`). Re-bless it with a logged-in session to get the full login-skip payoff.

## 5. Podfile.lock stamp: native-build staleness as an instant verdict *(follow-up from the [capture-session comment](https://github.com/blinkbitcoin/blink-mobile/issues/4092#issuecomment) )*

`native-stamp.sh write|check` records/verifies a `podfile-lock-hash` in any stamp file. `bless-golden.sh` writes it into the golden stamp, and `claim-session.sh` prints a `# golden verdict:` line (`matches` / `NATIVE BUILD STALE`) whenever it runs from an app worktree root — replacing the git archaeology that once mispriced a pre-geetest-rename build at a ~14 min locked rebuild discovered as a launch crash. A build you make can be stamped the same way (`demo-native-stamp` next to the `.app`) so the next agent gets the verdict too. A stamp without a hash *fails* `check` rather than passing vacuously — which honestly covers the `blink-demo-golden` currently on this Mac (blessed before this patch, from the pre-rename Jul 27 build): it will demand a re-bless.

## 6. Credential precheck at claim time *(same comment, addition 3)*

`DEMO_REQUIRED_ENV` (this repo's value added to `AGENTS.md`: `GALOY_STAGING_GLOBAL_OTP`) lists what real-account flows need; claim reports any unset name as a `# note: missing credentials` line so a session plans the stub-harness route up front instead of discovering the wall forty minutes in. Never blocks the claim; the skill stays app-agnostic (presence check only). The OTP value itself belongs in `.env.local` via direnv, never the repo.

The comment's addition 2 (a sanctioned `developerScreen` demo-trigger harness) is an app-code change, filed separately.

## Rejected alternatives (so review doesn't re-litigate them)

- **A simulator per side for before/after pairs** — halves wall-clock on paper; rejected in #4092 and now recorded in the screenshots SKILL.md (grep-pinned): two simulators are two devices (data, account state, remote-config fetches, timing), and any difference between the sides other than the code makes the pair dishonest.
- **A worktree per side against one simulator** — honest but strictly slower than the in-place flip: per-worktree `node_modules` install plus a Metro swap per side-switch, vs a file checkout plus a ~5 s reload. For native diffs the documented pattern stays build-once + `git checkout --detach` in the same worktree.
- **Repo-scoped warm-sim reuse (issue item 4b)** — superseded by the golden clone: same economy, immutable source, no cross-PR shared mutable state.
- **Locking Metro against the shared cache** — unnecessary by construction: entries are JSON keyed by content hash, a torn read is a miss, and two writers of one key write identical bytes (analysis in `metro-demo.config.js`).
