### PR TITLE
perf(agents): telemetry, benchmarks, and data-gated capture optimization

### DIFF
--- a/.claude/skills/github-pr-image-attachments/scripts/push-assets-branch.sh
+++ b/.claude/skills/github-pr-image-attachments/scripts/push-assets-branch.sh
@@ -19,6 +19,13 @@
 
 set -uo pipefail
 
+# Telemetry is best-effort and optional: this skill still works when the
+# simulator skill's lib is absent (skills get copied around individually).
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_PUSH=$(tel_now)
+
 PR=""; PURPOSE=""; FILES=(); DRY=""; REPO=""; REMOTE="origin"
 
 while [ $# -gt 0 ]; do
@@ -102,6 +109,8 @@ else
 fi
 
 # Machine-readable first, so callers can build their own markdown.
+tel_emit pub.push.total "$T_PUSH" pr="$PR" purpose="$PURPOSE" \
+  files="${#FILES[@]}" dry_run="$([ -n "$DRY" ] && echo 1 || echo 0)"
 echo "RAW_BASE=$RAW"
 for f in "${FILES[@]}"; do
   echo "RAW_FILE=$RAW/$(basename "$f")"

--- a/.claude/skills/github-pr-image-attachments/tests/run.sh
+++ b/.claude/skills/github-pr-image-attachments/tests/run.sh
@@ -18,6 +18,10 @@ WORK="$(mktemp -d "${TMPDIR:-/tmp}/pr-assets-tests.XXXXXX")"
 PASS=0; FAIL=0
 trap 'rm -rf "$WORK"' EXIT
 
+# Redirecting the registry keeps every test span inside $WORK (telemetry
+# derives its store from it).
+export DEMO_SIM_REGISTRY="$WORK/registry"
+
 ok()  { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n       %s\n' "$1" "$2"; }
 check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected '$2', got '$3'"; fi; }
@@ -56,6 +60,8 @@ check "pushed blob matches the local file" "$LOCAL_SHA" "$PUSHED_SHA"
 check "reports a usable RAW_BASE" "https://raw.githubusercontent.com/acme/sample-app/assets/pr-3712-screenshots" \
   "$(echo "$out" | grep '^RAW_BASE=' | cut -d= -f2-)"
 check "reports one RAW_FILE per input" "2" "$(echo "$out" | grep -c '^RAW_FILE=')"
+check "a successful push emits its telemetry span" "yes" \
+  "$(grep -l '"span":"pub.push.total"' "$WORK/registry/telemetry"/spans-*.jsonl >/dev/null 2>&1 && echo yes || echo no)"
 check "RAW_FILE points at a path that exists in the tree" "yes" \
   "$(f=$(echo "$out" | grep '^RAW_FILE=' | head -1 | sed 's#.*/##'); git -C "$WORK/origin.git" ls-tree -r --name-only refs/heads/assets/pr-3712-screenshots | grep -qx "$f" && echo yes || echo no)"
 

--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -141,7 +141,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 52 assertions, ~10s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 56 assertions, ~15s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -141,7 +141,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 47 assertions, ~5s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 52 assertions, ~10s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -141,7 +141,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 56 assertions, ~15s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 57 assertions, ~15s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
+++ b/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
@@ -19,6 +19,12 @@
 
 set -uo pipefail
 
+# Telemetry is best-effort and optional: this skill still works when the
+# simulator skill's lib is absent (skills get copied around individually).
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
 LABEL=""; OUTDIR="."
 UDID="${DEMO_UDID:-}"; SERIAL="${DEMO_ANDROID_SERIAL:-}"; FORCE=""
 SETTLE="${SHOT_SETTLE:-0.6}"     # gap between comparison frames
@@ -80,8 +86,16 @@ else
   shoot() { xcrun simctl io "$UDID" screenshot "$1" >/dev/null 2>&1; }
 fi
 
+# One span for the whole capture - never per frame: a python3 spawn inside the
+# settle loop would distort the very latency being measured. Frame count and
+# stability land in meta; `ok` mirrors stability so the report can keep
+# timed-out captures out of the latency percentiles (they are failure samples).
+T_CAPTURE=$(tel_now)
+FRAMES=0
+
 if [ -n "$NO_WAIT" ]; then
   shoot "$OUT" || die "screenshot failed"
+  FRAMES=1
 else
   # Two identical frames in a row means nothing is animating. Comparing file
   # digests is enough and avoids depending on an image differ.
@@ -97,6 +111,7 @@ else
   STABLE=""
   while :; do
     shoot "$TMP/frame.png" || die "screenshot failed - is ${UDID:-$SERIAL} booted?"
+    FRAMES=$((FRAMES + 1))
     [ -s "$TMP/frame.png" ] || die "screenshot produced an empty file"
     CUR=$(shasum -a 256 "$TMP/frame.png" | cut -d' ' -f1)
     if [ -n "$PREV" ] && [ "$CUR" = "$PREV" ]; then STABLE=1; break; fi
@@ -109,6 +124,14 @@ else
 fi
 
 [ -s "$OUT" ] || die "no screenshot was written to $OUT"
+
+if [ -n "$NO_WAIT" ]; then
+  tel_emit shot.capture.total "$T_CAPTURE" platform="$PLATFORM" frames=1 no_wait=1
+else
+  STABLE_FLAG="$([ -n "$STABLE" ] && echo 1 || echo 0)"
+  tel_emit shot.capture.total "$T_CAPTURE" platform="$PLATFORM" frames="$FRAMES" \
+    settle="$SETTLE" stable="$STABLE_FLAG" ok="$STABLE_FLAG"
+fi
 
 # A PNG that is not a PNG means simctl wrote an error into the file.
 if command -v magick >/dev/null 2>&1; then

--- a/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
+++ b/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
@@ -83,7 +83,15 @@ if [ "$PLATFORM" = android ]; then
   # exec-out is binary-safe stdout; `shell screencap` would mangle line endings.
   shoot() { adb -s "$SERIAL" exec-out screencap -p > "$1" 2>/dev/null; }
 else
-  shoot() { xcrun simctl io "$UDID" screenshot "$1" >/dev/null 2>&1; }
+  # Resolve simctl once: xcrun dispatch costs ~80ms per shot on top of the
+  # ~0.27s screenshot itself (measured: p50 0.35s via xcrun vs 0.27s direct,
+  # bench-20260808-023805), and a settle capture pays it per frame.
+  SIMCTL="$(xcrun -f simctl 2>/dev/null || echo "")"
+  if [ -n "$SIMCTL" ]; then
+    shoot() { "$SIMCTL" io "$UDID" screenshot "$1" >/dev/null 2>&1; }
+  else
+    shoot() { xcrun simctl io "$UDID" screenshot "$1" >/dev/null 2>&1; }
+  fi
 fi
 
 # One span for the whole capture - never per frame: a python3 spawn inside the

--- a/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
+++ b/.claude/skills/react-native-demo-screenshots/scripts/capture.sh
@@ -85,7 +85,14 @@ if [ -n "$NO_WAIT" ]; then
 else
   # Two identical frames in a row means nothing is animating. Comparing file
   # digests is enough and avoids depending on an image differ.
-  DEADLINE=$(python3 -c "import time; print(time.time() + $TIMEOUT)")
+  #
+  # The deadline uses `date +%s`: 1s resolution is plenty for a 30s budget,
+  # and the two python3 spawns per frame this replaced cost 40-100ms each
+  # iteration - drift injected into the very loop whose latency the telemetry
+  # is supposed to report honestly.
+  START_S=$(date +%s)
+  TIMEOUT_S=${TIMEOUT%.*}
+  [ -n "$TIMEOUT_S" ] && [ "$TIMEOUT_S" -ge 1 ] 2>/dev/null || TIMEOUT_S=1
   PREV=""
   STABLE=""
   while :; do
@@ -94,9 +101,7 @@ else
     CUR=$(shasum -a 256 "$TMP/frame.png" | cut -d' ' -f1)
     if [ -n "$PREV" ] && [ "$CUR" = "$PREV" ]; then STABLE=1; break; fi
     PREV="$CUR"
-    NOW=$(python3 -c "import time; print(time.time())")
-    OVER=$(python3 -c "print(1 if $NOW >= $DEADLINE else 0)")
-    [ "$OVER" = "1" ] && break
+    [ $(( $(date +%s) - START_S )) -ge "$TIMEOUT_S" ] && break
     sleep "$SETTLE"
   done
   cp "$TMP/frame.png" "$OUT"

--- a/.claude/skills/react-native-demo-screenshots/tests/fixtures/bin/xcrun
+++ b/.claude/skills/react-native-demo-screenshots/tests/fixtures/bin/xcrun
@@ -20,7 +20,11 @@ case "${1:-}" in
     OUT="${4:?fake xcrun: screenshot needs an output path}"
     [ "$OP" = "screenshot" ] || { echo "fake xcrun: unsupported io op '$OP'" >&2; exit 64; }
 
-    echo "screenshot udid=$UDID out=$OUT" >> "$ARGS_LOG"
+    # The t= stamp lets the bench assert on inter-shot gaps (a settle sleep
+    # that silently disappears shows up as gap ~ 0); FAKE_SHOT_DELAY plants a
+    # slow shot so the bench can prove it detects planted regressions.
+    echo "screenshot udid=$UDID out=$OUT t=$(python3 -c 'import time; print("%.3f" % time.time())')" >> "$ARGS_LOG"
+    [ -n "${FAKE_SHOT_DELAY:-}" ] && sleep "$FAKE_SHOT_DELAY"
 
     if [ -n "${FAKE_DEVICES:-}" ] && [ -f "${FAKE_DEVICES}" ]; then
       grep -q "^${UDID}|" "$FAKE_DEVICES" || { echo "fake xcrun: no device $UDID" >&2; exit 1; }

--- a/.claude/skills/react-native-demo-screenshots/tests/fixtures/bin/xcrun
+++ b/.claude/skills/react-native-demo-screenshots/tests/fixtures/bin/xcrun
@@ -8,8 +8,17 @@
 
 set -uo pipefail
 
-[ "${1:-}" = "simctl" ] || { echo "fake xcrun: only simctl is supported" >&2; exit 64; }
-shift
+# capture.sh resolves simctl once via `xcrun -f simctl`; handing back this
+# fake keeps the resolved-binary path testable - later calls arrive without
+# the `simctl` prefix and are logged direct=1, which is what the assertion
+# that the caching actually happened keys on.
+if [ "${1:-}" = "-f" ]; then
+  echo "$0"
+  exit 0
+fi
+
+DIRECT=1
+[ "${1:-}" = "simctl" ] && { DIRECT=0; shift; }
 
 ARGS_LOG="${FAKE_ARGS_LOG:-/dev/null}"
 
@@ -23,7 +32,7 @@ case "${1:-}" in
     # The t= stamp lets the bench assert on inter-shot gaps (a settle sleep
     # that silently disappears shows up as gap ~ 0); FAKE_SHOT_DELAY plants a
     # slow shot so the bench can prove it detects planted regressions.
-    echo "screenshot udid=$UDID out=$OUT t=$(python3 -c 'import time; print("%.3f" % time.time())')" >> "$ARGS_LOG"
+    echo "screenshot udid=$UDID out=$OUT direct=$DIRECT t=$(python3 -c 'import time; print("%.3f" % time.time())')" >> "$ARGS_LOG"
     [ -n "${FAKE_SHOT_DELAY:-}" ] && sleep "$FAKE_SHOT_DELAY"
 
     if [ -n "${FAKE_DEVICES:-}" ] && [ -f "${FAKE_DEVICES}" ]; then

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -23,6 +23,10 @@ export SHOT_SETTLE=0.05
 # keeps every test span inside $WORK - the same isolation trick the simulator
 # suite uses for session state.
 export DEMO_SIM_REGISTRY="$WORK/registry"
+# A shell with a live claimed session exports DEMO_UDID etc.; inherited, they
+# flip the host-OS platform default under the android tests. Trust only what
+# each test sets explicitly.
+unset DEMO_UDID DEMO_ANDROID_SERIAL DEMO_HOST_OS DEMO_SESSION_DIR DEMO_PORT 2>/dev/null || true
 
 printf 'DEMO-UDID|rn-demo-pr3712|Booted\n' > "$FAKE_DEVICES"
 printf 'emulator-5554|rn-demo-pr3712-avd|device\n' > "$FAKE_ADB_DEVICES"

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -19,6 +19,10 @@ export FAKE_ADB_DEVICES="$WORK/adb-devices.txt"
 export FAKE_ARGS_LOG="$WORK/args.log"
 export FAKE_FRAME_COUNTER="$WORK/frames.n"
 export SHOT_SETTLE=0.05
+# Telemetry derives its store from the registry, so redirecting the registry
+# keeps every test span inside $WORK - the same isolation trick the simulator
+# suite uses for session state.
+export DEMO_SIM_REGISTRY="$WORK/registry"
 
 printf 'DEMO-UDID|rn-demo-pr3712|Booted\n' > "$FAKE_DEVICES"
 printf 'emulator-5554|rn-demo-pr3712-avd|device\n' > "$FAKE_ADB_DEVICES"
@@ -176,6 +180,60 @@ check "rejects a malformed crop box" "1" "$?"
 
 "$SCRIPTS/crop-pair.sh" "$WORK/before.png" "$WORK/after.png" >/dev/null 2>&1
 check "requires --crop" "1" "$?"
+
+echo
+echo "telemetry"
+
+TELEMETRY_DIR="$WORK/registry/telemetry"
+tel_spans() { cat "$TELEMETRY_DIR"/spans-*.jsonl 2>/dev/null; }
+span_meta() { # span_meta <span> <key>
+  tel_spans | python3 -c '
+import json, sys
+span, key = sys.argv[1], sys.argv[2]
+for l in sys.stdin:
+    r = json.loads(l)
+    if r["span"] == span:
+        print(r["meta"].get(key, "")); break' "$1" "$2" 2>/dev/null
+}
+
+# --- frames meta cross-checked against the fake's own shot log ---------------
+# Two different sequences on purpose: a hardcoded frames value survives one
+# of these runs, never both.
+reset; rm -rf "$TELEMETRY_DIR"
+FAKE_FRAMES="red blue blue" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" tele3 "$WORK/shots" >/dev/null 2>&1
+check "capture span frames == the fake's shot count (3-frame run)" \
+  "$(grep -c "screenshot udid=" "$FAKE_ARGS_LOG")" "$(span_meta shot.capture.total frames)"
+check "one capture emits exactly one capture span (no per-frame spans)" "1" \
+  "$(tel_spans | grep -c '"span":"shot.capture.total"')"
+
+reset; rm -rf "$TELEMETRY_DIR"
+FAKE_FRAMES="red green blue blue" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" tele4 "$WORK/shots" >/dev/null 2>&1
+check "capture span frames == the fake's shot count (4-frame run)" \
+  "$(grep -c "screenshot udid=" "$FAKE_ARGS_LOG")" "$(span_meta shot.capture.total frames)"
+
+# --- a timed-out capture is a failure sample, not a slow success -------------
+reset; rm -rf "$TELEMETRY_DIR"
+FAKE_NEVER_SETTLE=1 SHOT_TIMEOUT=1 DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" tele-busy "$WORK/shots" >/dev/null 2>&1
+check "a never-settled capture's span carries ok=false" "yes" \
+  "$(tel_spans | python3 -c '
+import json, sys
+for l in sys.stdin:
+    r = json.loads(l)
+    if r["span"] == "shot.capture.total":
+        print("yes" if r["ok"] is False and r["meta"].get("stable") == 0 else "no"); break' 2>/dev/null)"
+
+# --- telemetry never escapes to the real HOME --------------------------------
+# With the registry override dropped, the default chain must land inside the
+# redirected HOME - proving nothing in this suite can write outside $WORK.
+reset
+env -u DEMO_SIM_REGISTRY -u DEMO_TELEMETRY_DIR HOME="$WORK/fake-home" \
+  FAKE_FRAMES="red red" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" homebound "$WORK/shots" >/dev/null 2>&1
+check "the default telemetry store derives from HOME" "yes" \
+  "$(ls "$WORK/fake-home/.claude/rn-sim-sessions/telemetry"/spans-*.jsonl >/dev/null 2>&1 && echo yes || echo no)"
 
 echo
 echo "documented behavior matches the scripts"

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -247,6 +247,54 @@ check "SKILL.md rejects a simulator per side, with the honesty rationale" "yes" 
   "$(grep -qi "simulator per side" "$SKILL_MD" && echo yes || echo no)"
 
 echo
+echo "bench (hermetic: counts first, loose clocks second)"
+
+# Policy: counted assertions catch loop-shaped regressions deterministically;
+# lower bounds prove waits exist and cannot flake on a slow machine; upper
+# bounds sit at >=5x locally measured (2s floor) and only catch runaway
+# sleeps. python3 is warmed once so no timed section pays interpreter start.
+python3 -c 'pass' 2>/dev/null
+py_now() { python3 -c 'import time; print("%.3f" % time.time())'; }
+
+# --- counted -----------------------------------------------------------------
+reset
+FAKE_FRAMES="red red" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" bench2 "$WORK/shots" >/dev/null 2>&1
+check "a two-frame settle shoots exactly 2 frames" "2" \
+  "$(grep -c "screenshot udid=" "$FAKE_ARGS_LOG")"
+
+# --- lower bound: the settle sleep exists ------------------------------------
+reset
+SHOT_SETTLE=0.5 FAKE_FRAMES="red red" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" bench-gap "$WORK/shots" >/dev/null 2>&1
+GAP=$(grep "screenshot udid=" "$FAKE_ARGS_LOG" | sed 's/.*t=//' | python3 -c '
+import sys
+ts = [float(l) for l in sys.stdin if l.strip()]
+print("%.3f" % (ts[1] - ts[0]) if len(ts) >= 2 else "nan")')
+check "the inter-shot gap honors the settle time (>=0.4s)" "yes" \
+  "$(python3 -c "print('yes' if float('$GAP') >= 0.4 else 'no ($GAP s)')" 2>/dev/null)"
+
+# --- upper bound: measured ~0.9s with fakes; 5s only catches runaway sleeps --
+reset
+T0=$(py_now)
+FAKE_FRAMES="red red" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" bench-fast "$WORK/shots" >/dev/null 2>&1
+DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
+check "a two-frame capture stays under the runaway budget (5s)" "yes" \
+  "$(python3 -c "print('yes' if float('$DUR') < 5 else 'no (${DUR}s)')")"
+
+# --- the bench's own mutation check: it must detect a planted regression -----
+# Two 3s-delayed shots put the same measurement well over the 5s budget; if
+# this stays under, the budget assertion above is measuring nothing.
+reset
+T0=$(py_now)
+FAKE_SHOT_DELAY=3 FAKE_FRAMES="red red" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/capture.sh" bench-slow "$WORK/shots" >/dev/null 2>&1
+DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
+check "a planted 3s shot delay is visible to the bench clock" "yes" \
+  "$(python3 -c "print('yes' if float('$DUR') >= 5 else 'no (${DUR}s)')")"
+
+echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -44,6 +44,8 @@ check "capture exits zero" "0" "$?"
 check "wrote the labelled png" "yes" "$([ -s "$WORK/shots/after.png" ] && echo yes || echo no)"
 check "output is a real PNG" "PNG" "$(magick identify -format '%m' "$WORK/shots/after.png" 2>/dev/null)"
 check "pinned the udid" "yes" "$(grep -q "screenshot udid=DEMO-UDID" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+check "shots go through the cached simctl path, not xcrun dispatch" "yes" \
+  "$(grep "screenshot udid=" "$FAKE_ARGS_LOG" | grep -qv "direct=1" && echo no || echo yes)"
 
 # --- stability polling ------------------------------------------------------
 # Three distinct frames then a repeat: capture must keep shooting until two

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -263,7 +263,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 96 assertions, ~35s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 97 assertions, ~40s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -267,7 +267,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 102 assertions, ~45s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 104 assertions, ~50s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -140,7 +140,11 @@ SKILL="$(git rev-parse --show-toplevel)"/.claude/skills/react-native-demo-videos
 ```
 
 Runs an unrecorded warm-up first (Maestro installs a driver on first contact
-with a device — ~20s with an installer on screen), starts the recorder, pads
+with a device — ~20s with an installer on screen) — unless it provably already
+happened: an earlier recording in this session, or a golden-sim clone whose
+baked driver still matches `maestro --version` (bless-golden.sh stamps the
+version; an upgraded CLI voids the bake and the warm-up runs again). Then it
+starts the recorder, pads
 lead-in and lead-out so the clip doesn't start or stop on a hard cut, runs the
 flow (forwarding `-e APP_ID` and `-e DEMO_PORT`), then interrupts the recorder
 and verifies with `ffprobe` that what came out is playable. Produces
@@ -263,7 +267,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 97 assertions, ~40s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 102 assertions, ~45s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -263,7 +263,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 88 assertions, ~30s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 96 assertions, ~35s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/flows/_warmup.yaml
+++ b/.claude/skills/react-native-demo-videos/flows/_warmup.yaml
@@ -1,9 +1,12 @@
-> Unrecorded warm-up. Maestro installs its driver onto a device the first time
-> it drives one — about 20 seconds with an installer visible on screen. Running
-> this before the recorder starts keeps that out of the demo.
->
-> APP_ID is injected by record-flow.sh (-e APP_ID=...) from DEMO_APP_ID_IOS on
-> an iOS simulator, DEMO_APP_ID_ANDROID on an Android emulator.
+# Unrecorded warm-up. Maestro installs its driver onto a device the first time
+# it drives one — about 20 seconds with an installer visible on screen. Running
+# this before the recorder starts keeps that out of the demo.
+#
+# APP_ID is injected by record-flow.sh (-e APP_ID=...) from DEMO_APP_ID_IOS on
+# an iOS simulator, DEMO_APP_ID_ANDROID on an Android emulator.
+#
+# `#` comments, never `>` prose lines: maestro 2.6.1 fails the whole flow at
+# parse time on a non-YAML header — silently, since warmup output is discarded.
 appId: ${APP_ID}
 ---
 - launchApp

--- a/.claude/skills/react-native-demo-videos/scripts/encode-demo.sh
+++ b/.claude/skills/react-native-demo-videos/scripts/encode-demo.sh
@@ -14,6 +14,12 @@
 
 set -uo pipefail
 
+# Telemetry is best-effort and optional: this skill still works when the
+# simulator skill's lib is absent (skills get copied around individually).
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
 IN=""; OUT=""; FORMAT=""; WIDTH=480; FPS=""; MAX_MB=10
 
 while [ $# -gt 0 ]; do
@@ -46,6 +52,10 @@ case "$FPS"   in ''|*[!0-9]*) die "--fps must be numeric, got '$FPS'" ;; esac
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/encode-demo.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
+
+T_ENCODE=$(tel_now)
+# Input duration makes the span a throughput number, not just a latency one.
+IN_DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$IN" 2>/dev/null || echo "")
 
 if [ "$FORMAT" = "webm" ]; then
   # VP9 at constant quality: -b:v 0 hands rate control entirely to -crf.
@@ -93,6 +103,8 @@ MB=$(python3 -c "print('%.1f' % ($BYTES/1048576.0))")
 echo "$FORMAT ${MB}MB (${WIDTH}px, ${FPS}fps) -> $OUT"
 
 OVER=$(python3 -c "print(1 if $BYTES > $MAX_MB*1048576 else 0)")
+tel_emit vid.encode.total "$T_ENCODE" fmt="$FORMAT" fps="$FPS" width="$WIDTH" \
+  in_dur_s="$IN_DUR" out_bytes="$BYTES" over="$OVER"
 if [ "$OVER" = "1" ]; then
   echo "WARNING: ${MB}MB exceeds the ${MAX_MB}MB budget." >&2
   echo "         Shorten the flow, or retry with --width $((WIDTH * 3 / 4))" >&2

--- a/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
+++ b/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
@@ -135,15 +135,37 @@ fi
 # and a progress bar at the head of every demo, so it happens before the
 # recorder starts. Failure here is not fatal: the real flow will report it.
 T_WARMUP=$(tel_now)
-if [ -z "$SKIP_WARMUP" ]; then
+# The warmup is only needed once per device per Maestro version - the driver
+# it installs persists. Three ways to know it already happened, checked in
+# order of directness (iOS only: the session markers live in the iOS session
+# dir, and an Android emulator never shares a device with an iOS session):
+#   manual   DEMO_SKIP_WARMUP=1, the caller's own judgment
+#   session  an earlier maestro run in this session left the warmed marker
+#   golden   the clone carries a driver baked by bless-golden.sh, and the
+#            stamped maestro version still matches - after a CLI upgrade the
+#            driver silently re-installs, so a mismatch must warm up again
+WARM_REASON=""
+if [ -n "$SKIP_WARMUP" ]; then
+  WARM_REASON="manual"
+elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/maestro-warmed" ]; then
+  WARM_REASON="session"
+elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/golden-stamp" ]; then
+  STAMP_MV=$(grep '^maestro-version=' "$DEMO_SESSION_DIR/golden-stamp" 2>/dev/null | cut -d= -f2- || true)
+  CUR_MV=$(maestro --version 2>/dev/null | head -1 || true)
+  if [ -n "$STAMP_MV" ] && [ "$STAMP_MV" = "$CUR_MV" ]; then
+    WARM_REASON="golden"
+  fi
+fi
+if [ -z "$WARM_REASON" ]; then
   WARMUP="$(dirname "${BASH_SOURCE[0]}")/../flows/_warmup.yaml"
   if [ -f "$WARMUP" ]; then
     echo "warming up the maestro driver..."
     maestro test --udid "$DEVICE" -e APP_ID="$APP_ID" "$WARMUP" >/dev/null 2>&1
+    [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && touch "$DEMO_SESSION_DIR/maestro-warmed" 2>/dev/null
   fi
   tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=0
 else
-  tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=1
+  tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=1 reason="$WARM_REASON"
 fi
 
 # --- Recorder ---------------------------------------------------------------
@@ -258,6 +280,11 @@ maestro test --udid "$DEVICE" -e APP_ID="$APP_ID" ${DEMO_PORT:+-e DEMO_PORT="$DE
 FLOW_RC=$?
 tel_emit vid.record.flow "$T_FLOW" platform="$PLATFORM" rc="$FLOW_RC" \
   ok="$([ "$FLOW_RC" -eq 0 ] && echo 1 || echo 0)"
+# A successful flow proves the driver works - later recordings in this
+# session need no warmup even if this one's was skipped manually.
+if [ "$FLOW_RC" -eq 0 ] && [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ]; then
+  touch "$DEMO_SESSION_DIR/maestro-warmed" 2>/dev/null || true
+fi
 
 sleep "$LEAD_OUT"
 T_STOP=$(tel_now)

--- a/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
+++ b/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
@@ -25,6 +25,12 @@
 
 set -uo pipefail
 
+# Telemetry is best-effort and optional: this skill still works when the
+# simulator skill's lib is absent (skills get copied around individually).
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
 LABEL=""; FLOW=""; OUTDIR="."
 UDID="${DEMO_UDID:-}"; SERIAL="${DEMO_ANDROID_SERIAL:-}"; FORCE=""
 LEAD_IN="${DEMO_LEAD_IN:-1.5}"     # a beat of the start state before the first tap
@@ -128,12 +134,16 @@ fi
 # with an installer visible on screen). Recording that would put a black screen
 # and a progress bar at the head of every demo, so it happens before the
 # recorder starts. Failure here is not fatal: the real flow will report it.
+T_WARMUP=$(tel_now)
 if [ -z "$SKIP_WARMUP" ]; then
   WARMUP="$(dirname "${BASH_SOURCE[0]}")/../flows/_warmup.yaml"
   if [ -f "$WARMUP" ]; then
     echo "warming up the maestro driver..."
     maestro test --udid "$DEVICE" -e APP_ID="$APP_ID" "$WARMUP" >/dev/null 2>&1
   fi
+  tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=0
+else
+  tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=1
 fi
 
 # --- Recorder ---------------------------------------------------------------
@@ -184,6 +194,7 @@ stop_recorder() {
 trap 'stop_recorder' EXIT INT TERM
 
 echo "recording $DEVICE -> $OUT"
+T_REC_START=$(tel_now)
 # The recorder is launched through a shim that resets SIGINT to its default
 # disposition before exec'ing.
 #
@@ -234,6 +245,7 @@ else
   done
   [ -n "$STARTED" ] || die "recorder never started writing $OUT (recorder process died)"
 fi
+tel_emit vid.record.start_wait "$T_REC_START" platform="$PLATFORM"
 
 sleep "$LEAD_IN"
 
@@ -241,11 +253,16 @@ sleep "$LEAD_IN"
 # APP_ID and DEMO_PORT are forwarded so flows can stay app-agnostic
 # (`appId: ${APP_ID}`) and clearState flows can re-pass the Metro redirect as a
 # launch argument. Unused variables are harmless.
+T_FLOW=$(tel_now)
 maestro test --udid "$DEVICE" -e APP_ID="$APP_ID" ${DEMO_PORT:+-e DEMO_PORT="$DEMO_PORT"} "$FLOW"
 FLOW_RC=$?
+tel_emit vid.record.flow "$T_FLOW" platform="$PLATFORM" rc="$FLOW_RC" \
+  ok="$([ "$FLOW_RC" -eq 0 ] && echo 1 || echo 0)"
 
 sleep "$LEAD_OUT"
+T_STOP=$(tel_now)
 stop_recorder
+tel_emit vid.record.stop "$T_STOP" platform="$PLATFORM"
 trap - EXIT INT TERM
 
 # --- Validate ---------------------------------------------------------------

--- a/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
+++ b/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
@@ -151,7 +151,13 @@ elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESS
   WARM_REASON="session"
 elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/golden-stamp" ]; then
   STAMP_MV=$(grep '^maestro-version=' "$DEMO_SESSION_DIR/golden-stamp" 2>/dev/null | cut -d= -f2- || true)
-  CUR_MV=$(maestro --version 2>/dev/null | head -1 || true)
+  # `maestro --version` boots a JVM (~3s, measured in the vid.record.warmup
+  # span) - cache it per session so only the first recording pays it.
+  CUR_MV=$(cat "$DEMO_SESSION_DIR/maestro-cli-version" 2>/dev/null || true)
+  if [ -z "$CUR_MV" ]; then
+    CUR_MV=$(maestro --version 2>/dev/null | head -1 || true)
+    [ -n "$CUR_MV" ] && echo "$CUR_MV" > "$DEMO_SESSION_DIR/maestro-cli-version" 2>/dev/null
+  fi
   if [ -n "$STAMP_MV" ] && [ "$STAMP_MV" = "$CUR_MV" ]; then
     WARM_REASON="golden"
   fi

--- a/.claude/skills/react-native-demo-videos/tests/fixtures/bin/maestro
+++ b/.claude/skills/react-native-demo-videos/tests/fixtures/bin/maestro
@@ -31,6 +31,6 @@ case "${1:-}" in
       *) sleep "${FAKE_FLOW_SECONDS:-0.3}"; exit "${FAKE_MAESTRO_RC:-0}" ;;
     esac
     ;;
-  --version) echo "2.6.1" ;;
+  --version) echo "${FAKE_MAESTRO_VERSION:-2.6.1}" ;;
   *) echo "fake maestro: unsupported subcommand '${1:-}'" >&2; exit 64 ;;
 esac

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -401,6 +401,20 @@ check "SKILL.md requires eyeballing extracted frames before publishing" "yes" \
   "$(grep -qi "extract" "$SKILL_MD" && grep -qi "frame" "$SKILL_MD" && echo yes || echo no)"
 
 echo
+echo "bench (hermetic: loose clock, runaway sleeps only)"
+
+# Real ffmpeg against the synthesized 2s clip; measured ~1-2s locally, so the
+# 15s budget only catches an order-of-magnitude regression (a dropped
+# hardware path, an accidental second decode of a full-res input).
+python3 -c 'pass' 2>/dev/null
+py_now() { python3 -c 'import time; print("%.3f" % time.time())'; }
+T0=$(py_now)
+"$SCRIPTS/encode-demo.sh" "$WORK/src.mov" "$WORK/bench.gif" --format gif --width 200 >/dev/null 2>&1
+DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
+check "gif encode of the 2s clip stays under the runaway budget (15s)" "yes" \
+  "$(python3 -c "print('yes' if float('$DUR') < 15 else 'no (${DUR}s)')")"
+
+echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -28,7 +28,10 @@ export DEMO_APP_ID_ANDROID=com.example.androidapp
 # Redirecting the registry keeps every test span inside $WORK (telemetry
 # derives its store from it).
 export DEMO_SIM_REGISTRY="$WORK/registry"
-unset DEMO_PORT DEMO_SESSION_DIR DEMO_SKIP_WARMUP 2>/dev/null || true
+# A shell with a live claimed session exports DEMO_UDID etc.; inherited, they
+# flip the host-OS platform default and every android test silently records
+# via simctl. The suite trusts only what each test sets explicitly.
+unset DEMO_PORT DEMO_SESSION_DIR DEMO_SKIP_WARMUP DEMO_UDID DEMO_ANDROID_SERIAL DEMO_HOST_OS 2>/dev/null || true
 
 printf 'DEMO-UDID|rn-demo-pr3712|Booted\n' > "$FAKE_DEVICES"
 printf 'emulator-5554|rn-demo-pr3712-avd|device\n' > "$FAKE_ADB_DEVICES"
@@ -387,6 +390,16 @@ DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
 check "a maestro upgrade voids the baked driver - warmup runs" "1" \
   "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
 
+# The version gate itself costs a ~3s JVM start, so it is cached per session.
+reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
+echo "maestro-version=2.6.1" > "$WSESS/golden-stamp"
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm6 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm7 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "the maestro version probe runs once per session, not per recording" "1" \
+  "$(grep -c "maestro --version" "$FAKE_ARGS_LOG")"
+
 reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
 DEMO_SKIP_WARMUP=1 DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
   "$SCRIPTS/record-flow.sh" warm5 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
@@ -436,6 +449,11 @@ check "SKILL.md warns clearState wipes the persisted redirect" "yes" \
   "$(grep -i "clearState" "$SKILL_MD" | grep -qi "redirect\|RCT_jsLocation\|8081" && echo yes || echo no)"
 check "SKILL.md before/after section uses the reload flip for JS-only changes" "yes" \
   "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
+# Real maestro (2.6.1) fails an entire flow at parse time if anything but
+# YAML precedes the header - and warmup output is discarded, so the failure
+# is silent. The fake maestro never parses YAML, hence this static gate.
+check "the warmup flow starts with YAML, not prose (maestro parse-fails on >)" "yes" \
+  "$(head -1 "$TESTS_DIR/../flows/_warmup.yaml" | grep -qE '^(#|appId:)' && echo yes || echo no)"
 check "SKILL.md teaches the launchApp arguments form" "yes" \
   "$(grep -q "RCT_jsLocation" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md requires eyeballing extracted frames before publishing" "yes" \

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -25,6 +25,9 @@ export FAKE_ARGS_LOG="$WORK/args.log"
 export DEMO_LEAD_IN=0.2 DEMO_LEAD_OUT=0.2
 export DEMO_APP_ID_IOS=com.example.demoapp
 export DEMO_APP_ID_ANDROID=com.example.androidapp
+# Redirecting the registry keeps every test span inside $WORK (telemetry
+# derives its store from it).
+export DEMO_SIM_REGISTRY="$WORK/registry"
 unset DEMO_PORT 2>/dev/null || true
 
 printf 'DEMO-UDID|rn-demo-pr3712|Booted\n' > "$FAKE_DEVICES"
@@ -348,6 +351,39 @@ sys.exit(1 if ('clearState' in raw and 'RCT_jsLocation' not in raw) else 0)
 " "$f"
   check "$name never clears state without re-passing the Metro redirect" "0" "$?"
 done
+
+echo
+echo "telemetry"
+
+TELEMETRY_DIR="$WORK/registry/telemetry"
+tel_spans() { cat "$TELEMETRY_DIR"/spans-*.jsonl 2>/dev/null; }
+
+# --- a recording emits its phase spans ---------------------------------------
+reset_logs; rm -rf "$TELEMETRY_DIR"
+DEMO_UDID=DEMO-UDID "$SCRIPTS/record-flow.sh" tele "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "record run exits zero with telemetry on" "0" "$?"
+for span in vid.record.warmup vid.record.start_wait vid.record.flow vid.record.stop; do
+  check "recording emits $span" "1" "$(tel_spans | grep -c "\"span\":\"$span\"")"
+done
+check "the warmup span says it was not skipped" "yes" \
+  "$(tel_spans | grep '"span":"vid.record.warmup"' | grep -q '"skipped":0' && echo yes || echo no)"
+
+reset_logs; rm -rf "$TELEMETRY_DIR"
+DEMO_SKIP_WARMUP=1 DEMO_UDID=DEMO-UDID "$SCRIPTS/record-flow.sh" tele2 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "a skipped warmup is labelled skipped, not silently absent" "yes" \
+  "$(tel_spans | grep '"span":"vid.record.warmup"' | grep -q '"skipped":1' && echo yes || echo no)"
+
+# --- encode span carries the fields that make it a throughput number ---------
+rm -rf "$TELEMETRY_DIR"
+"$SCRIPTS/encode-demo.sh" "$WORK/out/tele2.mov" "$WORK/tele.gif" --format gif --width 200 >/dev/null 2>&1
+check "encode emits vid.encode.total with format and size" "yes" \
+  "$(tel_spans | python3 -c '
+import json, sys
+for l in sys.stdin:
+    r = json.loads(l)
+    if r["span"] == "vid.encode.total":
+        m = r["meta"]
+        print("yes" if m.get("fmt") == "gif" and isinstance(m.get("out_bytes"), int) and m["out_bytes"] > 0 and m.get("in_dur_s") not in ("", None) else "no"); break' 2>/dev/null)"
 
 echo
 echo "documented behavior matches the scripts"

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -28,7 +28,7 @@ export DEMO_APP_ID_ANDROID=com.example.androidapp
 # Redirecting the registry keeps every test span inside $WORK (telemetry
 # derives its store from it).
 export DEMO_SIM_REGISTRY="$WORK/registry"
-unset DEMO_PORT 2>/dev/null || true
+unset DEMO_PORT DEMO_SESSION_DIR DEMO_SKIP_WARMUP 2>/dev/null || true
 
 printf 'DEMO-UDID|rn-demo-pr3712|Booted\n' > "$FAKE_DEVICES"
 printf 'emulator-5554|rn-demo-pr3712-avd|device\n' > "$FAKE_ADB_DEVICES"
@@ -351,6 +351,47 @@ sys.exit(1 if ('clearState' in raw and 'RCT_jsLocation' not in raw) else 0)
 " "$f"
   check "$name never clears state without re-passing the Metro redirect" "0" "$?"
 done
+
+echo
+echo "warmup skip"
+
+# The warmup is a one-time driver install per device per maestro version;
+# these pin the three legitimate skip paths and the one that must NOT skip.
+WSESS="$WORK/warm-session"
+
+reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm1 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "the first recording of a session warms up" "1" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+reset_logs
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm2 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "the second recording in the same session skips it" "0" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+
+reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
+echo "maestro-version=2.6.1" > "$WSESS/golden-stamp"
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm3 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "a clone with a version-matched baked driver skips the warmup" "0" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+
+# The driver is version-locked: an upgraded CLI reinstalls it, so a stamped
+# version that no longer matches must warm up - the fake's clone would let a
+# stale skip pass silently otherwise.
+reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
+echo "maestro-version=1.0.0" > "$WSESS/golden-stamp"
+DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm4 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "a maestro upgrade voids the baked driver - warmup runs" "1" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+
+reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
+DEMO_SKIP_WARMUP=1 DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
+  "$SCRIPTS/record-flow.sh" warm5 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
+check "the manual DEMO_SKIP_WARMUP override still works" "0" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
 
 echo
 echo "telemetry"

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -254,12 +254,16 @@ eval "$("$SKILL/scripts/claim-session.sh" 3712)"
 ```
 
 `bless-golden.sh` verifies the device is this session's (same ownership gate as
-release), stops the session's Metro, shuts the device down, renames it to
-`${DEMO_SIM_PREFIX:-rn-demo}-golden` (swapping out and deleting any previous
-golden — exactly one device ever carries the name), writes a stamp
-(`sha`/`date`/`device-type`/`runtime`), and adopts the session: port freed,
-manifest gone, nothing left to release. Both the swap and claim's clone run
-under a shared lock, so a clone can never race a re-bless.
+release), stops the session's Metro, **bakes the Maestro driver** (runs the
+videos skill's warm-up once, so every clone skips the ~20s per-recording
+warm-up; needs `DEMO_APP_ID_IOS` and maestro on PATH), shuts the device down,
+renames it to `${DEMO_SIM_PREFIX:-rn-demo}-golden` (swapping out and deleting
+any previous golden — exactly one device ever carries the name), writes a
+stamp (`sha`/`date`/`device-type`/`runtime`/`maestro-version`), and adopts the
+session: port freed, manifest gone, nothing left to release. Both the swap and
+claim's clone run under a shared lock, so a clone can never race a re-bless.
+The driver is version-locked — after a maestro upgrade, claim prints a
+re-bless note and recordings warm up again until someone re-blesses.
 
 **Staleness is judged, not guessed — and mechanically.** Bless hashes the
 build's `ios/Podfile.lock` into the stamp (`--lockfile` overrides the default
@@ -306,7 +310,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 189 assertions, ~90s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 197 assertions, ~100s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -281,13 +281,32 @@ thing — re-bless with a fresh login. Opt out of cloning with
 `DEMO_SIM_GOLDEN=<device name>`. The reaper never touches the golden: it has
 no session, and the name gate refuses it like any foreign device.
 
+## Telemetry: Where the Time Goes
+
+Every script emits one JSON line per phase (claim/boot/reload/capture/
+warmup/flow/encode/push) into a local spans file under the session registry —
+local only, nothing leaves the machine; `DEMO_TELEMETRY=0` disables. Rank the
+bottlenecks, or verify an optimization actually optimized:
+
+```bash
+"$SKILL/scripts/spans-report.sh"                      # ranked by total time, last 7d
+"$SKILL/scripts/spans-report.sh" --compare <rev> <rev>  # before/after a change
+```
+
+Failure samples (a timed-out capture) sit in their own FAILED rows and never
+inflate a latency percentile; claims are split by origin because reclaim,
+clone and create are three different distributions. When you add a new phase
+worth measuring, emit through `lib/telemetry.sh` (`tel_now`/`tel_emit`/
+`tel_span`) and never from inside a hot loop — time the loop once and put the
+count in meta.
+
 ## After Editing the Scripts
 
 The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 173 assertions, ~75s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 186 assertions, ~80s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -306,7 +306,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 186 assertions, ~80s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 189 assertions, ~90s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -287,7 +287,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 155 assertions, ~60s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 173 assertions, ~75s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -279,6 +279,13 @@ lockfile), fall back to diffing native paths against the stamp's SHA:
 git -C /path/to/your-app log <stamp-sha>..origin/main -- ios/ package.json yarn.lock
 ```
 
+**A fresh clone can refuse to launch the app** — `simctl launch` fails with
+`FBSOpenApplicationServiceErrorDomain ... denied by service delegate
+(SBMainWorkspace)` because the cloned SpringBoard's app registration is
+stale. The fix is a plain `simctl install` of the same build over it (an
+upgrade install: re-registers the app, **keeps the data container and the
+login**), then launch again. A shutdown/boot cycle alone does not clear it.
+
 A clone that comes up logged out (staging sessions do expire) means the same
 thing — re-bless with a fresh login. Opt out of cloning with
 `DEMO_SIM_GOLDEN=none`, or point at a differently named golden with

--- a/.claude/skills/react-native-ios-simulator/bench/live.sh
+++ b/.claude/skills/react-native-ios-simulator/bench/live.sh
@@ -1,0 +1,267 @@
+#!/bin/bash
+# Live capture/recording benchmark - the numbers that decide which
+# optimization is worth building. Report-only: no assertions (machine
+# variance), one JSON artifact per run plus a printed summary.
+#
+# Requires a claimed session (eval claim-session.sh first) and only ever
+# touches that session's simulator - every isolation rule of the skill
+# applies unchanged. The measurement loops run inside ONE python3 process
+# using time.monotonic() around subprocess calls, so the interpreter cost is
+# paid once, outside every measured interval - bash-timing each shot would
+# add two ~30ms spawns per sample and distort the distribution it measures.
+#
+# What it measures and why:
+#   shot latency distribution (xN)   the settle-sleep policy depends on the
+#                                    p50/p95 of ONE shot, not a mean
+#   xcrun dispatch vs direct simctl  if `xcrun` resolution costs 50-150ms per
+#                                    shot, caching $(xcrun -f simctl) is free
+#   png vs jpeg screenshot           encode time is part of shot latency
+#   shasum vs cmp frame compare      is the settle loop's hash cost real?
+#   capture settle at gap 0/0.3/0.6  does the sleep dominate, or the shot?
+#   recorder start/stop latency      how much of every recording is overhead
+#   encode throughput per codec      libx264 vs h264_videotoolbox, VP9
+#                                    cpu-used, single- vs double-decode GIF
+#
+# Not measured here: Metro first-bundle (needs an app worktree; measured in
+# real sessions by hand) and Maestro warmup decomposition (needs the app
+# installed and a driver state to compare; run a virgin-vs-warm pair manually
+# when gating the warmup-skip optimization).
+#
+# Usage: bench/live.sh [--shots N] [--skip-record] [--smoke] [--out FILE]
+#   --shots        samples per latency distribution (default 15)
+#   --skip-record  skip the recorder+encode sections (no clip written)
+#   --smoke        fake-backed schema check for the test suite: shot section
+#                  only, n=2, no direct-simctl probing
+#   --out          JSON path (default: <telemetry dir>/bench-<stamp>.json)
+
+set -euo pipefail
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+SHOTS=15; SKIP_RECORD=""; SMOKE=""; OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --shots)       SHOTS="${2:?--shots needs a number}"; shift 2 ;;
+    --skip-record) SKIP_RECORD=1; shift ;;
+    --smoke)       SMOKE=1; SKIP_RECORD=1; SHOTS=2; shift ;;
+    --out)         OUT="${2:?--out needs a path}"; shift 2 ;;
+    *) die "unknown argument '$1'" ;;
+  esac
+done
+
+# The bench only ever touches a simulator this agent claimed - benchmarking
+# whatever device happens to be booted would hammer the user's simulator with
+# screenshot and recording load.
+[ -n "${DEMO_UDID:-}" ] || die "no claimed session: eval claim-session.sh first (the bench must never touch a device you did not claim)"
+
+TEL_DIR="${DEMO_TELEMETRY_DIR:-${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}/telemetry}"
+mkdir -p "$TEL_DIR"
+[ -n "$OUT" ] || OUT="$TEL_DIR/bench-$(date +%Y%m%d-%H%M%S).json"
+
+CAPTURE="$(dirname "${BASH_SOURCE[0]}")/../../react-native-demo-screenshots/scripts/capture.sh"
+
+BENCH_UDID="$DEMO_UDID" BENCH_SHOTS="$SHOTS" BENCH_SMOKE="${SMOKE:-0}" \
+BENCH_SKIP_RECORD="${SKIP_RECORD:-0}" BENCH_OUT="$OUT" BENCH_CAPTURE="$CAPTURE" \
+python3 <<'PY'
+import json
+import os
+import shutil
+import signal
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+UDID = os.environ["BENCH_UDID"]
+SHOTS = int(os.environ["BENCH_SHOTS"])
+SMOKE = os.environ["BENCH_SMOKE"] == "1"
+SKIP_RECORD = os.environ["BENCH_SKIP_RECORD"] == "1"
+OUT = os.environ["BENCH_OUT"]
+CAPTURE = os.environ["BENCH_CAPTURE"]
+
+tmp = tempfile.mkdtemp(prefix="live-bench.")
+report = {"v": 1, "udid": UDID, "smoke": SMOKE,
+          "context": {}, "shot_latency": {}, "compare_cost": None,
+          "settle_capture": {}, "recorder": None, "encode": None}
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def timed(cmd, n, ok_codes=(0,)):
+    """n timed invocations -> list of seconds; None on first failure.
+    ok_codes: cmp -s legitimately exits 1 on differing files - still a sample."""
+    out = []
+    for _ in range(n):
+        t0 = time.monotonic()
+        r = run(cmd)
+        dt = time.monotonic() - t0
+        if r.returncode not in ok_codes:
+            return None
+        out.append(round(dt, 4))
+    return out
+
+
+def dist(samples):
+    if not samples:
+        return None
+    s = sorted(samples)
+    return {"n": len(s), "p50": s[len(s) // 2], "p95": s[max(0, -(-len(s) * 95 // 100) - 1)],
+            "min": s[0], "max": s[-1], "mean": round(sum(s) / len(s), 4)}
+
+
+def sysctl(name):
+    r = run(["sysctl", "-n", name])
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+# --- context: numbers without context cannot be compared across runs ---------
+report["context"] = {
+    "date": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    "model": sysctl("hw.model"),
+    "cpu": sysctl("machdep.cpu.brand_string"),
+    "loadavg": os.getloadavg(),
+    "maestro": (run(["maestro", "--version"]).stdout.strip() if shutil.which("maestro") else ""),
+    "ffmpeg": (run(["ffmpeg", "-version"]).stdout.splitlines()[0] if shutil.which("ffmpeg") else ""),
+}
+if not SMOKE:
+    r = run(["xcrun", "simctl", "list", "devices", "-j"])
+    try:
+        for rt, devs in json.loads(r.stdout)["devices"].items():
+            if any(d["udid"] == UDID for d in devs):
+                report["context"]["runtime"] = rt
+    except Exception:
+        pass
+
+# --- shot latency distributions ----------------------------------------------
+shot = os.path.join(tmp, "s.png")
+report["shot_latency"]["png_xcrun"] = dist(timed(["xcrun", "simctl", "io", UDID, "screenshot", shot], SHOTS))
+
+if not SMOKE:
+    r = run(["xcrun", "-f", "simctl"])
+    simctl = r.stdout.strip() if r.returncode == 0 else ""
+    if simctl:
+        report["shot_latency"]["png_direct"] = dist(timed([simctl, "io", UDID, "screenshot", shot], SHOTS))
+        jpg = os.path.join(tmp, "s.jpeg")
+        report["shot_latency"]["jpeg_direct"] = dist(timed([simctl, "io", UDID, "screenshot", "--type=jpeg", jpg], SHOTS))
+
+    # --- frame-compare cost: is the settle loop's shasum worth optimizing? ---
+    shot2 = os.path.join(tmp, "s2.png")
+    run(["xcrun", "simctl", "io", UDID, "screenshot", shot2])
+    if os.path.exists(shot) and os.path.exists(shot2):
+        report["compare_cost"] = {
+            "shasum": dist(timed(["shasum", "-a", "256", shot], 20)),
+            "cmp": dist(timed(["cmp", "-s", shot, shot2], 20, ok_codes=(0, 1))),
+        }
+
+    # --- capture.sh settle convergence at different gaps ---------------------
+    for gap in ("0.6", "0.3", "0"):
+        env = dict(os.environ, SHOT_SETTLE=gap, DEMO_UDID=UDID)
+        t0 = time.monotonic()
+        r = subprocess.run([CAPTURE, "bench-settle", tmp], env=env,
+                           capture_output=True, text=True)
+        report["settle_capture"]["gap_" + gap] = (
+            round(time.monotonic() - t0, 3) if r.returncode == 0 else None)
+
+# --- recorder start/stop latency + a clip for the encode section -------------
+if not SKIP_RECORD:
+    clip = os.path.join(tmp, "clip.mov")
+    t0 = time.monotonic()
+    rec = subprocess.Popen(
+        ["xcrun", "simctl", "io", UDID, "recordVideo", "--codec", "h264", clip],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        preexec_fn=lambda: signal.signal(signal.SIGINT, signal.SIG_DFL))
+    start_wait = None
+    while time.monotonic() - t0 < 3.0:
+        if os.path.exists(clip) and os.path.getsize(clip) > 0:
+            start_wait = round(time.monotonic() - t0, 3)
+            break
+        if rec.poll() is not None:
+            break
+        time.sleep(0.05)
+    time.sleep(4)   # a few seconds of material for the encode section
+    t1 = time.monotonic()
+    rec.send_signal(signal.SIGINT)
+    try:
+        rec.wait(timeout=15)
+        finalize = round(time.monotonic() - t1, 3)
+    except subprocess.TimeoutExpired:
+        rec.kill()
+        finalize = None
+    report["recorder"] = {
+        "start_wait_s": start_wait,          # None on new runtimes that buffer in memory
+        "finalize_s": finalize,
+        "clip_bytes": os.path.getsize(clip) if os.path.exists(clip) else 0,
+    }
+
+    # --- encode throughput per codec ----------------------------------------
+    if report["recorder"]["clip_bytes"] > 0 and shutil.which("ffmpeg"):
+        encoders = run(["ffmpeg", "-hide_banner", "-encoders"]).stdout
+        vf = "fps=24,scale=480:-2:flags=lanczos"
+        enc = {}
+
+        def encode(name, args, outfile):
+            t0 = time.monotonic()
+            r = run(["ffmpeg", "-y", "-v", "error", "-i", clip] + args + [outfile])
+            enc[name] = (round(time.monotonic() - t0, 3) if r.returncode == 0
+                         and os.path.getsize(outfile) > 0 else None)
+
+        encode("mp4_libx264", ["-vf", vf, "-c:v", "libx264", "-profile:v", "baseline",
+                               "-pix_fmt", "yuv420p", "-crf", "28", "-an"], os.path.join(tmp, "o1.mp4"))
+        if "h264_videotoolbox" in encoders:
+            encode("mp4_videotoolbox", ["-vf", vf, "-c:v", "h264_videotoolbox", "-q:v", "50",
+                                        "-pix_fmt", "yuv420p", "-an"], os.path.join(tmp, "o2.mp4"))
+        encode("webm_vp9_default", ["-vf", vf, "-c:v", "libvpx-vp9", "-crf", "34", "-b:v", "0",
+                                    "-row-mt", "1", "-pix_fmt", "yuv420p", "-an"], os.path.join(tmp, "o3.webm"))
+        encode("webm_vp9_cpu4", ["-vf", vf, "-c:v", "libvpx-vp9", "-crf", "34", "-b:v", "0",
+                                 "-row-mt", "1", "-cpu-used", "4", "-pix_fmt", "yuv420p", "-an"],
+               os.path.join(tmp, "o4.webm"))
+        # Current GIF pipeline decodes the full-res input twice...
+        t0 = time.monotonic()
+        pal = os.path.join(tmp, "pal.png")
+        gvf = "fps=12,scale=480:-1:flags=lanczos"
+        ok1 = run(["ffmpeg", "-y", "-v", "error", "-i", clip, "-vf", gvf + ",palettegen=stats_mode=diff", pal]).returncode == 0
+        ok2 = ok1 and run(["ffmpeg", "-y", "-v", "error", "-i", clip, "-i", pal, "-lavfi",
+                           gvf + ",paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle",
+                           os.path.join(tmp, "o5.gif")]).returncode == 0
+        enc["gif_double_decode"] = round(time.monotonic() - t0, 3) if ok2 else None
+        # ...vs pre-scaling once and paletting the small intermediate.
+        t0 = time.monotonic()
+        small = os.path.join(tmp, "small.mov")
+        ok1 = run(["ffmpeg", "-y", "-v", "error", "-i", clip, "-vf", gvf, "-c:v", "libx264",
+                   "-crf", "18", "-an", small]).returncode == 0
+        ok2 = ok1 and run(["ffmpeg", "-y", "-v", "error", "-i", small, "-vf", "palettegen=stats_mode=diff", pal]).returncode == 0
+        ok3 = ok2 and run(["ffmpeg", "-y", "-v", "error", "-i", small, "-i", pal, "-lavfi",
+                           "paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle",
+                           os.path.join(tmp, "o6.gif")]).returncode == 0
+        enc["gif_single_decode"] = round(time.monotonic() - t0, 3) if ok3 else None
+        report["encode"] = enc
+
+with open(OUT, "w") as f:
+    json.dump(report, f, indent=2)
+
+print("live bench -> %s" % OUT)
+sl = report["shot_latency"].get("png_xcrun")
+if sl:
+    print("shot latency (xcrun, png): p50 %.2fs  p95 %.2fs  n=%d" % (sl["p50"], sl["p95"], sl["n"]))
+for k in ("png_direct", "jpeg_direct"):
+    d = report["shot_latency"].get(k)
+    if d:
+        print("shot latency (%s):%s p50 %.2fs" % (k, " " * max(1, 12 - len(k)), d["p50"]))
+cc = report["compare_cost"] or {}
+if cc.get("shasum") and cc.get("cmp"):
+    print("frame compare: shasum p50 %.3fs vs cmp p50 %.3fs" %
+          (cc["shasum"]["p50"], cc["cmp"]["p50"]))
+for gap, dur in sorted(report["settle_capture"].items()):
+    print("capture settle %s: %s" % (gap, ("%.2fs" % dur) if dur else "failed"))
+if report["recorder"]:
+    print("recorder: start_wait=%s finalize=%s" %
+          (report["recorder"]["start_wait_s"], report["recorder"]["finalize_s"]))
+if report["encode"]:
+    for name, dur in sorted(report["encode"].items(), key=lambda kv: kv[1] or 9e9):
+        print("encode %-20s %s" % (name, ("%.2fs" % dur) if dur else "unavailable"))
+
+shutil.rmtree(tmp, ignore_errors=True)
+PY

--- a/.claude/skills/react-native-ios-simulator/lib/telemetry.sh
+++ b/.claude/skills/react-native-ios-simulator/lib/telemetry.sh
@@ -1,0 +1,156 @@
+# Local span telemetry for the demo skills. Source this; never execute it.
+#
+# Purpose: every skill script emits one JSON line per meaningful phase so
+# `spans-report.sh` can rank where capture time actually goes. Local files
+# only - no network, no export, nothing leaves the machine.
+#
+# The API has no start/end pairing on purpose: macOS bash 3.2 has no
+# associative arrays, so paired state either breaks nesting or forces a
+# hand-rolled stack. The start time lives in a variable the caller owns:
+#
+#   t0=$(tel_now)
+#   xcrun simctl boot "$UDID"
+#   tel_emit sim.claim.boot "$t0"
+#
+#   tel_span sim.bless.total udid="$UDID" -- some-command args...
+#
+# Ground rules, enforced by the test suite:
+# - Emitting can NEVER fail the caller. Every instrumented script runs
+#   `set -euo pipefail`; telemetry that can abort a claim is worse than no
+#   telemetry. All failure paths end in `|| true` / `return 0`.
+# - No spans inside hot loops (settle loops, poll loops). A python3 spawn is
+#   ~20-50ms; per-frame spans would distort the very numbers they measure.
+#   Time the loop once and record counts in meta instead.
+# - One record = one line = one O_APPEND write; appends of this size do not
+#   interleave on APFS, so concurrent agents share one file safely.
+# - Wall clock only (two separate spawns cannot share a monotonic clock);
+#   negative durations are clamped to 0 and flagged meta.clock_skew=1.
+#
+# Record schema (v1):
+#   {"v":1,"ts":<epoch>,"dur_ms":<int>,"span":"sim.claim.total",
+#    "skill":"sim","session":"blink-demo-pr4092","run_id":"<pid.ts>",
+#    "rev":"<git short sha>","ok":true,"meta":{...}}
+# `skill` is the span's first dot-segment. `rev` is the skills checkout's
+# HEAD, cached once per process - it is what makes before/after comparison
+# (`spans-report.sh --compare`) possible.
+#
+# Config:
+#   DEMO_TELEMETRY=0        kill switch - no files, no spawns
+#   DEMO_TELEMETRY_DIR      span dir; defaults inside the session registry so
+#                           the test suites' DEMO_SIM_REGISTRY redirect
+#                           isolates test telemetry automatically
+#
+# Explicit non-goal: Metro start -> first bundle. Metro is started by the
+# agent from SKILL.md prose, not by any script, so there is no script-owned
+# instrumentation point; only bench/live.sh measures it.
+
+TEL_ENABLED=1
+[ "${DEMO_TELEMETRY:-1}" = "0" ] && TEL_ENABLED=0
+
+# One run_id per process tree: reconstructing "this capture's spans" from a
+# shared machine-wide file needs more than the session name, which conflates
+# re-runs.
+if [ -z "${TEL_RUN_ID:-}" ]; then
+  TEL_RUN_ID="$$.$(date +%s)"
+  export TEL_RUN_ID
+fi
+
+# Which code produced the span - cached once, exported so child scripts
+# (claim calls reap, record calls maestro wrappers) reuse it for free.
+if [ -z "${TEL_REV:-}" ]; then
+  TEL_REV=$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --short HEAD 2>/dev/null || echo "")
+  export TEL_REV
+fi
+
+tel_dir() {
+  echo "${DEMO_TELEMETRY_DIR:-${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}/telemetry}"
+}
+
+# tel_now -> epoch seconds as a float. Exactly one python3 spawn.
+tel_now() {
+  [ "$TEL_ENABLED" = "1" ] || { echo 0; return 0; }
+  python3 -c 'import time; print("%.6f" % time.time())' 2>/dev/null || echo 0
+}
+
+# tel_emit <span> <t0> [k=v ...]
+# Builds the record and takes the end timestamp in ONE python3 spawn, then
+# appends it in one write. Never fails the caller.
+tel_emit() {
+  [ "$TEL_ENABLED" = "1" ] || return 0
+  local span="${1:-}" t0="${2:-0}"
+  [ -n "$span" ] || return 0
+  shift 2 2>/dev/null || return 0
+  local dir line
+  dir=$(tel_dir)
+  mkdir -p "$dir" 2>/dev/null || return 0
+  line=$(TEL_SPAN="$span" TEL_T0="$t0" TEL_SESSION="${DEMO_SIM_NAME:-}" \
+    python3 - "$@" <<'PY' 2>/dev/null
+import json, os, sys, time
+t1 = time.time()
+try:
+    t0 = float(os.environ.get("TEL_T0") or 0)
+except ValueError:
+    t0 = 0.0
+raw_ms = int(round((t1 - t0) * 1000)) if t0 > 0 else 0
+span = os.environ.get("TEL_SPAN", "")
+rec = {
+    "v": 1,
+    "ts": round(t1, 3),
+    "dur_ms": max(raw_ms, 0),
+    "span": span,
+    "skill": span.split(".", 1)[0],
+    "session": os.environ.get("TEL_SESSION", ""),
+    "run_id": os.environ.get("TEL_RUN_ID", ""),
+    "rev": os.environ.get("TEL_REV", ""),
+    "ok": True,
+    "meta": {},
+}
+if t0 > 0 and raw_ms < 0:
+    rec["meta"]["clock_skew"] = 1
+for kv in sys.argv[1:]:
+    if "=" not in kv:
+        continue
+    k, v = kv.split("=", 1)
+    if k == "ok":
+        rec["ok"] = v not in ("0", "false", "")
+    else:
+        try:
+            rec["meta"][k] = int(v)
+        except ValueError:
+            try:
+                rec["meta"][k] = float(v)
+            except ValueError:
+                rec["meta"][k] = v
+print(json.dumps(rec, separators=(",", ":")))
+PY
+  ) || return 0
+  [ -n "$line" ] || return 0
+  # stderr silenced FIRST: if the append-open itself fails (unwritable dir),
+  # the shell reports that failure before later redirects would apply.
+  printf '%s\n' "$line" 2>/dev/null >> "$dir/spans-$(date +%Y%m).jsonl" || true
+  return 0
+}
+
+# tel_span <span> [k=v ...] -- cmd args...
+# Times one command. Transparent: preserves exit code, stdout and stderr, so
+# a caller under `set -e` still fails when the command fails - only the
+# telemetry itself is swallowed.
+tel_span() {
+  local span="${1:-}"
+  [ -n "$span" ] || return 0
+  shift
+  local metas=() rc=0 t0
+  while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+    metas[${#metas[@]}]="$1"
+    shift
+  done
+  [ $# -gt 0 ] && shift   # the --
+  t0=$(tel_now)
+  "$@" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    tel_emit "$span" "$t0" ${metas[@]+"${metas[@]}"} ok=1 || true
+  else
+    tel_emit "$span" "$t0" ${metas[@]+"${metas[@]}"} ok=0 rc="$rc" || true
+  fi
+  return $rc
+}

--- a/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
@@ -102,6 +102,25 @@ if [ -n "$METRO_PID" ] && kill -0 "$METRO_PID" 2>/dev/null; then
   echo "stopped Metro pid $METRO_PID (port $PORT)"
 fi
 
+# --- Bake the Maestro driver -------------------------------------------------
+# Maestro installs a driver app pair on first contact with a device (~20s,
+# installer on screen). Doing it here, once, means every clone inherits the
+# driver and record-flow.sh can skip its per-recording warmup - as long as
+# the CLI version still matches (the driver is version-locked; the stamp
+# below is what a later claim compares against maestro --version).
+MAESTRO_VERSION=""
+WARMUP_FLOW="$(dirname "${BASH_SOURCE[0]}")/../../react-native-demo-videos/flows/_warmup.yaml"
+if command -v maestro >/dev/null 2>&1 && [ -f "$WARMUP_FLOW" ] && [ -n "${DEMO_APP_ID_IOS:-}" ]; then
+  if maestro test --udid "$UDID" -e APP_ID="$DEMO_APP_ID_IOS" "$WARMUP_FLOW" >/dev/null 2>&1; then
+    MAESTRO_VERSION=$(maestro --version 2>/dev/null | head -1 || true)
+    echo "baked the maestro driver (${MAESTRO_VERSION:-unknown version})"
+  else
+    echo "note: maestro warmup failed - the golden carries no baked driver; clones warm up themselves" >&2
+  fi
+else
+  echo "note: driver not baked (needs maestro, the videos skill's warmup flow, and DEMO_APP_ID_IOS) - clones warm up on first recording" >&2
+fi
+
 # Ours by the gate above, so shutting it down is as safe as release doing it.
 xcrun simctl shutdown "$UDID" 2>/dev/null || true
 
@@ -142,6 +161,10 @@ date=$(date +%Y-%m-%dT%H:%M:%S)
 device-type=$DEVICE_TYPE
 runtime=$RUNTIME
 EOF
+# Only a successfully baked driver earns a version line - record-flow.sh
+# treats its presence as "the clone is warm" and must never trust a bless
+# whose warmup failed.
+[ -n "$MAESTRO_VERSION" ] && echo "maestro-version=$MAESTRO_VERSION" >> "$GOLDEN_DIR/stamp"
 # The lockfile hash is what turns "is this golden's native build stale?" from
 # git archaeology into an instant claim-time comparison.
 if [ -f "$LOCKFILE" ]; then

--- a/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/bless-golden.sh
@@ -34,6 +34,12 @@
 
 set -euo pipefail
 
+# Telemetry is best-effort - a broken lib must never block a bless.
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_BLESS=$(tel_now)
+
 die() { echo "FATAL: $*" >&2; exit 1; }
 
 PR="${1:?usage: bless-golden.sh <pr-number> [--sha <sha>]}"
@@ -177,6 +183,8 @@ if [ -n "$PORT" ] && [ "$(cat "$REGISTRY/ports/$PORT/owner" 2>/dev/null)" = "$SI
   rm -rf "$REGISTRY/ports/$PORT"
 fi
 rm -rf "$SESSION_DIR"
+
+DEMO_SIM_NAME="$SIM_NAME" tel_emit sim.bless.total "$T_BLESS" golden="$GOLDEN_NAME" udid="$UDID"
 
 echo "blessed $GOLDEN_NAME ($UDID) - stamp: $GOLDEN_DIR/stamp"
 sed 's/^/  /' "$GOLDEN_DIR/stamp"

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -12,6 +12,13 @@
 
 set -euo pipefail
 
+# Telemetry is best-effort: a broken, unreadable or absent lib must never
+# break a claim - the fallbacks below turn every tel_* call into a no-op.
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_CLAIM=$(tel_now)
+
 PR="${1:?usage: claim-session.sh <pr-number> [device-type] [runtime]}"
 DEVICE_TYPE="${2:-iPhone 16 Pro}"
 RUNTIME="${3:-}"
@@ -39,9 +46,13 @@ SIM_NAME="${DEMO_SIM_PREFIX:-rn-demo}-pr${PR}"
 # once. The prefix is what keeps their sessions apart.
 SESSION_DIR="$REGISTRY/${SIM_NAME}"
 
+DEMO_SIM_NAME="$SIM_NAME"   # session label for telemetry spans
+
 # Sweep simulators from sessions released more than the TTL ago (default 72h),
 # then un-mark our own session: an active claim is never reaped.
+T_REAP=$(tel_now)
 "$(dirname "${BASH_SOURCE[0]}")/reap-stale.sh" >/dev/null 2>&1 || true
+tel_emit sim.claim.reap "$T_REAP"
 mkdir -p "$REGISTRY/ports" "$SESSION_DIR"
 rm -f "$SESSION_DIR/released-at"
 
@@ -93,6 +104,10 @@ fi
 # --- Simulator ---------------------------------------------------------------
 # Reuse our own named sim if a previous run left it; never adopt one we did not
 # name, because the name is the only ownership marker release-session trusts.
+# CLAIM_ORIGIN labels the telemetry span: reclaim (~1s), clone (~seconds) and
+# create (~a minute) are three different distributions, and aggregating them
+# under one name would make every percentile a lie.
+CLAIM_ORIGIN="reclaim"
 UDID=$(xcrun simctl list devices -j \
   | python3 -c "
 import json,sys
@@ -143,6 +158,7 @@ for _, devices in json.load(sys.stdin)['devices'].items():
         UDID=$("$(dirname "${BASH_SOURCE[0]}")/with-lock.sh" golden 300 \
           xcrun simctl clone "$GOLDEN_UDID" "$SIM_NAME" 2>/dev/null || true)
         if [ -n "$UDID" ]; then
+          CLAIM_ORIGIN="cloned-from-golden"
           echo "cloned-from-golden" > "$SESSION_DIR/origin"
           echo "$GOLDEN_NAME" > "$SESSION_DIR/golden-source"
           cp "$GOLDEN_DIR/stamp" "$SESSION_DIR/golden-stamp" 2>/dev/null || true
@@ -176,6 +192,7 @@ sys.exit('runtime not available: ' + name)
 " "$RUNTIME")
   fi
   UDID=$(xcrun simctl create "$SIM_NAME" "$DEVICE_TYPE" "$RUNTIME_ID")
+  CLAIM_ORIGIN="created"
   echo "created" > "$SESSION_DIR/origin"
   # Recorded so bless-golden.sh can stamp what hardware the golden actually is,
   # which is what lets a later claim refuse a device-type-mismatched clone.
@@ -187,7 +204,9 @@ echo "$UDID" > "$SESSION_DIR/udid"
 echo "$SIM_NAME" > "$SESSION_DIR/name"
 ln -sfn "$SESSION_DIR" "$REGISTRY/ports/$PORT/session" 2>/dev/null || true
 
+T_BOOT=$(tel_now)
 xcrun simctl bootstatus "$UDID" -b >/dev/null 2>&1 || xcrun simctl boot "$UDID"
+tel_emit sim.claim.boot "$T_BOOT" origin="$CLAIM_ORIGIN"
 
 # Persist the Metro redirect on THIS device only, so later plain `simctl launch`
 # calls keep using our bundler and never fall back to the user's 8081. Needs the
@@ -196,6 +215,9 @@ xcrun simctl bootstatus "$UDID" -b >/dev/null 2>&1 || xcrun simctl boot "$UDID"
 if [ -n "${DEMO_APP_ID_IOS:-}" ]; then
   xcrun simctl spawn "$UDID" defaults write "$DEMO_APP_ID_IOS" RCT_jsLocation "localhost:$PORT" || true
 fi
+
+tel_emit sim.claim.total "$T_CLAIM" origin="$CLAIM_ORIGIN" udid="$UDID" port="$PORT" \
+  device_type="$(cat "$SESSION_DIR/device-type" 2>/dev/null || echo "")"
 
 cat <<EOF
 # Claimed session for PR #$PR

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -246,6 +246,16 @@ if [ -f "$SESSION_DIR/golden-stamp" ]; then
       echo "# golden verdict: NATIVE BUILD STALE - ios/Podfile.lock changed since the bless; install a fresh build onto this clone, or re-bless the golden"
     fi
   fi
+  # The baked Maestro driver is version-locked: after a CLI upgrade it
+  # silently re-installs mid-recording and the ~20s warmup tax returns with
+  # no explanation - so say so here, where the session starts.
+  STAMP_MAESTRO=$(grep '^maestro-version=' "$SESSION_DIR/golden-stamp" 2>/dev/null | cut -d= -f2- || true)
+  if [ -n "$STAMP_MAESTRO" ] && command -v maestro >/dev/null 2>&1; then
+    CURRENT_MAESTRO=$(maestro --version 2>/dev/null | head -1 || true)
+    if [ -n "$CURRENT_MAESTRO" ] && [ "$CURRENT_MAESTRO" != "$STAMP_MAESTRO" ]; then
+      echo "# golden note: maestro upgraded since the bless ($STAMP_MAESTRO -> $CURRENT_MAESTRO) - the baked driver will re-install on first recording; re-bless to restore the warmup skip"
+    fi
+  fi
 fi
 
 # Fail-fast credential report: flows that need a real account (a staging login

--- a/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+# Telemetry is best-effort - a broken lib must never block a release.
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_RELEASE=$(tel_now)
+
 PR="${1:?usage: release-session.sh <pr-number> [--delete]}"
 DELETE="${2:-}"
 
@@ -118,3 +124,8 @@ if [ "$DELETE" = "--delete" ]; then
   rm -rf "$SESSION_DIR"
 fi
 "$(dirname "${BASH_SOURCE[0]}")/reap-stale.sh" || true
+
+# Only clean releases reach this line (the guards above exit non-zero), so
+# the absence of a release span for a session is itself a signal.
+DEMO_SIM_NAME="$EXPECTED_NAME" tel_emit sim.release.total "$T_RELEASE" \
+  deleted="$([ "$DELETE" = "--delete" ] && echo 1 || echo 0)"

--- a/.claude/skills/react-native-ios-simulator/scripts/reload-app.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/reload-app.sh
@@ -32,6 +32,11 @@
 
 set -euo pipefail
 
+# Telemetry is best-effort - a broken lib must never block a reload.
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
 die() { echo "FATAL: $*" >&2; exit 1; }
 
 PORT="${DEMO_PORT:-}"
@@ -54,7 +59,9 @@ case "$PORT" in
   ''|*[!0-9]*) die "port must be numeric, got '$PORT'" ;;
 esac
 
-python3 - "$PORT" "$TIMEOUT" "${NO_WAIT:-0}" <<'PYEOF'
+T_RELOAD=$(tel_now)
+RELOAD_RC=0
+python3 - "$PORT" "$TIMEOUT" "${NO_WAIT:-0}" <<'PYEOF' || RELOAD_RC=$?
 import base64, hashlib, json, os, socket, struct, sys, time
 
 port, timeout, no_wait = int(sys.argv[1]), float(sys.argv[2]), sys.argv[3] == "1"
@@ -204,3 +211,11 @@ sys.stderr.write(
 send_close(ev_sock)
 sys.exit(1)
 PYEOF
+
+# confirmed means the /events wait saw the bundle served; a --no-wait exit 0
+# is fire-and-forget, so the no_wait flag keeps the two apart in reports.
+tel_emit sim.reload.total "$T_RELOAD" port="$PORT" \
+  confirmed="$([ "$RELOAD_RC" -eq 0 ] && echo 1 || echo 0)" \
+  no_wait="$([ -n "$NO_WAIT" ] && echo 1 || echo 0)" \
+  ok="$([ "$RELOAD_RC" -eq 0 ] && echo 1 || echo 0)"
+exit "$RELOAD_RC"

--- a/.claude/skills/react-native-ios-simulator/scripts/spans-report.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/spans-report.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Rank where demo-session time actually goes, from the local span telemetry.
+#
+# Reads the spans-*.jsonl files the skills emit (see lib/telemetry.sh) and
+# prints per-span aggregates - count, p50, p95, max, total - ranked by total
+# time, which is the "what should we optimize next" ordering. Groups are
+# (span, origin-or-format, ok): reclaim/clone/create claims are different
+# distributions, and failure samples (a timed-out capture) sit in their own
+# ok=false rows so they can never inflate a latency percentile.
+#
+# Percentiles are nearest-rank (value at ceil(p*n)) - deterministic, no
+# interpolation, exact for the test fixtures.
+#
+# Usage: spans-report.sh [--since <N>d|<N>h] [--dir <telemetry-dir>]
+#                        [--compare <revA> <revB>]
+#   --since    default 7d - old, pre-optimization history must not poison the
+#              ranking forever
+#   --dir      defaults like the lib: $DEMO_TELEMETRY_DIR, else
+#              $DEMO_SIM_REGISTRY/telemetry, else ~/.claude/rn-sim-sessions/telemetry
+#   --compare  before/after table for two code revisions (the `rev` field
+#              every span carries) - the one command that verifies an
+#              optimization actually optimized
+#
+# Torn lines (a writer killed mid-append) are skipped and counted, never fatal.
+
+set -euo pipefail
+
+SINCE="7d"
+DIR="${DEMO_TELEMETRY_DIR:-${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}/telemetry}"
+REV_A=""; REV_B=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --since)   SINCE="${2:?--since needs e.g. 7d or 24h}"; shift 2 ;;
+    --dir)     DIR="${2:?--dir needs a path}"; shift 2 ;;
+    --compare) REV_A="${2:?--compare needs two revs}"; REV_B="${3:?--compare needs two revs}"; shift 3 ;;
+    *) echo "FATAL: unknown argument '$1' (usage: spans-report.sh [--since Nd|Nh] [--dir D] [--compare revA revB])" >&2; exit 64 ;;
+  esac
+done
+
+[ -d "$DIR" ] || { echo "no telemetry at $DIR - nothing has emitted spans yet" >&2; exit 1; }
+
+SINCE="$SINCE" REV_A="$REV_A" REV_B="$REV_B" python3 - "$DIR"/spans-*.jsonl <<'PY'
+import glob
+import json
+import math
+import os
+import re
+import sys
+import time
+
+def parse_since(text):
+    m = re.match(r"^(\d+)([dh])$", text)
+    if not m:
+        sys.stderr.write("FATAL: --since must look like 7d or 24h, got %r\n" % text)
+        sys.exit(64)
+    n, unit = int(m.group(1)), m.group(2)
+    return time.time() - n * (86400 if unit == "d" else 3600)
+
+cutoff = parse_since(os.environ.get("SINCE") or "7d")
+rev_a, rev_b = os.environ.get("REV_A") or "", os.environ.get("REV_B") or ""
+
+records, torn = [], 0
+for path in sys.argv[1:]:
+    try:
+        lines = open(path).read().splitlines()
+    except OSError:
+        continue
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+            r["dur_ms"]; r["span"]; r["ts"]
+        except (ValueError, KeyError, TypeError):
+            torn += 1
+            continue
+        if r["ts"] >= cutoff:
+            records.append(r)
+
+def discriminator(r):
+    meta = r.get("meta") or {}
+    return str(meta.get("origin") or meta.get("fmt") or "")
+
+def pctl(sorted_durs, p):
+    return sorted_durs[max(0, math.ceil(p * len(sorted_durs)) - 1)]
+
+def aggregate(rows):
+    groups = {}
+    for r in rows:
+        key = (r["span"], discriminator(r), bool(r.get("ok", True)))
+        groups.setdefault(key, []).append(r["dur_ms"])
+    out = []
+    for (span, disc, ok), durs in groups.items():
+        durs.sort()
+        out.append({
+            "span": span, "disc": disc, "ok": ok, "count": len(durs),
+            "p50": pctl(durs, 0.50), "p95": pctl(durs, 0.95),
+            "max": durs[-1], "total": sum(durs),
+        })
+    out.sort(key=lambda g: g["total"], reverse=True)
+    return out
+
+def label(g):
+    parts = [g["span"]]
+    if g["disc"]:
+        parts.append(g["disc"])
+    if not g["ok"]:
+        parts.append("FAILED")
+    return " ".join(parts)
+
+def print_table(rows, title):
+    print(title)
+    print("%-52s %6s %8s %8s %8s %10s" % ("span", "n", "p50ms", "p95ms", "maxms", "totalms"))
+    for g in rows:
+        print("%-52s %6d %8d %8d %8d %10d" % (label(g), g["count"], g["p50"], g["p95"], g["max"], g["total"]))
+
+if rev_a:
+    a = aggregate([r for r in records if r.get("rev") == rev_a])
+    b = aggregate([r for r in records if r.get("rev") == rev_b])
+    index_a = {(g["span"], g["disc"], g["ok"]): g for g in a}
+    index_b = {(g["span"], g["disc"], g["ok"]): g for g in b}
+    print("compare %s -> %s" % (rev_a, rev_b))
+    print("%-52s %14s %14s %8s" % ("span", rev_a + " p50/n", rev_b + " p50/n", "delta"))
+    for key in sorted(set(index_a) | set(index_b), key=lambda k: -(index_a.get(k, index_b.get(k))["total"])):
+        ga, gb = index_a.get(key), index_b.get(key)
+        fa = "%d/%d" % (ga["p50"], ga["count"]) if ga else "-"
+        fb = "%d/%d" % (gb["p50"], gb["count"]) if gb else "-"
+        if ga and gb and ga["p50"] > 0:
+            delta = "%+d%%" % round(100.0 * (gb["p50"] - ga["p50"]) / ga["p50"])
+        else:
+            delta = "-"
+        name = key[0] + ((" " + key[1]) if key[1] else "") + ("" if key[2] else " FAILED")
+        print("%-52s %14s %14s %8s" % (name, fa, fb, delta))
+else:
+    print_table(aggregate(records), "spans ranked by total time (since cutoff)")
+
+if torn:
+    print("(%d unparseable line%s skipped)" % (torn, "s" if torn != 1 else ""))
+PY

--- a/.claude/skills/react-native-ios-simulator/tests/fixtures/bin/maestro
+++ b/.claude/skills/react-native-ios-simulator/tests/fixtures/bin/maestro
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Fake `maestro` for the simulator-skill tests: bless-golden.sh bakes the
+# driver by running the warmup flow, and claim-session.sh compares stamped
+# vs current CLI versions. Logs to the shared args log; FAKE_MAESTRO_VERSION
+# lets the version-mismatch tests script an upgrade.
+
+set -uo pipefail
+
+echo "maestro $*" >> "${FAKE_ARGS_LOG:-/dev/null}"
+
+case "${1:-}" in
+  test) exit "${FAKE_MAESTRO_RC:-0}" ;;
+  --version) echo "${FAKE_MAESTRO_VERSION:-2.6.1}" ;;
+  *) echo "fake maestro: unsupported subcommand '${1:-}'" >&2; exit 64 ;;
+esac

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -387,6 +387,123 @@ check "reset without a port writes no defaults" "no" \
 "$SCRIPTS/release-session.sh" 622 --delete >/dev/null 2>&1
 
 echo
+echo "telemetry (lib/telemetry.sh)"
+
+TEL="$TESTS_DIR/../lib/telemetry.sh"
+TEL_TEST_DIR="$WORK/telemetry"
+spans_file() { ls "$1"/spans-*.jsonl 2>/dev/null | head -1; }
+span_lines() { cat "$(spans_file "$1")" 2>/dev/null; }
+
+# --- tel_span is transparent -------------------------------------------------
+rm -rf "$TEL_TEST_DIR"
+out=$(DEMO_TELEMETRY_DIR="$TEL_TEST_DIR" bash -c '
+  . "'"$TEL"'"
+  tel_span test.span k=v -- bash -c "echo real-out; echo real-err >&2; exit 3"
+' 2>"$WORK/tel-err.txt"); rc=$?
+check "tel_span preserves the exit code" "3" "$rc"
+check "tel_span preserves stdout" "real-out" "$out"
+check "tel_span preserves stderr" "real-err" "$(cat "$WORK/tel-err.txt")"
+check "one span, one line" "1" "$(span_lines "$TEL_TEST_DIR" | wc -l | tr -d ' ')"
+check "the line is valid v1 JSON with every schema key" "yes" \
+  "$(span_lines "$TEL_TEST_DIR" | python3 -c '
+import json, sys
+r = json.loads(sys.stdin.readline())
+need = {"v","ts","dur_ms","span","skill","session","run_id","rev","ok","meta"}
+ok = r["v"] == 1 and need <= set(r) and r["skill"] == "test" and r["ok"] is False and r["meta"]["rc"] == 3
+print("yes" if ok else "no")' 2>/dev/null)"
+
+# --- the unit trap: seconds-vs-ms is the classic telemetry bug ---------------
+rm -rf "$TEL_TEST_DIR"
+DEMO_TELEMETRY_DIR="$TEL_TEST_DIR" bash -c '. "'"$TEL"'"; tel_span test.sleep -- sleep 0.5' >/dev/null 2>&1
+DUR=$(span_lines "$TEL_TEST_DIR" | python3 -c 'import json,sys; print(json.loads(sys.stdin.readline())["dur_ms"])' 2>/dev/null)
+check "a 0.5s span records dur_ms in [400,5000]" "yes" \
+  "$([ -n "$DUR" ] && [ "$DUR" -ge 400 ] && [ "$DUR" -le 5000 ] && echo yes || echo "no ($DUR)")"
+
+# --- concurrent writers never tear each other's lines ------------------------
+rm -rf "$TEL_TEST_DIR"
+for i in $(seq 20); do
+  DEMO_TELEMETRY_DIR="$TEL_TEST_DIR" bash -c '
+    . "'"$TEL"'"
+    for j in 1 2 3 4 5 6 7 8 9 10; do t0=$(tel_now); tel_emit test.par "$t0" writer='"$i"' seq=$j; done
+  ' &
+done
+wait
+check "20 writers x 10 spans -> exactly 200 lines" "200" \
+  "$(span_lines "$TEL_TEST_DIR" | wc -l | tr -d ' ')"
+check "every concurrent line parses" "200" \
+  "$(span_lines "$TEL_TEST_DIR" | python3 -c '
+import json, sys
+print(sum(1 for l in sys.stdin if l.strip() and json.loads(l)))' 2>/dev/null)"
+
+# --- kill switch -------------------------------------------------------------
+rm -rf "$TEL_TEST_DIR"
+DEMO_TELEMETRY=0 DEMO_TELEMETRY_DIR="$TEL_TEST_DIR" bash -c '. "'"$TEL"'"; tel_span test.off -- true' >/dev/null 2>&1
+check "DEMO_TELEMETRY=0 runs the command" "0" "$?"
+check "DEMO_TELEMETRY=0 writes nothing" "absent" \
+  "$([ -d "$TEL_TEST_DIR" ] && echo present || echo absent)"
+
+# --- failure isolation: telemetry may never fail the caller ------------------
+# The instrumented scripts run set -euo pipefail; an unwritable telemetry dir
+# has to degrade to silence, not abort a claim.
+rm -rf "$TEL_TEST_DIR"; mkdir -p "$TEL_TEST_DIR"; chmod 0500 "$TEL_TEST_DIR"
+DEMO_TELEMETRY_DIR="$TEL_TEST_DIR" bash -c '
+  set -euo pipefail
+  . "'"$TEL"'"
+  t0=$(tel_now); tel_emit test.blocked "$t0"; tel_span test.blocked2 -- true
+  echo survived
+' > "$WORK/tel-iso.txt" 2>&1
+check "an unwritable telemetry dir cannot fail a set -e caller" "0" "$?"
+check "the caller actually ran to completion" "survived" "$(cat "$WORK/tel-iso.txt")"
+chmod 0700 "$TEL_TEST_DIR"
+
+# --- claims survive a broken lib and work without one ------------------------
+reset_world
+SAVED_LIB="$WORK/telemetry.sh.saved"
+cp "$TEL" "$SAVED_LIB"
+echo "this is not bash {{{" > "$TESTS_DIR/../lib/telemetry.sh"
+eval "$("$SCRIPTS/claim-session.sh" 730)" >/dev/null 2>&1
+check "a syntactically broken lib does not break a claim" "0" "$?"
+"$SCRIPTS/release-session.sh" 730 --delete >/dev/null 2>&1
+rm "$TESTS_DIR/../lib/telemetry.sh"
+eval "$("$SCRIPTS/claim-session.sh" 731)" >/dev/null 2>&1
+check "an absent lib does not break a claim" "0" "$?"
+"$SCRIPTS/release-session.sh" 731 --delete >/dev/null 2>&1
+cp "$SAVED_LIB" "$TESTS_DIR/../lib/telemetry.sh"
+
+# --- instrumented claims label origin from independent evidence --------------
+reset_world
+rm -rf "$DEMO_SIM_REGISTRY/telemetry"
+eval "$("$SCRIPTS/claim-session.sh" 732)" >/dev/null 2>&1
+ORIGIN_META=$(span_lines "$DEMO_SIM_REGISTRY/telemetry" | python3 -c '
+import json, sys
+for l in sys.stdin:
+    r = json.loads(l)
+    if r["span"] == "sim.claim.total":
+        print(r["meta"].get("origin", "")); break' 2>/dev/null)
+check "created claim emits origin=created, matching the session file" "yes" \
+  "$([ "$ORIGIN_META" = "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr732/origin")" ] && [ "$ORIGIN_META" = "created" ] && echo yes || echo "no ($ORIGIN_META)")"
+check "claim emits its sub-spans too" "yes" \
+  "$(span_lines "$DEMO_SIM_REGISTRY/telemetry" | grep -q '"span":"sim.claim.boot"' && span_lines "$DEMO_SIM_REGISTRY/telemetry" | grep -q '"span":"sim.claim.reap"' && echo yes || echo no)"
+"$SCRIPTS/release-session.sh" 732 >/dev/null 2>&1
+check "a clean release emits its span" "yes" \
+  "$(span_lines "$DEMO_SIM_REGISTRY/telemetry" | grep -q '"span":"sim.release.total"' && echo yes || echo no)"
+
+mkdir -p "$FAKE_APP_ROOT"   # bless needs the app-root scaffolding from earlier sections
+eval "$("$SCRIPTS/claim-session.sh" 733)" >/dev/null 2>&1
+"$SCRIPTS/bless-golden.sh" 733 --sha tel111 --lockfile /dev/null 2>/dev/null >/dev/null
+rm -rf "$DEMO_SIM_REGISTRY/telemetry"
+eval "$("$SCRIPTS/claim-session.sh" 734)" >/dev/null 2>&1
+ORIGIN_META=$(span_lines "$DEMO_SIM_REGISTRY/telemetry" | python3 -c '
+import json, sys
+for l in sys.stdin:
+    r = json.loads(l)
+    if r["span"] == "sim.claim.total":
+        print(r["meta"].get("origin", "")); break' 2>/dev/null)
+check "cloned claim emits origin=cloned-from-golden, matching the session file" "yes" \
+  "$([ "$ORIGIN_META" = "$(cat "$DEMO_SIM_REGISTRY/rn-demo-pr734/origin")" ] && [ "$ORIGIN_META" = "cloned-from-golden" ] && echo yes || echo "no ($ORIGIN_META)")"
+"$SCRIPTS/release-session.sh" 734 --delete >/dev/null 2>&1
+
+echo
 echo "native-build staleness stamp (native-stamp.sh)"
 
 NS="$SCRIPTS/native-stamp.sh"

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -737,6 +737,33 @@ check "no note when every required credential is present" "no" \
 "$SCRIPTS/release-session.sh" 721 --delete >/dev/null 2>&1
 unset FAKE_CRED_PRESENT
 
+# --- bless bakes the maestro driver and stamps the CLI version ---------------
+out=$("$SCRIPTS/claim-session.sh" 714) && eval "$out"
+: > "$FAKE_ARGS_LOG"
+DEMO_APP_ID_IOS=com.example.demoapp "$SCRIPTS/bless-golden.sh" 714 --sha warm77 \
+  --lockfile /dev/null >/dev/null 2>&1
+check "bless with maestro available runs the warmup against its own device" "yes" \
+  "$(grep "maestro test" "$FAKE_ARGS_LOG" | grep -q "_warmup.yaml" && echo yes || echo no)"
+check "the stamp records the maestro version" "yes" \
+  "$(grep -q '^maestro-version=2.6.1' "$GOLDEN_STAMP" && echo yes || echo no)"
+
+out=$("$SCRIPTS/claim-session.sh" 715)
+check "a version-matched clone gets no upgrade note" "0" \
+  "$(echo "$out" | grep -c "maestro upgraded")"
+eval "$out"; "$SCRIPTS/release-session.sh" 715 --delete >/dev/null 2>&1
+
+out=$(FAKE_MAESTRO_VERSION=9.9.9 "$SCRIPTS/claim-session.sh" 716)
+check "a maestro upgrade since the bless is called out at claim time" "yes" \
+  "$(echo "$out" | grep -q "maestro upgraded" && echo yes || echo no)"
+eval "$out"; "$SCRIPTS/release-session.sh" 716 --delete >/dev/null 2>&1
+
+# Without an app id the warmup cannot run - the stamp must NOT pretend a
+# driver was baked (record-flow trusts the version line as "warm").
+out=$("$SCRIPTS/claim-session.sh" 717) && eval "$out"
+DEMO_APP_ID_IOS= "$SCRIPTS/bless-golden.sh" 717 --sha warm78 --lockfile /dev/null >/dev/null 2>&1
+check "a bless that could not bake writes no maestro-version line" "0" \
+  "$(grep -c '^maestro-version=' "$GOLDEN_STAMP")"
+
 # --- bless safety gates ------------------------------------------------------
 reset_world
 eval "$("$SCRIPTS/claim-session.sh" 710)" >/dev/null 2>&1

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -973,6 +973,33 @@ check "releases the lock when the command fails" "absent" \
   "$([ -d "$DEMO_SIM_REGISTRY/locks/native-build" ] && echo present || echo absent)"
 
 echo
+echo "bench (hermetic: counts first, loose clocks second)"
+
+# Upper bounds sit at >=5x locally measured (claim+release cycle ~2.4s with
+# fakes, reload roundtrip ~0.9s) and only catch runaway sleeps; the counted
+# assertion is the deterministic net. python3 warmed before timing.
+python3 -c 'pass' 2>/dev/null
+py_now() { python3 -c 'import time; print("%.3f" % time.time())'; }
+
+reset_world
+T0=$(py_now)
+eval "$("$SCRIPTS/claim-session.sh" 900)" >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 900 --delete >/dev/null 2>&1
+DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
+check "a claim+release cycle stays under the runaway budget (12s)" "yes" \
+  "$(python3 -c "print('yes' if float('$DUR') < 12 else 'no (${DUR}s)')")"
+
+start_ws_fake bundle-done
+T0=$(py_now)
+"$SCRIPTS/reload-app.sh" --port "$WS_PORT" --timeout 10 >/dev/null 2>&1
+DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
+check "a confirmed reload roundtrip stays under the runaway budget (5s)" "yes" \
+  "$(python3 -c "print('yes' if float('$DUR') < 5 else 'no (${DUR}s)')")"
+check "a reload opens exactly two websocket connections" "2" \
+  "$(grep -c "^connect " "$WS_LOG")"
+kill "$WS_PID" 2>/dev/null
+
+echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -504,6 +504,62 @@ check "cloned claim emits origin=cloned-from-golden, matching the session file" 
 "$SCRIPTS/release-session.sh" 734 --delete >/dev/null 2>&1
 
 echo
+echo "spans report (spans-report.sh)"
+
+REPORT="$SCRIPTS/spans-report.sh"
+RPT_DIR="$WORK/report-telemetry"
+rm -rf "$RPT_DIR"; mkdir -p "$RPT_DIR"
+mkspan() { # mkspan <span> <dur_ms> <ok 1|0> <origin> <rev> [ts]
+  python3 -c '
+import json, sys, time
+span, dur, ok, origin, rev = sys.argv[1:6]
+ts = float(sys.argv[6]) if len(sys.argv) > 6 else time.time()
+meta = {"origin": origin} if origin else {}
+print(json.dumps({"v": 1, "ts": ts, "dur_ms": int(dur), "span": span,
+  "skill": span.split(".")[0], "session": "s", "run_id": "r", "rev": rev,
+  "ok": ok == "1", "meta": meta}))' "$@" >> "$RPT_DIR/spans-000000.jsonl"
+}
+
+for d in 100 200 300 400 500 600 700 800 900 1000; do mkspan a.big "$d" 1 "" rev1; done
+mkspan a.big 99999 0 "" rev1     # a failure sample with a huge duration
+mkspan b.small 50 1 "" rev1
+mkspan c.claim 10 1 created rev1
+mkspan c.claim 20 1 cloned rev1
+
+out=$("$REPORT" --dir "$RPT_DIR")
+BIG_ROW=$(echo "$out" | grep "^a\.big  ")
+check "p50 is nearest-rank exact" "500" "$(echo "$BIG_ROW" | awk '{print $3}')"
+check "p95 is nearest-rank exact" "1000" "$(echo "$BIG_ROW" | awk '{print $4}')"
+check "total sums the group" "5500" "$(echo "$BIG_ROW" | awk '{print $6}')"
+check "ranking puts the biggest total first" "yes" \
+  "$(echo "$out" | sed -n 3p | grep -q "^a\.big" && echo yes || echo no)"
+check "failure samples form their own FAILED row" "yes" \
+  "$(echo "$out" | grep -q "^a\.big FAILED" && echo yes || echo no)"
+check "and never inflate the success percentiles" "1000" "$(echo "$BIG_ROW" | awk '{print $5}')"
+check "groups split by origin" "yes" \
+  "$(echo "$out" | grep -q "^c\.claim created" && echo "$out" | grep -q "^c\.claim cloned" && echo yes || echo no)"
+
+mkspan d.ancient 5000 1 "" rev1 1000000    # emitted decades ago
+out=$("$REPORT" --dir "$RPT_DIR" --since 1d)
+check "--since excludes stale history from the ranking" "0" \
+  "$(echo "$out" | grep -c "^d\.ancient")"
+
+for d in 400 400; do mkspan e.opt "$d" 1 "" revA; done
+for d in 100 100; do mkspan e.opt "$d" 1 "" revB; done
+out=$("$REPORT" --dir "$RPT_DIR" --compare revA revB)
+OPT_ROW=$(echo "$out" | grep "^e\.opt")
+check "--compare shows both revisions' numbers" "yes" \
+  "$(echo "$OPT_ROW" | grep -q "400/2" && echo "$OPT_ROW" | grep -q "100/2" && echo yes || echo no)"
+check "--compare computes the delta" "yes" \
+  "$(echo "$OPT_ROW" | grep -q -- "-75%" && echo yes || echo no)"
+
+printf '{"v":1,"ts":12345,"dur' >> "$RPT_DIR/spans-000000.jsonl"   # a torn write
+out=$("$REPORT" --dir "$RPT_DIR" 2>&1); rc=$?
+check "a torn line never crashes the report" "0" "$rc"
+check "and is counted, not hidden" "yes" \
+  "$(echo "$out" | grep -q "1 unparseable line" && echo yes || echo no)"
+
+echo
 echo "native-build staleness stamp (native-stamp.sh)"
 
 NS="$SCRIPTS/native-stamp.sh"
@@ -860,6 +916,8 @@ check "SKILL.md ties golden staleness to the stamp sha" "yes" \
   "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the native-stamp verdict" "yes" \
   "$(grep -q "native-stamp.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents telemetry and the spans report" "yes" \
+  "$(grep -q "spans-report.sh" "$SKILL_MD" && grep -q "DEMO_TELEMETRY=0" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the credential precheck" "yes" \
   "$(grep -q "DEMO_REQUIRED_ENV" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the 72h retention default" "yes" \

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -973,6 +973,31 @@ check "releases the lock when the command fails" "absent" \
   "$([ -d "$DEMO_SIM_REGISTRY/locks/native-build" ] && echo present || echo absent)"
 
 echo
+echo "live bench smoke (bench/live.sh)"
+
+LIVE="$TESTS_DIR/../bench/live.sh"
+SHOT_FIXTURES="$TESTS_DIR/../../react-native-demo-screenshots/tests/fixtures/bin"
+
+env -u DEMO_UDID "$LIVE" --smoke >/dev/null 2>&1
+check "live bench refuses to run without a claimed session" "1" "$?"
+
+rm -f "$WORK/bench-smoke.json"
+printf 'DEMO-UDID|bench-sim|Booted\n' > "$WORK/bench-devices.txt"
+PATH="$SHOT_FIXTURES:$PATH" FAKE_DEVICES="$WORK/bench-devices.txt" \
+  FAKE_ARGS_LOG="$WORK/bench-args.log" FAKE_FRAME_COUNTER="$WORK/bench-frames.n" \
+  DEMO_UDID=DEMO-UDID DEMO_SESSION_DIR="$WORK" \
+  "$LIVE" --smoke --out "$WORK/bench-smoke.json" >/dev/null 2>&1
+check "smoke run exits zero against the fake simctl" "0" "$?"
+check "the bench artifact is schema-complete" "yes" \
+  "$(python3 -c '
+import json, sys
+r = json.load(open(sys.argv[1]))
+need = {"v","udid","smoke","context","shot_latency","compare_cost","settle_capture","recorder","encode"}
+sl = r["shot_latency"].get("png_xcrun") or {}
+print("yes" if need <= set(r) and sl.get("n") == 2 and isinstance(sl.get("p50"), float) else "no")
+' "$WORK/bench-smoke.json" 2>/dev/null)"
+
+echo
 echo "bench (hermetic: counts first, loose clocks second)"
 
 # Upper bounds sit at >=5x locally measured (claim+release cycle ~2.4s with


### PR DESCRIPTION
Follow-up to #4092 / #4106, stacked on `feat/demo-capture-speedups` — only the commits after `ad7897c` are this PR.

#4106 cut the *setup* taxes. This PR makes the remaining capture/recording pipeline measurable, benchmarked, and then optimizes **only what the measurements gated in** — five of seven candidates were killed by their own numbers before costing any complexity.

## 1. Local span telemetry (`lib/telemetry.sh`)

Every skill script emits one JSON line per phase (claim/boot/reload/capture/warmup/flow/encode/push) into a local spans file under the session registry. Local only; `DEMO_TELEMETRY=0` kills it. No start/end pairing API (bash 3.2 has no sane home for that state) — `t0=$(tel_now); …; tel_emit span "$t0" k=v`. Two rules are tested, not asserted: **emitting can never fail a `set -e` caller** (unwritable dir, broken lib file, absent lib → claim still exits 0), and **no spans inside hot loops** (a python3 spawn is 20–50 ms; loop totals + counts in meta instead). Records carry `run_id`, `rev`, `ok`, and an `origin` label because reclaim/clone/create are three distributions — aggregating them under one name would make every percentile a lie. En route, capture.sh's settle loop lost the two python3 spawns *per frame* it was paying just to check a deadline.

## 2. `spans-report.sh`

count/p50/p95/max/total per `(span, origin/format, ok)`, ranked by total time; failure samples (timed-out captures) sit in their own FAILED rows and never inflate a percentile; `--since` (default 7 d) keeps stale history out of rankings; `--compare revA revB` prints the before/after table optimization commits cite. Nearest-rank percentiles — deterministic and exact against the fixtures. Torn lines are counted, never fatal.

## 3. Hermetic benches, in-suite

Counts before clocks (a two-frame settle shoots exactly two frames; a reload opens exactly two websocket connections — deterministic, budget-free), lower bounds prove waits exist (inter-shot gap ≥ settle, from new per-line timestamps in the fake simctl), upper bounds only at ≥5× locally measured with a 2 s floor (capture 0.9 s→5 s, claim+release 2.4 s→12 s, reload 0.9 s→5 s, encode→15 s) so they only catch runaways. No committed baseline files. The bench carries its own mutation check: the fakes gained `FAKE_SHOT_DELAY`, and a planted 3 s delay must be visible to the same clock that enforces the budgets.

## 4. Live bench + baseline (`bench/live.sh`)

Report-only, requires a claimed session, touches only that device; all timed loops inside one python3 process (monotonic clock around subprocess calls). Artifact: `bench-<stamp>.json` with host/load/runtime context. Baseline on this Mac (M5 Max, idle — `bench-20260808-023805.json`; an earlier run under load-average 153 measured everything 2–10× worse, which is exactly why the context block exists):

| measurement | result | verdict |
|---|---|---|
| shot latency p50, `xcrun simctl` | 0.35 s | — |
| shot latency p50, resolved binary | 0.27 s | **~80 ms/shot → gated IN** |
| settle capture, gap 0.6 vs 0 | 1.60 s vs 1.19 s | sleep is minor; shot dominates → sleep-skip dropped |
| frame compare, shasum vs cmp | 31 ms vs 10 ms | noise → dropped |
| recorder start/finalize | buffered / 22 ms | → dropped |
| mp4 videotoolbox vs libx264 | 6.5 s vs 0.07 s | HW session setup dominates demo-sized clips → dropped |
| GIF single- vs double-decode (15 s device-res clip) | 2.5 s vs 3.2 s, **but +20 % file size** | size regression on a budget-capped output → dropped |

## 5. Gated-in optimization: cached simctl path

`capture.sh` resolves `$(xcrun -f simctl)` once — ~80 ms saved per shot, ~23 % of shot latency, paid on every settle frame and liveness poll. The fake xcrun serves `-f` and labels direct calls, so the guarantee has a failing assertion (un-caching goes red).

## 6. Gated-in optimization: warmup skip via driver-baked golden

The ~20 s Maestro warmup (real-session data from #4092) is a one-time driver install per device per CLI version. `bless-golden.sh` now runs the warmup once at bless time so every clone inherits the driver, and stamps `maestro-version` — the driver is version-locked, and an upgraded CLI would silently re-install mid-"warmed" session, so `claim-session.sh` prints a re-bless note on mismatch and `record-flow.sh` refuses the skip. Skips happen for exactly three provable reasons (manual `DEMO_SKIP_WARMUP`, an earlier successful maestro run this session, version-matched baked golden), each labelled in the `vid.record.warmup` span so the skip *rate* is observable.

*Confirmed live (2026-08-13):* the golden on this Mac was re-provisioned end-to-end — staging login with the global OTP on a fresh native build, then `bless-golden.sh`: driver baked (`maestro-version=2.6.1` stamped mechanically), `podfile-lock-hash` stamped, and the claim-side `# golden verdict: native build matches` printed on the next clone. **A cloned golden boots straight to the logged-in home screen** (keychain survives the clone — the former caveat is closed), and a real recording on a clone emitted `vid.record.warmup skipped=1 reason=golden`.

That first real run also surfaced three defects, fixed in the final commit: the warmup flow's `>` prose header made maestro 2.6.1 parse-fail the whole flow (silently — warmup output is discarded), so every real warmup had been failing and the driver was being installed on camera by the first recorded flow; the version gate paid a ~3 s `maestro --version` JVM start per recording (now cached per session, probe asserted to run once); and the capture suites inherited `DEMO_UDID` from a live-session shell, flipping the android tests onto the iOS path (now unset — suites trust only what each test sets). Plus one SKILL.md gotcha: a fresh clone can refuse app launch with an SBMainWorkspace denial; an upgrade `simctl install` re-registers the app and keeps the login.

## Rejected alternatives

- OTel/collector export — local JSONL is the entire need; the schema carries `rev`/`run_id` so it could be exported later if ever needed.
- Committed bench baselines (ratcheting) — machine-specific, stale, recreates flake as maintenance.
- Everything in the baseline table marked "dropped" — each was a plausible optimization that the measurements killed before it cost complexity; the numbers are in the artifact and above.

Suites: 4 suites, 391 assertions (from 322 at branch point), every new guarantee mutation-spot-checked.
