### PR TITLE
fix(android): useScreenSecurity to enforce screenshot protection

### DIFF
--- a/__tests__/hooks/use-screen-security.spec.ts
+++ b/__tests__/hooks/use-screen-security.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-native"
+import { renderHook, waitFor } from "@testing-library/react-native"
 
 import { useScreenSecurity } from "@app/hooks/use-screen-security"
 
@@ -8,6 +8,11 @@ const mockDisableScreenSecurity = jest.fn()
 jest.mock("@app/utils/screen-security", () => ({
   enableScreenSecurity: (...args: string[]) => mockEnableScreenSecurity(...args),
   disableScreenSecurity: () => mockDisableScreenSecurity(),
+}))
+
+const mockReportError = jest.fn()
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
 }))
 
 jest.mock("@rn-vui/themed", () => ({
@@ -35,5 +40,31 @@ describe("useScreenSecurity", () => {
     unmount()
 
     expect(mockDisableScreenSecurity).toHaveBeenCalled()
+  })
+
+  /** The enable is fire-and-forget; a native failure to install the guard must be
+   *  reported, not leaked as an unhandled rejection while the screen renders its seed
+   *  words unprotected. */
+  it("reports a rejected enable instead of leaking an unhandled rejection", async () => {
+    const failure = new Error("native failure")
+    mockEnableScreenSecurity.mockRejectedValueOnce(failure)
+
+    renderHook(() => useScreenSecurity())
+
+    await waitFor(() =>
+      expect(mockReportError).toHaveBeenCalledWith("Enable screen security", failure),
+    )
+  })
+
+  it("reports a rejected disable on unmount", async () => {
+    const failure = new Error("native failure")
+    mockDisableScreenSecurity.mockRejectedValueOnce(failure)
+
+    const { unmount } = renderHook(() => useScreenSecurity())
+    unmount()
+
+    await waitFor(() =>
+      expect(mockReportError).toHaveBeenCalledWith("Disable screen security", failure),
+    )
   })
 })

--- a/__tests__/screens/api-key-create.spec.tsx
+++ b/__tests__/screens/api-key-create.spec.tsx
@@ -69,8 +69,8 @@ jest.mock("@react-native-clipboard/clipboard", () => ({
 }))
 
 jest.mock("@app/utils/screen-security", () => ({
-  enableScreenSecurity: jest.fn(),
-  disableScreenSecurity: jest.fn(),
+  enableScreenSecurity: jest.fn(() => Promise.resolve()),
+  disableScreenSecurity: jest.fn(() => Promise.resolve()),
 }))
 
 loadLocale("en")

--- a/__tests__/screens/api-key-secret-reveal.spec.tsx
+++ b/__tests__/screens/api-key-secret-reveal.spec.tsx
@@ -42,8 +42,8 @@ jest.mock("@react-native-clipboard/clipboard", () => ({
 }))
 
 jest.mock("@app/utils/screen-security", () => ({
-  enableScreenSecurity: jest.fn(),
-  disableScreenSecurity: jest.fn(),
+  enableScreenSecurity: jest.fn(() => Promise.resolve()),
+  disableScreenSecurity: jest.fn(() => Promise.resolve()),
 }))
 
 loadLocale("en")

--- a/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
@@ -117,6 +117,8 @@ describe("BackupPhraseConfirmScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+    mockEnableScreenSecurity.mockResolvedValue(undefined)
+    mockDisableScreenSecurity.mockResolvedValue(undefined)
     mockCheckpoint.mockReturnValue(null)
     mockMigrationAccountId.mockReturnValue("migration-uuid")
     mockCheckpointLoading.mockReturnValue(false)

--- a/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
@@ -99,6 +99,15 @@ jest.mock("@app/utils/error-logging", () => ({
   reportError: (...args: readonly unknown[]) => mockReportError(...args),
 }))
 
+const mockEnableScreenSecurity = jest.fn()
+const mockDisableScreenSecurity = jest.fn()
+jest.mock("@app/utils/screen-security", () => ({
+  enableScreenSecurity: (...args: readonly unknown[]) =>
+    mockEnableScreenSecurity(...args),
+  disableScreenSecurity: (...args: readonly unknown[]) =>
+    mockDisableScreenSecurity(...args),
+}))
+
 loadLocale("en")
 const LL = i18nObject("en")
 
@@ -565,6 +574,34 @@ describe("BackupPhraseConfirmScreen", () => {
         route: "accountMigrationBalancesOverview",
         accountId: "migration-uuid",
       },
+    })
+  })
+
+  /** The screen shows individual mnemonic words with their positions, so it must carry
+   *  the same screenshot/screen-recording protection as the backup-phrase screen. */
+  describe("screen security", () => {
+    it("enables screenshot protection on mount", async () => {
+      render(
+        <ContextForScreen>
+          <BackupPhraseConfirmScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      expect(mockEnableScreenSecurity).toHaveBeenCalledTimes(1)
+    })
+
+    it("disables screenshot protection on unmount", async () => {
+      const { unmount } = render(
+        <ContextForScreen>
+          <BackupPhraseConfirmScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      unmount()
+
+      expect(mockDisableScreenSecurity).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__tests__/screens/self-custodial/onboarding/restore/restore-phrase-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/restore/restore-phrase-screen.spec.tsx
@@ -32,6 +32,15 @@ jest.mock("@app/utils/error-logging", () => ({
   reportError: (...args: readonly unknown[]) => mockReportError(...args),
 }))
 
+const mockEnableScreenSecurity = jest.fn()
+const mockDisableScreenSecurity = jest.fn()
+jest.mock("@app/utils/screen-security", () => ({
+  enableScreenSecurity: (...args: readonly unknown[]) =>
+    mockEnableScreenSecurity(...args),
+  disableScreenSecurity: (...args: readonly unknown[]) =>
+    mockDisableScreenSecurity(...args),
+}))
+
 type MnemonicWordInputProps = {
   index: number
   value: string
@@ -533,6 +542,38 @@ describe("RestorePhraseScreen", () => {
       headerRight: undefined,
       // eslint-disable-next-line camelcase -- name dictated by @react-navigation/native-stack
       unstable_headerRightItems: undefined,
+    })
+  })
+
+  /** The screen shows a funded wallet's mnemonic, so it must carry the same
+   *  screenshot/screen-recording protection as the backup-creation screen. */
+  describe("screen security", () => {
+    it("enables screenshot protection on mount", async () => {
+      renderScreen()
+      await flushEffects()
+
+      expect(mockEnableScreenSecurity).toHaveBeenCalledTimes(1)
+    })
+
+    it("keeps screenshot protection active on the restoring and error states", async () => {
+      for (const status of ["restoring", "error"]) {
+        jest.clearAllMocks()
+        mockUseRestorePhrase.mockReturnValue({ ...defaultHookReturn, status })
+
+        renderScreen()
+        await flushEffects()
+
+        expect(mockEnableScreenSecurity).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    it("disables screenshot protection on unmount", async () => {
+      const { unmount } = renderScreen()
+      await flushEffects()
+
+      unmount()
+
+      expect(mockDisableScreenSecurity).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__tests__/screens/self-custodial/onboarding/restore/restore-phrase-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/restore/restore-phrase-screen.spec.tsx
@@ -130,6 +130,8 @@ const renderScreen = () =>
 describe("RestorePhraseScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockEnableScreenSecurity.mockResolvedValue(undefined)
+    mockDisableScreenSecurity.mockResolvedValue(undefined)
     mockRouteParams = { step: 2, words: [...validStep2Words] }
     mockUseRestorePhrase.mockReturnValue(defaultHookReturn)
   })

--- a/__tests__/utils/screen-security.spec.ts
+++ b/__tests__/utils/screen-security.spec.ts
@@ -8,6 +8,11 @@ jest.mock("react-native-screenguard", () => ({
   unregister: (...args: readonly unknown[]) => mockUnregister(...args),
 }))
 
+const mockReportError = jest.fn()
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
 /** The util keeps its reference count and call queue in module state, so each test
  *  loads a fresh copy. */
 const loadModule = (): typeof import("@app/utils/screen-security") => {
@@ -23,9 +28,17 @@ const loadModule = (): typeof import("@app/utils/screen-security") => {
 describe("screen-security", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // Fake timers keep a retry scheduled by a rejected enable inert unless the test
+    // advances the clock — otherwise a stray timer from one isolated module could
+    // fire mid-test in another and pollute the call counts.
+    jest.useFakeTimers()
     mockInitSettings.mockResolvedValue(undefined)
     mockRegister.mockResolvedValue(undefined)
     mockUnregister.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it("initializes and registers with the given background color on first enable", async () => {
@@ -160,5 +173,93 @@ describe("screen-security", () => {
 
     expect(mockRegister).toHaveBeenCalledTimes(2)
     expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  /** A rejected register is not the only way initSettings/register can fail: if
+   *  initialization itself rejects, no guard was installed and the next enable must
+   *  start over from initSettings. */
+  it("starts over from initSettings on the next enable when initialization fails", async () => {
+    const { enableScreenSecurity } = loadModule()
+    mockInitSettings.mockRejectedValueOnce(new Error("native failure"))
+
+    await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+    expect(mockRegister).not.toHaveBeenCalled()
+
+    await enableScreenSecurity("#000000")
+
+    expect(mockInitSettings).toHaveBeenCalledTimes(2)
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+  })
+
+  /** A rejected unregister leaves the native state unknown, and the call-time
+   *  activeScreens gate means no later disable ever reaches the queue to retry it.
+   *  If `registered` stayed true, every later enable would skip the register and the
+   *  JS and native states would stay desynced for the rest of the process — so the
+   *  next enable must re-register. The rejection still propagates so the hook can
+   *  report it. */
+  it("re-registers on the next enable after a rejected unregister", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+    mockUnregister.mockRejectedValueOnce(new Error("native failure"))
+
+    await enableScreenSecurity("#000000")
+    await expect(disableScreenSecurity()).rejects.toThrow("native failure")
+
+    await enableScreenSecurity("#000000")
+
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+  })
+
+  // Must match ENABLE_RETRY_DELAY_MS in the util; a change there should fail here.
+  const RETRY_DELAY_MS = 10_000
+  // Must match ENABLE_RETRY_LIMIT in the util.
+  const RETRY_LIMIT = 3
+
+  describe("enable retry", () => {
+    it("retries a rejected registration while a protected screen is still mounted", async () => {
+      const { enableScreenSecurity } = loadModule()
+      mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+      await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+      expect(mockRegister).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS)
+
+      expect(mockRegister).toHaveBeenCalledTimes(2)
+    })
+
+    it("stops retrying once the guard is registered", async () => {
+      const { enableScreenSecurity } = loadModule()
+      mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+      await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+      await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS)
+      expect(mockRegister).toHaveBeenCalledTimes(2)
+
+      await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS * (RETRY_LIMIT + 1))
+      expect(mockRegister).toHaveBeenCalledTimes(2)
+    })
+
+    it("reports each failed retry and gives up after a bounded number", async () => {
+      const { enableScreenSecurity } = loadModule()
+      mockRegister.mockRejectedValue(new Error("native failure"))
+
+      await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+      await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS * (RETRY_LIMIT + 2))
+
+      expect(mockRegister).toHaveBeenCalledTimes(1 + RETRY_LIMIT)
+      expect(mockReportError).toHaveBeenCalledTimes(RETRY_LIMIT)
+    })
+
+    it("does not retry once the last protected screen has unmounted", async () => {
+      const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+      mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+      await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+      await disableScreenSecurity()
+
+      await jest.advanceTimersByTimeAsync(RETRY_DELAY_MS * (RETRY_LIMIT + 2))
+
+      expect(mockRegister).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/__tests__/utils/screen-security.spec.ts
+++ b/__tests__/utils/screen-security.spec.ts
@@ -20,11 +20,6 @@ const loadModule = (): typeof import("@app/utils/screen-security") => {
   return mod
 }
 
-const flushQueue = () =>
-  new Promise<void>((resolve) => {
-    setImmediate(resolve)
-  })
-
 describe("screen-security", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -102,14 +97,68 @@ describe("screen-security", () => {
     expect(mockUnregister).not.toHaveBeenCalled()
   })
 
-  it("keeps processing the queue after a native call rejects", async () => {
+  /** Registration state is tracked separately from the screen count: a rejected
+   *  register must not leave the module claiming protection that was never
+   *  installed. */
+  it("does not unregister after a rejected register, since no guard was installed", async () => {
     const { enableScreenSecurity, disableScreenSecurity } = loadModule()
     mockRegister.mockRejectedValueOnce(new Error("native failure"))
 
     await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
     await disableScreenSecurity()
-    await flushQueue()
 
+    expect(mockUnregister).not.toHaveBeenCalled()
+  })
+
+  it("retries registration on the next enable after a rejected register", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+    mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+    await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+    await disableScreenSecurity()
+
+    await enableScreenSecurity("#000000")
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+  })
+
+  /** Finding: the phrase screen's register rejects, the confirm screen is pushed on
+   *  top, and its enable must retry the registration rather than early-returning on a
+   *  count that claims protection which was never installed. */
+  it("registers for a screen pushed after another screen's registration failed", async () => {
+    const { enableScreenSecurity } = loadModule()
+    mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+    await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+    await enableScreenSecurity("#000000")
+
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+  })
+
+  /** The replace path unmounts one protected screen as another mounts; the queued
+   *  disable sees the arriving screen and skips the unregister/register churn. */
+  it("does not churn the guard when one protected screen replaces another", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+
+    const first = enableScreenSecurity("#000000")
+    const leaving = disableScreenSecurity()
+    const arriving = enableScreenSecurity("#000000")
+    await Promise.all([first, leaving, arriving])
+
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(mockUnregister).not.toHaveBeenCalled()
+  })
+
+  it("keeps processing the queue after a native call rejects", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+    mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+    await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+
+    await enableScreenSecurity("#000000")
+    await disableScreenSecurity()
+    await disableScreenSecurity()
+
+    expect(mockRegister).toHaveBeenCalledTimes(2)
     expect(mockUnregister).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/utils/screen-security.spec.ts
+++ b/__tests__/utils/screen-security.spec.ts
@@ -1,0 +1,115 @@
+const mockInitSettings = jest.fn()
+const mockRegister = jest.fn()
+const mockUnregister = jest.fn()
+
+jest.mock("react-native-screenguard", () => ({
+  initSettings: (...args: readonly unknown[]) => mockInitSettings(...args),
+  register: (...args: readonly unknown[]) => mockRegister(...args),
+  unregister: (...args: readonly unknown[]) => mockUnregister(...args),
+}))
+
+/** The util keeps its reference count and call queue in module state, so each test
+ *  loads a fresh copy. */
+const loadModule = (): typeof import("@app/utils/screen-security") => {
+  let mod: typeof import("@app/utils/screen-security") | undefined
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    mod = require("@app/utils/screen-security")
+  })
+  if (!mod) throw new Error("failed to load screen-security module")
+  return mod
+}
+
+const flushQueue = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve)
+  })
+
+describe("screen-security", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockInitSettings.mockResolvedValue(undefined)
+    mockRegister.mockResolvedValue(undefined)
+    mockUnregister.mockResolvedValue(undefined)
+  })
+
+  it("initializes and registers with the given background color on first enable", async () => {
+    const { enableScreenSecurity } = loadModule()
+
+    await enableScreenSecurity("#000000")
+
+    expect(mockInitSettings).toHaveBeenCalledTimes(1)
+    expect(mockRegister).toHaveBeenCalledWith({ backgroundColor: "#000000" })
+  })
+
+  it("unregisters when the last protected screen disables", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+
+    await enableScreenSecurity("#000000")
+    await disableScreenSecurity()
+
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  /** Back-navigation scenario: the confirm screen is pushed on top of the phrase
+   *  screen; its unmount must not tear down the guard for the phrase screen still
+   *  showing the seed words underneath. */
+  it("keeps the guard registered when a stacked screen unmounts", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+
+    await enableScreenSecurity("#000000") // phrase screen mounts
+    await enableScreenSecurity("#000000") // confirm screen pushed on top
+    await disableScreenSecurity() // confirm screen unmounts on back-navigation
+
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(mockUnregister).not.toHaveBeenCalled()
+  })
+
+  it("unregisters once the last stacked screen unmounts", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+
+    await enableScreenSecurity("#000000")
+    await enableScreenSecurity("#000000")
+    await disableScreenSecurity()
+    await disableScreenSecurity()
+
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+
+  /** Replace scenario: enable awaits initSettings before register (two ticks) while
+   *  disable is a single unregister (one tick); without serialization the shorter
+   *  disable could resolve after the longer enable and unregister a freshly mounted
+   *  screen. The queue must run the native calls in call order. */
+  it("serializes register before unregister when enable and disable race", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+
+    const enablePromise = enableScreenSecurity("#000000")
+    const disablePromise = disableScreenSecurity()
+    await Promise.all([enablePromise, disablePromise])
+
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+    expect(mockRegister.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUnregister.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("ignores a disable with no protected screen mounted", async () => {
+    const { disableScreenSecurity } = loadModule()
+
+    await disableScreenSecurity()
+
+    expect(mockUnregister).not.toHaveBeenCalled()
+  })
+
+  it("keeps processing the queue after a native call rejects", async () => {
+    const { enableScreenSecurity, disableScreenSecurity } = loadModule()
+    mockRegister.mockRejectedValueOnce(new Error("native failure"))
+
+    await expect(enableScreenSecurity("#000000")).rejects.toThrow("native failure")
+    await disableScreenSecurity()
+    await flushQueue()
+
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/hooks/use-screen-security.ts
+++ b/app/hooks/use-screen-security.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react"
 import { useTheme } from "@rn-vui/themed"
 
 import { enableScreenSecurity, disableScreenSecurity } from "@app/utils/screen-security"
+import { reportError } from "@app/utils/error-logging"
 
 export const useScreenSecurity = (): void => {
   const {
@@ -10,9 +11,16 @@ export const useScreenSecurity = (): void => {
   } = useTheme()
 
   useEffect(() => {
-    enableScreenSecurity(colors.black)
+    // The calls are fire-and-forget, so without the catch a native failure to install
+    // the guard would surface only as an unhandled rejection while the screen renders
+    // its seed words unprotected.
+    enableScreenSecurity(colors.black).catch((err: unknown) =>
+      reportError("Enable screen security", err),
+    )
     return () => {
-      disableScreenSecurity()
+      disableScreenSecurity().catch((err: unknown) =>
+        reportError("Disable screen security", err),
+      )
     }
   }, [colors.black])
 }

--- a/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx
+++ b/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx
@@ -9,6 +9,7 @@ import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { Screen } from "@app/components/screen"
 import { SuggestionBar } from "@app/components/suggestion-bar"
+import { useScreenSecurity } from "@app/hooks/use-screen-security"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { PhraseStep, RootStackParamList } from "@app/navigation/stack-param-lists"
 import { useMigrationCheckpoint } from "@app/screens/account-migration/hooks"
@@ -59,6 +60,8 @@ export const BackupPhraseConfirmScreen: React.FC = () => {
 
   const { loading: checkpointLoading } = useMigrationCheckpoint()
   const completeBackup = useCompleteBackup()
+
+  useScreenSecurity()
 
   const onComplete = useCallback(() => {
     logSelfCustodialBackupCompleted({ backupMethod: "manual" })

--- a/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
+++ b/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
@@ -11,6 +11,7 @@ import { GaloyTertiaryButton } from "@app/components/atomic/galoy-tertiary-butto
 import { headerRightNoGlass, noHeaderRight } from "@app/components/header-no-glass"
 import { WarningCard } from "@app/components/warning-card"
 import { SuggestionBar } from "@app/components/suggestion-bar"
+import { useScreenSecurity } from "@app/hooks/use-screen-security"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import {
   isPhraseStep,
@@ -64,6 +65,8 @@ export const RestorePhraseScreen: React.FC = () => {
       { dedupKey: "restore-phrase-params-missing", alwaysRecord: true },
     )
   }, [hasValidParams])
+
+  useScreenSecurity()
 
   const {
     stepWords,

--- a/app/utils/screen-security.ts
+++ b/app/utils/screen-security.ts
@@ -1,10 +1,36 @@
 import ScreenGuard from "react-native-screenguard"
 
+/** ScreenGuard's register/unregister are global, not per-screen, but protected screens
+ *  can stack on each other (backup phrase -> backup confirm, restore phrase step 1 ->
+ *  step 2). Count the mounted protected screens so one screen's unmount only
+ *  unregisters when it is the last one left; without this, leaving the confirm screen
+ *  exposed the still-mounted phrase screen's seed words. The native calls are also
+ *  serialized: enable awaits initSettings before register while disable is a single
+ *  unregister, so without a queue the shorter disable could resolve after the longer
+ *  enable and tear down a freshly registered guard. */
+let activeScreens = 0
+let pending: Promise<void> = Promise.resolve()
+
+const enqueue = (task: () => Promise<void>): Promise<void> => {
+  // Keep the queue alive even when a native call rejects.
+  pending = pending.then(task, task)
+  return pending
+}
+
 export const enableScreenSecurity = async (backgroundColor: string): Promise<void> => {
-  await ScreenGuard.initSettings()
-  await ScreenGuard.register({ backgroundColor })
+  activeScreens += 1
+  if (activeScreens > 1) return
+  await enqueue(async () => {
+    await ScreenGuard.initSettings()
+    await ScreenGuard.register({ backgroundColor })
+  })
 }
 
 export const disableScreenSecurity = async (): Promise<void> => {
-  await ScreenGuard.unregister()
+  if (activeScreens === 0) return
+  activeScreens -= 1
+  if (activeScreens > 0) return
+  await enqueue(async () => {
+    await ScreenGuard.unregister()
+  })
 }

--- a/app/utils/screen-security.ts
+++ b/app/utils/screen-security.ts
@@ -1,5 +1,7 @@
 import ScreenGuard from "react-native-screenguard"
 
+import { reportError } from "@app/utils/error-logging"
+
 /** ScreenGuard's register/unregister are global, not per-screen, but protected screens
  *  can stack on each other (backup phrase -> backup confirm, restore phrase step 1 ->
  *  step 2). Count the mounted protected screens so one screen's unmount only
@@ -14,10 +16,18 @@ import ScreenGuard from "react-native-screenguard"
  *  time: a rejected register leaves `registered` false, so the next mounted screen
  *  retries instead of trusting a count that claims protection which was never
  *  installed, and a screen replaced by another protected screen does not churn the
- *  guard through unregister/register. */
+ *  guard through unregister/register. A rejected register also schedules its own
+ *  bounded retry — see scheduleEnableRetry — and a rejected unregister resets
+ *  `registered` rather than wedging it true — see disableScreenSecurity. */
 let activeScreens = 0
 let registered = false
 let pending: Promise<void> = Promise.resolve()
+
+// A screen whose enable rejected would otherwise stay unprotected for its whole
+// lifetime: without a retry here, protection only came back if *another* protected
+// screen happened to mount later.
+const ENABLE_RETRY_DELAY_MS = 10_000
+const ENABLE_RETRY_LIMIT = 3
 
 const enqueue = (task: () => Promise<void>): Promise<void> => {
   // Keep the queue alive even when a native call rejects.
@@ -25,15 +35,45 @@ const enqueue = (task: () => Promise<void>): Promise<void> => {
   return pending
 }
 
+const registerGuard = async (backgroundColor: string): Promise<void> => {
+  await ScreenGuard.initSettings()
+  await ScreenGuard.register({ backgroundColor })
+  // Serialized by the queue: no other task can touch `registered` while this runs.
+  // eslint-disable-next-line require-atomic-updates
+  registered = true
+}
+
+/** Retries run through the same queue and re-check state at fire time, so a retry
+ *  landing after the last protected screen unmounted — or after another attempt
+ *  already registered — is a no-op rather than a register nobody will unregister.
+ *  The task catches its own failures, so a retry chain never rejects the queue. */
+const scheduleEnableRetry = (backgroundColor: string, attemptsLeft: number): void => {
+  if (attemptsLeft <= 0) return
+  setTimeout(() => {
+    enqueue(async () => {
+      if (registered || activeScreens === 0) return
+      try {
+        await registerGuard(backgroundColor)
+      } catch (error) {
+        reportError("Retry enable screen security", error)
+        scheduleEnableRetry(backgroundColor, attemptsLeft - 1)
+      }
+    })
+  }, ENABLE_RETRY_DELAY_MS)
+}
+
 export const enableScreenSecurity = async (backgroundColor: string): Promise<void> => {
   activeScreens += 1
   await enqueue(async () => {
     if (registered) return
-    await ScreenGuard.initSettings()
-    await ScreenGuard.register({ backgroundColor })
-    // Serialized by the queue: no other task can touch `registered` while this runs.
-    // eslint-disable-next-line require-atomic-updates
-    registered = true
+    try {
+      await registerGuard(backgroundColor)
+    } catch (error) {
+      // The caller still sees the rejection (and reports it); the retry is the
+      // recovery for the screen that stays mounted.
+      scheduleEnableRetry(backgroundColor, ENABLE_RETRY_LIMIT)
+      throw error
+    }
   })
 }
 
@@ -42,9 +82,17 @@ export const disableScreenSecurity = async (): Promise<void> => {
   activeScreens -= 1
   await enqueue(async () => {
     if (activeScreens > 0 || !registered) return
-    await ScreenGuard.unregister()
-    // Serialized by the queue: no other task can touch `registered` while this runs.
-    // eslint-disable-next-line require-atomic-updates
-    registered = false
+    try {
+      await ScreenGuard.unregister()
+    } finally {
+      // A rejected unregister leaves the native state unknown — the shield may or
+      // may not have come down — and no later disable can reach this task to retry,
+      // since the call-time gate above keeps activeScreens at 0. Leaving
+      // `registered` true would wedge the guard: every later enable would skip the
+      // register on the strength of it. `false` is the only recoverable state; the
+      // next enable re-registers, which is harmless if the shield is in fact on.
+      // eslint-disable-next-line require-atomic-updates
+      registered = false
+    }
   })
 }

--- a/app/utils/screen-security.ts
+++ b/app/utils/screen-security.ts
@@ -7,8 +7,16 @@ import ScreenGuard from "react-native-screenguard"
  *  exposed the still-mounted phrase screen's seed words. The native calls are also
  *  serialized: enable awaits initSettings before register while disable is a single
  *  unregister, so without a queue the shorter disable could resolve after the longer
- *  enable and tear down a freshly registered guard. */
+ *  enable and tear down a freshly registered guard.
+ *
+ *  Registration state is tracked separately from the screen count, and the
+ *  register/unregister decisions are made inside the queued task rather than at call
+ *  time: a rejected register leaves `registered` false, so the next mounted screen
+ *  retries instead of trusting a count that claims protection which was never
+ *  installed, and a screen replaced by another protected screen does not churn the
+ *  guard through unregister/register. */
 let activeScreens = 0
+let registered = false
 let pending: Promise<void> = Promise.resolve()
 
 const enqueue = (task: () => Promise<void>): Promise<void> => {
@@ -19,18 +27,24 @@ const enqueue = (task: () => Promise<void>): Promise<void> => {
 
 export const enableScreenSecurity = async (backgroundColor: string): Promise<void> => {
   activeScreens += 1
-  if (activeScreens > 1) return
   await enqueue(async () => {
+    if (registered) return
     await ScreenGuard.initSettings()
     await ScreenGuard.register({ backgroundColor })
+    // Serialized by the queue: no other task can touch `registered` while this runs.
+    // eslint-disable-next-line require-atomic-updates
+    registered = true
   })
 }
 
 export const disableScreenSecurity = async (): Promise<void> => {
   if (activeScreens === 0) return
   activeScreens -= 1
-  if (activeScreens > 0) return
   await enqueue(async () => {
+    if (activeScreens > 0 || !registered) return
     await ScreenGuard.unregister()
+    // Serialized by the queue: no other task can touch `registered` while this runs.
+    // eslint-disable-next-line require-atomic-updates
+    registered = false
   })
 }


### PR DESCRIPTION
<html><head></head><body><h1>Restore-phrase screen has no <code>useScreenSecurity()</code> — the funded mnemonic is screenshot- and recording-capturable</h1>
<p><strong>Component:</strong> <code>app/screens/self-custodial/onboarding/restore/</code>
<strong>Severity:</strong> Medium–High — impact is total, irreversible loss of a funded wallet; likelihood requires an already-present capture channel on the device.
<strong>Type:</strong> Missing security control / inconsistent application of an existing one</p>
<hr>
<h2>Summary</h2>
<p><code>useScreenSecurity()</code> is applied to the two screens that <strong>display</strong> a mnemonic and to the API-key reveal, but not to <code>RestorePhraseScreen</code> — the screen where a user <strong>types in an existing, already-funded</strong> 12-word phrase.</p>
<p>The asymmetry runs backwards. On the backup-creation screens the mnemonic is freshly generated and controls a wallet with a zero balance; a leak there is recoverable — generate a new wallet, back it up again. On the restore screen the phrase controls a wallet that already holds funds, and a BIP39 seed cannot be rotated. The protection is present where the loss is smallest and absent where it is largest.</p>
<p>The restore screen is also the <em>longest-lived</em> mnemonic surface in the app. It renders across two steps, six <code>TextInput</code>s each, with the user typing 12 words and a <code>SuggestionBar</code> rendering live BIP39 completions the whole time — minutes of exposure, versus a display screen the user glances at.</p>
<hr>
<h2>Current state of the control</h2>
<p><code>useScreenSecurity()</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-screen-security.ts#L7-L18"><code>app/hooks/use-screen-security.ts</code></a>) wraps <code>react-native-screenguard</code>:</p>
<pre><code class="language-ts">export const useScreenSecurity = (): void =&gt; {
  const { theme: { colors } } = useTheme()
  useEffect(() =&gt; {
    enableScreenSecurity(colors.black)
    return () =&gt; { disableScreenSecurity() }
  }, [colors.black])
}
</code></pre>
<p>Complete inventory of call sites at <code>8727998</code>:</p>
<pre><code class="language-console">$ grep -rn "useScreenSecurity()" app/
app/screens/settings-screen/api/api-key-secret-reveal.tsx:27
app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx:34
app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx:55
</code></pre>

Screen | Sensitive material | Protected
-- | -- | --
manual-backup/backup-phrase-screen.tsx | Displays new mnemonic, 6 words/step | ✅ L55
manual-backup/view-backup-phrase-screen.tsx | Displays existing mnemonic (biometric-gated) | ✅ L34
settings-screen/api/api-key-secret-reveal.tsx | API key secret | ✅ L27
restore/restore-phrase-screen.tsx | User types a funded 12-word mnemonic | ❌ none
manual-backup/backup-phrase-confirm-screen.tsx | User types real mnemonic words from challenges route param | ❌ none
restore/cloud-restore-screen.tsx | Backup-decryption password (PasswordInput) | ❌ none
onboarding/cloud-backup-screen.tsx | Backup-encryption password | ❌ none


<p><code>RestorePhraseScreen</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx">full file</a>) imports 15 modules and calls neither <code>useScreenSecurity</code> nor anything equivalent. Words are rendered into plain <code>MnemonicWordInput</code> fields at <a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx#L196-L219">L196–L219</a>.</p>
<hr>
<h2>What the missing flag actually costs</h2>
<p><code>react-native-screenguard@2.0.0-beta5</code> is not a soft warning layer. Per its native sources:</p>
<ul>
<li><strong>Android</strong> — <code>ScreenGuardModule.java</code> calls <code>getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE)</code>. Without it, on the restore screen:
<ul>
<li>The <strong>Recents/app-switcher thumbnail is captured and written to disk</strong> under <code>/data/system_ce/&lt;user&gt;/snapshots/</code>. Backgrounding the app mid-restore — an incoming call, a notification tap, checking the paper backup in another app — persists an image of the entered words to storage that survives the app being killed.</li>
<li><strong><code>MediaProjection</code> screen recorders capture the screen.</strong> Any installed app holding an active projection session — legitimate screen recorders, mirroring/casting tools, remote-support apps, or malware that social-engineered the projection consent dialog once — records the phrase as it is typed.</li>
<li>Third-party <strong>display mirroring</strong> to a non-secure external display shows the phrase.</li>
</ul>
</li>
<li><strong>iOS</strong> — <code>ScreenGuardImpl.mm</code> overlays a <code>UITextField</code> with <code>isSecureTextEntry</code> and registers a <code>UIApplicationUserDidTakeScreenshotNotification</code> observer, so both stills and screen recordings of the guarded layer come out blank. Without it the phrase lands in the camera roll on a screenshot, and in any active ReplayKit recording or AirPlay mirror.</li>
</ul>
<p>None of these require a compromised device or root. The recents-snapshot vector in particular fires on completely ordinary user behaviour.</p>
<hr>
<h2>Threat model</h2>
<p>The realistic chain is: a user is restoring a funded wallet onto a new or borrowed phone. During those two typing steps, any of the following captures the phrase —</p>
<ol>
<li><strong>Accidental self-capture.</strong> The user screenshots the screen to "save their place", or has a screen recorder running. Screenshots sync to Google Photos / iCloud Photos, at which point the seed is in a cloud account protected by a password, not by the seed's own security model.</li>
<li><strong>Backgrounding.</strong> Android writes the recents snapshot to disk. Anyone with brief physical access to the unlocked device, or a later forensic/ADB-backup extraction, recovers it.</li>
<li><strong>A capture-capable app already installed.</strong> Screen-recording, mirroring, and remote-support apps hold <code>MediaProjection</code>/ReplayKit permission indefinitely once granted. This is the single most common real-world path and is exactly the class <code>FLAG_SECURE</code> exists to close.</li>
<li><strong>Shoulder-surfing amplification.</strong> Not blocked by <code>FLAG_SECURE</code>, but the same long on-screen dwell time that makes recording effective makes this worse too.</li>
</ol>
<p>Outcome in every case: an attacker holding 12 words drains the wallet. There is no revocation, no rotation, no server-side control that helps.</p>
<hr>
<h2>Adjacent findings from the same review</h2>
<p>These came up while tracing the data flow. Two are real gaps; two are checks that came back <strong>clean</strong> and are recorded here so nobody re-investigates them.</p>
<h3>1. The confirm screen carries real mnemonic words in route params — and is also unprotected</h3>
<p><a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/navigation/stack-param-lists.ts#L224-L227"><code>stack-param-lists.ts</code> L224–L227</a>:</p>
<pre><code class="language-ts">selfCustodialBackupPhraseConfirm: {
  challenges: Array&lt;{ index: number; word: string }&gt;
  successMessage?: string
}
</code></pre>
<p><code>Challenge = { index, word }</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/utils.ts#L14"><code>utils.ts</code> L14</a>) holds the actual words, and <code>BackupPhraseConfirmScreen</code> has no <code>useScreenSecurity()</code>. Same for restore:</p>
<pre><code class="language-ts">selfCustodialRestorePhrase: { step: PhraseStep; words?: string[] }   // L244
</code></pre>
<p><code>useRestorePhrase.handleContinue</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/hooks/use-restore-phrase.ts#L72-L77">L72–L77</a>) puts the full 12-word array into navigation state on the step 1 → step 2 transition.</p>
<h3>2. Cleared: route params do <strong>not</strong> reach Crashlytics or Firebase Analytics</h3>
<p>Worth stating explicitly, because "mnemonic in route params" reads alarming.</p>
<ul>
<li><code>onStateChange</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/navigation/navigation-container-wrapper.tsx#L276-L288"><code>navigation-container-wrapper.tsx</code> L276–L288</a>) logs <code>screen_name</code> / <code>screen_class</code> only. No params.</li>
<li><code>reportError</code> → <code>recordAppError</code> → <code>crashlytics().recordError</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/utils/error-reporting.ts"><code>error-reporting.ts</code></a>) records the <code>Error</code> and a dedup key. The <code>restore-phrase-params-missing</code> report passes a synthetic <code>Error</code> with no param contents.</li>
<li><code>MainActivity.onCreate</code> calls <code>super.onCreate(null)</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/java/com/galoyapp/MainActivity.kt#L27-L30">L27–L30</a>), so Android does not persist and rehydrate the navigation state — the words never hit disk through that path.</li>
<li><code>selfCustodialRestorePhrase</code> is not present in the <code>linking.config.screens</code> map, so it is not reachable as a deep link with attacker-supplied <code>words</code>.</li>
</ul>
<p>So the route-param exposure is process-memory only. Still worth minimising, but it is not an exfiltration path today.</p>
<h3>3. Keyboard/IME hardening is right on Android, thinner on iOS</h3>
<p><code>MnemonicWordInput</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/components/mnemonic-word-input/mnemonic-word-input.tsx#L48-L60">L48–L60</a>) already sets <code>autoCorrect={false}</code> and <code>keyboardType="visible-password"</code>, which is the correct Android signal to keep the IME from learning the words. But <code>visible-password</code> is <strong>Android-only</strong> in React Native and is ignored on iOS, so an iOS third-party keyboard sees the phrase through the standard text-input path. Explicit <code>spellCheck={false}</code>, <code>textContentType="none"</code>, <code>autoComplete="off"</code>, and <code>importantForAutofill="no"</code> would be cheap defence in depth. (Out of scope for this issue; filing separately is fine.)</p>
<h3>4. Clipboard round-trip</h3>
<p>The backup screens expose a <strong>Copy</strong> header button and the restore screen a <strong>Paste</strong> one (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/hooks/use-restore-phrase.ts#L57-L65"><code>use-restore-phrase.ts</code> L57–L65</a>), so the mnemonic transits the system clipboard by design. <code>ApiKeySecretReveal</code> already uses <code>useClipboard(CLIPBOARD_CLEAR_MS)</code> to auto-clear; the mnemonic paths do not appear to. Separate issue, noted for completeness.</p>
<hr>
<h2>Reproduction</h2>
<p>Android, release or debug build:</p>
<ol>
<li>Navigate to <strong>Restore wallet → Recovery phrase</strong>.</li>
<li>Enter any six words on step 1 and continue.</li>
<li>Take a screenshot → succeeds, image saved to the gallery.</li>
<li>Press Recents → the phrase is legible in the app thumbnail. Kill the app; the snapshot file persists under <code>/data/system_ce/&lt;user&gt;/snapshots/</code>.</li>
<li>Start any screen recorder and repeat → the phrase is recorded.</li>
<li>Repeat steps 3–5 on <strong>Back up wallet → Manual → Recovery phrase</strong>: the screenshot is black, the recents thumbnail is black, the recording is black.</li>
</ol>
<p>Or assert the window flag directly while each screen is foregrounded:</p>
<pre><code class="language-bash">adb shell dumpsys window windows | grep -A3 'com.galoyapp' | grep -i 'FLAG_SECURE\|fl='
</code></pre>
<p>iOS: screenshot the restore screen (captures) vs. the backup phrase screen (blank).</p>
<hr>
<h2>Proposed fix</h2>
<h3>1. Add the hook to <code>RestorePhraseScreen</code></h3>
<pre><code class="language-diff">--- a/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
+++ b/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
@@
 import { headerRightNoGlass, noHeaderRight } from "@app/components/header-no-glass"
 import { WarningCard } from "@app/components/warning-card"
 import { SuggestionBar } from "@app/components/suggestion-bar"
+import { useScreenSecurity } from "@app/hooks/use-screen-security"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@
   const navigation = useNavigation&lt;NativeStackNavigationProp&lt;RootStackParamList&gt;&gt;()
 
+  useScreenSecurity()
+
   /** Deep links and navigation-state rehydration can deliver missing or malformed params
</code></pre>
<p>Place it before the early returns so the <code>Restoring</code> and <code>Error</code> branches stay covered too.</p>
<h3>2. Extend to the other three mnemonic/password screens</h3>
<p><code>backup-phrase-confirm-screen.tsx</code>, <code>cloud-restore-screen.tsx</code>, <code>cloud-backup-screen.tsx</code>.</p>
<h3>3. ⚠️ Make the control ref-counted first — it is currently global, not per-screen</h3>
<p>This is a prerequisite, not a nice-to-have. <code>ScreenGuard.register()</code> / <code>unregister()</code> operate on the <strong>activity window</strong>, not on a component. The cleanup in <code>useScreenSecurity</code> unconditionally unregisters. <code>BackupPhraseScreen</code> pushes <code>BackupPhraseConfirmScreen</code> (<a href="https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/hooks/use-backup-phrase.ts#L56"><code>use-backup-phrase.ts</code> L56</a>) and stays mounted underneath it. If step 2 simply adds <code>useScreenSecurity()</code> to the confirm screen, then popping back to <code>BackupPhraseScreen</code> runs the confirm screen's cleanup and <strong>strips <code>FLAG_SECURE</code> from a screen that is still displaying the mnemonic</strong> — a regression introduced by the fix.</p>
<p>A module-level counter fixes it:</p>
<pre><code class="language-ts">// app/hooks/use-screen-security.ts
let activeGuards = 0

export const useScreenSecurity = (): void =&gt; {
  const { theme: { colors } } = useTheme()

  useEffect(() =&gt; {
    activeGuards += 1
    if (activeGuards === 1) enableScreenSecurity(colors.black)
    return () =&gt; {
      activeGuards -= 1
      if (activeGuards === 0) disableScreenSecurity()
    }
  }, [colors.black])
}
</code></pre>
<p>Two further details worth handling in the same change:</p>
<ul>
<li><code>enableScreenSecurity</code> is <code>async</code> and the hook does not await it, so there is a short unguarded window between mount and <code>FLAG_SECURE</code> landing. Setting the flag before the first sensitive frame paints (or rendering the inputs behind a <code>guardReady</code> gate) closes it.</li>
<li>Consider <code>useFocusEffect</code> instead of <code>useEffect</code>, so a screen left mounted lower in the stack does not hold the guard indefinitely. With ref-counting this is a refinement, not a correctness requirement.</li>
</ul>
<h3>4. Add a guard test so the next screen does not miss it</h3>
<pre><code class="language-ts">// __tests__/screen-security-coverage.test.ts
const MUST_GUARD = [
  "app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx",
  "app/screens/self-custodial/onboarding/restore/cloud-restore-screen.tsx",
  "app/screens/self-custodial/onboarding/cloud-backup-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx",
  "app/screens/settings-screen/api/api-key-secret-reveal.tsx",
]

it.each(MUST_GUARD)("%s calls useScreenSecurity", (file) =&gt; {
  expect(readFileSync(file, "utf8")).toContain("useScreenSecurity()")
})
</code></pre>
<hr>
<h2>Acceptance criteria</h2>
<ul>
<li>[ ] <code>RestorePhraseScreen</code> calls <code>useScreenSecurity()</code>, covering the input, <code>Restoring</code>, and <code>Error</code> render branches.</li>
<li>[ ] <code>useScreenSecurity</code> is ref-counted; popping a guarded child back to a guarded parent leaves the parent guarded.</li>
<li>[ ] Android: screenshot, screen recording, and the Recents thumbnail are all blank on the restore screen (verified via <code>dumpsys window</code> showing <code>FLAG_SECURE</code>).</li>
<li>[ ] iOS: screenshot and ReplayKit recording of the restore screen come out blank.</li>
<li>[ ] <code>backup-phrase-confirm-screen</code>, <code>cloud-restore-screen</code>, and <code>cloud-backup-screen</code> are guarded.</li>
<li>[ ] A test fails if a screen on the list drops the hook.</li>
<li>[ ] Follow-up issues opened for iOS keyboard hardening (§3) and mnemonic clipboard auto-clear (§4).</li>
</ul>
<hr>
<h2>References</h2>
<ul>
<li><a href="https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE"><code>FLAG_SECURE</code> — <code>WindowManager.LayoutParams</code></a></li>
<li><a href="https://developer.android.com/reference/android/media/projection/MediaProjection"><code>MediaProjection</code> — Android Developers</a></li>
<li><a href="https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/">OWASP MASVS — MASVS-PLATFORM-3 (sensitive data in the UI)</a></li>
<li><a href="https://mas.owasp.org/MASTG/tests/">OWASP MASTG — Testing for Sensitive Data in Screenshots / Backgrounding</a></li>
<li><a href="https://github.com/gbumps/react-native-screenguard"><code>react-native-screenguard</code></a> — <code>android/.../ScreenGuardModule.java</code>, <code>ios/ScreenGuardImpl.mm</code></li>
<li><a href="https://reactnative.dev/docs/textinput#keyboardtype">React Native <code>TextInput.keyboardType</code></a> — <code>visible-password</code> is Android-only</li>
</ul></body></html># Restore-phrase screen has no `useScreenSecurity()` — the funded mnemonic is screenshot- and recording-capturable

**Component:** `app/screens/self-custodial/onboarding/restore/`
**Severity:** Medium–High — impact is total, irreversible loss of a funded wallet; likelihood requires an already-present capture channel on the device.
**Type:** Missing security control / inconsistent application of an existing one

---

## Summary

`useScreenSecurity()` is applied to the two screens that **display** a mnemonic and to the API-key reveal, but not to `RestorePhraseScreen` — the screen where a user **types in an existing, already-funded** 12-word phrase.

The asymmetry runs backwards. On the backup-creation screens the mnemonic is freshly generated and controls a wallet with a zero balance; a leak there is recoverable — generate a new wallet, back it up again. On the restore screen the phrase controls a wallet that already holds funds, and a BIP39 seed cannot be rotated. The protection is present where the loss is smallest and absent where it is largest.

The restore screen is also the *longest-lived* mnemonic surface in the app. It renders across two steps, six `TextInput`s each, with the user typing 12 words and a `SuggestionBar` rendering live BIP39 completions the whole time — minutes of exposure, versus a display screen the user glances at.

---

## Current state of the control

`useScreenSecurity()` ([`[app/hooks/use-screen-security.ts](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-screen-security.ts#L7-L18)`](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-screen-security.ts#L7-L18)) wraps `react-native-screenguard`:

```ts
export const useScreenSecurity = (): void => {
  const { theme: { colors } } = useTheme()
  useEffect(() => {
    enableScreenSecurity(colors.black)
    return () => { disableScreenSecurity() }
  }, [colors.black])
}
```

Complete inventory of call sites at `8727998`:

```console
$ grep -rn "useScreenSecurity()" app/
app/screens/settings-screen/api/api-key-secret-reveal.tsx:27
app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx:34
app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx:55
```

| Screen | Sensitive material | Protected |
|---|---|---|
| `manual-backup/backup-phrase-screen.tsx` | Displays new mnemonic, 6 words/step | ✅ [[L55](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx#L55)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx#L55) |
| `manual-backup/view-backup-phrase-screen.tsx` | Displays existing mnemonic (biometric-gated) | ✅ [[L34](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx#L34)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx#L34) |
| `settings-screen/api/api-key-secret-reveal.tsx` | API key secret | ✅ [[L27](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/settings-screen/api/api-key-secret-reveal.tsx#L27)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/settings-screen/api/api-key-secret-reveal.tsx#L27) |
| **`restore/restore-phrase-screen.tsx`** | **User types a funded 12-word mnemonic** | ❌ **none** |
| `manual-backup/backup-phrase-confirm-screen.tsx` | User types real mnemonic words from `challenges` route param | ❌ none |
| `restore/cloud-restore-screen.tsx` | Backup-decryption password (`PasswordInput`) | ❌ none |
| `onboarding/cloud-backup-screen.tsx` | Backup-encryption password | ❌ none |

`RestorePhraseScreen` ([[full file](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx)) imports 15 modules and calls neither `useScreenSecurity` nor anything equivalent. Words are rendered into plain `MnemonicWordInput` fields at [[L196–L219](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx#L196-L219)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx#L196-L219).

---

## What the missing flag actually costs

`react-native-screenguard@2.0.0-beta5` is not a soft warning layer. Per its native sources:

- **Android** — `ScreenGuardModule.java` calls `getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE)`. Without it, on the restore screen:
  - The **Recents/app-switcher thumbnail is captured and written to disk** under `/data/system_ce/<user>/snapshots/`. Backgrounding the app mid-restore — an incoming call, a notification tap, checking the paper backup in another app — persists an image of the entered words to storage that survives the app being killed.
  - **`MediaProjection` screen recorders capture the screen.** Any installed app holding an active projection session — legitimate screen recorders, mirroring/casting tools, remote-support apps, or malware that social-engineered the projection consent dialog once — records the phrase as it is typed.
  - Third-party **display mirroring** to a non-secure external display shows the phrase.
- **iOS** — `ScreenGuardImpl.mm` overlays a `UITextField` with `isSecureTextEntry` and registers a `UIApplicationUserDidTakeScreenshotNotification` observer, so both stills and screen recordings of the guarded layer come out blank. Without it the phrase lands in the camera roll on a screenshot, and in any active ReplayKit recording or AirPlay mirror.

None of these require a compromised device or root. The recents-snapshot vector in particular fires on completely ordinary user behaviour.

---

## Threat model

The realistic chain is: a user is restoring a funded wallet onto a new or borrowed phone. During those two typing steps, any of the following captures the phrase —

1. **Accidental self-capture.** The user screenshots the screen to "save their place", or has a screen recorder running. Screenshots sync to Google Photos / iCloud Photos, at which point the seed is in a cloud account protected by a password, not by the seed's own security model.
2. **Backgrounding.** Android writes the recents snapshot to disk. Anyone with brief physical access to the unlocked device, or a later forensic/ADB-backup extraction, recovers it.
3. **A capture-capable app already installed.** Screen-recording, mirroring, and remote-support apps hold `MediaProjection`/ReplayKit permission indefinitely once granted. This is the single most common real-world path and is exactly the class `FLAG_SECURE` exists to close.
4. **Shoulder-surfing amplification.** Not blocked by `FLAG_SECURE`, but the same long on-screen dwell time that makes recording effective makes this worse too.

Outcome in every case: an attacker holding 12 words drains the wallet. There is no revocation, no rotation, no server-side control that helps.

---

## Adjacent findings from the same review

These came up while tracing the data flow. Two are real gaps; two are checks that came back **clean** and are recorded here so nobody re-investigates them.

### 1. The confirm screen carries real mnemonic words in route params — and is also unprotected

[`stack-param-lists.ts` L224–L227](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/navigation/stack-param-lists.ts#L224-L227):

```ts
selfCustodialBackupPhraseConfirm: {
  challenges: Array<{ index: number; word: string }>
  successMessage?: string
}
```

`Challenge = { index, word }` ([`utils.ts` L14](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/utils.ts#L14)) holds the actual words, and `BackupPhraseConfirmScreen` has no `useScreenSecurity()`. Same for restore:

```ts
selfCustodialRestorePhrase: { step: PhraseStep; words?: string[] }   // L244
```

`useRestorePhrase.handleContinue` ([[L72–L77](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/hooks/use-restore-phrase.ts#L72-L77)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/hooks/use-restore-phrase.ts#L72-L77)) puts the full 12-word array into navigation state on the step 1 → step 2 transition.

### 2. Cleared: route params do **not** reach Crashlytics or Firebase Analytics

Worth stating explicitly, because "mnemonic in route params" reads alarming.

- `onStateChange` ([`navigation-container-wrapper.tsx` L276–L288](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/navigation/navigation-container-wrapper.tsx#L276-L288)) logs `screen_name` / `screen_class` only. No params.
- `reportError` → `recordAppError` → `crashlytics().recordError` ([`[error-reporting.ts](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/utils/error-reporting.ts)`](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/utils/error-reporting.ts)) records the `Error` and a dedup key. The `restore-phrase-params-missing` report passes a synthetic `Error` with no param contents.
- `MainActivity.onCreate` calls `super.onCreate(null)` ([[L27–L30](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/java/com/galoyapp/MainActivity.kt#L27-L30)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/java/com/galoyapp/MainActivity.kt#L27-L30)), so Android does not persist and rehydrate the navigation state — the words never hit disk through that path.
- `selfCustodialRestorePhrase` is not present in the `linking.config.screens` map, so it is not reachable as a deep link with attacker-supplied `words`.

So the route-param exposure is process-memory only. Still worth minimising, but it is not an exfiltration path today.

### 3. Keyboard/IME hardening is right on Android, thinner on iOS

`MnemonicWordInput` ([[L48–L60](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/components/mnemonic-word-input/mnemonic-word-input.tsx#L48-L60)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/components/mnemonic-word-input/mnemonic-word-input.tsx#L48-L60)) already sets `autoCorrect={false}` and `keyboardType="visible-password"`, which is the correct Android signal to keep the IME from learning the words. But `visible-password` is **Android-only** in React Native and is ignored on iOS, so an iOS third-party keyboard sees the phrase through the standard text-input path. Explicit `spellCheck={false}`, `textContentType="none"`, `autoComplete="off"`, and `importantForAutofill="no"` would be cheap defence in depth. (Out of scope for this issue; filing separately is fine.)

### 4. Clipboard round-trip

The backup screens expose a **Copy** header button and the restore screen a **Paste** one ([`use-restore-phrase.ts` L57–L65](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/restore/hooks/use-restore-phrase.ts#L57-L65)), so the mnemonic transits the system clipboard by design. `ApiKeySecretReveal` already uses `useClipboard(CLIPBOARD_CLEAR_MS)` to auto-clear; the mnemonic paths do not appear to. Separate issue, noted for completeness.

---

## Reproduction

Android, release or debug build:

1. Navigate to **Restore wallet → Recovery phrase**.
2. Enter any six words on step 1 and continue.
3. Take a screenshot → succeeds, image saved to the gallery.
4. Press Recents → the phrase is legible in the app thumbnail. Kill the app; the snapshot file persists under `/data/system_ce/<user>/snapshots/`.
5. Start any screen recorder and repeat → the phrase is recorded.
6. Repeat steps 3–5 on **Back up wallet → Manual → Recovery phrase**: the screenshot is black, the recents thumbnail is black, the recording is black.

Or assert the window flag directly while each screen is foregrounded:

```bash
adb shell dumpsys window windows | grep -A3 'com.galoyapp' | grep -i 'FLAG_SECURE\|fl='
```

iOS: screenshot the restore screen (captures) vs. the backup phrase screen (blank).

---

## Proposed fix

### 1. Add the hook to `RestorePhraseScreen`

```diff
--- a/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
+++ b/app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx
@@
 import { headerRightNoGlass, noHeaderRight } from "@app/components/header-no-glass"
 import { WarningCard } from "@app/components/warning-card"
 import { SuggestionBar } from "@app/components/suggestion-bar"
+import { useScreenSecurity } from "@app/hooks/use-screen-security"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
+  useScreenSecurity()
+
   /** Deep links and navigation-state rehydration can deliver missing or malformed params
```

Place it before the early returns so the `Restoring` and `Error` branches stay covered too.

### 2. Extend to the other three mnemonic/password screens

`backup-phrase-confirm-screen.tsx`, `cloud-restore-screen.tsx`, `cloud-backup-screen.tsx`.

### 3. ⚠️ Make the control ref-counted first — it is currently global, not per-screen

This is a prerequisite, not a nice-to-have. `ScreenGuard.register()` / `unregister()` operate on the **activity window**, not on a component. The cleanup in `useScreenSecurity` unconditionally unregisters. `BackupPhraseScreen` pushes `BackupPhraseConfirmScreen` ([`use-backup-phrase.ts` L56](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/self-custodial/onboarding/hooks/use-backup-phrase.ts#L56)) and stays mounted underneath it. If step 2 simply adds `useScreenSecurity()` to the confirm screen, then popping back to `BackupPhraseScreen` runs the confirm screen's cleanup and **strips `FLAG_SECURE` from a screen that is still displaying the mnemonic** — a regression introduced by the fix.

A module-level counter fixes it:

```ts
// app/hooks/use-screen-security.ts
let activeGuards = 0

export const useScreenSecurity = (): void => {
  const { theme: { colors } } = useTheme()

  useEffect(() => {
    activeGuards += 1
    if (activeGuards === 1) enableScreenSecurity(colors.black)
    return () => {
      activeGuards -= 1
      if (activeGuards === 0) disableScreenSecurity()
    }
  }, [colors.black])
}
```

Two further details worth handling in the same change:

- `enableScreenSecurity` is `async` and the hook does not await it, so there is a short unguarded window between mount and `FLAG_SECURE` landing. Setting the flag before the first sensitive frame paints (or rendering the inputs behind a `guardReady` gate) closes it.
- Consider `useFocusEffect` instead of `useEffect`, so a screen left mounted lower in the stack does not hold the guard indefinitely. With ref-counting this is a refinement, not a correctness requirement.

### 4. Add a guard test so the next screen does not miss it

```ts
// __tests__/screen-security-coverage.test.ts
const MUST_GUARD = [
  "app/screens/self-custodial/onboarding/restore/restore-phrase-screen.tsx",
  "app/screens/self-custodial/onboarding/restore/cloud-restore-screen.tsx",
  "app/screens/self-custodial/onboarding/cloud-backup-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/backup-phrase-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx",
  "app/screens/self-custodial/onboarding/manual-backup/view-backup-phrase-screen.tsx",
  "app/screens/settings-screen/api/api-key-secret-reveal.tsx",
]

it.each(MUST_GUARD)("%s calls useScreenSecurity", (file) => {
  expect(readFileSync(file, "utf8")).toContain("useScreenSecurity()")
})
```

---

## Acceptance criteria

- [ ] `RestorePhraseScreen` calls `useScreenSecurity()`, covering the input, `Restoring`, and `Error` render branches.
- [ ] `useScreenSecurity` is ref-counted; popping a guarded child back to a guarded parent leaves the parent guarded.
- [ ] Android: screenshot, screen recording, and the Recents thumbnail are all blank on the restore screen (verified via `dumpsys window` showing `FLAG_SECURE`).
- [ ] iOS: screenshot and ReplayKit recording of the restore screen come out blank.
- [ ] `backup-phrase-confirm-screen`, `cloud-restore-screen`, and `cloud-backup-screen` are guarded.
- [ ] A test fails if a screen on the list drops the hook.
- [ ] Follow-up issues opened for iOS keyboard hardening (§3) and mnemonic clipboard auto-clear (§4).

---

## References

- [`FLAG_SECURE` — `WindowManager.LayoutParams`](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE)
- [`MediaProjection` — Android Developers](https://developer.android.com/reference/android/media/projection/MediaProjection)
- [[OWASP MASVS — MASVS-PLATFORM-3 (sensitive data in the UI)](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)
- [[OWASP MASTG — Testing for Sensitive Data in Screenshots / Backgrounding](https://mas.owasp.org/MASTG/tests/)](https://mas.owasp.org/MASTG/tests/)
- [`[react-native-screenguard](https://github.com/gbumps/react-native-screenguard)`](https://github.com/gbumps/react-native-screenguard) — `android/.../ScreenGuardModule.java`, `ios/ScreenGuardImpl.mm`
- [React Native `TextInput.keyboardType`](https://reactnative.dev/docs/textinput#keyboardtype) — `visible-password` is Android-only