### PR TITLE
fix(migration): keep checklist content clear of the sticky CTA in enlarged text mode

### DIFF
--- a/__tests__/components/atomic/galoy-primary-button.spec.tsx
+++ b/__tests__/components/atomic/galoy-primary-button.spec.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import {
   ActivityIndicator,
   StyleSheet,
+  Text,
   View,
   type TextStyle,
   type ViewStyle,
@@ -164,5 +165,22 @@ describe("GaloyPrimaryButton", () => {
     )
 
     expect(getSpinnerColor()).toBe("#123456")
+  })
+
+  it("takes its testID from a string title, and skips it for a rendered one", () => {
+    renderButton()
+    expect(screen.getByTestId("Continue")).toBeTruthy()
+    screen.unmount()
+
+    // A node title has no string to name the button by, so the automatic
+    // testProps are skipped rather than stringified into a useless id.
+    render(
+      <ContextForScreen>
+        <GaloyPrimaryButton title={<Text>Continue</Text>} onPress={() => {}} />
+      </ContextForScreen>,
+    )
+
+    expect(screen.getByText("Continue")).toBeTruthy()
+    expect(screen.queryByTestId("Continue")).toBeNull()
   })
 })

--- a/__tests__/components/atomic/galoy-primary-button.spec.tsx
+++ b/__tests__/components/atomic/galoy-primary-button.spec.tsx
@@ -1,12 +1,5 @@
 import React from "react"
-import {
-  ActivityIndicator,
-  StyleSheet,
-  Text,
-  View,
-  type TextStyle,
-  type ViewStyle,
-} from "react-native"
+import { ActivityIndicator, StyleSheet, Text, type TextStyle } from "react-native"
 import { render, screen } from "@testing-library/react-native"
 
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
@@ -19,137 +12,24 @@ const renderButton = (props: { disabled?: boolean; loading?: boolean } = {}) =>
     </ContextForScreen>,
   )
 
-/**
- * The button's own painted surface: the innermost view carrying a background,
- * which is where buttonStyle and disabledStyle end up merged together.
- */
-const getButtonSurfaceStyle = () => {
-  const surface = screen.UNSAFE_getAllByType(View).find((node) => {
-    const style = StyleSheet.flatten(node.props.style) as ViewStyle | undefined
-    return Boolean(style?.backgroundColor)
-  })
-  if (!surface) {
-    throw new Error("No painted button surface found")
-  }
-  return StyleSheet.flatten(surface.props.style) as ViewStyle
-}
-
 const getTitleColor = () =>
   (StyleSheet.flatten(screen.getByText("Continue").props.style) as TextStyle).color
 
 const getSpinnerColor = () =>
   screen.UNSAFE_getByType(ActivityIndicator).props.color as string
 
-/** WCAG relative luminance of an `#rrggbb` colour. */
-const luminance = (hex: string) => {
-  const channels = [1, 3, 5].map((offset) => {
-    const value = parseInt(hex.slice(offset, offset + 2), 16) / 255
-    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
-  })
-  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
-}
-
-/** WCAG contrast ratio between two `#rrggbb` colours, 1 (identical) to 21. */
-const contrastRatio = (a: string, b: string) => {
-  const [lighter, darker] = [luminance(a), luminance(b)].sort((x, y) => y - x)
-  return (lighter + 0.05) / (darker + 0.05)
-}
-
-// The disabled title is 20pt/600, which WCAG counts as large text: 3:1, not 4.5:1.
-const LARGE_TEXT_AA = 3
-
 describe("GaloyPrimaryButton", () => {
-  describe("contrast helper", () => {
-    it("scores identical colours as 1 and black against white as 21", () => {
-      expect(contrastRatio("#7f7f7f", "#7f7f7f")).toBeCloseTo(1, 5)
-      expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1)
-    })
-  })
+  it("draws the spinner in the same colour as the title", () => {
+    // The title is replaced by the spinner while loading, so read it from the
+    // idle render. Dark theme inverts `white`, and the library's literal
+    // 'white' spinner would drift from the title it stands in for.
+    renderButton()
+    const titleColor = getTitleColor()
+    screen.unmount()
 
-  describe("when disabled", () => {
-    it("paints an opaque surface", () => {
-      renderButton({ disabled: true })
-      const style = getButtonSurfaceStyle()
+    renderButton({ loading: true })
 
-      // A translucent disabled button composites whatever sits behind it, so
-      // content could read straight through the CTA. It has to own its pixels.
-      expect(style.backgroundColor).toBeTruthy()
-      expect(style.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
-      expect(style.opacity === undefined || style.opacity === 1).toBe(true)
-    })
-
-    it("keeps a distinct surface from the enabled state", () => {
-      renderButton()
-      const enabledBackground = getButtonSurfaceStyle().backgroundColor
-      screen.unmount()
-
-      renderButton({ disabled: true })
-      const disabledBackground = getButtonSurfaceStyle().backgroundColor
-
-      expect(disabledBackground).not.toBe(enabledBackground)
-    })
-
-    it("outlines the surface so it survives a low-contrast background", () => {
-      renderButton({ disabled: true })
-      const style = getButtonSurfaceStyle()
-
-      // Modals paint grey5 and the disabled fill is grey4 — about 1.13:1 apart,
-      // so without an edge the CTA reads as absent rather than as disabled.
-      expect(style.borderWidth).toBeGreaterThan(0)
-      expect(style.borderColor).toBeTruthy()
-      expect(style.borderColor).not.toBe(style.backgroundColor)
-    })
-
-    it("keeps the title readable against the disabled surface", () => {
-      renderButton({ disabled: true })
-
-      expect(
-        contrastRatio(
-          getTitleColor() as string,
-          getButtonSurfaceStyle().backgroundColor as string,
-        ),
-      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
-    })
-
-    it("keeps the spinner visible against the disabled surface", () => {
-      // Screens that gate on an in-flight call pass disabled and loading at the
-      // same time (the explainer CTA does, for the whole provisioning wait). The
-      // library's hardcoded white spinner disappears on the grey fill.
-      renderButton({ disabled: true, loading: true })
-
-      expect(
-        contrastRatio(
-          getSpinnerColor(),
-          getButtonSurfaceStyle().backgroundColor as string,
-        ),
-      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
-    })
-  })
-
-  describe("when enabled", () => {
-    it("keeps the spinner visible against the primary surface", () => {
-      renderButton({ loading: true })
-
-      expect(
-        contrastRatio(
-          getSpinnerColor(),
-          getButtonSurfaceStyle().backgroundColor as string,
-        ),
-      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
-    })
-
-    it("draws the spinner in the same colour as the title", () => {
-      // The title is replaced by the spinner while loading, so read it from the
-      // idle render. Dark theme inverts `white`, and the library's literal
-      // 'white' spinner would drift from the title it stands in for.
-      renderButton()
-      const titleColor = getTitleColor()
-      screen.unmount()
-
-      renderButton({ loading: true })
-
-      expect(getSpinnerColor()).toBe(titleColor)
-    })
+    expect(getSpinnerColor()).toBe(titleColor)
   })
 
   it("lets callers override the spinner colour", () => {

--- a/__tests__/components/atomic/galoy-primary-button.spec.tsx
+++ b/__tests__/components/atomic/galoy-primary-button.spec.tsx
@@ -1,14 +1,20 @@
 import React from "react"
-import { StyleSheet, View, type ViewStyle } from "react-native"
+import {
+  ActivityIndicator,
+  StyleSheet,
+  View,
+  type TextStyle,
+  type ViewStyle,
+} from "react-native"
 import { render, screen } from "@testing-library/react-native"
 
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { ContextForScreen } from "../../screens/helper"
 
-const renderButton = (disabled: boolean) =>
+const renderButton = (props: { disabled?: boolean; loading?: boolean } = {}) =>
   render(
     <ContextForScreen>
-      <GaloyPrimaryButton title="Continue" disabled={disabled} onPress={() => {}} />
+      <GaloyPrimaryButton title="Continue" onPress={() => {}} {...props} />
     </ContextForScreen>,
   )
 
@@ -27,26 +33,136 @@ const getButtonSurfaceStyle = () => {
   return StyleSheet.flatten(surface.props.style) as ViewStyle
 }
 
-describe("GaloyPrimaryButton", () => {
-  it("paints an opaque surface when disabled", () => {
-    renderButton(true)
-    const style = getButtonSurfaceStyle()
+const getTitleColor = () =>
+  (StyleSheet.flatten(screen.getByText("Continue").props.style) as TextStyle).color
 
-    // A translucent disabled button composites whatever sits behind it, so
-    // content could read straight through the CTA. It has to own its pixels.
-    expect(style.backgroundColor).toBeTruthy()
-    expect(style.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
-    expect(style.opacity === undefined || style.opacity === 1).toBe(true)
+const getSpinnerColor = () =>
+  screen.UNSAFE_getByType(ActivityIndicator).props.color as string
+
+/** WCAG relative luminance of an `#rrggbb` colour. */
+const luminance = (hex: string) => {
+  const channels = [1, 3, 5].map((offset) => {
+    const value = parseInt(hex.slice(offset, offset + 2), 16) / 255
+    return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+}
+
+/** WCAG contrast ratio between two `#rrggbb` colours, 1 (identical) to 21. */
+const contrastRatio = (a: string, b: string) => {
+  const [lighter, darker] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+// The disabled title is 20pt/600, which WCAG counts as large text: 3:1, not 4.5:1.
+const LARGE_TEXT_AA = 3
+
+describe("GaloyPrimaryButton", () => {
+  describe("contrast helper", () => {
+    it("scores identical colours as 1 and black against white as 21", () => {
+      expect(contrastRatio("#7f7f7f", "#7f7f7f")).toBeCloseTo(1, 5)
+      expect(contrastRatio("#000000", "#ffffff")).toBeCloseTo(21, 1)
+    })
   })
 
-  it("keeps a distinct surface between the enabled and disabled states", () => {
-    renderButton(false)
-    const enabledBackground = getButtonSurfaceStyle().backgroundColor
-    screen.unmount()
+  describe("when disabled", () => {
+    it("paints an opaque surface", () => {
+      renderButton({ disabled: true })
+      const style = getButtonSurfaceStyle()
 
-    renderButton(true)
-    const disabledBackground = getButtonSurfaceStyle().backgroundColor
+      // A translucent disabled button composites whatever sits behind it, so
+      // content could read straight through the CTA. It has to own its pixels.
+      expect(style.backgroundColor).toBeTruthy()
+      expect(style.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
+      expect(style.opacity === undefined || style.opacity === 1).toBe(true)
+    })
 
-    expect(disabledBackground).not.toBe(enabledBackground)
+    it("keeps a distinct surface from the enabled state", () => {
+      renderButton()
+      const enabledBackground = getButtonSurfaceStyle().backgroundColor
+      screen.unmount()
+
+      renderButton({ disabled: true })
+      const disabledBackground = getButtonSurfaceStyle().backgroundColor
+
+      expect(disabledBackground).not.toBe(enabledBackground)
+    })
+
+    it("outlines the surface so it survives a low-contrast background", () => {
+      renderButton({ disabled: true })
+      const style = getButtonSurfaceStyle()
+
+      // Modals paint grey5 and the disabled fill is grey4 — about 1.13:1 apart,
+      // so without an edge the CTA reads as absent rather than as disabled.
+      expect(style.borderWidth).toBeGreaterThan(0)
+      expect(style.borderColor).toBeTruthy()
+      expect(style.borderColor).not.toBe(style.backgroundColor)
+    })
+
+    it("keeps the title readable against the disabled surface", () => {
+      renderButton({ disabled: true })
+
+      expect(
+        contrastRatio(
+          getTitleColor() as string,
+          getButtonSurfaceStyle().backgroundColor as string,
+        ),
+      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
+    })
+
+    it("keeps the spinner visible against the disabled surface", () => {
+      // Screens that gate on an in-flight call pass disabled and loading at the
+      // same time (the explainer CTA does, for the whole provisioning wait). The
+      // library's hardcoded white spinner disappears on the grey fill.
+      renderButton({ disabled: true, loading: true })
+
+      expect(
+        contrastRatio(
+          getSpinnerColor(),
+          getButtonSurfaceStyle().backgroundColor as string,
+        ),
+      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
+    })
+  })
+
+  describe("when enabled", () => {
+    it("keeps the spinner visible against the primary surface", () => {
+      renderButton({ loading: true })
+
+      expect(
+        contrastRatio(
+          getSpinnerColor(),
+          getButtonSurfaceStyle().backgroundColor as string,
+        ),
+      ).toBeGreaterThanOrEqual(LARGE_TEXT_AA)
+    })
+
+    it("draws the spinner in the same colour as the title", () => {
+      // The title is replaced by the spinner while loading, so read it from the
+      // idle render. Dark theme inverts `white`, and the library's literal
+      // 'white' spinner would drift from the title it stands in for.
+      renderButton()
+      const titleColor = getTitleColor()
+      screen.unmount()
+
+      renderButton({ loading: true })
+
+      expect(getSpinnerColor()).toBe(titleColor)
+    })
+  })
+
+  it("lets callers override the spinner colour", () => {
+    render(
+      <ContextForScreen>
+        <GaloyPrimaryButton
+          title="Continue"
+          loading
+          loadingProps={{ color: "#123456" }}
+          onPress={() => {}}
+        />
+      </ContextForScreen>,
+    )
+
+    expect(getSpinnerColor()).toBe("#123456")
   })
 })

--- a/__tests__/components/atomic/galoy-primary-button.spec.tsx
+++ b/__tests__/components/atomic/galoy-primary-button.spec.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import { StyleSheet, View, type ViewStyle } from "react-native"
+import { render, screen } from "@testing-library/react-native"
+
+import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
+import { ContextForScreen } from "../../screens/helper"
+
+const renderButton = (disabled: boolean) =>
+  render(
+    <ContextForScreen>
+      <GaloyPrimaryButton title="Continue" disabled={disabled} onPress={() => {}} />
+    </ContextForScreen>,
+  )
+
+/**
+ * The button's own painted surface: the innermost view carrying a background,
+ * which is where buttonStyle and disabledStyle end up merged together.
+ */
+const getButtonSurfaceStyle = () => {
+  const surface = screen.UNSAFE_getAllByType(View).find((node) => {
+    const style = StyleSheet.flatten(node.props.style) as ViewStyle | undefined
+    return Boolean(style?.backgroundColor)
+  })
+  if (!surface) {
+    throw new Error("No painted button surface found")
+  }
+  return StyleSheet.flatten(surface.props.style) as ViewStyle
+}
+
+describe("GaloyPrimaryButton", () => {
+  it("paints an opaque surface when disabled", () => {
+    renderButton(true)
+    const style = getButtonSurfaceStyle()
+
+    // A translucent disabled button composites whatever sits behind it, so
+    // content could read straight through the CTA. It has to own its pixels.
+    expect(style.backgroundColor).toBeTruthy()
+    expect(style.backgroundColor).not.toBe("rgba(0, 0, 0, 0)")
+    expect(style.opacity === undefined || style.opacity === 1).toBe(true)
+  })
+
+  it("keeps a distinct surface between the enabled and disabled states", () => {
+    renderButton(false)
+    const enabledBackground = getButtonSurfaceStyle().backgroundColor
+    screen.unmount()
+
+    renderButton(true)
+    const disabledBackground = getButtonSurfaceStyle().backgroundColor
+
+    expect(disabledBackground).not.toBe(enabledBackground)
+  })
+})

--- a/__tests__/screens/account-migration/migration-step-layout.spec.tsx
+++ b/__tests__/screens/account-migration/migration-step-layout.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { ScrollView, StyleSheet, Text } from "react-native"
-import { render, screen } from "@testing-library/react-native"
+import { fireEvent, render, screen } from "@testing-library/react-native"
 import type { ReactTestInstance } from "react-test-renderer"
 
 import { MigrationStepLayout } from "@app/screens/account-migration/migration-step-layout"
@@ -70,5 +70,96 @@ describe("MigrationStepLayout", () => {
     renderLayout({ header: <Text>header row</Text> })
 
     expect(screen.getByText("header row")).toBeTruthy()
+  })
+
+  it("keeps contentStyle off the scroll view itself", () => {
+    // Spacing passed as contentStyle belongs between the children; landing on
+    // the scroll view it would pad the viewport instead and do nothing useful.
+    renderLayout({ contentStyle: { gap: 20 } })
+
+    expect(StyleSheet.flatten(getScrollView().props.style)).not.toMatchObject({ gap: 20 })
+  })
+
+  it("shows the scroll indicator", () => {
+    renderLayout()
+
+    // The scaffold has no visible clipping edge — content simply ends above the
+    // footer — so the indicator is the only cue that more exists below. It only
+    // appears when the content actually overflows, so it costs nothing at
+    // normal text sizes.
+    expect(getScrollView().props.showsVerticalScrollIndicator).not.toBe(false)
+  })
+
+  describe("when the content grows", () => {
+    const scrollToEnd = ScrollView.prototype.scrollToEnd as jest.Mock
+
+    /** Report a scroll position, in the shape RN's onScroll event delivers it. */
+    const scrollTo = (offsetY: number, viewport: number, contentHeight: number) =>
+      fireEvent.scroll(getScrollView(), {
+        nativeEvent: {
+          contentOffset: { x: 0, y: offsetY },
+          layoutMeasurement: { width: 400, height: viewport },
+          contentSize: { width: 400, height: contentHeight },
+        },
+      })
+
+    const measure = (height: number) =>
+      fireEvent(getScrollView(), "contentSizeChange", 400, height)
+
+    beforeEach(() => {
+      scrollToEnd.mockClear()
+    })
+
+    it("follows content that appears while the user is at the bottom", () => {
+      // The explainer reveals its acknowledgement boxes one at a time. At large
+      // text sizes the newly revealed box renders below the fold, and the user
+      // is left with a disabled CTA and nothing visibly left to do.
+      renderLayout()
+      measure(600)
+
+      measure(900)
+
+      expect(scrollToEnd).toHaveBeenCalledWith({ animated: true })
+    })
+
+    it("stays put on the first measurement", () => {
+      // Initial layout is not growth; following it would drop the user at the
+      // bottom of a screen they have not read a word of yet.
+      renderLayout()
+
+      measure(2000)
+
+      expect(scrollToEnd).not.toHaveBeenCalled()
+    })
+
+    it("stays put when the user has scrolled up", () => {
+      renderLayout()
+      measure(600)
+      scrollTo(0, 300, 600)
+
+      measure(900)
+
+      expect(scrollToEnd).not.toHaveBeenCalled()
+    })
+
+    it("follows again once the user scrolls back to the bottom", () => {
+      renderLayout()
+      measure(600)
+      scrollTo(0, 300, 600)
+      scrollTo(300, 300, 600)
+
+      measure(900)
+
+      expect(scrollToEnd).toHaveBeenCalledWith({ animated: true })
+    })
+
+    it("stays put when the content shrinks", () => {
+      renderLayout()
+      measure(900)
+
+      measure(600)
+
+      expect(scrollToEnd).not.toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/screens/account-migration/migration-step-layout.spec.tsx
+++ b/__tests__/screens/account-migration/migration-step-layout.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ScrollView, StyleSheet, Text } from "react-native"
+import { ScrollView, StyleSheet, Text, type ViewStyle } from "react-native"
 import { fireEvent, render, screen } from "@testing-library/react-native"
 import type { ReactTestInstance } from "react-test-renderer"
 
@@ -18,6 +18,15 @@ const renderLayout = (
   )
 
 const getScrollView = () => screen.UNSAFE_getByType(ScrollView)
+
+/** The nearest ancestor of `node` that paints a background colour. */
+const getPaintedAncestor = (node: ReactTestInstance): ReactTestInstance | undefined => {
+  for (let current = node.parent; current; current = current.parent) {
+    const style = StyleSheet.flatten(current.props.style) as ViewStyle | undefined
+    if (style?.backgroundColor) return current
+  }
+  return undefined
+}
 
 /** Whether `node` is rendered anywhere beneath `ancestor`. */
 const isInside = (node: ReactTestInstance, ancestor: ReactTestInstance): boolean => {
@@ -42,6 +51,19 @@ describe("MigrationStepLayout", () => {
     // The footer must stay a sibling below the scroll area, never an overlay,
     // so the scroll viewport is always the height the buttons leave behind.
     expect(isInside(screen.getByText("footer action"), getScrollView())).toBe(false)
+  })
+
+  it("paints the footer band itself, not just the screen behind it", () => {
+    renderLayout()
+
+    // A disabled primary button is a translucent fill, so the band beneath it
+    // has to own its pixels. Painting is only the band's if the nearest painted
+    // ancestor stops short of the scroll area — the screen paints too, and
+    // leaning on that would leave the button compositing whatever it overlaps.
+    const band = getPaintedAncestor(screen.getByText("footer action"))
+
+    expect(band).toBeDefined()
+    expect(band && isInside(getScrollView(), band)).toBe(false)
   })
 
   it("lets the content container grow so tall content can scroll", () => {

--- a/__tests__/screens/account-migration/migration-step-layout.spec.tsx
+++ b/__tests__/screens/account-migration/migration-step-layout.spec.tsx
@@ -1,0 +1,74 @@
+import React from "react"
+import { ScrollView, StyleSheet, Text } from "react-native"
+import { render, screen } from "@testing-library/react-native"
+import type { ReactTestInstance } from "react-test-renderer"
+
+import { MigrationStepLayout } from "@app/screens/account-migration/migration-step-layout"
+import { ContextForScreen } from "../helper"
+
+const renderLayout = (
+  props: Partial<React.ComponentProps<typeof MigrationStepLayout>> = {},
+) =>
+  render(
+    <ContextForScreen>
+      <MigrationStepLayout footer={<Text>footer action</Text>} {...props}>
+        <Text>step content</Text>
+      </MigrationStepLayout>
+    </ContextForScreen>,
+  )
+
+const getScrollView = () => screen.UNSAFE_getByType(ScrollView)
+
+/** Whether `node` is rendered anywhere beneath `ancestor`. */
+const isInside = (node: ReactTestInstance, ancestor: ReactTestInstance): boolean => {
+  for (let current = node.parent; current; current = current.parent) {
+    if (current === ancestor) return true
+  }
+  return false
+}
+
+describe("MigrationStepLayout", () => {
+  it("renders the step content inside a scroll view", () => {
+    renderLayout()
+
+    // The bug this guards: content laid out in a plain View overflows into the
+    // footer once enlarged system text makes it taller than the viewport.
+    expect(isInside(screen.getByText("step content"), getScrollView())).toBe(true)
+  })
+
+  it("renders the footer outside the scroll view", () => {
+    renderLayout()
+
+    // The footer must stay a sibling below the scroll area, never an overlay,
+    // so the scroll viewport is always the height the buttons leave behind.
+    expect(isInside(screen.getByText("footer action"), getScrollView())).toBe(false)
+  })
+
+  it("lets the content container grow so tall content can scroll", () => {
+    renderLayout()
+
+    expect(StyleSheet.flatten(getScrollView().props.contentContainerStyle)).toMatchObject(
+      {
+        flexGrow: 1,
+      },
+    )
+  })
+
+  it("applies contentStyle to the scroll content container", () => {
+    // migration-required-screen passes { gap: 20 }, which is spacing between
+    // children and so has to land on the content container, not the scroll view.
+    renderLayout({ contentStyle: { gap: 20 } })
+
+    expect(StyleSheet.flatten(getScrollView().props.contentContainerStyle)).toMatchObject(
+      {
+        gap: 20,
+      },
+    )
+  })
+
+  it("renders the header above the content", () => {
+    renderLayout({ header: <Text>header row</Text> })
+
+    expect(screen.getByText("header row")).toBeTruthy()
+  })
+})

--- a/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
+++ b/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
@@ -2,16 +2,23 @@ import React, { FC, PropsWithChildren } from "react"
 
 import { testProps } from "@app/utils/testProps"
 import { TouchableHighlight } from "@app/utils/touchable-wrapper"
-import { Button, ButtonProps, makeStyles } from "@rn-vui/themed"
+import { Button, ButtonProps, makeStyles, useTheme } from "@rn-vui/themed"
 
 export const GaloyPrimaryButton: FC<PropsWithChildren<ButtonProps>> = (props) => {
   const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
 
   return (
     <Button
       {...(typeof props.title === "string" ? testProps(props.title) : {})}
       activeOpacity={0.85}
       TouchableComponent={TouchableHighlight}
+      // The library hardcodes a white spinner for solid buttons, which vanishes
+      // on the grey disabled surface (and on the light title colour in dark
+      // theme). Track whichever colour the title is wearing instead.
+      loadingProps={{ color: props.disabled ? colors.grey1 : colors.white }}
       buttonStyle={styles.buttonStyle}
       titleStyle={styles.titleStyle}
       disabledStyle={styles.disabledStyle}
@@ -28,16 +35,22 @@ const useStyles = makeStyles(({ colors }) => ({
     fontWeight: "600",
     color: colors.white,
   },
+  // grey1 rather than a lighter grey: on the grey4 surface the muted greys land
+  // around 2.4:1, under the 3:1 floor WCAG AA sets even for large bold text.
   disabledTitleStyle: {
-    color: colors.grey2,
+    color: colors.grey1,
   },
   buttonStyle: {
     minHeight: 50,
     backgroundColor: colors.primary,
   },
   // Opaque rather than a translucent primary: `opacity` blends the button with
-  // whatever sits behind it, so content could show through a disabled CTA.
+  // whatever sits behind it, so content could show through a disabled CTA. The
+  // outline keeps the button's shape readable on surfaces close to grey4 —
+  // modals paint grey5, which is barely a shade away from the fill.
   disabledStyle: {
     backgroundColor: colors.grey4,
+    borderWidth: 1,
+    borderColor: colors.grey3,
   },
 }))

--- a/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
+++ b/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
@@ -15,10 +15,10 @@ export const GaloyPrimaryButton: FC<PropsWithChildren<ButtonProps>> = (props) =>
       {...(typeof props.title === "string" ? testProps(props.title) : {})}
       activeOpacity={0.85}
       TouchableComponent={TouchableHighlight}
-      // The library hardcodes a white spinner for solid buttons, which vanishes
-      // on the grey disabled surface (and on the light title colour in dark
-      // theme). Track whichever colour the title is wearing instead.
-      loadingProps={{ color: props.disabled ? colors.grey1 : colors.white }}
+      // The library hardcodes a white spinner for solid buttons. In dark theme
+      // the title on the orange fill is black, so the spinner drifted from the
+      // text it stands in for. Track the title's colour instead.
+      loadingProps={{ color: colors.white }}
       buttonStyle={styles.buttonStyle}
       titleStyle={styles.titleStyle}
       disabledStyle={styles.disabledStyle}
@@ -35,22 +35,17 @@ const useStyles = makeStyles(({ colors }) => ({
     fontWeight: "600",
     color: colors.white,
   },
-  // grey1 rather than a lighter grey: on the grey4 surface the muted greys land
-  // around 2.4:1, under the 3:1 floor WCAG AA sets even for large bold text.
   disabledTitleStyle: {
-    color: colors.grey1,
+    color: colors.grey5,
   },
   buttonStyle: {
     minHeight: 50,
     backgroundColor: colors.primary,
   },
-  // Opaque rather than a translucent primary: `opacity` blends the button with
-  // whatever sits behind it, so content could show through a disabled CTA. The
-  // outline keeps the button's shape readable on surfaces close to grey4 —
-  // modals paint grey5, which is barely a shade away from the fill.
+  // Translucent by design: the surface a sticky button sits on is responsible
+  // for painting itself, so nothing can show through the button.
   disabledStyle: {
-    backgroundColor: colors.grey4,
-    borderWidth: 1,
-    borderColor: colors.grey3,
+    opacity: 0.5,
+    backgroundColor: colors.primary,
   },
 }))

--- a/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
+++ b/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
@@ -29,14 +29,15 @@ const useStyles = makeStyles(({ colors }) => ({
     color: colors.white,
   },
   disabledTitleStyle: {
-    color: colors.grey5,
+    color: colors.grey2,
   },
   buttonStyle: {
     minHeight: 50,
     backgroundColor: colors.primary,
   },
+  // Opaque rather than a translucent primary: `opacity` blends the button with
+  // whatever sits behind it, so content could show through a disabled CTA.
   disabledStyle: {
-    opacity: 0.5,
-    backgroundColor: colors.primary,
+    backgroundColor: colors.grey4,
   },
 }))

--- a/app/screens/account-migration/migration-step-layout.tsx
+++ b/app/screens/account-migration/migration-step-layout.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { StyleProp, View, ViewStyle } from "react-native"
+import { ScrollView, StyleProp, View, ViewStyle } from "react-native"
 
 import { makeStyles } from "@rn-vui/themed"
 
@@ -16,6 +16,10 @@ type MigrationStepLayoutProps = {
 /**
  * The migration flow's shared step scaffold: an optional header row, the step content,
  * and the footer actions pinned to the bottom with the flow's spacing.
+ *
+ * The content scrolls so that enlarged system text can never push it into the footer,
+ * and the footer is a sibling below the scroll view rather than an overlay, so the
+ * scroll area is always whatever height the buttons leave behind.
  */
 export const MigrationStepLayout: React.FC<MigrationStepLayoutProps> = ({
   children,
@@ -30,7 +34,13 @@ export const MigrationStepLayout: React.FC<MigrationStepLayoutProps> = ({
     <Screen preset="fixed" headerShown={headerShown}>
       <View style={styles.container}>
         {header}
-        <View style={[styles.content, contentStyle]}>{children}</View>
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={[styles.content, contentStyle]}
+          showsVerticalScrollIndicator={false}
+        >
+          {children}
+        </ScrollView>
         <View style={styles.buttonsContainer}>{footer}</View>
       </View>
     </Screen>
@@ -42,8 +52,14 @@ const useStyles = makeStyles(() => ({
     flex: 1,
     justifyContent: "space-between",
   },
-  content: {
+  scroll: {
     flex: 1,
+  },
+  content: {
+    // flexGrow rather than flex so short content keeps today's full-height box
+    // while tall content is allowed to grow past the viewport and scroll.
+    flexGrow: 1,
+    paddingBottom: 10,
   },
   buttonsContainer: {
     gap: 10,

--- a/app/screens/account-migration/migration-step-layout.tsx
+++ b/app/screens/account-migration/migration-step-layout.tsx
@@ -88,7 +88,7 @@ export const MigrationStepLayout: React.FC<MigrationStepLayoutProps> = ({
   )
 }
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ colors }) => ({
   container: {
     flex: 1,
     justifyContent: "space-between",
@@ -107,5 +107,9 @@ const useStyles = makeStyles(() => ({
     paddingHorizontal: 20,
     paddingBottom: 20,
     paddingTop: 10,
+    // The band paints its own surface rather than leaning on the screen showing
+    // through: a disabled primary button is a translucent fill, so whatever is
+    // visible behind the band would be visible through the button.
+    backgroundColor: colors.white,
   },
 }))

--- a/app/screens/account-migration/migration-step-layout.tsx
+++ b/app/screens/account-migration/migration-step-layout.tsx
@@ -1,9 +1,19 @@
-import React from "react"
-import { ScrollView, StyleProp, View, ViewStyle } from "react-native"
+import React, { useCallback, useRef } from "react"
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleProp,
+  View,
+  ViewStyle,
+} from "react-native"
 
 import { makeStyles } from "@rn-vui/themed"
 
 import { Screen } from "@app/components/screen"
+
+/** Rounding and bounce leave the offset a hair short of the exact bottom. */
+const AT_BOTTOM_SLACK = 8
 
 type MigrationStepLayoutProps = {
   children: React.ReactNode
@@ -20,6 +30,11 @@ type MigrationStepLayoutProps = {
  * The content scrolls so that enlarged system text can never push it into the footer,
  * and the footer is a sibling below the scroll view rather than an overlay, so the
  * scroll area is always whatever height the buttons leave behind.
+ *
+ * Content that grows while the user is already at the bottom pulls the view down with
+ * it. The explainer step reveals its acknowledgement boxes one at a time, and at large
+ * text sizes the next box lands off-screen; without this the user sees the CTA stay
+ * disabled with no visible reason why.
  */
 export const MigrationStepLayout: React.FC<MigrationStepLayoutProps> = ({
   children,
@@ -30,14 +45,40 @@ export const MigrationStepLayout: React.FC<MigrationStepLayoutProps> = ({
 }) => {
   const styles = useStyles()
 
+  const scrollRef = useRef<ScrollView>(null)
+  const contentHeightRef = useRef(0)
+  const isAtBottomRef = useRef(true)
+
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { contentOffset, layoutMeasurement, contentSize } = event.nativeEvent
+    isAtBottomRef.current =
+      contentOffset.y + layoutMeasurement.height >= contentSize.height - AT_BOTTOM_SLACK
+  }, [])
+
+  const handleContentSizeChange = useCallback((_width: number, height: number) => {
+    const previousHeight = contentHeightRef.current
+    contentHeightRef.current = height
+
+    // The first measurement is the initial layout, not growth — following it
+    // would drop the user at the bottom of a screen they have not read yet.
+    if (previousHeight === 0) return
+
+    if (height > previousHeight && isAtBottomRef.current) {
+      scrollRef.current?.scrollToEnd({ animated: true })
+    }
+  }, [])
+
   return (
     <Screen preset="fixed" headerShown={headerShown}>
       <View style={styles.container}>
         {header}
         <ScrollView
+          ref={scrollRef}
           style={styles.scroll}
           contentContainerStyle={[styles.content, contentStyle]}
-          showsVerticalScrollIndicator={false}
+          onScroll={handleScroll}
+          onContentSizeChange={handleContentSizeChange}
+          scrollEventThrottle={16}
         >
           {children}
         </ScrollView>


### PR DESCRIPTION
Fixes #4123

## Problem

With iOS accessibility text scaling turned up, the migration checklist screen ("What does it mean to move to non-custodial?") renders its last checkbox row on top of the **I understand** button, and the label reads straight *through* the button.

Two things combine to produce that one screenshot:

**1. The migration step content could not scroll.** Every migration step screen is built on `migration-step-layout.tsx`, which laid its content out in a plain `<View style={{flex: 1}}>` inside a `preset="fixed"` Screen. Enlarged text makes the hero plus five checkbox cards taller than that box, and React Native does not clip overflowing children — it draws them outside their parent, over the footer beneath. Nothing scrolled either, so rows 3–5 were unreachable and the checklist could never be satisfied.

**2. The footer band did not paint itself.** A disabled `GaloyPrimaryButton` is `opacity: 0.5` over primary, which is not a colour — it blends the button with whatever is behind it. The band under the sticky CTA relied on the screen showing through, so anything that reached those pixels was composited into the button.

## Changes

**`app/screens/account-migration/migration-step-layout.tsx`** — the content slot becomes a `ScrollView` with `contentContainerStyle: { flexGrow: 1 }`. `flexGrow` rather than `flex` means short content keeps exactly today's full-height box, so nothing moves at normal text sizes, while tall content is free to grow past the viewport and scroll. `contentStyle` now routes to `contentContainerStyle`, where the `{ gap: 20 }` that `migration-required-screen` passes belongs.

The footer stays a **flex sibling below** the scroll view rather than an overlay. That is the load-bearing part: the scroll viewport is always whatever height the buttons leave behind, so content cannot reach the footer's pixels — the overlap is impossible by construction rather than tuned away with padding, which would only hold until someone picks a larger text size. On top of that the band now paints `colors.white`, the same screen-surface token `Screen` uses, so the translucent CTA has an opaque surface of its own instead of borrowing one.

The scaffold also keeps the scroll indicator (it has no visible clipping edge, so the indicator is the only cue that content continues below the fold) and follows content that grows while the user is already at the bottom — `RevealedCheckboxList` reveals its next acknowledgement box only once the previous one is ticked, and at large text that box lands off-screen with nothing to scroll it into view.

This one edit covers all five screens on the scaffold: explainer, keep-receiving, download-history, api-service and migration-required. `balances-overview-screen` and `contact-support-screen` hand-rolled the same layout and already have their own ScrollViews.

**`app/components/atomic/galoy-primary-button/galoy-primary-button.tsx`** — one line: the loading spinner takes the title's colour rather than the library's hardcoded `'white'`, which was wrong against the black title the orange fill carries in dark theme. The button's resting appearance is untouched.

## Decisions

- **The button is not restyled.** An earlier revision of this PR gave every disabled primary button in the app an opaque `grey4` fill, a `grey3` outline and a darker title, so no CTA anywhere could composite content behind it. @designsats reviewed that and asked for the opposite split: the surface a sticky button sits on paints itself, the button stays exactly as designed. That is what is on the branch now — the app-wide restyle is withdrawn, along with the WCAG-contrast argument that only applied to the grey fill it introduced.
- **The band, not the button, owns the pixels.** `backgroundColor` on `buttonsContainer` rather than on the button means the invariant holds for whatever the footer contains — primary, secondary, or two stacked buttons — and costs nothing at normal text sizes.
- **Sibling footer, not an absolute overlay.** An overlay would need the scroll content padded by the measured footer height to keep the last row reachable; the sibling gives the same result (rows clip at the scroll edge, band solid below) with no measurement, and matches `contact-support-screen`, `balances-overview-screen` and `onboarding-screen-layout`, which all use this shape.

## Tests

- `__tests__/screens/account-migration/migration-step-layout.spec.tsx` (new, 13 tests) — asserts structure rather than pixel values: content renders inside a scroll container, the footer renders *outside* it, the band's paint comes from the footer rather than the screen behind it (the nearest painted ancestor must stop short of the scroll area), the content container can grow, `contentStyle` reaches the content container and not the scroll view, the indicator is not suppressed, and the five auto-scroll cases (grows at the bottom, first measurement, user scrolled up, user scrolled back down, content shrinks).
- `__tests__/components/atomic/galoy-primary-button.spec.tsx` (new, 3 tests) — the spinner tracks the title colour, callers can still override it, and the testID falls back correctly for a rendered title.

Reverting both source files to `main` fails 13 of the 16, so none are vacuous. Typecheck and lint clean; the 12 specs covering screens on this scaffold (236 tests) pass unchanged.
