### PR TITLE
fix(migration): measure the receive and restore the missing-key handover

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -90,6 +90,7 @@ describe("useMigrationReceiveConfirmation", () => {
     expect(result.current).toEqual({
       isReceiveConfirmed: false,
       isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
     })
   })
 
@@ -132,6 +133,7 @@ describe("useMigrationReceiveConfirmation", () => {
     expect(result.current).toEqual({
       isReceiveConfirmed: true,
       isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
     })
   })
 
@@ -150,6 +152,7 @@ describe("useMigrationReceiveConfirmation", () => {
     expect(result.current).toEqual({
       isReceiveConfirmed: false,
       isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
     })
     expect(mockCheckReceiveLanded.mock.calls).toHaveLength(checksSoFar)
   })
@@ -224,6 +227,7 @@ describe("useMigrationReceiveConfirmation", () => {
       accountId: "sc-account-1",
       network: "regtest",
       leewaySatPerVbyte: 1,
+      expectedReceiveSats: 21000,
     })
     expect(result.current.isReceiveConfirmed).toBe(true)
   })
@@ -318,6 +322,70 @@ describe("useMigrationReceiveConfirmation", () => {
       "Migration receive check",
       expect.objectContaining({ message: "No mnemonic for the provisioned account" }),
     )
+  })
+
+  /** One reading is not enough to call it permanent: a briefly unavailable keystore (a
+   *  locked device) answers the same way as an entry that is genuinely gone, and the
+   *  handover this raises is not something to trigger on a blip. */
+  it("does not call a single missing-key reading unrecoverable", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    const { result } = renderGate()
+    await flushCheck()
+
+    expect(result.current.isReceiveUnrecoverable).toBe(false)
+  })
+
+  it("reports the wait as unrecoverable once the key is missing twice running", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    const { result } = renderGate()
+    await flushCheck()
+    await advance(RECEIVE_CHECK_RETRY_MS)
+
+    expect(result.current.isReceiveUnrecoverable).toBe(true)
+    expect(result.current.isReceiveConfirmed).toBe(false)
+  })
+
+  it("withdraws the unrecoverable verdict once the keystore reads again", async () => {
+    mockCheckReceiveLanded
+      .mockResolvedValueOnce({ status: MigrationSdkStatus.NoMnemonic })
+      .mockResolvedValueOnce({ status: MigrationSdkStatus.NoMnemonic })
+      .mockResolvedValue(ok(stillEmpty))
+
+    const { result } = renderGate()
+    await flushCheck()
+    await advance(RECEIVE_CHECK_RETRY_MS)
+    expect(result.current.isReceiveUnrecoverable).toBe(true)
+
+    await advance(RECEIVE_CHECK_RETRY_MS)
+
+    expect(result.current.isReceiveUnrecoverable).toBe(false)
+  })
+
+  it("keeps a skipped gate inert even after an unrecoverable verdict", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    const { result, rerender } = renderGate()
+    await flushCheck()
+    await advance(RECEIVE_CHECK_RETRY_MS)
+    expect(result.current.isReceiveUnrecoverable).toBe(true)
+
+    rerender({ skip: true })
+
+    expect(result.current.isReceiveUnrecoverable).toBe(false)
+  })
+
+  /** The zero-receive short-circuit never opens an SDK connection, so there is no keystore
+   *  reading to go wrong and nothing to hand over. */
+  it("raises nothing unrecoverable for a zero-receive migration", async () => {
+    mockCheckReceiveLanded.mockResolvedValue({ status: MigrationSdkStatus.NoMnemonic })
+
+    const { result } = renderGate({ expectedReceiveSats: 0 })
+    await flushCheck()
+
+    expect(result.current.isReceiveUnrecoverable).toBe(false)
+    expect(result.current.isReceiveConfirmed).toBe(true)
   })
 
   it("keeps checking after a missing mnemonic, in case the keystore reads again", async () => {

--- a/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-resume-completed-migration.spec.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react-native"
 
 import { MigrationStatus } from "@app/graphql/generated"
+import { MigrationCheckpoint } from "@app/screens/account-migration/utils/migration-checkpoint-storage"
 import { useResumeCompletedMigration } from "@app/screens/account-migration/hooks/use-resume-completed-migration"
 
 import { flushEffects } from "../../../helpers/flush-effects"
@@ -23,6 +24,9 @@ jest.mock("@react-navigation/native", () => ({
 let mockStatus: MigrationStatus | null = MigrationStatus.Completed
 let mockMigrationAccountId: string | null = "sc-account-1"
 let mockMigrationLoading = false
+let mockMigrationCheckpoint: MigrationCheckpoint | null =
+  MigrationCheckpoint.BalancesOverview
+const mockSaveCheckpoint = jest.fn()
 
 /** The swap function the hook receives. Its identity can change between renders in
  *  production (a wallet-registry refresh rebuilds it); a test can point it elsewhere to
@@ -31,16 +35,22 @@ let mockCompleteMigrationRef: () => Promise<boolean> = mockCompleteMigration
 
 jest.mock("@app/screens/account-migration/hooks/use-complete-migration", () => ({
   useCompleteMigration: () => ({
+    migrationCheckpoint: mockMigrationCheckpoint,
     migrationAccountId: mockMigrationAccountId,
     migrationExpectedReceiveSats: 21000,
     migrationLoading: mockMigrationLoading,
     completeMigration: mockCompleteMigrationRef,
+    saveCheckpoint: mockSaveCheckpoint,
   }),
 }))
 
 /** Confirmed by default so the server phase stays the deciding voice in the existing
  *  cases; the receive-gate cases below flip it. */
-let mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+let mockReceiveConfirmation = {
+  isReceiveConfirmed: true,
+  isReceiveDelayed: false,
+  isReceiveUnrecoverable: false,
+}
 const mockUseReceiveConfirmation = jest.fn()
 
 jest.mock(
@@ -73,7 +83,13 @@ describe("useResumeCompletedMigration", () => {
     mockMigrationLoading = false
     mockCompleteMigrationRef = mockCompleteMigration
     mockCompleteMigration.mockResolvedValue(true)
-    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+    mockMigrationCheckpoint = MigrationCheckpoint.BalancesOverview
+    mockSaveCheckpoint.mockResolvedValue(true)
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: true,
+      isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
+    }
   })
 
   /**
@@ -110,7 +126,11 @@ describe("useResumeCompletedMigration", () => {
    *  not swap into a wallet whose funds are still in transit. No swap this session is
    *  fine — the custodial session stays intact and the gate keeps checking. */
   it("holds the swap while the receive is unconfirmed", async () => {
-    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: false,
+      isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
+    }
     renderHook(() => useResumeCompletedMigration())
     await flushEffects()
 
@@ -118,12 +138,20 @@ describe("useResumeCompletedMigration", () => {
   })
 
   it("finishes the swap once the receive confirms", async () => {
-    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: false,
+      isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
+    }
     const { rerender } = renderHook(() => useResumeCompletedMigration())
     await flushEffects()
     expect(mockCompleteMigration).not.toHaveBeenCalled()
 
-    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: true,
+      isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
+    }
     rerender({})
     await flushEffects()
 
@@ -166,7 +194,11 @@ describe("useResumeCompletedMigration", () => {
   /** This path has no screen of its own to say the wait is unusual, so the crossing is at
    *  least reported rather than leaving a stuck receive invisible. */
   it("reports a receive that has not landed within the notice window", async () => {
-    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: true }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: false,
+      isReceiveDelayed: true,
+      isReceiveUnrecoverable: false,
+    }
     renderHook(() => useResumeCompletedMigration())
     await flushEffects()
 
@@ -177,7 +209,11 @@ describe("useResumeCompletedMigration", () => {
   })
 
   it("reports the delayed receive once, however often it re-renders", async () => {
-    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: true }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: false,
+      isReceiveDelayed: true,
+      isReceiveUnrecoverable: false,
+    }
     const { rerender } = renderHook(() => useResumeCompletedMigration())
     await flushEffects()
     rerender({})
@@ -188,7 +224,11 @@ describe("useResumeCompletedMigration", () => {
   })
 
   it("stays quiet while the wait is still inside the notice window", async () => {
-    mockReceiveConfirmation = { isReceiveConfirmed: false, isReceiveDelayed: false }
+    mockReceiveConfirmation = {
+      isReceiveConfirmed: false,
+      isReceiveDelayed: false,
+      isReceiveUnrecoverable: false,
+    }
     renderHook(() => useResumeCompletedMigration())
     await flushEffects()
 
@@ -314,6 +354,101 @@ describe("useResumeCompletedMigration", () => {
 
     await act(async () => {
       settle(true)
+    })
+  })
+
+  /**
+   * The gate refuses to confirm a receive whose key it cannot read, which is deliberate —
+   * confirming would swap away a working session for a wallet nobody can open. That also
+   * means the swap never runs and never resolves false, so this is the only path left to
+   * the handover that names the condition.
+   */
+  describe("when the provisioned wallet's key is gone from the device", () => {
+    beforeEach(() => {
+      mockReceiveConfirmation = {
+        isReceiveConfirmed: false,
+        isReceiveDelayed: false,
+        isReceiveUnrecoverable: true,
+      }
+    })
+
+    it("hands the user to support with the reason that names it", async () => {
+      renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+
+      expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+        reason: "self-custodial-account-not-on-device",
+        origin: "resume",
+      })
+      expect(mockReportError).toHaveBeenCalledWith(
+        "Migration resume without destination account",
+        expect.objectContaining({
+          message: "Provisioned self-custodial account is not on this device",
+        }),
+      )
+    })
+
+    it("never swaps the session", async () => {
+      renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+
+      expect(mockCompleteMigration).not.toHaveBeenCalled()
+    })
+
+    it("hands over once however many times the effect re-runs", async () => {
+      const { rerender } = renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+      rerender({})
+      await flushEffects()
+
+      expect(mockNavigate).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  /**
+   * The checkpoint expires 48h after its last write while the receive gate has no bound, so
+   * without this a wait spanning two days would lose the record that says there is anything
+   * to finish — stranding a funded wallet the switcher also hides.
+   */
+  describe("keeping the checkpoint alive", () => {
+    it("rewrites the stored step once per launch", async () => {
+      const { rerender } = renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+      rerender({})
+      await flushEffects()
+
+      expect(mockSaveCheckpoint).toHaveBeenCalledTimes(1)
+      expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+        MigrationCheckpoint.BalancesOverview,
+      )
+    })
+
+    /** No figure of its own, so `mergeCheckpoint` keeps the stored one: this write moves
+     *  `savedAt` and nothing else. */
+    it("sends no fresh receive figure with it", async () => {
+      renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+
+      expect(mockSaveCheckpoint).toHaveBeenCalledWith(expect.anything())
+      expect(mockSaveCheckpoint.mock.calls[0]).toHaveLength(1)
+    })
+
+    it("writes nothing when there is no migration to finish", async () => {
+      mockMigrationCheckpoint = null
+
+      renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+
+      expect(mockSaveCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it("waits for the checkpoint to hydrate before rewriting it", async () => {
+      mockMigrationLoading = true
+
+      renderHook(() => useResumeCompletedMigration())
+      await flushEffects()
+
+      expect(mockSaveCheckpoint).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
@@ -188,6 +188,7 @@ const renderScreen = () =>
 
 const resetScreenMocks = () => {
   jest.clearAllMocks()
+  mockSaveCheckpoint.mockResolvedValue(true)
   loadLocale("en")
   mockDollarRestricted = false
   mockCurrentDollarRestricted = false
@@ -668,9 +669,7 @@ describe("MigrationBalancesOverviewScreen", () => {
 
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.BalancesOverview,
-      {
-        expectedReceiveSats: 990,
-      },
+      expect.objectContaining({ expectedReceiveSats: 990 }),
     )
   })
 
@@ -690,9 +689,7 @@ describe("MigrationBalancesOverviewScreen", () => {
 
     expect(mockSaveCheckpoint).toHaveBeenCalledWith(
       MigrationCheckpoint.BalancesOverview,
-      {
-        expectedReceiveSats: 0,
-      },
+      expect.objectContaining({ expectedReceiveSats: 0 }),
     )
   })
 
@@ -974,5 +971,78 @@ describe("MigrationBalancesOverviewScreen lightning-address re-point gating", ()
     expect(mockUseLnAddressTransfer).not.toHaveBeenCalledWith(
       expect.objectContaining({ skip: false }),
     )
+  })
+})
+
+/**
+ * The receive figure is what the gate waits for, and whether it may be refreshed depends on
+ * whether the server has drained anything yet. Kept in its own block so the main suite stays
+ * within the file's per-function line budget.
+ */
+describe("MigrationBalancesOverviewScreen commit-point checkpoint", () => {
+  beforeEach(resetScreenMocks)
+
+  /**
+   * Nothing has left the custodial wallet in these phases, so this reading is the truth
+   * about a balance that may have changed since an earlier visit — a zero captured while
+   * the balance was dust must not outlive a later top-up.
+   */
+  it("replaces a stale receive figure before the migration has started", async () => {
+    mockMigrationStatus = MigrationStatus.NotStarted
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+      MigrationCheckpoint.BalancesOverview,
+      expect.objectContaining({ replaceExpectedReceiveSats: true }),
+    )
+  })
+
+  it("replaces a stale receive figure while the server awaits a destination", async () => {
+    mockMigrationStatus = MigrationStatus.InProgress
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+      MigrationCheckpoint.BalancesOverview,
+      expect.objectContaining({ replaceExpectedReceiveSats: true }),
+    )
+  })
+
+  /** Past the drain the same read is a post-drain zero, and letting it overwrite a good
+   *  figure is exactly the swap-before-funds-land of #4102. */
+  it("leaves the stored figure alone once the drain is under way", async () => {
+    mockMigrationStatus = MigrationStatus.Transferring
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith(
+      MigrationCheckpoint.BalancesOverview,
+      expect.objectContaining({ replaceExpectedReceiveSats: false }),
+    )
+  })
+
+  /**
+   * The figure is what the receive gate waits for, so committing without it having reached
+   * storage leaves the next screen watching for an amount it never recorded. Approve is the
+   * point of no return, which makes it the right place to stop.
+   */
+  it("keeps Approve off when the checkpoint could not be written", async () => {
+    mockSaveCheckpoint.mockResolvedValue(false)
+
+    const { getByTestId } = renderScreen()
+    await flushEffects()
+
+    expect(getByTestId("migration-balances-overview-approve")).toBeDisabled()
+  })
+
+  it("enables Approve once the checkpoint write lands", async () => {
+    const { getByTestId } = renderScreen()
+    await flushEffects()
+
+    expect(getByTestId("migration-balances-overview-approve")).not.toBeDisabled()
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -31,7 +31,18 @@ const mockNavigate = jest.fn()
 const mockGoBack = jest.fn()
 const mockSetOptions = jest.fn()
 const mockRemoveListener = jest.fn()
-type BeforeRemoveListener = (event: { preventDefault: () => void }) => void
+type BeforeRemoveEvent = {
+  preventDefault: () => void
+  data: { action: { type: string } }
+}
+type BeforeRemoveListener = (event: BeforeRemoveEvent) => void
+
+/** The listener only redirects a back press now, so every existing case has to say which
+ *  action is removing the screen. */
+const backEvent = (preventDefault = jest.fn()): BeforeRemoveEvent => ({
+  preventDefault,
+  data: { action: { type: "GO_BACK" } },
+})
 const mockAddListener = jest.fn(
   (_event: string, _listener: BeforeRemoveListener) => mockRemoveListener,
 )
@@ -141,9 +152,41 @@ describe("MigrationContactSupportScreen", () => {
 
     const [event, listener] = mockAddListener.mock.calls.at(-1) ?? []
     const preventDefault = jest.fn()
-    listener?.({ preventDefault })
+    listener?.(backEvent(preventDefault))
 
     expect(event).toBe("beforeRemove")
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationBalancesOverview")
+  })
+
+  /**
+   * `beforeRemove` fires for every action that drops this route, not only a back press, so
+   * without narrowing the guard a logout — or the 401 handler, or the migration blocker
+   * arming — would be cancelled and the user bounced back into the flow they were trying
+   * to leave.
+   */
+  it("lets a reset through instead of redirecting it", async () => {
+    renderScreen()
+    await flushEffects()
+
+    const listener = mockAddListener.mock.calls.at(-1)?.[1]
+    const preventDefault = jest.fn()
+    listener?.({ preventDefault, data: { action: { type: "RESET" } } })
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /** The native stack header and the iOS swipe dispatch POP rather than GO_BACK depending
+   *  on the path, so both count as the back press this screen redirects. */
+  it("redirects a POP the same way as a GO_BACK", async () => {
+    renderScreen()
+    await flushEffects()
+
+    const listener = mockAddListener.mock.calls.at(-1)?.[1]
+    const preventDefault = jest.fn()
+    listener?.({ preventDefault, data: { action: { type: "POP" } } })
+
     expect(preventDefault).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationBalancesOverview")
   })
@@ -155,10 +198,10 @@ describe("MigrationContactSupportScreen", () => {
     await flushEffects()
 
     const listener = mockAddListener.mock.calls.at(-1)?.[1]
-    listener?.({ preventDefault: jest.fn() })
+    listener?.(backEvent())
 
     const preventDefault = jest.fn()
-    listener?.({ preventDefault })
+    listener?.(backEvent(preventDefault))
 
     expect(preventDefault).not.toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledTimes(1)

--- a/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
@@ -395,4 +395,78 @@ describe("MigrationTransferringFundsScreen", () => {
       routes: [{ name: "selfCustodialBackupSuccess", params: { reBackup: false } }],
     })
   })
+
+  /**
+   * Past the notice window the handover happens on its own rather than waiting for the user
+   * to notice a secondary button — which on the resume-less path they may never do.
+   */
+  it("hands over to support by itself once the receive is delayed", async () => {
+    mockIsReceiveDelayed = true
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+      reason: MigrationSupportReason.ReceiveDelayed,
+      origin: "receive-delayed",
+    })
+  })
+
+  it("does not hand over while the wait is still inside the notice window", async () => {
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /** A lost connection explains the wait better, and its retry is the more useful footer,
+   *  so the automatic handover yields to it exactly as the notice does. */
+  it("does not hand over while a recoverable issue owns the screen", async () => {
+    mockIsReceiveDelayed = true
+    mockHasConnectionIssue = true
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /** Returning from support to watch the wait out must not be undone on the next render. */
+  it("hands over once however often it re-renders", async () => {
+    mockIsReceiveDelayed = true
+    const { rerender } = renderScreen()
+    await flushEffects()
+    rerender(
+      <ContextForScreen>
+        <MigrationTransferringFundsScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The whole argument for handing over automatically: this screen stays mounted underneath
+   * and the gate keeps polling, so a receive that lands afterwards still completes the swap.
+   * The handover explains the wait, it does not abandon it.
+   */
+  it("still completes the swap when the receive lands after the handover", async () => {
+    mockIsReceiveDelayed = true
+    const { rerender } = renderScreen()
+    await flushEffects()
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+
+    mockIsTransferred = true
+    rerender(
+      <ContextForScreen>
+        <MigrationTransferringFundsScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(mockCompleteMigration).toHaveBeenCalledTimes(1)
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: "selfCustodialBackupSuccess", params: { reBackup: false } }],
+    })
+  })
 })

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -13,6 +13,7 @@ import {
   savePendingProvisionedAccount,
   clearPendingProvisionedAccount,
   validateStoredCheckpoint,
+  mergeCheckpoint,
 } from "@app/screens/account-migration/utils/migration-checkpoint-storage"
 
 const mockLoadJson = jest.fn()
@@ -277,6 +278,100 @@ describe("migration-checkpoint-storage", () => {
 
       const result = await loadCheckpoint("test-key")
       expect(result).toBeNull()
+    })
+  })
+
+  /**
+   * The receive figure decides whether the gate waits at all, so which of the two records
+   * wins is the difference between a correct wait and the #4102 swap-before-funds-land.
+   */
+  describe("mergeCheckpoint", () => {
+    const stored = {
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: 1,
+      custodialAccountId: "owner-1",
+      expectedReceiveSats: 21000,
+    }
+
+    /** The default, and the reason the rule exists: a figure read after the drain is a zero
+     *  meaning "the balance already moved", which the gate would read as "nothing is
+     *  coming" and swap on immediately. */
+    it("keeps the stored figure when the update does not claim to replace it", () => {
+      const merged = mergeCheckpoint(stored, {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "owner-1",
+        expectedReceiveSats: 0,
+      })
+
+      expect(merged.expectedReceiveSats).toBe(21000)
+    })
+
+    /** Only the commit screen sets the flag, and only while the server says nothing has
+     *  been drained — a zero captured while the balance was dust must not outlive a
+     *  later top-up. */
+    it("takes the fresh figure when the update claims to replace it", () => {
+      const merged = mergeCheckpoint(
+        { ...stored, expectedReceiveSats: 0 },
+        {
+          step: MigrationCheckpoint.BalancesOverview,
+          custodialAccountId: "owner-1",
+          expectedReceiveSats: 21000,
+          replaceExpectedReceiveSats: true,
+        },
+      )
+
+      expect(merged.expectedReceiveSats).toBe(21000)
+    })
+
+    it("records the figure when nothing was stored yet", () => {
+      const merged = mergeCheckpoint(null, {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "owner-1",
+        expectedReceiveSats: 21000,
+      })
+
+      expect(merged.expectedReceiveSats).toBe(21000)
+    })
+
+    /** Another profile's flow must inherit nothing, replacement flag or not. */
+    it("never carries a figure across a different owner", () => {
+      const merged = mergeCheckpoint(stored, {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "owner-2",
+        expectedReceiveSats: 500,
+      })
+
+      expect(merged.expectedReceiveSats).toBe(500)
+    })
+
+    it("keeps the provisioned account id across steps for one owner", () => {
+      const merged = mergeCheckpoint(
+        { ...stored, accountId: "sc-account-1" },
+        { step: MigrationCheckpoint.BackupMethod, custodialAccountId: "owner-1" },
+      )
+
+      expect(merged.accountId).toBe("sc-account-1")
+      expect(merged.step).toBe(MigrationCheckpoint.BackupMethod)
+    })
+
+    it("drops the provisioned account id for a different owner", () => {
+      const merged = mergeCheckpoint(
+        { ...stored, accountId: "sc-account-1" },
+        { step: MigrationCheckpoint.BackupMethod, custodialAccountId: "owner-2" },
+      )
+
+      expect(merged.accountId).toBeUndefined()
+    })
+
+    /** A record written before owners existed is claimed by whoever saves onto it. */
+    it("lets an ownerless record be claimed by the first owner to save", () => {
+      const merged = mergeCheckpoint(
+        { step: MigrationCheckpoint.BalancesOverview, savedAt: 1, accountId: "sc-1" },
+        { step: MigrationCheckpoint.BalancesOverview, custodialAccountId: "owner-1" },
+      )
+
+      expect(merged.accountId).toBe("sc-1")
+      expect(merged.custodialAccountId).toBe("owner-1")
     })
   })
 

--- a/__tests__/self-custodial/migration-transfer-request.spec.ts
+++ b/__tests__/self-custodial/migration-transfer-request.spec.ts
@@ -301,11 +301,12 @@ describe("buildMigrationTransferRequest", () => {
 describe("checkMigrationReceiveLanded", () => {
   const mockGetInfo = jest.fn()
 
-  const check = () =>
+  const check = (expectedReceiveSats: number | null = null) =>
     checkMigrationReceiveLanded({
       accountId: "sc-account-1",
       network: Network.Regtest,
       leewaySatPerVbyte: 1,
+      expectedReceiveSats,
     })
 
   beforeEach(() => {
@@ -339,6 +340,57 @@ describe("checkMigrationReceiveLanded", () => {
     expect(result).toEqual({
       status: MigrationSdkStatus.Ok,
       value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  /** A wallet reused from an abandoned run can already hold sats, so a balance that has not
+   *  reached the previewed figure is not this migration's payment. */
+  it("does not confirm a balance short of the expected receive", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(500) })
+
+    const result = await check(21000)
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 500 },
+    })
+  })
+
+  it("confirms once the balance reaches the expected receive", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(21000) })
+
+    const result = await check(21000)
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: true, balanceSats: 21000 },
+    })
+  })
+
+  /** The comparison is a floor, not an equality: a wallet holding more than the figure has
+   *  certainly received it. */
+  it("confirms a balance above the expected receive", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(30000) })
+
+    const result = await check(21000)
+
+    expect(result).toMatchObject({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: true },
+    })
+  })
+
+  /** Checkpoints written before the figure was persisted have nothing to measure against,
+   *  so they keep the original any-balance rule rather than waiting on a number they never
+   *  recorded. */
+  it("falls back to any positive balance when no figure was recorded", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(1) })
+
+    const result = await check(null)
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: true, balanceSats: 1 },
     })
   })
 

--- a/app/screens/account-migration/hooks/use-complete-migration.ts
+++ b/app/screens/account-migration/hooks/use-complete-migration.ts
@@ -14,8 +14,14 @@ import { usePendingMigrationAccounts } from "./use-pending-migration-accounts"
  *  with the checkpoint intact, never stranded on an empty self-custodial account. Also
  *  surfaces the migration's checkpoint and account id from a single source of truth. */
 export const useCompleteMigration = () => {
-  const { checkpoint, accountId, expectedReceiveSats, loading, clearCheckpoint } =
-    useMigrationCheckpointState()
+  const {
+    checkpoint,
+    accountId,
+    expectedReceiveSats,
+    loading,
+    clearCheckpoint,
+    saveCheckpoint,
+  } = useMigrationCheckpointState()
   const { clearPendingAccount } = usePendingMigrationAccounts()
   const { setActiveAccountId, accounts, loading: accountsLoading } = useAccountRegistry()
   const { ownerId: custodialOwnerId } = useCustodialOwnerId()
@@ -59,5 +65,8 @@ export const useCompleteMigration = () => {
     migrationExpectedReceiveSats: expectedReceiveSats,
     migrationLoading: isMigrationDataLoading,
     completeMigration,
+    /** Exposed so a wait that outlives the checkpoint's 48h expiry can refresh it: the
+     *  record is what tells the next launch there is a migration to finish at all. */
+    saveCheckpoint,
   }
 }

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -22,6 +22,9 @@ import { useCustodialOwnerId } from "./use-custodial-owner-id"
 type SaveCheckpointOptions = {
   provisionedAccountId?: string
   expectedReceiveSats?: number
+  /** Only the commit screen sets this, and only before the drain starts — see
+   *  `CheckpointUpdate`. Everything else carries the stored figure forward untouched. */
+  replaceExpectedReceiveSats?: boolean
 }
 
 /**
@@ -102,6 +105,7 @@ export const useMigrationCheckpointState = () => {
       {
         provisionedAccountId,
         expectedReceiveSats: expectedReceiveSatsUpdate,
+        replaceExpectedReceiveSats,
       }: SaveCheckpointOptions = {},
     ): Promise<boolean> => {
       /** Without a resolved owner the checkpoint cannot be keyed, and saving would erase the
@@ -114,6 +118,10 @@ export const useMigrationCheckpointState = () => {
         custodialAccountId: ownerId,
         expectedReceiveSats:
           expectedReceiveSatsUpdate ?? expectedReceiveSats ?? undefined,
+        /** Only meaningful alongside a figure of this call's own: a carry-forward save has
+         *  nothing fresher to offer, so it must never claim the right to replace. */
+        replaceExpectedReceiveSats:
+          replaceExpectedReceiveSats && expectedReceiveSatsUpdate !== undefined,
       }
       setStored((existing) => mergeCheckpoint(existing, update))
       try {

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -18,6 +18,9 @@ const RECEIVE_CHECK_RETRY_MS = 5000
  *  rest of the session. */
 const DELAYED_RECEIVE_CHECK_RETRY_MS = 30_000
 
+/** Two settled readings, not one, before a missing key is treated as permanent. */
+const NO_MNEMONIC_READINGS_BEFORE_TERMINAL = 2
+
 type UseMigrationReceiveConfirmationArgs = {
   selfCustodialAccountId: string | null
   /**
@@ -34,6 +37,13 @@ type UseMigrationReceiveConfirmationArgs = {
 type UseMigrationReceiveConfirmation = {
   isReceiveConfirmed: boolean
   isReceiveDelayed: boolean
+  /**
+   * The wallet's key is gone from this device, so no amount of waiting produces a receive.
+   * Kept separate from a confirmation on purpose: confirming would release a swap that
+   * discards the working custodial session for a wallet nobody can open. The caller owns
+   * what to do with it — this gate only reports that waiting is pointless.
+   */
+  isReceiveUnrecoverable: boolean
 }
 
 /**
@@ -61,6 +71,7 @@ export const useMigrationReceiveConfirmation = ({
   } = useRemoteConfig()
   const [isReceiveConfirmed, setIsReceiveConfirmed] = useState(false)
   const [isReceiveDelayed, setIsReceiveDelayed] = useState(false)
+  const [isReceiveUnrecoverable, setIsReceiveUnrecoverable] = useState(false)
 
   /** A zero-receive migration (balance at or under an uncovered fee) gets no payment, so
    *  the gate opens without ever touching the SDK; waiting would strand the user forever. */
@@ -84,6 +95,12 @@ export const useMigrationReceiveConfirmation = ({
   /** Mirrors the state for the polling effect, which outlives the flip and must read the
    *  current cadence without re-arming (a re-armed effect fires an extra check at once). */
   const isReceiveDelayedRef = useRef(false)
+
+  /** A missing key is only called unrecoverable once it has settled that way twice running.
+   *  One reading is not enough: a keystore that is briefly unavailable (a locked device)
+   *  can answer the same way as one whose entry is truly gone, and the handover this
+   *  ultimately triggers is not something to raise on a blip. */
+  const consecutiveNoMnemonicRef = useRef(0)
 
   useEffect(() => {
     if (!isWatching || selfCustodialAccountId === null) return
@@ -112,6 +129,7 @@ export const useMigrationReceiveConfirmation = ({
           accountId,
           network,
           leewaySatPerVbyte: selfCustodialDepositClaimLeewayVbyte,
+          expectedReceiveSats,
         })
       } catch (err) {
         /** A keystore read that threw before the SDK result shape existed: transient as
@@ -128,14 +146,25 @@ export const useMigrationReceiveConfirmation = ({
        * confirmation: the swap it would release checks the account index rather than the
        * keystore, so it would discard the working custodial session for a wallet whose key
        * is unrecoverable, leaving the user with neither. Treated as not-landed instead,
-       * which keeps the working session and lets the delayed notice route to support. The
-       * re-read is cheap — it settles before any SDK connection is opened.
+       * which keeps the working session, and raised separately so the caller can hand the
+       * user over rather than leave them waiting on a receive that cannot arrive. Polling
+       * continues: if the reading was a blip, a later check clears it. The re-read is cheap
+       * — it settles before any SDK connection is opened.
        */
       if (result.status === MigrationSdkStatus.NoMnemonic) {
+        consecutiveNoMnemonicRef.current += 1
+        if (consecutiveNoMnemonicRef.current >= NO_MNEMONIC_READINGS_BEFORE_TERMINAL) {
+          setIsReceiveUnrecoverable(true)
+        }
         reportOnce(new Error("No mnemonic for the provisioned account"))
         scheduleNextCheck()
         return
       }
+
+      /** Any other settled answer means the keystore was readable, so a previous missing-key
+       *  reading was the blip and not this one. */
+      consecutiveNoMnemonicRef.current = 0
+      setIsReceiveUnrecoverable(false)
 
       if (result.status === MigrationSdkStatus.Ok && result.value.hasReceived) {
         setIsReceiveConfirmed(true)
@@ -155,7 +184,13 @@ export const useMigrationReceiveConfirmation = ({
       isActive = false
       if (timer) clearTimeout(timer)
     }
-  }, [isWatching, selfCustodialAccountId, network, selfCustodialDepositClaimLeewayVbyte])
+  }, [
+    isWatching,
+    selfCustodialAccountId,
+    network,
+    selfCustodialDepositClaimLeewayVbyte,
+    expectedReceiveSats,
+  ])
 
   /** The notice measures the wait for the receive, not the whole transfer: it runs from a
    *  timestamp rather than the effect's own lifetime because both callers recompute `skip`
@@ -196,6 +231,14 @@ export const useMigrationReceiveConfirmation = ({
     isReceiveDelayed:
       !skip &&
       isReceiveDelayed &&
+      !isReceiveConfirmed &&
+      !isConfirmedWithoutWaiting &&
+      !isReleasedByTimeout,
+    /** Masked by a confirmation for the same reason: a receive that landed settles the
+     *  question of whether the key was readable. */
+    isReceiveUnrecoverable:
+      !skip &&
+      isReceiveUnrecoverable &&
       !isReceiveConfirmed &&
       !isConfirmedWithoutWaiting &&
       !isReleasedByTimeout,

--- a/app/screens/account-migration/hooks/use-resume-completed-migration.ts
+++ b/app/screens/account-migration/hooks/use-resume-completed-migration.ts
@@ -28,11 +28,31 @@ const MAX_SWAP_ATTEMPTS = 3
 export const useResumeCompletedMigration = (): void => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const {
+    migrationCheckpoint,
     migrationAccountId,
     migrationExpectedReceiveSats,
     migrationLoading,
     completeMigration,
+    saveCheckpoint,
   } = useCompleteMigration()
+
+  /**
+   * The checkpoint expires 48h after its last write, and the receive gate below has no
+   * bound at all, so a receive that stays unconfirmed for two days would have the record it
+   * depends on deleted underneath it — leaving the provisioned wallet funded, hidden from
+   * the switcher by a pending record that never expires, and no longer resumable. Rewriting
+   * it once per launch keeps the two lifetimes in step, and costs a single storage write on
+   * the launches where a migration is genuinely unfinished. The step is re-sent unchanged
+   * and carries no fresh figure, so nothing but `savedAt` moves.
+   */
+  const hasRefreshedCheckpointRef = useRef(false)
+  useEffect(() => {
+    if (!migrationCheckpoint || migrationLoading || hasRefreshedCheckpointRef.current) {
+      return
+    }
+    hasRefreshedCheckpointRef.current = true
+    saveCheckpoint(migrationCheckpoint)
+  }, [migrationCheckpoint, migrationLoading, saveCheckpoint])
 
   const hasUnfinishedMigration = Boolean(migrationAccountId)
   const { status } = useMigrationStatus({ skip: !hasUnfinishedMigration })
@@ -47,11 +67,12 @@ export const useResumeCompletedMigration = (): void => {
    *  into a wallet whose funds are still in transit either (#4102). Unconfirmed simply
    *  means no swap this session — the custodial session stays intact and the next launch
    *  (or this one, once a check lands) picks the swap back up. */
-  const { isReceiveConfirmed, isReceiveDelayed } = useMigrationReceiveConfirmation({
-    selfCustodialAccountId: migrationAccountId,
-    expectedReceiveSats: migrationExpectedReceiveSats,
-    skip: !isServerCompleted,
-  })
+  const { isReceiveConfirmed, isReceiveDelayed, isReceiveUnrecoverable } =
+    useMigrationReceiveConfirmation({
+      selfCustodialAccountId: migrationAccountId,
+      expectedReceiveSats: migrationExpectedReceiveSats,
+      skip: !isServerCompleted,
+    })
 
   /** This path has no screen of its own to say the wait is unusual, so the crossing is at
    *  least reported: a receive that never lands would otherwise be invisible, the user
@@ -71,6 +92,27 @@ export const useResumeCompletedMigration = (): void => {
    *  once the user has been handed to support, so the handover happens exactly once. */
   const hasHandedOverRef = useRef(false)
   const isSwapPending = isServerCompleted && isReceiveConfirmed
+
+  /**
+   * The same terminal condition reached from the other side. The gate refuses to confirm a
+   * receive it cannot read the key for, which is right — confirming would swap away a
+   * working session for an unopenable wallet — but it also means the swap below never runs
+   * and never resolves false, so without this the handover it owns would be unreachable and
+   * the user would wait on a receive that cannot arrive. Shares the one-shot latch with the
+   * swap's own handover so only one of the two ever fires.
+   */
+  useEffect(() => {
+    if (!isReceiveUnrecoverable || hasHandedOverRef.current) return
+    hasHandedOverRef.current = true
+    reportError(
+      "Migration resume without destination account",
+      new Error("Provisioned self-custodial account is not on this device"),
+    )
+    navigation.navigate("accountMigrationContactSupport", {
+      reason: MigrationSupportReason.SelfCustodialAccountNotOnDevice,
+      origin: MigrationSupportOrigin.Resume,
+    })
+  }, [isReceiveUnrecoverable, navigation])
 
   useEffect(() => {
     const canAttempt =

--- a/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { ActivityIndicator, ScrollView, View } from "react-native"
 import { useFocusEffect, useIsFocused, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -104,10 +104,33 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
    *  re-saves the checkpoint the migration just cleared, and on ready figures so it is
    *  never recorded before the commit point exists. */
   const expectedReceiveSats = preview.expectedReceiveSats
+
+  /** Nothing has left the custodial wallet in either of these phases, so the preview this
+   *  screen just read is the truth about a balance that may well have changed since an
+   *  earlier visit. Once the server is TRANSFERRING or past it, the same read would be a
+   *  post-drain zero, and replacing a good figure with it is precisely #4102. */
+  const isBeforeDrain =
+    migrationStatus === MigrationStatus.NotStarted ||
+    migrationStatus === MigrationStatus.InProgress
+
+  /** A checkpoint that never reached storage leaves the receive gate with no figure to wait
+   *  for, so Approve — the point of no return — stays off until the write is known to have
+   *  landed. Mirrors `accept-t-and-c`, which gates its own advance on the same boolean. */
+  const [hasSavedCheckpoint, setHasSavedCheckpoint] = useState(false)
+
   useEffect(() => {
     if (!isFocused || checkpointLoading || expectedReceiveSats === null) return
-    saveCheckpoint(MigrationCheckpoint.BalancesOverview, { expectedReceiveSats })
-  }, [isFocused, checkpointLoading, expectedReceiveSats, saveCheckpoint])
+    let isActive = true
+    saveCheckpoint(MigrationCheckpoint.BalancesOverview, {
+      expectedReceiveSats,
+      replaceExpectedReceiveSats: isBeforeDrain,
+    }).then((isSaved) => {
+      if (isActive) setHasSavedCheckpoint(isSaved)
+    })
+    return () => {
+      isActive = false
+    }
+  }, [isFocused, checkpointLoading, expectedReceiveSats, isBeforeDrain, saveCheckpoint])
 
   /**
    * The ways this screen ends without an Approve to offer, as one value: the preview
@@ -189,7 +212,10 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
    *  confirmed one exists and the lightning address has moved, not merely until the
    *  figures render. */
   const isApproveDisabled =
-    !preview.isReady || !migrationStart.isStarted || !lnAddressTransfer.isTransferred
+    !preview.isReady ||
+    !migrationStart.isStarted ||
+    !lnAddressTransfer.isTransferred ||
+    !hasSavedCheckpoint
 
   return (
     <Screen preset="fixed" headerShown={false}>

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -105,6 +105,14 @@ export const MigrationContactSupportScreen: React.FC = () => {
   useEffect(() => {
     if (!isBackToCommitScreen) return
     return navigation.addListener("beforeRemove", (event) => {
+      /** Only a back press is redirected. `beforeRemove` fires for every action that drops
+       *  this route, so without the check a reset — logout, the 401 handler, the migration
+       *  blocker arming — would be cancelled too and the user could not leave. Both types
+       *  are listed because the native stack header and the iOS swipe dispatch either one
+       *  depending on the path. */
+      const actionType = event.data.action.type
+      if (actionType !== "POP" && actionType !== "GO_BACK") return
+
       /** The redirect removes this screen too; letting that second pass through is what
        *  ends the interception instead of looping on it. */
       if (isRedirectingBackRef.current) return
@@ -130,7 +138,10 @@ export const MigrationContactSupportScreen: React.FC = () => {
   }, [copyToClipboard, supportDetailsText])
 
   return (
-    <Screen preset="fixed">
+    /** The gate origin hides the navigator header, and Screen derives its top safe-area
+     *  edge from this prop rather than from the navigator, so without it the hero would
+     *  draw under the status bar on exactly that origin. */
+    <Screen preset="fixed" headerShown={isGateOrigin ? false : undefined}>
       <View style={styles.container}>
         <IconHero
           icon="headset"

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -134,6 +134,20 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
    *  wait better than the wait itself, and its retry is the more useful footer. */
   const isDelayedNoticeShown = isReceiveDelayed && !isRecoverable
 
+  /**
+   * Past the notice window the handover happens on its own rather than waiting for the user
+   * to find the button. It costs them nothing: this screen stays mounted underneath and the
+   * gate keeps polling, so a receive that lands afterwards still completes the swap — the
+   * handover explains the wait, it does not abandon it. Once only, so returning from support
+   * to watch the wait out is not immediately undone.
+   */
+  const hasHandedOverDelayRef = useRef(false)
+  useEffect(() => {
+    if (!isDelayedNoticeShown || hasHandedOverDelayRef.current) return
+    hasHandedOverDelayRef.current = true
+    goToDelayedSupport()
+  }, [isDelayedNoticeShown, goToDelayedSupport])
+
   const recoverableMessage = isClockOutOfSync
     ? LLMigration.clockOutOfSync.body()
     : LL.errors.network.connection()

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -121,6 +121,13 @@ export type CheckpointUpdate = {
   accountId?: string
   custodialAccountId?: string
   expectedReceiveSats?: number
+  /**
+   * Lets this update's figure replace a stored one. Set only by the commit screen, and only
+   * while the server says nothing has been drained yet — that is the whole safety condition,
+   * because a figure read after the drain is a zero that means "balance already moved", not
+   * "nothing is coming". Every other save leaves it unset and inherits.
+   */
+  replaceExpectedReceiveSats?: boolean
 }
 
 /**
@@ -137,12 +144,15 @@ export const mergeCheckpoint = (
     existing?.custodialAccountId === undefined ||
     existing.custodialAccountId === update.custodialAccountId
 
-  /** Write-once for one owner's flow: the figure is only knowable before the drain, so a
-   *  re-entered commit screen would carry the post-drain zero the gate reads as "nothing
-   *  will ever arrive" and swap while the funds are still in transit (#4102). */
-  const inheritedExpectedReceiveSats = hasSameOwner
-    ? existing?.expectedReceiveSats
-    : undefined
+  /** The stored figure wins by default, because a re-entered commit screen would otherwise
+   *  carry the post-drain zero the gate reads as "nothing will ever arrive" and swap while
+   *  the funds are still in transit (#4102). The exception is a caller that has established
+   *  the drain has not started, whose figure is the fresher reading of the same balance —
+   *  without it a zero captured while the balance was dust would outlive a later top-up. */
+  const inheritedExpectedReceiveSats =
+    hasSameOwner && !update.replaceExpectedReceiveSats
+      ? existing?.expectedReceiveSats
+      : undefined
 
   return {
     step: update.step,

--- a/app/self-custodial/migration-transfer-request.ts
+++ b/app/self-custodial/migration-transfer-request.ts
@@ -199,19 +199,30 @@ type MigrationReceiveCheck = {
 }
 
 /**
- * Whether the migration payment has landed in the provisioned wallet. Any positive
- * balance is the receive: the wallet is provisioned by this flow and never used before
- * the session swap, so nothing else can have funded it. The forced sync is the point of
- * the call — Spark holds an incoming payment for an offline wallet and claims it on
- * sync, so this read is the detector and the actuator in one.
+ * Whether the migration payment has landed in the provisioned wallet. The balance is
+ * measured against what the server said it would send, because a positive balance alone
+ * is not proof: `resolveReusablePendingAccount` hands back a wallet left over from an
+ * earlier abandoned run, and that wallet may already hold sats from a prior partial
+ * receive or a deposit made against a phrase the user wrote down. The forced sync is the
+ * point of the call — Spark holds an incoming payment for an offline wallet and claims it
+ * on sync, so this read is the detector and the actuator in one.
  */
 export const checkMigrationReceiveLanded = (
-  args: MigrationSdkConnectionArgs,
+  args: MigrationSdkConnectionArgs & {
+    /** Null on a checkpoint written before the figure was persisted: there is nothing to
+     *  measure against, so those fall back to the original any-balance rule rather than
+     *  waiting forever on a number they never recorded. */
+    expectedReceiveSats: number | null
+  },
 ): Promise<MigrationSdkResult<MigrationReceiveCheck>> =>
   withMigrationSdk(args, async (sdk) => {
     const info = await sdk.getInfo({ ensureSynced: true })
     const balanceSats = Number(info.balanceSats)
-    return { hasReceived: balanceSats > 0, balanceSats }
+    const hasReceived =
+      args.expectedReceiveSats === null
+        ? balanceSats > 0
+        : balanceSats >= args.expectedReceiveSats
+    return { hasReceived, balanceSats }
   })
 
 /** The two proof fields `migrationLnAddressTransfer` takes; it re-points the lightning


### PR DESCRIPTION
Follow-up to #4103 (merged as 47876eb4), which added the gate that waits for a confirmed Spark receive before swapping the session. Reviewing the merged code turned up ten issues; this covers eight of them. The two smallest are listed as out of scope at the bottom.

## What was wrong

**The gate watched for the wrong thing.** `checkMigrationReceiveLanded` confirmed on any positive balance, justified by a comment saying nothing else could have funded the wallet. That does not hold: `resolveReusablePendingAccount` deliberately reuses a wallet left over from an abandoned earlier run, with no check that it is empty. A wallet holding sats from a partial receive — or from a deposit made against a phrase the user wrote down — confirmed on the very first poll, swapping the session while this migration's payment was still in transit. That is #4102 wearing a confirmation.

It now measures the balance against the `expectedReceiveSats` the checkpoint already persists. A checkpoint written before that field existed has nothing to compare against and keeps the original any-balance rule.

**The figure it measures against could go stale.** `mergeCheckpoint` was write-once per owner. The reason is sound and is spelled out in its comment: after the drain the custodial balance reads zero, and letting that zero overwrite a good figure tells the gate "nothing is coming". But the rule was too broad — it also froze a zero captured while the balance was dust, so a user who topped up and came back within 48h still had `0` recorded, and the gate opened instantly.

The commit screen may now replace the figure, but only while the server reports `NOT_STARTED` or `IN_PROGRESS`. That is the only durable pre-drain signal available, because it lives on the server and survives a relaunch — there is no local marker for it.

**The missing-key handover had become unreachable.** The gate maps `NoMnemonic` to not-landed, which is the right call: confirming would release a swap that discards a working custodial session for a wallet nobody can open. But `isSwapPending` requires a confirmation, so `completeMigration()` never ran and never resolved `false`, and the `SelfCustodialAccountNotOnDevice` handover lost its only trigger. Affected users sat on a drained custodial session with one Crashlytics report and no route anywhere.

The gate now raises `isReceiveUnrecoverable` as its own outcome, and the resume path hands over on it. It takes two consecutive readings, so a briefly unavailable keystore on a locked device does not raise a handover on a blip, and polling continues either way so a later successful read withdraws the verdict.

**Waiting had no end.** Past the notice window — one minute, the existing `migrationReceiveDelayedNoticeMs` default, so no new Firebase parameter — the transfer screen now hands over on its own instead of waiting for the user to notice a secondary button.

Nothing is abandoned by that. The `ReceiveDelayed` origin is already designed to sit on top of the still-mounted transfer screen, so the gate underneath keeps polling and a receive that lands at minute three still completes the swap. There is a test asserting exactly that.

## Also fixed

- **Logout was cancelled.** The contact-support `beforeRemove` listener called `preventDefault()` on every removal, and React Navigation fires it for `navigation.reset` too — so logout, the 401 handler and the migration blocker were all swallowed and bounced back into the flow. Narrowed to `POP`/`GO_BACK`, matching the three onboarding screens that already do this.
- **Approve could commit on a failed save.** `saveCheckpoint` resolves `false` without throwing and its own comment says callers should gate on it; the result was dropped, and the effect never retried. Approve now waits on the write landing, as `accept-t-and-c` already does.
- **A long wait could outlive its own checkpoint.** The record expires 48h after its last write while the gate has no bound, so a two-day wait lost the record that says there is anything to finish — leaving a funded wallet the switcher also hides. The resume path now rewrites it once per launch, carrying no fresh figure, so only `savedAt` moves.
- **The gate-origin support screen drew under the notch.** `headerShown: false` was set on the navigator but not passed to `<Screen>`, which derives its top safe-area edge from that prop.

## Tests

`mergeCheckpoint` gains direct coverage — it had none, only indirect coverage through `saveCheckpointToStorage`. Beyond that: the balance comparison and its legacy fallback, the unrecoverable outcome and its two-reading debounce, the restored resume handover, the automatic handover and the swap still completing after it, a `RESET` passing through the back guard while `POP` still redirects, the replace-before-drain rule on both sides, and Approve gated on the write.

332 tests pass across the ten affected suites; typecheck and lint are clean.

## Out of scope

Two low-severity items are deliberately left out: the shared error-report latch, where a transient failure can suppress the permanent missing-key report, and the Android hardware back navigating twice on the commit origin.