### PR TITLE
fix(migration): restart pre-commit checkpoints at the explainer on resume (regardless of checkpoint)

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -359,24 +359,6 @@ describe("useMigrationCheckpoint", () => {
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
-  it("restarts at the explainer when resuming from the terms checkpoint", async () => {
-    mockLoadCheckpoint.mockResolvedValue({
-      step: MigrationCheckpoint.TermsAndConditions,
-      savedAt: Date.now(),
-      accountId: "sc-account-1",
-    })
-
-    const { result } = renderHook(() => useMigrationCheckpoint())
-
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    act(() => {
-      result.current.navigateToCheckpoint()
-    })
-
-    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
-  })
-
   it("resumes at the balances overview after reaching the commit point", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.BalancesOverview,

--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -341,7 +341,7 @@ describe("useMigrationCheckpoint", () => {
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
-  it("navigates to the checkpoint's screen for a provisioned checkpoint", async () => {
+  it("restarts at the migration gate for a provisioned checkpoint before the commit point", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.BackupMethod,
       savedAt: Date.now(),
@@ -356,10 +356,10 @@ describe("useMigrationCheckpoint", () => {
       result.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
   })
 
-  it("forwards the migration flow param when resuming at the terms screen", async () => {
+  it("restarts at the migration gate when resuming from the terms checkpoint", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.TermsAndConditions,
       savedAt: Date.now(),
@@ -374,9 +374,7 @@ describe("useMigrationCheckpoint", () => {
       result.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("acceptTermsAndConditions", {
-      flow: "migration",
-    })
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
   })
 
   it("resumes at the balances overview after reaching the commit point", async () => {
@@ -399,7 +397,7 @@ describe("useMigrationCheckpoint", () => {
 
   it("replaces the current screen when resuming through replaceToCheckpoint", async () => {
     mockLoadCheckpoint.mockResolvedValue({
-      step: MigrationCheckpoint.TermsAndConditions,
+      step: MigrationCheckpoint.BalancesOverview,
       savedAt: Date.now(),
       accountId: "sc-account-1",
     })
@@ -412,13 +410,11 @@ describe("useMigrationCheckpoint", () => {
       result.current.replaceToCheckpoint()
     })
 
-    expect(mockReplace).toHaveBeenCalledWith("acceptTermsAndConditions", {
-      flow: "migration",
-    })
+    expect(mockReplace).toHaveBeenCalledWith("accountMigrationBalancesOverview")
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it("replaces to a param-less destination when the checkpoint is past the terms", async () => {
+  it("replaces to the migration gate when the checkpoint is before the commit point", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.BackupMethod,
       savedAt: Date.now(),
@@ -433,7 +429,7 @@ describe("useMigrationCheckpoint", () => {
       result.current.replaceToCheckpoint()
     })
 
-    expect(mockReplace).toHaveBeenCalledWith("selfCustodialBackupMethod")
+    expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
   })
 
   it("resumes from the explainer when the checkpoint has no provisioned account", async () => {
@@ -621,7 +617,7 @@ describe("useMigrationCheckpoint", () => {
       result2.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupSecurityChecks")
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
   })
 
   it("does not update state when the load fails after unmount", async () => {

--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -341,7 +341,7 @@ describe("useMigrationCheckpoint", () => {
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
-  it("restarts at the migration gate for a provisioned checkpoint before the commit point", async () => {
+  it("restarts at the explainer for a provisioned checkpoint before the commit point", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.BackupMethod,
       savedAt: Date.now(),
@@ -356,10 +356,10 @@ describe("useMigrationCheckpoint", () => {
       result.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
-  it("restarts at the migration gate when resuming from the terms checkpoint", async () => {
+  it("restarts at the explainer when resuming from the terms checkpoint", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.TermsAndConditions,
       savedAt: Date.now(),
@@ -374,7 +374,7 @@ describe("useMigrationCheckpoint", () => {
       result.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
   it("resumes at the balances overview after reaching the commit point", async () => {
@@ -414,7 +414,7 @@ describe("useMigrationCheckpoint", () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it("replaces to the migration gate when the checkpoint is before the commit point", async () => {
+  it("replaces to the explainer when the checkpoint is before the commit point", async () => {
     mockLoadCheckpoint.mockResolvedValue({
       step: MigrationCheckpoint.BackupMethod,
       savedAt: Date.now(),
@@ -429,7 +429,7 @@ describe("useMigrationCheckpoint", () => {
       result.current.replaceToCheckpoint()
     })
 
-    expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
+    expect(mockReplace).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
   it("resumes from the explainer when the checkpoint has no provisioned account", async () => {
@@ -484,6 +484,50 @@ describe("useMigrationCheckpoint", () => {
     await waitFor(() => expect(result.current.loading).toBe(false))
 
     expect(result.current.hasResumableCheckpoint).toBe(false)
+  })
+
+  it("reports the commit point once the balances overview is stored", async () => {
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: Date.now(),
+      accountId: "sc-account-1",
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.isAtCommitPoint).toBe(true)
+  })
+
+  /** The distinction the restart rests on: a resumable checkpoint is not a committed one,
+   *  so an abandoned backup step reopens the flow from scratch (#4109). */
+  it("is not at the commit point for a resumable checkpoint before it", async () => {
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BackupAlerts,
+      savedAt: Date.now(),
+      accountId: "sc-account-1",
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.hasResumableCheckpoint).toBe(true)
+    expect(result.current.isAtCommitPoint).toBe(false)
+  })
+
+  it("is not at the commit point when the balances step has no provisioned account", async () => {
+    mockLoadCheckpoint.mockResolvedValue({
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: Date.now(),
+    })
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.isAtCommitPoint).toBe(false)
   })
 
   it("hides a checkpoint owned by a different custodial account", async () => {
@@ -617,7 +661,7 @@ describe("useMigrationCheckpoint", () => {
       result2.current.navigateToCheckpoint()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationStart")
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
   })
 
   it("does not update state when the load fails after unmount", async () => {

--- a/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react-native"
 import { useMigrationNextStep } from "@app/screens/account-migration/hooks/use-migration-next-step"
 
 const mockNavigate = jest.fn()
+const mockReplace = jest.fn()
 const mockNavigateToCheckpoint = jest.fn()
 const mockReplaceToCheckpoint = jest.fn()
 let mockIsAtCommitPoint = false
@@ -12,7 +13,7 @@ let mockTransactionsLoading = false
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ navigate: mockNavigate }),
+  useNavigation: () => ({ navigate: mockNavigate, replace: mockReplace }),
 }))
 
 jest.mock("@app/screens/account-migration/hooks/use-migration-checkpoint", () => ({
@@ -90,10 +91,42 @@ describe("useMigrationNextStep", () => {
     expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
   })
 
-  it("exposes the same checkpoint instance's replace for skip guards", () => {
-    const { result } = renderHook(() => useMigrationNextStep())
+  /** A screen that skips itself must land where advancing through it would have, or the
+   *  history export is silently lost on that path (#4109). */
+  it("replaces onto the history download for a skip guard with history", () => {
+    mockHasTransactions = true
 
-    expect(result.current.replaceToCheckpoint).toBe(mockReplaceToCheckpoint)
+    const { result } = renderHook(() => useMigrationNextStep())
+    act(() => {
+      result.current.replaceToNextStep()
+    })
+
+    expect(mockReplace).toHaveBeenCalledWith("accountMigrationDownloadHistory")
+    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("replaces onto the checkpoint for a skip guard without history", () => {
+    const { result } = renderHook(() => useMigrationNextStep())
+    act(() => {
+      result.current.replaceToNextStep()
+    })
+
+    expect(mockReplaceToCheckpoint).toHaveBeenCalledTimes(1)
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it("replaces onto the checkpoint for a skip guard at the commit point", () => {
+    mockHasTransactions = true
+    mockIsAtCommitPoint = true
+
+    const { result } = renderHook(() => useMigrationNextStep())
+    act(() => {
+      result.current.replaceToNextStep()
+    })
+
+    expect(mockReplaceToCheckpoint).toHaveBeenCalledTimes(1)
+    expect(mockReplace).not.toHaveBeenCalled()
   })
 
   it("reports loading while the transaction check loads", () => {

--- a/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
@@ -5,7 +5,7 @@ import { useMigrationNextStep } from "@app/screens/account-migration/hooks/use-m
 const mockNavigate = jest.fn()
 const mockNavigateToCheckpoint = jest.fn()
 const mockReplaceToCheckpoint = jest.fn()
-let mockHasResumableCheckpoint = false
+let mockIsAtCommitPoint = false
 let mockCheckpointLoading = false
 let mockHasTransactions = false
 let mockTransactionsLoading = false
@@ -19,7 +19,7 @@ jest.mock("@app/screens/account-migration/hooks/use-migration-checkpoint", () =>
   useMigrationCheckpoint: () => ({
     navigateToCheckpoint: mockNavigateToCheckpoint,
     replaceToCheckpoint: mockReplaceToCheckpoint,
-    hasResumableCheckpoint: mockHasResumableCheckpoint,
+    isAtCommitPoint: mockIsAtCommitPoint,
     loading: mockCheckpointLoading,
   }),
 }))
@@ -34,7 +34,7 @@ jest.mock("@app/screens/account-migration/hooks/use-has-transactions", () => ({
 describe("useMigrationNextStep", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockHasResumableCheckpoint = false
+    mockIsAtCommitPoint = false
     mockCheckpointLoading = false
     mockHasTransactions = false
     mockTransactionsLoading = false
@@ -62,9 +62,9 @@ describe("useMigrationNextStep", () => {
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it("returns to the checkpoint when resuming even with history", () => {
+  it("returns to the checkpoint when resuming at the commit point even with history", () => {
     mockHasTransactions = true
-    mockHasResumableCheckpoint = true
+    mockIsAtCommitPoint = true
 
     const { result } = renderHook(() => useMigrationNextStep())
     act(() => {
@@ -73,6 +73,21 @@ describe("useMigrationNextStep", () => {
 
     expect(mockNavigateToCheckpoint).toHaveBeenCalledTimes(1)
     expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /** A flow left before the commit point replays every step, so the download it already
+   *  skipped once is offered again rather than jumped over (#4109). */
+  it("offers the history download again to a restarted pre-commit migration", () => {
+    mockHasTransactions = true
+    mockIsAtCommitPoint = false
+
+    const { result } = renderHook(() => useMigrationNextStep())
+    act(() => {
+      result.current.goToNextStep()
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationDownloadHistory")
+    expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
   })
 
   it("exposes the same checkpoint instance's replace for skip guards", () => {

--- a/__tests__/screens/account-migration/to-non-custodial/keep-receiving-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/keep-receiving-screen.spec.tsx
@@ -41,14 +41,14 @@ jest.mock("@app/utils/error-logging", () => ({
 }))
 
 const mockGoToNextStep = jest.fn()
-const mockReplaceToCheckpoint = jest.fn()
+const mockReplaceToNextStep = jest.fn()
 let mockNextStepLoading = false
 
 jest.mock("@app/screens/account-migration/hooks", () => ({
   ...jest.requireActual("@app/screens/account-migration/hooks"),
   useMigrationNextStep: () => ({
     goToNextStep: mockGoToNextStep,
-    replaceToCheckpoint: mockReplaceToCheckpoint,
+    replaceToNextStep: mockReplaceToNextStep,
     loading: mockNextStepLoading,
   }),
 }))
@@ -133,7 +133,7 @@ describe("MigrationKeepReceivingScreen", () => {
     renderScreen()
     await flushEffects()
 
-    expect(mockReplaceToCheckpoint).toHaveBeenCalledTimes(1)
+    expect(mockReplaceToNextStep).toHaveBeenCalledTimes(1)
     expect(screen.queryByText(LL.AccountMigration.keepReceivingTitle())).toBeNull()
   })
 
@@ -143,7 +143,7 @@ describe("MigrationKeepReceivingScreen", () => {
     renderScreen()
     await flushEffects()
 
-    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    expect(mockReplaceToNextStep).not.toHaveBeenCalled()
   })
 
   it("shows a spinner (not a blank screen) while the address is still loading", async () => {
@@ -153,7 +153,7 @@ describe("MigrationKeepReceivingScreen", () => {
 
     expect(screen.getByTestId("migration-keep-receiving-loading")).toBeTruthy()
     expect(screen.queryByText(LL.AccountMigration.keepReceivingTitle())).toBeNull()
-    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    expect(mockReplaceToNextStep).not.toHaveBeenCalled()
   })
 
   it("shows a retry state, not a spinner, and does not skip when the address query errors", async () => {
@@ -171,7 +171,7 @@ describe("MigrationKeepReceivingScreen", () => {
     /** The spinner-forever bug: an errored query must render a way forward, not a spinner. */
     expect(screen.queryByTestId("migration-keep-receiving-loading")).toBeNull()
     /** A failed query must not read as "no address" and skip the warning. */
-    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    expect(mockReplaceToNextStep).not.toHaveBeenCalled()
   })
 
   it("refetches the address when Try Again is pressed on the error state", async () => {
@@ -225,6 +225,6 @@ describe("MigrationKeepReceivingScreen", () => {
     fireEvent.press(screen.getByText(LL.common.continue()))
 
     expect(mockGoToNextStep).toHaveBeenCalledTimes(1)
-    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    expect(mockReplaceToNextStep).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/migration-entry-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-entry-screen.spec.tsx
@@ -28,6 +28,9 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 const mockReplaceToCheckpoint = jest.fn()
+let mockIsAtCommitPoint = false
+/** Kept alongside isAtCommitPoint so a screen wired back to the looser flag fails here
+ *  instead of silently resuming a pre-commit checkpoint again (#4109). */
 let mockHasResumableCheckpoint = false
 let mockCheckpointLoading = false
 let mockSelfCustodialDisabled = false
@@ -36,6 +39,7 @@ jest.mock("@app/screens/account-migration/hooks", () => ({
   useMigrationCheckpoint: () => ({
     loading: mockCheckpointLoading,
     replaceToCheckpoint: mockReplaceToCheckpoint,
+    isAtCommitPoint: mockIsAtCommitPoint,
     hasResumableCheckpoint: mockHasResumableCheckpoint,
   }),
   useSelfCustodialDisabled: () => mockSelfCustodialDisabled,
@@ -56,6 +60,7 @@ describe("MigrationEntryScreen", () => {
     jest.clearAllMocks()
     mockCanGoBack = true
     mockActiveAccountType = AccountType.Custodial
+    mockIsAtCommitPoint = false
     mockHasResumableCheckpoint = false
     mockCheckpointLoading = false
     mockSelfCustodialDisabled = false
@@ -70,7 +75,8 @@ describe("MigrationEntryScreen", () => {
     expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
   })
 
-  it("resumes at the stored checkpoint when one exists", () => {
+  it("resumes at the stored checkpoint once the flow reached the commit point", () => {
+    mockIsAtCommitPoint = true
     mockHasResumableCheckpoint = true
 
     render(<MigrationEntryScreen />)
@@ -79,9 +85,20 @@ describe("MigrationEntryScreen", () => {
     expect(mockReplace).not.toHaveBeenCalled()
   })
 
+  /** The flow reopens at its first step, not at the backup screen the user walked away
+   *  from, so a provisioned account alone no longer earns a resume (#4109). */
+  it("restarts at the gate when the flow was left before the commit point", () => {
+    mockHasResumableCheckpoint = true
+
+    render(<MigrationEntryScreen />)
+
+    expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
+    expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+  })
+
   it("routes to the gate instead of resuming when the kill-switch is off", () => {
     mockSelfCustodialDisabled = true
-    mockHasResumableCheckpoint = true
+    mockIsAtCommitPoint = true
 
     render(<MigrationEntryScreen />)
 
@@ -91,7 +108,7 @@ describe("MigrationEntryScreen", () => {
 
   it("waits for the remote config to resolve before dispatching", () => {
     mockRemoteConfigReady = false
-    mockHasResumableCheckpoint = true
+    mockIsAtCommitPoint = true
 
     render(<MigrationEntryScreen />)
 

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -125,28 +125,25 @@ describe("migration-checkpoint-storage", () => {
   })
 
   describe("resolveCheckpointRoute", () => {
+    const preCommitCheckpoints = [
+      MigrationCheckpoint.TermsAndConditions,
+      MigrationCheckpoint.BackupMethod,
+      MigrationCheckpoint.CloudBackup,
+      MigrationCheckpoint.BackupAlerts,
+    ]
+
     it("returns the default destination for a null checkpoint", () => {
       expect(resolveCheckpointRoute(null)).toEqual({
         name: "accountMigrationExplainer",
       })
     })
 
-    it("restarts at the migration gate for a terms checkpoint", () => {
-      expect(resolveCheckpointRoute(MigrationCheckpoint.TermsAndConditions)).toEqual({
-        name: "accountMigrationStart",
-      })
-    })
-
-    it("restarts at the migration gate for BackupMethod", () => {
-      expect(resolveCheckpointRoute(MigrationCheckpoint.BackupMethod)).toEqual({
-        name: "accountMigrationStart",
-      })
-    })
-
-    it("restarts at the migration gate for BackupAlerts", () => {
-      expect(resolveCheckpointRoute(MigrationCheckpoint.BackupAlerts)).toEqual({
-        name: "accountMigrationStart",
-      })
+    it("restarts at the explainer for every checkpoint before the commit point", () => {
+      for (const checkpoint of preCommitCheckpoints) {
+        expect(resolveCheckpointRoute(checkpoint)).toEqual({
+          name: "accountMigrationExplainer",
+        })
+      }
     })
 
     it("returns the balances-overview destination for the commit point", () => {
@@ -155,17 +152,28 @@ describe("migration-checkpoint-storage", () => {
       })
     })
 
-    it("restarts at the migration gate for CloudBackup on every platform", () => {
+    it("restarts at the explainer for CloudBackup on every platform", () => {
       for (const os of ["android", "ios"] as const) {
         const original = Platform.OS
         Object.defineProperty(Platform, "OS", { value: os })
 
         expect(resolveCheckpointRoute(MigrationCheckpoint.CloudBackup)).toEqual({
-          name: "accountMigrationStart",
+          name: "accountMigrationExplainer",
         })
 
         Object.defineProperty(Platform, "OS", { value: original })
       }
+    })
+
+    /** The gate reaches the rest of the flow through this resolver, so a checkpoint that
+     *  resolves back to the gate leaves the user cycling between the two with no way
+     *  forward. No stored step, present or future, may name it. */
+    it("never resolves to the migration gate", () => {
+      const everyDestination = [null, ...Object.values(MigrationCheckpoint)].map(
+        (checkpoint) => resolveCheckpointRoute(checkpoint).name,
+      )
+
+      expect(everyDestination).not.toContain("accountMigrationStart")
     })
   })
 

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -131,22 +131,21 @@ describe("migration-checkpoint-storage", () => {
       })
     })
 
-    it("resumes the terms screen with the migration flow param", () => {
+    it("restarts at the migration gate for a terms checkpoint", () => {
       expect(resolveCheckpointRoute(MigrationCheckpoint.TermsAndConditions)).toEqual({
-        name: "acceptTermsAndConditions",
-        params: { flow: "migration" },
+        name: "accountMigrationStart",
       })
     })
 
-    it("returns the backup-method destination for BackupMethod", () => {
+    it("restarts at the migration gate for BackupMethod", () => {
       expect(resolveCheckpointRoute(MigrationCheckpoint.BackupMethod)).toEqual({
-        name: "selfCustodialBackupMethod",
+        name: "accountMigrationStart",
       })
     })
 
-    it("returns the security-checks destination for BackupAlerts", () => {
+    it("restarts at the migration gate for BackupAlerts", () => {
       expect(resolveCheckpointRoute(MigrationCheckpoint.BackupAlerts)).toEqual({
-        name: "selfCustodialBackupSecurityChecks",
+        name: "accountMigrationStart",
       })
     })
 
@@ -156,13 +155,13 @@ describe("migration-checkpoint-storage", () => {
       })
     })
 
-    it("resumes forward to the cloud-backup destination on every platform", () => {
+    it("restarts at the migration gate for CloudBackup on every platform", () => {
       for (const os of ["android", "ios"] as const) {
         const original = Platform.OS
         Object.defineProperty(Platform, "OS", { value: os })
 
         expect(resolveCheckpointRoute(MigrationCheckpoint.CloudBackup)).toEqual({
-          name: "selfCustodialCloudBackup",
+          name: "accountMigrationStart",
         })
 
         Object.defineProperty(Platform, "OS", { value: original })

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -1,9 +1,8 @@
-import { Platform } from "react-native"
-
 import {
   MigrationCheckpoint,
   clearCheckpointFromStorage,
   getStorageKey,
+  isCommitPointCheckpoint,
   isExpired,
   loadCheckpoint,
   resolveCheckpointRoute,
@@ -152,19 +151,6 @@ describe("migration-checkpoint-storage", () => {
       })
     })
 
-    it("restarts at the explainer for CloudBackup on every platform", () => {
-      for (const os of ["android", "ios"] as const) {
-        const original = Platform.OS
-        Object.defineProperty(Platform, "OS", { value: os })
-
-        expect(resolveCheckpointRoute(MigrationCheckpoint.CloudBackup)).toEqual({
-          name: "accountMigrationExplainer",
-        })
-
-        Object.defineProperty(Platform, "OS", { value: original })
-      }
-    })
-
     /** The gate reaches the rest of the flow through this resolver, so a checkpoint that
      *  resolves back to the gate leaves the user cycling between the two with no way
      *  forward. No stored step, present or future, may name it. */
@@ -174,6 +160,26 @@ describe("migration-checkpoint-storage", () => {
       )
 
       expect(everyDestination).not.toContain("accountMigrationStart")
+    })
+  })
+
+  describe("isCommitPointCheckpoint", () => {
+    it("holds only for the balances overview", () => {
+      const commitPointByCheckpoint = Object.values(MigrationCheckpoint).map(
+        (checkpoint) => [checkpoint, isCommitPointCheckpoint(checkpoint)] as const,
+      )
+
+      expect(commitPointByCheckpoint).toEqual([
+        [MigrationCheckpoint.TermsAndConditions, false],
+        [MigrationCheckpoint.BackupMethod, false],
+        [MigrationCheckpoint.CloudBackup, false],
+        [MigrationCheckpoint.BackupAlerts, false],
+        [MigrationCheckpoint.BalancesOverview, true],
+      ])
+    })
+
+    it("does not hold without a checkpoint", () => {
+      expect(isCommitPointCheckpoint(null)).toBe(false)
     })
   })
 

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -121,6 +121,12 @@ export const useMigrationCheckpointState = () => {
   /** A provisioned account is only stored alongside a checkpoint, so it gates resumability. */
   const hasResumableCheckpoint = Boolean(accountId)
 
+  /** The commit point is the only step a reopened flow jumps forward to: the balances
+   *  screen already claimed the account server-side, so re-walking backup ahead of it
+   *  would offer a transfer the user cannot decline. Every earlier step restarts. */
+  const isAtCommitPoint =
+    hasResumableCheckpoint && checkpoint === MigrationCheckpoint.BalancesOverview
+
   return {
     checkpoint,
     accountId,
@@ -135,5 +141,6 @@ export const useMigrationCheckpointState = () => {
     saveCheckpoint,
     clearCheckpoint,
     hasResumableCheckpoint,
+    isAtCommitPoint,
   }
 }

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -10,6 +10,7 @@ import {
   type StoredCheckpoint,
   clearCheckpointFromStorage,
   getStorageKey,
+  isCommitPointCheckpoint,
   loadCheckpoint,
   mergeCheckpoint,
   saveCheckpointToStorage,
@@ -121,11 +122,10 @@ export const useMigrationCheckpointState = () => {
   /** A provisioned account is only stored alongside a checkpoint, so it gates resumability. */
   const hasResumableCheckpoint = Boolean(accountId)
 
-  /** The commit point is the only step a reopened flow jumps forward to: the balances
-   *  screen already claimed the account server-side, so re-walking backup ahead of it
-   *  would offer a transfer the user cannot decline. Every earlier step restarts. */
-  const isAtCommitPoint =
-    hasResumableCheckpoint && checkpoint === MigrationCheckpoint.BalancesOverview
+  /** Reads the same predicate the route resolver does, so the decision to resume and the
+   *  screen resumed to stay one rule. Without a provisioned account there is nothing to
+   *  jump forward to, whatever the stored step says. */
+  const isAtCommitPoint = hasResumableCheckpoint && isCommitPointCheckpoint(checkpoint)
 
   return {
     checkpoint,

--- a/app/screens/account-migration/hooks/use-migration-checkpoint.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint.ts
@@ -27,28 +27,18 @@ export const useMigrationCheckpoint = () => {
     [checkpoint, accountId],
   )
 
-  /** Resumes at the checkpoint's screen, forwarding the terms screen its flow param.
-   *  Dollars received after provisioning are caught by the backend, which re-validates an
-   *  empty USD wallet on both migrationStart and migrationCommit. The API-key warning has
-   *  no such backstop: the backend only refuses callers authenticating WITH an API key,
-   *  never accounts that merely hold one, so that precondition stays client-side. */
+  /** Resumes at the checkpoint's screen. Dollars received after provisioning are caught
+   *  by the backend, which re-validates an empty USD wallet on both migrationStart and
+   *  migrationCommit. The API-key warning has no such backstop: the backend only refuses
+   *  callers authenticating WITH an API key, never accounts that merely hold one, so that
+   *  precondition stays client-side. */
   const navigateToCheckpoint = useCallback(() => {
-    const destination = resolveDestination()
-    if (destination.name === "acceptTermsAndConditions") {
-      navigation.navigate(destination.name, destination.params)
-      return
-    }
-    navigation.navigate(destination.name)
+    navigation.navigate(resolveDestination().name)
   }, [resolveDestination, navigation])
 
   /** Same as navigateToCheckpoint but replacing the current screen (skip guards). */
   const replaceToCheckpoint = useCallback(() => {
-    const destination = resolveDestination()
-    if (destination.name === "acceptTermsAndConditions") {
-      navigation.replace(destination.name, destination.params)
-      return
-    }
-    navigation.replace(destination.name)
+    navigation.replace(resolveDestination().name)
   }, [resolveDestination, navigation])
 
   return {

--- a/app/screens/account-migration/hooks/use-migration-next-step.ts
+++ b/app/screens/account-migration/hooks/use-migration-next-step.ts
@@ -9,8 +9,8 @@ import { useHasTransactions } from "./use-has-transactions"
 import { useMigrationCheckpoint } from "./use-migration-checkpoint"
 
 /**
- * Routes to the migration flow's next step: a resumed migration already passed the
- * download step so it returns to its checkpoint, while a fresh one only sees the
+ * Routes to the migration flow's next step: a migration resumed at the commit point
+ * jumps straight to its checkpoint, while every other run walks the flow and sees the
  * history-download step when there is history to download. replaceToCheckpoint comes
  * from the same checkpoint instance that decides the routing, so a guard that gates on
  * this hook's loading never replaces with a stale destination.
@@ -21,18 +21,20 @@ export const useMigrationNextStep = () => {
   const {
     navigateToCheckpoint,
     replaceToCheckpoint,
-    hasResumableCheckpoint,
+    isAtCommitPoint,
     loading: checkpointLoading,
   } = useMigrationCheckpoint()
 
+  /** A restarted flow is offered the download again (#4109): it replays every step, and
+   *  only the commit point still skips ahead. */
   const goToNextStep = useCallback(() => {
-    const shouldOfferHistoryDownload = hasTransactions && !hasResumableCheckpoint
+    const shouldOfferHistoryDownload = hasTransactions && !isAtCommitPoint
     if (shouldOfferHistoryDownload) {
       navigation.navigate("accountMigrationDownloadHistory")
       return
     }
     navigateToCheckpoint()
-  }, [navigation, hasTransactions, hasResumableCheckpoint, navigateToCheckpoint])
+  }, [navigation, hasTransactions, isAtCommitPoint, navigateToCheckpoint])
 
   return {
     goToNextStep,

--- a/app/screens/account-migration/hooks/use-migration-next-step.ts
+++ b/app/screens/account-migration/hooks/use-migration-next-step.ts
@@ -11,9 +11,10 @@ import { useMigrationCheckpoint } from "./use-migration-checkpoint"
 /**
  * Routes to the migration flow's next step: a migration resumed at the commit point
  * jumps straight to its checkpoint, while every other run walks the flow and sees the
- * history-download step when there is history to download. replaceToCheckpoint comes
- * from the same checkpoint instance that decides the routing, so a guard that gates on
- * this hook's loading never replaces with a stale destination.
+ * history-download step when there is history to download. Both entry points share one
+ * destination, so a screen that skips itself lands where advancing through it would have.
+ * The checkpoint instance deciding the routing is the one this hook reports loading for,
+ * so a guard that gates on it never navigates with a stale destination.
  */
 export const useMigrationNextStep = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
@@ -26,19 +27,30 @@ export const useMigrationNextStep = () => {
   } = useMigrationCheckpoint()
 
   /** A restarted flow is offered the download again (#4109): it replays every step, and
-   *  only the commit point still skips ahead. */
+   *  only the commit point still skips ahead to its checkpoint. */
+  const shouldOfferHistoryDownload = hasTransactions && !isAtCommitPoint
+
   const goToNextStep = useCallback(() => {
-    const shouldOfferHistoryDownload = hasTransactions && !isAtCommitPoint
     if (shouldOfferHistoryDownload) {
       navigation.navigate("accountMigrationDownloadHistory")
       return
     }
     navigateToCheckpoint()
-  }, [navigation, hasTransactions, isAtCommitPoint, navigateToCheckpoint])
+  }, [navigation, shouldOfferHistoryDownload, navigateToCheckpoint])
+
+  /** Same destination as goToNextStep, replacing the current screen: for a guard that
+   *  skips its own screen, which must not leave it behind for the back gesture. */
+  const replaceToNextStep = useCallback(() => {
+    if (shouldOfferHistoryDownload) {
+      navigation.replace("accountMigrationDownloadHistory")
+      return
+    }
+    replaceToCheckpoint()
+  }, [navigation, shouldOfferHistoryDownload, replaceToCheckpoint])
 
   return {
     goToNextStep,
-    replaceToCheckpoint,
+    replaceToNextStep,
     loading: transactionsLoading || checkpointLoading,
   }
 }

--- a/app/screens/account-migration/to-non-custodial/keep-receiving-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/keep-receiving-screen.tsx
@@ -34,7 +34,7 @@ export const MigrationKeepReceivingScreen: React.FC = () => {
 
   const {
     goToNextStep,
-    replaceToCheckpoint,
+    replaceToNextStep,
     loading: nextStepLoading,
   } = useMigrationNextStep()
 
@@ -66,10 +66,12 @@ export const MigrationKeepReceivingScreen: React.FC = () => {
    *  background instance replace itself into the flow again. */
   const shouldSkipScreen = isFocused && isConfirmedWithoutAddress
 
-  /** Guard: this screen needs a lightning address; without one, skip into the flow. */
+  /** Guard: this screen needs a lightning address; without one, skip into the flow. Skipping
+   *  lands on the same step the CTA would have, so a user with history is still offered the
+   *  export they would otherwise never see on this path. */
   useEffect(() => {
-    if (shouldSkipScreen) replaceToCheckpoint()
-  }, [shouldSkipScreen, replaceToCheckpoint])
+    if (shouldSkipScreen) replaceToNextStep()
+  }, [shouldSkipScreen, replaceToNextStep])
 
   const [isRetrying, setIsRetrying] = useState(false)
   /** Retry re-runs the address query over the network; a still-failing refetch rejects, so

--- a/app/screens/account-migration/to-non-custodial/migration-entry-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-entry-screen.tsx
@@ -19,16 +19,17 @@ import { AccountType } from "@app/types/wallet"
 export const MigrationEntryScreen: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const { activeAccount, loading: registryLoading } = useAccountRegistry()
-  const { loading, replaceToCheckpoint, hasResumableCheckpoint } =
-    useMigrationCheckpoint()
+  const { loading, replaceToCheckpoint, isAtCommitPoint } = useMigrationCheckpoint()
   const isSelfCustodialDisabled = useSelfCustodialDisabled()
   const { remoteConfigReady } = useFeatureFlags()
 
   const isSelfCustodialAccount = activeAccount?.type === AccountType.SelfCustodial
 
-  /** The kill-switch outranks resume: a disabled stack falls through to the gate (which shows
-   *  the temporarily-unavailable screen) instead of resuming a checkpoint straight past it. */
-  const shouldResume = !isSelfCustodialDisabled && hasResumableCheckpoint
+  /** Only the commit point resumes (#4109): a flow left before it restarts at the gate, so
+   *  reopening replays the whole thing from its first step instead of dropping the user
+   *  into a backup screen they have no context for. The kill-switch outranks even that: a
+   *  disabled stack falls through to the gate, which shows the unavailable screen. */
+  const shouldResume = !isSelfCustodialDisabled && isAtCommitPoint
 
   useEffect(() => {
     /** Wait for the account list and the flag too, not just the checkpoint: an unhydrated

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -29,6 +29,24 @@ const CHECKPOINT_EXPIRATION_MS = 48 * 60 * 60 * 1000 // 48h
 
 const DEFAULT_DESTINATION: CheckpointDestination = { name: "accountMigrationExplainer" }
 
+/** Exhaustive on purpose: a step added to the enum has no entry here and fails to compile,
+ *  so a checkpoint past the commit point can never inherit the restart by omission. */
+const IS_COMMIT_POINT_BY_CHECKPOINT: Record<MigrationCheckpoint, boolean> = {
+  [MigrationCheckpoint.TermsAndConditions]: false,
+  [MigrationCheckpoint.BackupMethod]: false,
+  [MigrationCheckpoint.CloudBackup]: false,
+  [MigrationCheckpoint.BackupAlerts]: false,
+  [MigrationCheckpoint.BalancesOverview]: true,
+}
+
+/** The commit point is the only step a reopened flow jumps forward to: the balances screen
+ *  already claimed the account server-side, so re-walking backup ahead of it would offer a
+ *  transfer the user cannot decline. The route resolver and the entry screen both read this
+ *  one predicate, so the destination and the decision to resume can never disagree. */
+export const isCommitPointCheckpoint = (
+  checkpoint: MigrationCheckpoint | null,
+): boolean => checkpoint !== null && IS_COMMIT_POINT_BY_CHECKPOINT[checkpoint]
+
 export const getStorageKey = (environment: string): string =>
   `${STORAGE_KEY_PREFIX}_${environment.toLowerCase()}`
 
@@ -59,13 +77,10 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
  *  cycle the user cannot leave. */
 export const resolveCheckpointRoute = (
   checkpoint: MigrationCheckpoint | null,
-): CheckpointDestination => {
-  if (checkpoint === MigrationCheckpoint.BalancesOverview) {
-    return { name: "accountMigrationBalancesOverview" }
-  }
-
-  return DEFAULT_DESTINATION
-}
+): CheckpointDestination =>
+  isCommitPointCheckpoint(checkpoint)
+    ? { name: "accountMigrationBalancesOverview" }
+    : DEFAULT_DESTINATION
 
 export const loadCheckpoint = async (
   storageKey: string,

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -17,35 +17,16 @@ export type StoredCheckpoint = {
 }
 
 /**
- * Where a checkpoint resumes. Every destination is a param-less route except the
- * terms screen, which is shared across flows and needs the migration flow param.
+ * Where a checkpoint resumes. Every destination is a param-less route.
  */
-type CheckpointDestination =
-  | {
-      name:
-        | "accountMigrationExplainer"
-        | "selfCustodialBackupMethod"
-        | "selfCustodialCloudBackup"
-        | "selfCustodialBackupSecurityChecks"
-        | "accountMigrationBalancesOverview"
-      params?: undefined
-    }
-  | { name: "acceptTermsAndConditions"; params: { flow: "migration" } }
+type CheckpointDestination = {
+  name: "accountMigrationExplainer" | "accountMigrationStart" | "accountMigrationBalancesOverview"
+  params?: undefined
+}
 
 const STORAGE_KEY_PREFIX = "migrationCheckpoint"
 
 const CHECKPOINT_EXPIRATION_MS = 48 * 60 * 60 * 1000 // 48h
-
-const CHECKPOINT_DESTINATION_MAP: Record<MigrationCheckpoint, CheckpointDestination> = {
-  [MigrationCheckpoint.TermsAndConditions]: {
-    name: "acceptTermsAndConditions",
-    params: { flow: "migration" },
-  },
-  [MigrationCheckpoint.BackupMethod]: { name: "selfCustodialBackupMethod" },
-  [MigrationCheckpoint.CloudBackup]: { name: "selfCustodialCloudBackup" },
-  [MigrationCheckpoint.BackupAlerts]: { name: "selfCustodialBackupSecurityChecks" },
-  [MigrationCheckpoint.BalancesOverview]: { name: "accountMigrationBalancesOverview" },
-}
 
 const DEFAULT_DESTINATION: CheckpointDestination = { name: "accountMigrationExplainer" }
 
@@ -72,12 +53,19 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
   return { step, savedAt, accountId, custodialAccountId }
 }
 
+/** Only the commit point resumes mid-flow; every earlier step restarts at the
+ *  migration gate so the flow re-walks backup before offering the funds transfer
+ *  again. */
 export const resolveCheckpointRoute = (
   checkpoint: MigrationCheckpoint | null,
 ): CheckpointDestination => {
   if (!checkpoint) return DEFAULT_DESTINATION
 
-  return CHECKPOINT_DESTINATION_MAP[checkpoint]
+  if (checkpoint === MigrationCheckpoint.BalancesOverview) {
+    return { name: "accountMigrationBalancesOverview" }
+  }
+
+  return { name: "accountMigrationStart" }
 }
 
 export const loadCheckpoint = async (

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -20,11 +20,7 @@ export type StoredCheckpoint = {
  * Where a checkpoint resumes. Every destination is a param-less route.
  */
 type CheckpointDestination = {
-  name:
-    | "accountMigrationExplainer"
-    | "accountMigrationStart"
-    | "accountMigrationBalancesOverview"
-  params?: undefined
+  name: "accountMigrationExplainer" | "accountMigrationBalancesOverview"
 }
 
 const STORAGE_KEY_PREFIX = "migrationCheckpoint"
@@ -56,19 +52,19 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
   return { step, savedAt, accountId, custodialAccountId }
 }
 
-/** Only the commit point resumes mid-flow; every earlier step restarts at the
- *  migration gate so the flow re-walks backup before offering the funds transfer
- *  again. */
+/** Only the commit point resumes mid-flow; every earlier step restarts at the explainer,
+ *  so the user re-walks terms and backup before the funds transfer is offered again. The
+ *  restart may not target the migration gate: the gate walks into the rest of the flow
+ *  through this same resolver, so pointing a pre-commit checkpoint back at it closes a
+ *  cycle the user cannot leave. */
 export const resolveCheckpointRoute = (
   checkpoint: MigrationCheckpoint | null,
 ): CheckpointDestination => {
-  if (!checkpoint) return DEFAULT_DESTINATION
-
   if (checkpoint === MigrationCheckpoint.BalancesOverview) {
     return { name: "accountMigrationBalancesOverview" }
   }
 
-  return { name: "accountMigrationStart" }
+  return DEFAULT_DESTINATION
 }
 
 export const loadCheckpoint = async (

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -20,7 +20,10 @@ export type StoredCheckpoint = {
  * Where a checkpoint resumes. Every destination is a param-less route.
  */
 type CheckpointDestination = {
-  name: "accountMigrationExplainer" | "accountMigrationStart" | "accountMigrationBalancesOverview"
+  name:
+    | "accountMigrationExplainer"
+    | "accountMigrationStart"
+    | "accountMigrationBalancesOverview"
   params?: undefined
 }
 


### PR DESCRIPTION
Only the BalancesOverview commit point resumes mid-flow; every earlier checkpoint (terms, backup method, cloud backup, backup alerts) now resolves to accountMigrationExplainer so the flow re-walks backup before offering the funds transfer again.