### PR TITLE
fix(security): store the session token only in the secure key store

### DIFF
--- a/__tests__/hooks/use-app-config.spec.ts
+++ b/__tests__/hooks/use-app-config.spec.ts
@@ -1,0 +1,112 @@
+import { renderHook, act } from "@testing-library/react-native"
+
+import { resolveGaloyInstanceOrDefault } from "@app/config"
+import { useAppConfig } from "@app/hooks/use-app-config"
+
+const mockReportError = jest.fn()
+const mockUpdateState = jest.fn()
+
+const mockSecureStore = new Map<string, string>()
+const failSetFor = new Set<string>()
+jest.mock("react-native-secure-key-store", () => ({
+  __esModule: true,
+  default: {
+    get: (key: string) =>
+      mockSecureStore.has(key)
+        ? Promise.resolve(mockSecureStore.get(key))
+        : Promise.reject(new Error(`key not found: ${key}`)),
+    set: (key: string, value: string) => {
+      if (failSetFor.has(key)) return Promise.reject(new Error("keystore locked"))
+      mockSecureStore.set(key, value)
+      return Promise.resolve(true)
+    },
+    remove: (key: string) => {
+      mockSecureStore.delete(key)
+      return Promise.resolve(true)
+    },
+  },
+  ACCESSIBLE: {
+    ALWAYS_THIS_DEVICE_ONLY: "ALWAYS_THIS_DEVICE_ONLY",
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  },
+}))
+
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: { galoyAuthToken: "", galoyInstance: { id: "Main" } },
+    updateState: mockUpdateState,
+  }),
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
+// Applies the updater the way PersistentStateProvider would, so tests can see
+// what the in-memory state became.
+const applyLastUpdate = (state: Record<string, unknown>) =>
+  mockUpdateState.mock.calls.map(([update]) => update(state)).at(-1)
+
+describe("useAppConfig token persistence", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSecureStore.clear()
+    failSetFor.clear()
+  })
+
+  it("saveToken writes the token to the key store and into in-memory state", async () => {
+    const { result } = renderHook(() => useAppConfig())
+
+    await act(async () => {
+      await result.current.saveToken("session-token")
+    })
+
+    expect(mockSecureStore.get("activeAuthToken")).toBe("session-token")
+    expect(applyLastUpdate({ galoyAuthToken: "" })).toEqual({
+      galoyAuthToken: "session-token",
+    })
+  })
+
+  it('saveToken("") removes the key-store token', async () => {
+    mockSecureStore.set("activeAuthToken", "session-token")
+    const { result } = renderHook(() => useAppConfig())
+
+    await act(async () => {
+      await result.current.saveToken("")
+    })
+
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+  })
+
+  it("saveTokenAndInstance persists the token alongside the instance switch", async () => {
+    const { result } = renderHook(() => useAppConfig())
+
+    await act(async () => {
+      await result.current.saveTokenAndInstance({
+        token: "session-token",
+        instance: resolveGaloyInstanceOrDefault({ id: "Main" }),
+      })
+    })
+
+    expect(mockSecureStore.get("activeAuthToken")).toBe("session-token")
+  })
+
+  it("reports a rejected key-store write instead of resolving silently", async () => {
+    failSetFor.add("activeAuthToken")
+    const { result } = renderHook(() => useAppConfig())
+
+    await act(async () => {
+      await result.current.saveToken("session-token")
+    })
+
+    // The in-memory login proceeds for this session, but the failure to
+    // persist is surfaced — otherwise the session would evaporate at next
+    // launch with nothing recorded anywhere.
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+    expect(mockReportError.mock.calls[0][0]).toBe("persist auth token")
+    expect(applyLastUpdate({ galoyAuthToken: "" })).toEqual({
+      galoyAuthToken: "session-token",
+    })
+  })
+})

--- a/__tests__/hooks/use-logout.spec.ts
+++ b/__tests__/hooks/use-logout.spec.ts
@@ -1,0 +1,246 @@
+import { renderHook, act } from "@testing-library/react-native"
+
+import { SCHEMA_VERSION_KEY } from "@app/config"
+import useLogout from "@app/hooks/use-logout"
+
+const mockResetState = jest.fn()
+const mockUserLogoutMutation = jest.fn()
+const mockMultiRemove = jest.fn()
+const mockGetDeviceToken = jest.fn()
+const mockReportError = jest.fn()
+
+// In-memory stand-in for the secure key store: the assertions below run
+// against the real KeyStoreWrapper, so the profile/active-token interplay is
+// exercised end to end rather than through mocked wrapper methods.
+const mockSecureStore = new Map<string, string>()
+const failRemoveFor = new Set<string>()
+jest.mock("react-native-secure-key-store", () => ({
+  __esModule: true,
+  default: {
+    get: (key: string) =>
+      mockSecureStore.has(key)
+        ? Promise.resolve(mockSecureStore.get(key))
+        : Promise.reject(new Error(`key not found: ${key}`)),
+    set: (key: string, value: string) => {
+      mockSecureStore.set(key, value)
+      return Promise.resolve(true)
+    },
+    remove: (key: string) => {
+      if (failRemoveFor.has(key)) return Promise.reject(new Error("keystore locked"))
+      mockSecureStore.delete(key)
+      return Promise.resolve(true)
+    },
+  },
+  ACCESSIBLE: {
+    ALWAYS_THIS_DEVICE_ONLY: "ALWAYS_THIS_DEVICE_ONLY",
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  },
+}))
+
+jest.mock("@react-native-async-storage/async-storage", () => ({
+  multiRemove: (...args: unknown[]) => mockMultiRemove(...args),
+}))
+
+jest.mock("@react-native-firebase/messaging", () => () => ({
+  getToken: () => mockGetDeviceToken(),
+}))
+
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({ resetState: mockResetState }),
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useUserLogoutMutation: () => [mockUserLogoutMutation],
+}))
+
+jest.mock("@app/utils/analytics", () => ({ logLogout: jest.fn() }))
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
+const profileA = { token: "tok-a", username: "alice", accountId: "acct-a" }
+const profileB = { token: "tok-b", username: "bob", accountId: "acct-b" }
+
+const seedProfiles = (profiles: { token: string }[]) =>
+  mockSecureStore.set("sessionProfiles", JSON.stringify(profiles))
+
+const storedProfiles = (): { token: string }[] =>
+  JSON.parse(mockSecureStore.get("sessionProfiles") ?? "[]")
+
+describe("useLogout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSecureStore.clear()
+    failRemoveFor.clear()
+    mockUserLogoutMutation.mockResolvedValue({ data: { userLogout: { success: true } } })
+    mockMultiRemove.mockResolvedValue(undefined)
+    mockGetDeviceToken.mockResolvedValue("device-token")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("full logout clears the active token and all profiles from the key store", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA, profileB])
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(mockSecureStore.has("sessionProfiles")).toBe(false)
+    expect(mockResetState).toHaveBeenCalled()
+  })
+
+  it("full logout also wipes PIN, biometrics and the schema version key, without calling the server mutation", async () => {
+    mockSecureStore.set("PIN", "1234")
+    mockSecureStore.set("pinAttempts", "3")
+    mockSecureStore.set("isBiometricsEnabled", "1")
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA])
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(mockSecureStore.has("PIN")).toBe(false)
+    expect(mockSecureStore.has("pinAttempts")).toBe(false)
+    expect(mockSecureStore.has("isBiometricsEnabled")).toBe(false)
+    expect(mockMultiRemove).toHaveBeenCalledWith([SCHEMA_VERSION_KEY])
+    // No token context means there is nothing to revoke server-side.
+    expect(mockUserLogoutMutation).not.toHaveBeenCalled()
+  })
+
+  it("full logout with stateToDefault: false keeps the in-memory state", async () => {
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ stateToDefault: false })
+    })
+
+    expect(mockResetState).not.toHaveBeenCalled()
+  })
+
+  it("removing the profile backing the active session clears the active token", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA, profileB])
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ stateToDefault: false, token: "tok-a" })
+    })
+
+    // Regression: the deleted profile's token must not linger as the active
+    // token — it would otherwise be hydrated back into memory on next launch.
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(storedProfiles().map((p) => p.token)).toEqual(["tok-b"])
+    expect(mockResetState).not.toHaveBeenCalled()
+    expect(mockUserLogoutMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: { headers: { authorization: "Bearer tok-a" } },
+      }),
+    )
+  })
+
+  it("removing an inactive profile keeps the active token untouched", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-b")
+    seedProfiles([profileA, profileB])
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ stateToDefault: false, token: "tok-a" })
+    })
+
+    expect(mockSecureStore.get("activeAuthToken")).toBe("tok-b")
+    expect(storedProfiles().map((p) => p.token)).toEqual(["tok-b"])
+  })
+
+  it("isValidToken: false skips the server revocation but still cleans up locally", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA, profileB])
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({
+        stateToDefault: false,
+        token: "tok-a",
+        isValidToken: false,
+      })
+    })
+
+    expect(mockUserLogoutMutation).not.toHaveBeenCalled()
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(storedProfiles().map((p) => p.token)).toEqual(["tok-b"])
+  })
+
+  it("still clears the active token when the server-side revocation fails", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA, profileB])
+    mockUserLogoutMutation.mockRejectedValue(new Error("network down"))
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ stateToDefault: false, token: "tok-a" })
+    })
+
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(storedProfiles().map((p) => p.token)).toEqual(["tok-b"])
+  })
+
+  it("completes via the timeout when the revocation mutation hangs", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA])
+    mockUserLogoutMutation.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useLogout())
+
+    // Fire the logout timeout immediately instead of faking all timers, which
+    // would freeze React's scheduler and hang the renderer.
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(((
+      cb: () => void,
+    ) => {
+      cb()
+      return 0
+    }) as unknown as typeof setTimeout)
+
+    await act(async () => {
+      await result.current.logout({ token: "tok-a" })
+    })
+    setTimeoutSpy.mockRestore()
+
+    expect(mockReportError).toHaveBeenCalled()
+    expect(mockResetState).toHaveBeenCalled()
+  })
+
+  it("a keystore removal failure does not abort the logout or the state reset", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA])
+    failRemoveFor.add("activeAuthToken")
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ token: "tok-a" })
+    })
+
+    // The removal failed, so the key survives — but the logout flow itself
+    // must not blow up, and the in-memory state is still reset.
+    expect(mockSecureStore.has("activeAuthToken")).toBe(true)
+    expect(mockResetState).toHaveBeenCalled()
+  })
+
+  it("resets state even when fetching the push device token fails", async () => {
+    mockGetDeviceToken.mockRejectedValue(new Error("fcm unavailable"))
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    expect(mockReportError).toHaveBeenCalled()
+    expect(mockResetState).toHaveBeenCalled()
+  })
+})

--- a/__tests__/hooks/use-logout.spec.ts
+++ b/__tests__/hooks/use-logout.spec.ts
@@ -232,7 +232,9 @@ describe("useLogout", () => {
     expect(mockResetState).toHaveBeenCalled()
   })
 
-  it("resets state even when fetching the push device token fails", async () => {
+  it("a failed push-token fetch still runs the full key-store cleanup", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA])
     mockGetDeviceToken.mockRejectedValue(new Error("fcm unavailable"))
 
     const { result } = renderHook(() => useLogout())
@@ -240,7 +242,28 @@ describe("useLogout", () => {
       await result.current.logout()
     })
 
+    // Regression: the fetch used to throw ahead of every removal, so the
+    // token survived in the key store and was hydrated back on next launch.
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(mockSecureStore.has("sessionProfiles")).toBe(false)
     expect(mockReportError).toHaveBeenCalled()
     expect(mockResetState).toHaveBeenCalled()
+  })
+
+  it("skips the server revocation when the push-token fetch fails, but still removes the session locally", async () => {
+    mockSecureStore.set("activeAuthToken", "tok-a")
+    seedProfiles([profileA, profileB])
+    mockGetDeviceToken.mockRejectedValue(new Error("fcm unavailable"))
+
+    const { result } = renderHook(() => useLogout())
+    await act(async () => {
+      await result.current.logout({ stateToDefault: false, token: "tok-a" })
+    })
+
+    // No device token means no revocation attempt — but the local cleanup
+    // must not depend on it.
+    expect(mockUserLogoutMutation).not.toHaveBeenCalled()
+    expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+    expect(storedProfiles().map((p) => p.token)).toEqual(["tok-b"])
   })
 })

--- a/__tests__/hooks/use-switch-to-next-profile.spec.ts
+++ b/__tests__/hooks/use-switch-to-next-profile.spec.ts
@@ -1,0 +1,113 @@
+import { renderHook, act } from "@testing-library/react-native"
+
+import { useSwitchToNextProfile } from "@app/hooks/use-switch-to-next-profile"
+
+const mockLogout = jest.fn()
+const mockSaveToken = jest.fn()
+const mockNavigate = jest.fn()
+const mockToastShow = jest.fn()
+
+// Real KeyStoreWrapper over an in-memory key store, so the profile lookup is
+// exercised rather than stubbed.
+const mockSecureStore = new Map<string, string>()
+jest.mock("react-native-secure-key-store", () => ({
+  __esModule: true,
+  default: {
+    get: (key: string) =>
+      mockSecureStore.has(key)
+        ? Promise.resolve(mockSecureStore.get(key))
+        : Promise.reject(new Error(`key not found: ${key}`)),
+    set: (key: string, value: string) => {
+      mockSecureStore.set(key, value)
+      return Promise.resolve(true)
+    },
+    remove: (key: string) => {
+      mockSecureStore.delete(key)
+      return Promise.resolve(true)
+    },
+  },
+  ACCESSIBLE: {
+    ALWAYS_THIS_DEVICE_ONLY: "ALWAYS_THIS_DEVICE_ONLY",
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  },
+}))
+
+jest.mock("@app/hooks/use-logout", () => ({
+  __esModule: true,
+  default: () => ({ logout: mockLogout }),
+}))
+
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({ saveToken: mockSaveToken }),
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: { ProfileScreen: { switchAccount: () => "Switched" } },
+  }),
+}))
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (...args: unknown[]) => mockToastShow(...args),
+}))
+
+const profileA = { token: "tok-a", username: "alice", accountId: "acct-a" }
+const profileB = { token: "tok-b", username: "bob", accountId: "acct-b" }
+
+describe("useSwitchToNextProfile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSecureStore.clear()
+    mockLogout.mockResolvedValue(undefined)
+    mockSaveToken.mockResolvedValue(undefined)
+  })
+
+  it("deactivates the old token before saving the next profile's token", async () => {
+    mockSecureStore.set("sessionProfiles", JSON.stringify([profileA, profileB]))
+
+    const { result } = renderHook(() => useSwitchToNextProfile())
+    let nextProfile
+    await act(async () => {
+      nextProfile = await result.current.switchToNextProfile("tok-a")
+    })
+
+    expect(nextProfile).toEqual(profileB)
+    // No server revocation for a session the caller has already invalidated.
+    expect(mockLogout).toHaveBeenCalledWith({
+      stateToDefault: false,
+      token: "tok-a",
+      isValidToken: false,
+    })
+    expect(mockSaveToken).toHaveBeenCalledWith("tok-b")
+    // Ordering is the invariant: the old active token must be cleared before
+    // (or as) the new one is saved — never the other way round.
+    expect(mockLogout.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSaveToken.mock.invocationCallOrder[0],
+    )
+    expect(mockNavigate).toHaveBeenCalledWith("Primary")
+    expect(mockToastShow).toHaveBeenCalled()
+  })
+
+  it("does not touch the active token when there is no next profile", async () => {
+    mockSecureStore.set("sessionProfiles", JSON.stringify([profileA]))
+
+    const { result } = renderHook(() => useSwitchToNextProfile())
+    let nextProfile
+    await act(async () => {
+      nextProfile = await result.current.switchToNextProfile("tok-a")
+    })
+
+    expect(nextProfile).toBeUndefined()
+    expect(mockLogout).toHaveBeenCalledWith({
+      stateToDefault: false,
+      token: "tok-a",
+      isValidToken: false,
+    })
+    expect(mockSaveToken).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -24,6 +24,30 @@ jest.mock("@react-native-firebase/crashlytics", () => () => ({
   log: jest.fn(),
 }))
 
+// In-memory stand-in for the secure key store, where the session token now lives.
+const mockSecureStore = new Map<string, string>()
+jest.mock("react-native-secure-key-store", () => ({
+  __esModule: true,
+  default: {
+    get: (key: string) =>
+      mockSecureStore.has(key)
+        ? Promise.resolve(mockSecureStore.get(key))
+        : Promise.reject(new Error(`key not found: ${key}`)),
+    set: (key: string, value: string) => {
+      mockSecureStore.set(key, value)
+      return Promise.resolve(true)
+    },
+    remove: (key: string) => {
+      mockSecureStore.delete(key)
+      return Promise.resolve(true)
+    },
+  },
+  ACCESSIBLE: {
+    ALWAYS_THIS_DEVICE_ONLY: "ALWAYS_THIS_DEVICE_ONLY",
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY",
+  },
+}))
+
 const TestConsumer: React.FC = () => {
   const ctx = React.useContext(PersistentStateContext)
   if (!ctx) return <Text testID="loading">Loading</Text>
@@ -48,6 +72,7 @@ const TestConsumer: React.FC = () => {
 describe("PersistentStateProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockSecureStore.clear()
     mockSaveJson.mockResolvedValue(undefined)
     mockSaveString.mockResolvedValue(true)
   })
@@ -160,7 +185,9 @@ describe("PersistentStateProvider", () => {
 
     expect(mockSaveJson).toHaveBeenCalledWith(
       "persistentState",
-      expect.objectContaining({ galoyAuthToken: "new-token" }),
+      // The token is stripped from the AsyncStorage blob — the in-memory value
+      // ("new-token", asserted above) never reaches disk in plaintext.
+      expect.objectContaining({ galoyAuthToken: "" }),
     )
   })
 
@@ -350,6 +377,67 @@ describe("PersistentStateProvider", () => {
 
       expect(mockRecordError).not.toHaveBeenCalled()
       expect(mockSaveString).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("session token storage", () => {
+    it("hydrates the token from the secure key store, ignoring the blank on-disk copy", async () => {
+      mockSecureStore.set("activeAuthToken", "secure-token")
+      mockLoadJson.mockResolvedValue({
+        schemaVersion: 6,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      })
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token").props.children).toBe("secure-token")
+      })
+    })
+
+    it("moves a legacy plaintext token from the AsyncStorage blob into the key store on load", async () => {
+      mockLoadJson.mockResolvedValue({
+        schemaVersion: 6,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "legacy-token",
+      })
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token").props.children).toBe("legacy-token")
+      })
+      expect(mockSecureStore.get("activeAuthToken")).toBe("legacy-token")
+    })
+
+    it("prefers the key store token over a stale blob copy", async () => {
+      mockSecureStore.set("activeAuthToken", "secure-token")
+      mockLoadJson.mockResolvedValue({
+        schemaVersion: 6,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "stale-blob-token",
+      })
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token").props.children).toBe("secure-token")
+      })
+      // No legacy move happened: the blob token is discarded, not promoted.
+      expect(mockSecureStore.get("activeAuthToken")).toBe("secure-token")
     })
   })
 })

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -26,6 +26,7 @@ jest.mock("@react-native-firebase/crashlytics", () => () => ({
 
 // In-memory stand-in for the secure key store, where the session token now lives.
 const mockSecureStore = new Map<string, string>()
+const failSetFor = new Set<string>()
 jest.mock("react-native-secure-key-store", () => ({
   __esModule: true,
   default: {
@@ -34,6 +35,7 @@ jest.mock("react-native-secure-key-store", () => ({
         ? Promise.resolve(mockSecureStore.get(key))
         : Promise.reject(new Error(`key not found: ${key}`)),
     set: (key: string, value: string) => {
+      if (failSetFor.has(key)) return Promise.reject(new Error("keystore locked"))
       mockSecureStore.set(key, value)
       return Promise.resolve(true)
     },
@@ -73,6 +75,7 @@ describe("PersistentStateProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockSecureStore.clear()
+    failSetFor.clear()
     mockSaveJson.mockResolvedValue(undefined)
     mockSaveString.mockResolvedValue(true)
   })
@@ -308,7 +311,9 @@ describe("PersistentStateProvider", () => {
       const timestamp = Number(key.split(".").pop())
       expect(timestamp).toBeGreaterThanOrEqual(before)
       expect(timestamp).toBeLessThanOrEqual(after)
-      expect(JSON.parse(payload)).toEqual(corruptedState3)
+      // The quarantine keeps the raw blob for forensics but never the token:
+      // it is stripped before the payload hits AsyncStorage.
+      expect(JSON.parse(payload)).toEqual({ ...corruptedState3, galoyAuthToken: "" })
 
       // Provider must still mount with defaults so the app can launch.
       expect(screen.getByTestId("token").props.children).toBe(
@@ -438,6 +443,77 @@ describe("PersistentStateProvider", () => {
       })
       // No legacy move happened: the blob token is discarded, not promoted.
       expect(mockSecureStore.get("activeAuthToken")).toBe("secure-token")
+    })
+
+    it("does NOT hydrate on a fresh install, even when the key store still holds a token", async () => {
+      // iOS: the keychain outlives app deletion. No persisted blob must mean
+      // logged out — not "resume the previous install's session".
+      mockSecureStore.set("activeAuthToken", "previous-install-token")
+      mockLoadJson.mockResolvedValue(null)
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token")).toBeTruthy()
+      })
+      expect(screen.getByTestId("token").props.children).toBe(
+        defaultPersistentState.galoyAuthToken,
+      )
+    })
+
+    it("does NOT hydrate after a failed migration — the clean slate stays logged out", async () => {
+      // The quarantine-and-reset path must not pair the live token with the
+      // default instance's backend.
+      mockSecureStore.set("activeAuthToken", "secure-token")
+      mockLoadJson.mockResolvedValue({
+        schemaVersion: 3,
+        hasShownStableSatsWelcome: false,
+        isUsdDisabled: false,
+        galoyInstance: { id: "Main", name: "DefinitelyNotARealInstance" },
+        galoyAuthToken: "token-v3",
+        isAnalyticsEnabled: true,
+      })
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token")).toBeTruthy()
+      })
+      expect(screen.getByTestId("token").props.children).toBe(
+        defaultPersistentState.galoyAuthToken,
+      )
+    })
+
+    it("reports a failed key-store write during the legacy token move, keeping the token in memory", async () => {
+      failSetFor.add("activeAuthToken")
+      mockLoadJson.mockResolvedValue({
+        schemaVersion: 6,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "legacy-token",
+      })
+
+      render(
+        <PersistentStateProvider>
+          <TestConsumer />
+        </PersistentStateProvider>,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("token").props.children).toBe("legacy-token")
+      })
+      expect(mockSecureStore.has("activeAuthToken")).toBe(false)
+      expect(mockRecordError).toHaveBeenCalledTimes(1)
+      expect(mockRecordError.mock.calls[0][0].message).toContain(
+        "Failed to move legacy auth token",
+      )
     })
   })
 })

--- a/__tests__/utils/secure-storage.spec.ts
+++ b/__tests__/utils/secure-storage.spec.ts
@@ -536,4 +536,59 @@ describe("KeyStoreWrapper session-profile methods", () => {
       expect(result).toBe(false)
     })
   })
+
+  describe("active auth token", () => {
+    it("getActiveAuthToken reads the activeAuthToken key", async () => {
+      mockGet.mockResolvedValue("session-token")
+
+      const result = await KeyStoreWrapper.getActiveAuthToken()
+
+      expect(result).toBe("session-token")
+      expect(mockGet).toHaveBeenCalledWith("activeAuthToken")
+    })
+
+    it("getActiveAuthToken returns null on keystore error", async () => {
+      mockGet.mockRejectedValue(new Error("keychain unavailable"))
+
+      const result = await KeyStoreWrapper.getActiveAuthToken()
+
+      expect(result).toBeNull()
+    })
+
+    it("setActiveAuthToken writes device-only and returns true", async () => {
+      mockSet.mockResolvedValue(undefined)
+
+      const result = await KeyStoreWrapper.setActiveAuthToken("session-token")
+
+      expect(result).toBe(true)
+      expect(mockSet).toHaveBeenCalledWith("activeAuthToken", "session-token", {
+        accessible: "ALWAYS_THIS_DEVICE_ONLY",
+      })
+    })
+
+    it("setActiveAuthToken returns false when the write fails", async () => {
+      mockSet.mockRejectedValue(new Error("write locked"))
+
+      const result = await KeyStoreWrapper.setActiveAuthToken("session-token")
+
+      expect(result).toBe(false)
+    })
+
+    it("removeActiveAuthToken removes the key and returns true", async () => {
+      mockRemove.mockResolvedValue(undefined)
+
+      const result = await KeyStoreWrapper.removeActiveAuthToken()
+
+      expect(result).toBe(true)
+      expect(mockRemove).toHaveBeenCalledWith("activeAuthToken")
+    })
+
+    it("removeActiveAuthToken returns false on keystore error", async () => {
+      mockRemove.mockRejectedValue(new Error("not found"))
+
+      const result = await KeyStoreWrapper.removeActiveAuthToken()
+
+      expect(result).toBe(false)
+    })
+  })
 })

--- a/app/hooks/use-app-config.ts
+++ b/app/hooks/use-app-config.ts
@@ -2,15 +2,23 @@ import { useCallback, useMemo } from "react"
 
 import { GaloyInstance, resolveGaloyInstanceOrDefault } from "@app/config"
 import { usePersistentStateContext } from "@app/store/persistent-state"
+import { reportError } from "@app/utils/error-logging"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 // The session token is persisted only in the secure key store; the persistent
 // state copy is in-memory (its on-disk blob is written with the token stripped).
+// A rejected key-store write leaves the token memory-only — the session
+// evaporates at next launch — so surface it instead of resolving silently.
 const persistToken = async (token: string): Promise<void> => {
-  if (token) {
-    await KeyStoreWrapper.setActiveAuthToken(token)
-  } else {
-    await KeyStoreWrapper.removeActiveAuthToken()
+  const persisted = token
+    ? await KeyStoreWrapper.setActiveAuthToken(token)
+    : await KeyStoreWrapper.removeActiveAuthToken()
+  if (!persisted) {
+    reportError(
+      "persist auth token",
+      new Error("secure key store rejected the auth token update"),
+      { alwaysRecord: true },
+    )
   }
 }
 

--- a/app/hooks/use-app-config.ts
+++ b/app/hooks/use-app-config.ts
@@ -2,6 +2,17 @@ import { useCallback, useMemo } from "react"
 
 import { GaloyInstance, resolveGaloyInstanceOrDefault } from "@app/config"
 import { usePersistentStateContext } from "@app/store/persistent-state"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+
+// The session token is persisted only in the secure key store; the persistent
+// state copy is in-memory (its on-disk blob is written with the token stripped).
+const persistToken = async (token: string): Promise<void> => {
+  if (token) {
+    await KeyStoreWrapper.setActiveAuthToken(token)
+  } else {
+    await KeyStoreWrapper.removeActiveAuthToken()
+  }
+}
 
 export const useAppConfig = () => {
   const { persistentState, updateState } = usePersistentStateContext()
@@ -30,6 +41,7 @@ export const useAppConfig = () => {
 
   const saveToken = useCallback(
     async (token: string) => {
+      await persistToken(token)
       updateState((state) => {
         if (state)
           return {
@@ -44,6 +56,7 @@ export const useAppConfig = () => {
 
   const saveTokenAndInstance = useCallback(
     async ({ token, instance }: { token: string; instance: GaloyInstance }) => {
+      await persistToken(token)
       updateState((state) => {
         if (state)
           return {

--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -38,9 +38,18 @@ const useLogout = () => {
       isValidToken = true,
     }: LogoutOptions = {}): Promise<void> => {
       try {
-        let context
-        const deviceToken = await messaging().getToken()
+        // Isolated: a failed push-token fetch must never skip the local
+        // key-store cleanup below — that would leave the session token behind
+        // to be hydrated back on next launch. The server-side revocation is
+        // best-effort and simply skipped without a device token.
+        let deviceToken: string | undefined
+        try {
+          deviceToken = await messaging().getToken()
+        } catch (err) {
+          reportError("logout device token fetch", err)
+        }
 
+        let context
         if (token) {
           await KeyStoreWrapper.removeSessionProfileByToken(token)
           // Removing the profile that backs the active session must also drop
@@ -61,7 +70,7 @@ const useLogout = () => {
 
         logLogout()
 
-        if (token && isValidToken) {
+        if (token && isValidToken && deviceToken) {
           await Promise.race([
             userLogoutMutation({
               context,

--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -43,6 +43,12 @@ const useLogout = () => {
 
         if (token) {
           await KeyStoreWrapper.removeSessionProfileByToken(token)
+          // Removing the profile that backs the active session must also drop
+          // the active token, or it would be hydrated back on next launch.
+          const activeToken = await KeyStoreWrapper.getActiveAuthToken()
+          if (activeToken === token) {
+            await KeyStoreWrapper.removeActiveAuthToken()
+          }
           context = { headers: { authorization: `Bearer ${token}` } }
         } else {
           await AsyncStorage.multiRemove([SCHEMA_VERSION_KEY])
@@ -50,6 +56,7 @@ const useLogout = () => {
           await KeyStoreWrapper.removePin()
           await KeyStoreWrapper.removePinAttempts()
           await KeyStoreWrapper.removeSessionProfiles()
+          await KeyStoreWrapper.removeActiveAuthToken()
         }
 
         logLogout()

--- a/app/store/persistent-state/index.tsx
+++ b/app/store/persistent-state/index.tsx
@@ -17,9 +17,16 @@ import {
 const PERSISTENT_STATE_KEY = "persistentState"
 const PERSISTENT_STATE_QUARANTINE_PREFIX = "persistentStateQuarantine"
 
+// The raw blob can predate the token/keystore split and still carry a
+// plaintext galoyAuthToken — never write that copy back to disk.
+const sanitizeForQuarantine = (rawData: unknown): unknown =>
+  rawData && typeof rawData === "object" && "galoyAuthToken" in rawData
+    ? { ...rawData, galoyAuthToken: "" }
+    : rawData
+
 const quarantineRawState = async (rawData: unknown): Promise<void> => {
   const key = `${PERSISTENT_STATE_QUARANTINE_PREFIX}.${Date.now()}`
-  const ok = await saveString(key, JSON.stringify(rawData))
+  const ok = await saveString(key, JSON.stringify(sanitizeForQuarantine(rawData)))
   if (!ok) {
     recordAppError(new Error(`Quarantine write failed for key ${key}`), {
       alwaysRecord: true,
@@ -28,18 +35,28 @@ const quarantineRawState = async (rawData: unknown): Promise<void> => {
 }
 
 /**
- * The session token is never persisted in this AsyncStorage blob: it lives in
- * the secure key store (KeyStoreWrapper) and is hydrated into memory on load.
- * A token still present in a blob written before this split is moved to the
- * key store here, then stripped from disk on the next save.
+ * The session token is never persisted in the AsyncStorage blob: it lives in
+ * the secure key store (KeyStoreWrapper) and is attached to the in-memory
+ * state here, on the Ok path only. NoData is a fresh install (the iOS
+ * keychain can outlive the app, so "no blob" must not mean "resume the old
+ * session"), and Failed is a deliberate clean slate — neither should come up
+ * authenticated. A token still present in a pre-split blob is moved to the
+ * key store, then stripped from disk on the next save.
  */
-const hydrateAuthToken = async (state: PersistentState): Promise<PersistentState> => {
+const resolveAuthToken = async (state: PersistentState): Promise<PersistentState> => {
   const secureToken = await KeyStoreWrapper.getActiveAuthToken()
   if (secureToken) {
     return { ...state, galoyAuthToken: secureToken }
   }
   if (state.galoyAuthToken) {
-    await KeyStoreWrapper.setActiveAuthToken(state.galoyAuthToken)
+    const moved = await KeyStoreWrapper.setActiveAuthToken(state.galoyAuthToken)
+    if (!moved) {
+      // The token now exists only in memory; the next save strips the blob
+      // copy, so the session ends at next launch. Make that visible.
+      recordAppError(new Error("Failed to move legacy auth token to the key store"), {
+        alwaysRecord: true,
+      })
+    }
   }
   return state
 }
@@ -50,13 +67,13 @@ export const loadPersistentState = async (): Promise<PersistentState> => {
 
   switch (result.status) {
     case MigrationStatus.Ok:
-      return hydrateAuthToken(result.state)
+      return resolveAuthToken(result.state)
     case MigrationStatus.NoData:
-      return hydrateAuthToken(defaultPersistentState)
+      return defaultPersistentState
     case MigrationStatus.Failed:
       recordAppError(result.error, { alwaysRecord: true })
       await quarantineRawState(result.rawData)
-      return hydrateAuthToken(defaultPersistentState)
+      return defaultPersistentState
   }
 }
 

--- a/app/store/persistent-state/index.tsx
+++ b/app/store/persistent-state/index.tsx
@@ -5,6 +5,7 @@ import { recordAppError } from "@app/utils/error-reporting"
 
 import { reportError } from "@app/utils/error-logging"
 import { loadJson, saveJson, saveString } from "@app/utils/storage"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 import {
   defaultPersistentState,
@@ -26,25 +27,44 @@ const quarantineRawState = async (rawData: unknown): Promise<void> => {
   }
 }
 
+/**
+ * The session token is never persisted in this AsyncStorage blob: it lives in
+ * the secure key store (KeyStoreWrapper) and is hydrated into memory on load.
+ * A token still present in a blob written before this split is moved to the
+ * key store here, then stripped from disk on the next save.
+ */
+const hydrateAuthToken = async (state: PersistentState): Promise<PersistentState> => {
+  const secureToken = await KeyStoreWrapper.getActiveAuthToken()
+  if (secureToken) {
+    return { ...state, galoyAuthToken: secureToken }
+  }
+  if (state.galoyAuthToken) {
+    await KeyStoreWrapper.setActiveAuthToken(state.galoyAuthToken)
+  }
+  return state
+}
+
 export const loadPersistentState = async (): Promise<PersistentState> => {
   const data = await loadJson(PERSISTENT_STATE_KEY)
   const result = await migratePersistentState(data)
 
   switch (result.status) {
     case MigrationStatus.Ok:
-      return result.state
+      return hydrateAuthToken(result.state)
     case MigrationStatus.NoData:
-      return defaultPersistentState
+      return hydrateAuthToken(defaultPersistentState)
     case MigrationStatus.Failed:
       recordAppError(result.error, { alwaysRecord: true })
       await quarantineRawState(result.rawData)
-      return defaultPersistentState
+      return hydrateAuthToken(defaultPersistentState)
   }
 }
 
 const savePersistentState = async (state: PersistentState): Promise<void> => {
   try {
-    await saveJson(PERSISTENT_STATE_KEY, state)
+    // galoyAuthToken stays in memory only — the plaintext copy on disk is
+    // always blank; the real token is in the secure key store.
+    await saveJson(PERSISTENT_STATE_KEY, { ...state, galoyAuthToken: "" })
   } catch (err) {
     // Storage failures are crash-adjacent: never downgrade on message wording.
     reportError("Persistent state save", err, { alwaysRecord: true })

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -120,6 +120,9 @@ type PersistentState_14 = {
 type PersistentState_15 = {
   schemaVersion: 15
   galoyInstance: GaloyInstanceInput
+  // In-memory only: always written to disk as "" (see savePersistentState) and
+  // hydrated from the secure key store on load. Migrations must keep passing it
+  // through so a token in a pre-split blob can still be moved to the key store.
   galoyAuthToken: string
   activeAccountId?: string
   selfCustodialDefaultWalletCurrency?: "BTC" | "USD"

--- a/app/utils/storage/secureStorage.ts
+++ b/app/utils/storage/secureStorage.ts
@@ -5,6 +5,7 @@ export default class KeyStoreWrapper {
   private static readonly PIN = "PIN"
   private static readonly PIN_ATTEMPTS = "pinAttempts"
   private static readonly SESSION_PROFILES = "sessionProfiles"
+  private static readonly ACTIVE_AUTH_TOKEN = "activeAuthToken"
   private static readonly MNEMONIC = "mnemonic"
   private static readonly MNEMONIC_NETWORK = "mnemonic_network"
 
@@ -133,6 +134,38 @@ export default class KeyStoreWrapper {
       await RNSecureKeyStore.remove(KeyStoreWrapper.SESSION_PROFILES)
       return true
     } catch (err) {
+      return false
+    }
+  }
+
+  /**
+   * The active session token. Stored only here (secure key store) and kept in
+   * memory at runtime — it must never be written to AsyncStorage.
+   */
+  public static async getActiveAuthToken(): Promise<string | null> {
+    try {
+      return await RNSecureKeyStore.get(KeyStoreWrapper.ACTIVE_AUTH_TOKEN)
+    } catch {
+      return null
+    }
+  }
+
+  public static async setActiveAuthToken(token: string): Promise<boolean> {
+    try {
+      await RNSecureKeyStore.set(KeyStoreWrapper.ACTIVE_AUTH_TOKEN, token, {
+        accessible: ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY,
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  public static async removeActiveAuthToken(): Promise<boolean> {
+    try {
+      await RNSecureKeyStore.remove(KeyStoreWrapper.ACTIVE_AUTH_TOKEN)
+      return true
+    } catch {
       return false
     }
   }


### PR DESCRIPTION
The session auth token was persisted twice: in the secure key store (session profiles) and in plaintext AsyncStorage via persistentState.galoyAuthToken — the latter being the live credential sent with every GraphQL request.

- KeyStoreWrapper: dedicated activeAuthToken key with get/set/remove
- persistent-state: strip the token from the AsyncStorage blob on save, hydrate it from the key store on load; a legacy blob token is moved to the key store on first launch so existing sessions survive
- use-app-config: saveToken/saveTokenAndInstance mirror the token to the key store (empty token removes the key)
- use-logout: clear the active-token key on full logout and when removing the profile backing the active session

---

# Session JWT is persisted in plaintext AsyncStorage alongside the encrypted Keystore copy

**Component:** `app/store/persistent-state/`, `app/hooks/use-app-config.ts`, `app/utils/storage/`
**Severity:** Medium — full account takeover if the plaintext store is read, but reaching it needs root, a physical extraction, or a forensic toolchain. The quarantine sub-finding below raises it, because that copy survives logout.
**Type:** Sensitive data stored insecurely / duplicated source of truth

---

## Summary

The Galoy session JWT lives in two places at once:

- **Encrypted** — inside `sessionProfiles` in `react-native-secure-key-store`, which is AES-256-GCM `EncryptedSharedPreferences` on Android and a Keychain generic password on iOS.
- **Plaintext** — as `persistentState.galoyAuthToken`, `JSON.stringify`'d into the AsyncStorage key `persistentState`.

Every custodial login writes both. The second write buys nothing that the first does not already provide, and it undoes the protection the first one was chosen for.

**One correction to the framing:** the plaintext copy is not the redundant one — it is the **authoritative** one. `useAppConfig().token` reads `persistentState.galoyAuthToken` and that value is what Apollo attaches as the `Bearer` header on every request. The Keystore copy is a secondary list used for multi-account switching. So the fix is not "delete the AsyncStorage copy"; it is "invert which store is the source of truth," and the write ordering in `saveProfile` has to change with it (see [[Why this is not a one-line deletion](https://github.com/blinkbitcoin/blink-mobile/pull/4139#why-this-is-not-a-one-line-deletion)](#why-this-is-not-a-one-line-deletion)).

---

## Evidence

**The plaintext write path.** `saveToken` puts the JWT into React state ([`use-app-config.ts` L31–L43](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-app-config.ts#L31-L43)):

```ts
const saveToken = useCallback(async (token: string) => {
  updateState((state) => (state ? { ...state, galoyAuthToken: token } : undefined))
}, [updateState])
```

`PersistentStateProvider` flushes that state on every change ([`index.tsx` L45–L52, L74–L78](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/store/persistent-state/index.tsx#L45-L78)):

```ts
const savePersistentState = async (state: PersistentState): Promise<void> => {
  try { await saveJson(PERSISTENT_STATE_KEY, state) } catch (err) { ... }
}
```

and `saveJson` is a bare `AsyncStorage.setItem` ([`storage.ts` L37–L39](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/utils/storage/storage.ts#L37-L39)):

```ts
export const saveJson = async (key: string, value: unknown): Promise<void> => {
  await AsyncStorage.setItem(key, JSON.stringify(value))
}
```

`galoyAuthToken` is a first-class field of every schema version and of the default state ([`state-migrations.ts` L287–L291](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/store/persistent-state/state-migrations.ts#L287-L291)). It has been there since at least `8a3573a1` (2023-03-16).

**The encrypted write path.** The same login also stores the token inside a `ProfileProps` record ([`index.types.d.ts` L1–L14](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/screens/settings-screen/account/multi-account/index.types.d.ts#L1-L14) — the type carries `token: string`) via [`secureStorage.ts` L109–L119](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/utils/storage/secureStorage.ts#L109-L119):

```ts
public static async saveSessionProfiles(profiles: ProfileProps[]): Promise<boolean> {
  const serialized = JSON.stringify(profiles)
  await RNSecureKeyStore.set(KeyStoreWrapper.SESSION_PROFILES, serialized, {
    accessible: ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY,
  })
  ...
}
```

Both writes happen inside one function ([`use-save-session-profile.ts` L88–L127](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-save-session-profile.ts#L88-L127)) — `await saveToken(token)` at L92, `KeyStoreWrapper.saveSessionProfiles(...)` at L117. Every login route funnels through it: phone (`phone-login-validation.tsx:234,267`), email (`email-login-validate.tsx:63`), Telegram (`telegram-auth.ts:121`), device account (`use-create-device-account.ts:91`).

---

## What the two stores actually give you

**Android.** `react-native-secure-key-store@2.0.10` is a thin wrapper over AndroidX Security ([`[RNSecureKeyStoreModule.java](https://github.com/pradeep1991singh/react-native-secure-key-store/blob/master/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java)`](https://github.com/pradeep1991singh/react-native-secure-key-store/blob/master/android/src/main/java/com/reactlibrary/securekeystore/RNSecureKeyStoreModule.java)):

```java
return EncryptedSharedPreferences.create(
  "secret_shared_prefs",
  MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
  reactContext,
  EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
  EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
);
```

The master key lives in the AndroidKeyStore and is non-exportable — hardware-backed where a TEE/StrongBox is present. Lifting `secret_shared_prefs` off the device yields ciphertext.

AsyncStorage writes to an unencrypted SQLite database in the app's private `databases/` directory (`RKStorage` on the 2.x line). Lifting that file yields the JWT as a readable string.

So on Android the delta is total: one copy resists offline extraction, the other does not.

**iOS.** The Keystore copy is a `kSecClassGenericPassword` Keychain item; the AsyncStorage copy is a file in `Library/Application Support/RCTAsyncLocalStorage_V1/`. Both sit behind iOS Data Protection class keys, so the gap is narrower than on Android — but the Keychain item is still the one with an explicit accessibility class and per-item protection, and it is the store a reviewer or scanner expects a bearer token to be in.

### Threat model

The plaintext copy is what an attacker gets from: a rooted or jailbroken device; malware with root; a physical extraction or forensic toolchain (Cellebrite/GrayKey-class); a custom-recovery data pull; or any future bug that exposes the app's private directory. In every one of those the Keystore copy holds and the AsyncStorage copy does not.

A stolen JWT is full account access — balance, transaction history, and the ability to spend, for as long as the token is valid.

---

## Checks that came back clean

Recording these so nobody re-runs them.

- **Android backups are off.** `android:allowBackup="false"` ([`AndroidManifest.xml` L40](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/android/app/src/main/AndroidManifest.xml#L40)), so the token is not in `adb backup` or Auto Backup / Google Drive backup.
- **iOS backups are excluded by default.** `RNCAsyncStorage.mm` sets `NSURLIsExcludedFromBackupKey` on its storage directory unless the `RCTAsyncStorageExcludeFromBackup` Info.plist key says otherwise, and the default is `@YES`. `ios/GaloyApp/Info.plist` does not override it. The token is not in iCloud/iTunes backups.
- **The token is not logged or reported.** No `console.log` of the token or of `persistentState`; `recordAppError` records `Error` objects and dedup keys only; `logScreenView` sends route names only.
- **The developer screen is dev-only.** Its "Copy access token" / "Share access token" buttons are behind `__DEV__` at [`root-navigator.tsx` L184–L186](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/navigation/root-navigator.tsx#L184-L186) and are not in release builds.

---

## Sub-finding: quarantined state copies the token to keys nothing ever deletes

This one is worse than the main finding and should probably be fixed first.

When a persisted-state migration fails, the raw blob is written to a fresh, timestamped AsyncStorage key ([`index.tsx` L16–L27](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/store/persistent-state/index.tsx#L16-L27)):

```ts
const PERSISTENT_STATE_QUARANTINE_PREFIX = "persistentStateQuarantine"

const quarantineRawState = async (rawData: unknown): Promise<void> => {
  const key = `${PERSISTENT_STATE_QUARANTINE_PREFIX}.${Date.now()}`
  const ok = await saveString(key, JSON.stringify(rawData))
  ...
}
```

`rawData` is the whole prior state, `galoyAuthToken` included, and it is stringified with no redaction. The existing test asserts exactly that round-trip (`__tests__/store/persistent-state/index.spec.tsx:280` — `expect(JSON.parse(payload)).toEqual(corruptedState3)`).

Then:

```console
$ grep -rn "persistentStateQuarantine\|QUARANTINE" app/ __tests__/
app/store/persistent-state/index.tsx:17:  const PERSISTENT_STATE_QUARANTINE_PREFIX = "persistentStateQuarantine"
app/store/persistent-state/index.tsx:20:  const key = `${PERSISTENT_STATE_QUARANTINE_PREFIX}.${Date.now()}`
__tests__/store/persistent-state/index.spec.tsx:280: expect(key).toMatch(/^persistentStateQuarantine\.\d+$/)
```

Nothing reads them. Nothing deletes them. `resetState()` rewrites only the `persistentState` key ([[L95–L98](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/store/persistent-state/index.tsx#L95-L98)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/store/persistent-state/index.tsx#L95-L98)), and `useLogout` clears `SCHEMA_VERSION_KEY` plus Keystore entries ([`use-logout.ts` L44–L53](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-logout.ts#L44-L53)) — neither touches the quarantine prefix.

Result: one failed migration leaves a plaintext JWT in AsyncStorage that **survives logout, survives account switching, and accumulates one new key per failure, forever.** Whatever bound the live token's lifetime does not apply to these.

## Sub-finding: overwriting is not erasing

`savePersistentState` overwrites the JSON value in place. SQLite does not zero freed pages, and AsyncStorage never issues a `VACUUM`, so the previous value — including a logged-out token — can remain recoverable in the database file until the pages are reused. Not a headline on its own; it does mean "logout clears it" is weaker than it looks.

## Note: the `accessible` option is a no-op on Android

`saveSessionProfiles` passes `accessible: ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY`, but `RNSecureKeyStoreModule.set()` never reads its `options` argument — the flag only takes effect on iOS. There, `ALWAYS_THIS_DEVICE_ONLY` maps to `kSecAttrAccessibleAlwaysThisDeviceOnly`, which Apple deprecated; `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY` is the current equivalent and keeps the item out of backups just the same. Worth correcting while this code is open.

Separately, `react-native-secure-key-store` has not shipped a release in years. The repo already depends on `react-native-keychain@^10` (used for device-account credentials and the iOS mnemonic backup), so consolidating onto it is a natural follow-up.

---

## Reproduction

Android, release build, logged in:

```bash
# 1. Plaintext copy — readable string
adb shell "run-as com.galoyapp ls databases/"          # debuggable builds; on release use a rooted device
adb shell "su -c sqlite3 /data/data/com.galoyapp/databases/RKStorage \
  \"select value from catalystLocalStorage where key='persistentState';\""
# → {"schemaVersion":15,"galoyInstance":{"id":"Main"},"galoyAuthToken":"eyJhbGciOi..."}

# 2. Encrypted copy — ciphertext
adb shell "su -c cat /data/data/com.galoyapp/shared_prefs/secret_shared_prefs.xml"
# → base64 AES-256-GCM blobs; no readable token

# 3. Confirm the token works
curl -H "Authorization: Bearer <token from step 1>" https://api.blink.sv/graphql \
  -H 'content-type: application/json' -d '{"query":"{ me { id username defaultAccount { id } } }"}'
```

Quarantine persistence:

```bash
# Corrupt the stored state so migration fails, relaunch, then log out and check:
adb shell "su -c sqlite3 /data/data/com.galoyapp/databases/RKStorage \
  \"select key from catalystLocalStorage where key like 'persistentStateQuarantine%';\""
# → keys remain, each containing a full plaintext token
```

---

## Proposed fix

### 1. Purge and redact quarantine records (ship first, independently)

```ts
const REDACTED_KEYS = ["galoyAuthToken"] as const

const quarantineRawState = async (rawData: unknown): Promise<void> => {
  const safe =
    rawData && typeof rawData === "object"
      ? { ...(rawData as Record<string, unknown>),
          ...Object.fromEntries(REDACTED_KEYS.map((k) => [k, "[redacted]"])) }
      : rawData
  const key = `${PERSISTENT_STATE_QUARANTINE_PREFIX}.${Date.now()}`
  ...
}
```

Migration diagnostics need the *shape* of the broken state, not its secrets. Then add a sweep — on boot and in `useLogout` — that `AsyncStorage.getAllKeys()`, filters the prefix, and `multiRemove`s anything older than a short retention window (or all of them on logout).

### 2. Make the Keystore the single source of truth for the token

Drop `galoyAuthToken` from `PersistentState` and resolve the active token from `KeyStoreWrapper.getSessionProfiles()` (the record already carries `selected: boolean`), holding it in React context / memory for the app's lifetime. `useAppConfig().token` and `useEffectiveAuthToken()` keep their signatures; only the backing store changes.

Add schema version 16 whose migration drops the field and, in the same pass, removes any lingering quarantine keys:

```ts
const migrate15ToCurrent = async (state: PersistentState_15): Promise<PersistentState> => {
  const { galoyAuthToken, ...rest } = state
  if (galoyAuthToken) await ensureTokenInKeystore(galoyAuthToken)   // don't strand logged-in users
  return { ...rest, schemaVersion: 16 }
}
```

### 3. Why this is not a one-line deletion

`saveProfile` writes the plaintext copy **before** it knows the Keystore copy will land ([[L88–L117](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-save-session-profile.ts#L88-L117)](https://github.com/GaloyMoney/blink-mobile/blob/8727998d16c334581f2d0f3d7d82a19ec2703ecf/app/hooks/use-save-session-profile.ts#L88-L117)):

```ts
await saveToken(token)                       // L92  → AsyncStorage
...
const profile = await tryFetchUserProps({ token, fetchUsername })
if (!profile) return                         // L106 → bails; Keystore never written
...
await KeyStoreWrapper.saveSessionProfiles([{ ...profile, ...}, ...cleaned])   // L117
```

`tryFetchUserProps` swallows its errors and returns `undefined` on any network failure, so a login on a flaky connection today produces a session that exists **only** in AsyncStorage. Delete that write without reordering and those users are logged out on the spot.

The write order has to become: persist to Keystore first with whatever identity fields are available, then enrich the profile once `getUsernames` succeeds. The existing "heal a profile saved without `accountId`" logic at L100–L103 already anticipates this shape — it just needs the token write moved inside the same guarantee. `saveTokenAndInstance` (developer screen) and the direct `saveToken` call sites in `use-switch-to-next-profile.ts`, `use-resolve-transaction-account.ts:359`, `multi-account/profile.tsx`, and `use-discard-custodial-session.ts` all need the same treatment.

### 4. Follow-ups

- Migrate `KeyStoreWrapper` from the unmaintained `react-native-secure-key-store` to `react-native-keychain@^10`, already in the dependency tree.
- Switch iOS accessibility from `ALWAYS_THIS_DEVICE_ONLY` to `AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY`.

---

## Acceptance criteria

- [ ] `select value from catalystLocalStorage where key='persistentState'` on a logged-in device contains no JWT.
- [ ] No `persistentStateQuarantine.*` key contains a token; quarantine records are redacted at write time.
- [ ] Quarantine keys are swept on boot and cleared on logout.
- [ ] A user logged in on a build with schema 15 stays logged in after upgrading to schema 16 — the migration moves the token into the Keystore rather than dropping it.
- [ ] A login whose `getUsernames` call fails still produces a session recoverable from the Keystore alone (regression test for §3).
- [ ] Logout leaves no readable token in either store.
- [ ] Follow-up issues opened for the `react-native-keychain` migration and the iOS accessibility class.

---

## References

- [[OWASP MASVS — MASVS-STORAGE-1: sensitive data in system credential storage](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)
- [[MASTG — Testing Local Storage for Sensitive Data (Android)](https://mas.owasp.org/MASTG/tests/android/MASVS-STORAGE/MASTG-TEST-0001/)](https://mas.owasp.org/MASTG/tests/android/MASVS-STORAGE/MASTG-TEST-0001/)
- [AndroidX `EncryptedSharedPreferences`](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences)
- [[Android Keystore system](https://developer.android.com/privacy-and-security/keystore)](https://developer.android.com/privacy-and-security/keystore)
- [`[@react-native-async-storage/async-storage](https://github.com/react-native-async-storage/async-storage)`](https://github.com/react-native-async-storage/async-storage) — `RNCAsyncStorage.mm`, backup-exclusion default
- [`[react-native-secure-key-store](https://github.com/pradeep1991singh/react-native-secure-key-store)`](https://github.com/pradeep1991singh/react-native-secure-key-store) — `RNSecureKeyStoreModule.java`
- [`[kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly)`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly)