### PR TITLE
fix(lnurl): require https for decoded lnurl urls and service callbacks

### DIFF
--- a/__tests__/payment-destination/lnurl.spec.ts
+++ b/__tests__/payment-destination/lnurl.spec.ts
@@ -1,3 +1,4 @@
+import { bech32 } from "bech32"
 import { LNURLResponse, LNURLWithdrawParams, getParams } from "js-lnurl"
 import { requestPayServiceParams, LnUrlPayServiceResponse, Satoshis } from "lnurl-pay"
 
@@ -5,7 +6,10 @@ import {
   createLnurlPaymentDestination,
   resolveLnurlDestination,
 } from "@app/screens/send-bitcoin-screen/payment-destination"
-import { DestinationDirection } from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
+import {
+  DestinationDirection,
+  InvalidDestinationReason,
+} from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
 import { createLnurlPaymentDetails } from "@app/screens/send-bitcoin-screen/payment-details"
 import { ZeroBtcMoneyAmount } from "@app/types/amounts"
 import { PaymentType } from "@blinkbitcoin/blink-client"
@@ -40,7 +44,7 @@ const throwError = () => {
 const manualMockLnUrlPayServiceResponse = (
   identifier: string,
 ): LnUrlPayServiceResponse => ({
-  callback: "mocked_callback",
+  callback: "https://example.com/callback",
   fixed: true,
   min: 0 as Satoshis,
   max: 2000 as Satoshis,
@@ -68,7 +72,7 @@ const manualMockLNURLWithdrawParams = (): LNURLWithdrawParams => ({
   // Example structure. Adjust according to your actual LNURLWithdrawParams type
   tag: "withdrawRequest",
   k1: "some_random_string",
-  callback: "http://example.com/callback",
+  callback: "https://example.com/callback",
   domain: "example.com",
   maxWithdrawable: 2000,
   minWithdrawable: 0,
@@ -404,5 +408,116 @@ describe("create lnurl destination", () => {
       destinationSpecifiedMemo: lnurlPaymentDestinationParams.lnurlParams.description,
       isMerchant: false,
     })
+  })
+})
+
+describe("lnurl https enforcement", () => {
+  const encodeLnurl = (url: string): string =>
+    bech32.encode("lnurl", bech32.toWords(Buffer.from(url, "utf8")), 20000)
+
+  const baseParams = {
+    lnurlDomains: ["ourdomain.com"],
+    accountDefaultWalletQuery: jest.fn(),
+    myWalletIds: ["testwalletid"],
+  }
+
+  beforeEach(() => {
+    mockRequestPayServiceParams.mockClear()
+    mockGetParams.mockClear()
+  })
+
+  it("rejects a bare bech32 lnurl that decodes to an http URL before any fetch", async () => {
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: encodeLnurl("http://example.com/lnurl"),
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlError,
+      }),
+    )
+    expect(mockGetParams).not.toHaveBeenCalled()
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+  })
+
+  it("accepts a bare bech32 lnurl that decodes to an https URL", async () => {
+    const lnurl = encodeLnurl("https://example.com/lnurl")
+    const lnurlPayParams = manualMockLnUrlPayServiceResponse(lnurl)
+    mockRequestPayServiceParams.mockResolvedValue(lnurlPayParams)
+    mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl,
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(mockGetParams).toHaveBeenCalledWith(lnurl)
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        destinationDirection: DestinationDirection.Send,
+      }),
+    )
+  })
+
+  it("rejects a withdraw request whose callback is not https", async () => {
+    mockGetParams.mockResolvedValue({
+      ...manualMockLNURLWithdrawParams(),
+      callback: "http://example.com/callback",
+    })
+
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "lnurlrandomstring",
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlUnsupported,
+      }),
+    )
+  })
+
+  it("rejects a pay request whose callback is not https", async () => {
+    mockGetParams.mockResolvedValue(manualMockLNURLResponse())
+    mockRequestPayServiceParams.mockResolvedValue({
+      ...manualMockLnUrlPayServiceResponse("bob@external.com"),
+      callback: "http://example.com/callback",
+    })
+
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "bob@external.com",
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlUnsupported,
+      }),
+    )
   })
 })

--- a/__tests__/payment-destination/lnurl.spec.ts
+++ b/__tests__/payment-destination/lnurl.spec.ts
@@ -491,7 +491,7 @@ describe("lnurl https enforcement", () => {
     expect(destination).toEqual(
       expect.objectContaining({
         valid: false,
-        invalidReason: InvalidDestinationReason.LnurlUnsupported,
+        invalidReason: InvalidDestinationReason.LnurlError,
       }),
     )
   })
@@ -516,7 +516,72 @@ describe("lnurl https enforcement", () => {
     expect(destination).toEqual(
       expect.objectContaining({
         valid: false,
-        invalidReason: InvalidDestinationReason.LnurlUnsupported,
+        invalidReason: InvalidDestinationReason.LnurlError,
+      }),
+    )
+  })
+
+  it("rejects a lnurl1 string it cannot decode instead of passing it through unchecked", async () => {
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "lnurl1qqqqqq",
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlError,
+      }),
+    )
+    expect(mockGetParams).not.toHaveBeenCalled()
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+  })
+
+  it("rejects a LUD-17 lnurlw URI whose payload contains .onion (cleartext http downgrade)", async () => {
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "lnurlw://attacker.com/w/.onion/x",
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlError,
+      }),
+    )
+    expect(mockGetParams).not.toHaveBeenCalled()
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+  })
+
+  it("accepts a LUD-17 lnurlw URI over a clearnet host (derived URL is https)", async () => {
+    const lnurl = "lnurlw://example.com/withdraw"
+    mockGetParams.mockResolvedValue(manualMockLNURLWithdrawParams())
+
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl,
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(mockGetParams).toHaveBeenCalledWith(lnurl)
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        destinationDirection: DestinationDirection.Receive,
       }),
     )
   })

--- a/__tests__/payment-destination/lnurl.spec.ts
+++ b/__tests__/payment-destination/lnurl.spec.ts
@@ -563,6 +563,27 @@ describe("lnurl https enforcement", () => {
     expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
   })
 
+  it("rejects a LUD-17 lnurlp URI whose .onion is followed by a word character", async () => {
+    const destination = await resolveLnurlDestination({
+      parsedLnurlDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: true,
+        lnurl: "lnurlp://attacker.com/x.onionz",
+        isMerchant: false,
+      },
+      ...baseParams,
+    })
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlError,
+      }),
+    )
+    expect(mockGetParams).not.toHaveBeenCalled()
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+  })
+
   it("accepts a LUD-17 lnurlw URI over a clearnet host (derived URL is https)", async () => {
     const lnurl = "lnurlw://example.com/withdraw"
     mockGetParams.mockResolvedValue(manualMockLNURLWithdrawParams())

--- a/__tests__/payment-destination/merchant.integration.spec.ts
+++ b/__tests__/payment-destination/merchant.integration.spec.ts
@@ -110,7 +110,7 @@ describe("merchant payment destination integration", () => {
       termsUrl: "https://boltz.exchange/terms",
     }
     const lnurlParams = {
-      callback: "mocked_callback",
+      callback: "https://example.com/callback",
       fixed: true,
       min: 0 as Satoshis,
       max: 2000 as Satoshis,
@@ -161,7 +161,7 @@ describe("merchant payment destination integration", () => {
     }
     const selectedMerchant = merchantChoices.validDestination.merchants[0]
     const lnurlParams = {
-      callback: "mocked_callback",
+      callback: "https://example.com/callback",
       fixed: true,
       min: 0 as Satoshis,
       max: 2000 as Satoshis,

--- a/__tests__/payment-destination/merchant.spec.ts
+++ b/__tests__/payment-destination/merchant.spec.ts
@@ -103,7 +103,7 @@ describe("merchant payment destinations", () => {
       termsUrl: "https://boltz.exchange/terms",
     }
     const lnurlParams = {
-      callback: "mocked_callback",
+      callback: "https://example.com/callback",
       fixed: true,
       min: 0 as Satoshis,
       max: 2000 as Satoshis,
@@ -164,7 +164,7 @@ describe("merchant payment destinations", () => {
     const sdk = { id: "spark-sdk" } as never
     const wrapped = { valid: true, wrapped: true }
     const lnurlParams = {
-      callback: "mocked_callback",
+      callback: "https://example.com/callback",
       fixed: true,
       min: 0 as Satoshis,
       max: 2000 as Satoshis,

--- a/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-lnurl-withdraw.spec.ts
@@ -138,6 +138,26 @@ describe("useLnurlWithdraw", () => {
     expect(calledUrl).toContain("pr=lnbc1test_payment_request")
   })
 
+  it("refuses a non-https callback without fetching it", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert")
+
+    const { result } = renderHook(() =>
+      useLnurlWithdraw(validPr as Parameters<typeof useLnurlWithdraw>[0]),
+    )
+
+    await act(async () => {
+      await result.current({
+        validDestination: {
+          callback: "http://example.com/lnurl/withdraw",
+          k1: "random_k1_value",
+        },
+      } as Parameters<ReturnType<typeof useLnurlWithdraw>>[0])
+    })
+
+    expect(alertSpy).toHaveBeenCalledWith("Redeeming error")
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
   it("shows submission error on non-ok response", async () => {
     // The hook logs the simulated failure via console.error; capture it so the
     // expected error doesn't pollute CI logs (and assert it actually happened).

--- a/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
+++ b/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
@@ -370,6 +370,30 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
     expect(fetchedUrl).toContain("pr=lnbc-bolt11-string")
   })
 
+  it("refuses a non-https callback and never fetches it", async () => {
+    const invoice = {
+      paymentRequest: "lnbc-bolt11-string",
+      paymentHash: "hash-A",
+    }
+    mockLnInvoiceCreate.mockResolvedValueOnce({
+      data: { lnInvoiceCreate: { invoice, errors: [] } },
+    })
+
+    const { result } = renderHook(() =>
+      useLnurlWithdrawRedemption({
+        ...defaultParams,
+        callback: "http://example.com/lnurl/withdraw",
+      }),
+    )
+
+    await flushEffects()
+    await flushEffects()
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(result.current.errorMessage).toBe("fallback-redeeming-error")
+    expect(result.current.paid).toBe(false)
+  })
+
   it("flips paid=true when the LN update hash matches the generated invoice paymentHash, and refetches the Home query", async () => {
     const invoice = { paymentRequest: "lnbc-bolt11-string", paymentHash: "hash-A" }
     mockLnInvoiceCreate.mockResolvedValueOnce({

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -226,7 +226,7 @@ describe("SendBitcoinDestinationScreen", () => {
   })
 
   const createLnurlPayParams = (identifier: string): LnUrlPayServiceResponse => ({
-    callback: "mocked_callback",
+    callback: "https://example.com/callback",
     fixed: true,
     min: 0 as Satoshis,
     max: 2000 as Satoshis,

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -24,9 +24,12 @@ import { PaymentType } from "@blinkbitcoin/blink-client"
 import { ContextForScreen } from "./helper"
 
 const mockRequestInvoice = jest.fn()
+const mockRequestInvoiceWithServiceParams = jest.fn()
 jest.mock("lnurl-pay", () => ({
   ...jest.requireActual("lnurl-pay"),
   requestInvoice: (...args: unknown[]) => mockRequestInvoice(...args),
+  requestInvoiceWithServiceParams: (...args: unknown[]) =>
+    mockRequestInvoiceWithServiceParams(...args),
 }))
 
 const mockNavigate = jest.fn()
@@ -282,6 +285,7 @@ describe("SendBitcoinDetailsScreen — LNURL requestInvoice gate", () => {
     await flushAsync()
 
     expect(mockRequestInvoice).not.toHaveBeenCalled()
+    expect(mockRequestInvoiceWithServiceParams).not.toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith(
       "sendBitcoinConfirmation",
       expect.objectContaining({ paymentDetail: expect.any(Object) }),
@@ -291,7 +295,7 @@ describe("SendBitcoinDetailsScreen — LNURL requestInvoice gate", () => {
   it("calls lnurl-pay requestInvoice when paymentDetail.sendPaymentMutation is missing (custodial path)", async () => {
     const detail = buildLnurlPaymentDetail({ withSendMutation: false })
     const LL = i18nObject("en")
-    mockRequestInvoice.mockResolvedValue({
+    mockRequestInvoiceWithServiceParams.mockResolvedValue({
       invoice: "lnbc10n1pjxample",
       successAction: undefined,
     })
@@ -308,9 +312,38 @@ describe("SendBitcoinDetailsScreen — LNURL requestInvoice gate", () => {
     fireEvent.press(screen.getByText(LL.common.next()))
     await flushAsync()
 
-    expect(mockRequestInvoice).toHaveBeenCalledTimes(1)
-    expect(mockRequestInvoice).toHaveBeenCalledWith(
-      expect.objectContaining({ lnUrlOrAddress: "lnurl1abc" }),
+    expect(mockRequestInvoiceWithServiceParams).toHaveBeenCalledTimes(1)
+    expect(mockRequestInvoiceWithServiceParams).toHaveBeenCalledWith(
+      expect.objectContaining({ params: lnurlParams }),
     )
+  })
+
+  // requestInvoice(lnUrlOrAddress) would resolve the destination again and fetch
+  // whatever callback the second response carries, bypassing the https check
+  // resolveLnurlDestination performed on the params held here.
+  it("pays with the vetted service params and never re-resolves the destination", async () => {
+    const detail = buildLnurlPaymentDetail({ withSendMutation: false })
+    const LL = i18nObject("en")
+    mockRequestInvoiceWithServiceParams.mockResolvedValue({
+      invoice: "lnbc10n1pjxample",
+      successAction: undefined,
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDetailsScreen route={buildRoute(detail)} />
+      </ContextForScreen>,
+    )
+
+    await flushAsync()
+    await flushAsync()
+
+    fireEvent.press(screen.getByText(LL.common.next()))
+    await flushAsync()
+
+    const args = mockRequestInvoiceWithServiceParams.mock.calls[0][0]
+    expect(args.params.callback).toBe("https://example.com/cb")
+    expect(args).not.toHaveProperty("lnUrlOrAddress")
+    expect(mockRequestInvoice).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/utils/lnurl.spec.ts
+++ b/__tests__/utils/lnurl.spec.ts
@@ -92,6 +92,19 @@ describe("lud17Url", () => {
       "http://hiddenservice.onion/withdraw",
     )
   })
+
+  // js-lnurl's /\.onion($|\W)/ does not match ".onion" followed by a word
+  // character, but lnurl-pay's includes(".onion") does and downgrades anyway.
+  // The wider rule has to win, or the payload passes the gate and is still
+  // fetched over cleartext.
+  it("maps a payload where .onion is followed by a word character to plain http", () => {
+    expect(lud17Url("lnurlp://attacker.com/x.onionz")).toBe(
+      "http://attacker.com/x.onionz",
+    )
+    expect(lud17Url("lnurlw://attacker.com/x.onion1")).toBe(
+      "http://attacker.com/x.onion1",
+    )
+  })
 })
 
 describe("isHttpsUrl", () => {

--- a/__tests__/utils/lnurl.spec.ts
+++ b/__tests__/utils/lnurl.spec.ts
@@ -1,0 +1,114 @@
+import { bech32 } from "bech32"
+
+import {
+  BareLnurlDecodeStatus,
+  decodeBareLnurl,
+  isHttpsUrl,
+  lud17Url,
+} from "@app/utils/lnurl"
+
+const encodeLnurl = (url: string): string =>
+  bech32.encode("lnurl", bech32.toWords(Buffer.from(url, "utf8")), 20000)
+
+describe("decodeBareLnurl", () => {
+  it("returns NotBareLnurl for lightning addresses", () => {
+    expect(decodeBareLnurl("alice@example.com")).toEqual({
+      status: BareLnurlDecodeStatus.NotBareLnurl,
+    })
+  })
+
+  it("returns NotBareLnurl for LUD-17 URIs", () => {
+    expect(decodeBareLnurl("lnurlw://example.com/withdraw")).toEqual({
+      status: BareLnurlDecodeStatus.NotBareLnurl,
+    })
+  })
+
+  it("returns NotBareLnurl for non-lnurl bech32 strings", () => {
+    expect(decodeBareLnurl("lnurlrandomstring")).toEqual({
+      status: BareLnurlDecodeStatus.NotBareLnurl,
+    })
+  })
+
+  it("decodes a bare lnurl1 string to its embedded URL", () => {
+    const url = "https://example.com/lnurl?q=1"
+    expect(decodeBareLnurl(encodeLnurl(url))).toEqual({
+      status: BareLnurlDecodeStatus.Decoded,
+      url,
+    })
+  })
+
+  it("decodes an uppercase LNURL1 string", () => {
+    const url = "https://example.com/lnurl"
+    expect(decodeBareLnurl(encodeLnurl(url).toUpperCase())).toEqual({
+      status: BareLnurlDecodeStatus.Decoded,
+      url,
+    })
+  })
+
+  it("decodes an embedded http URL verbatim (no scheme enforcement here)", () => {
+    const url = "http://example.com/lnurl"
+    expect(decodeBareLnurl(encodeLnurl(url))).toEqual({
+      status: BareLnurlDecodeStatus.Decoded,
+      url,
+    })
+  })
+
+  it("returns DecodeError for a lnurl1 string with an invalid checksum", () => {
+    expect(decodeBareLnurl("lnurl1qqqqqq")).toEqual({
+      status: BareLnurlDecodeStatus.DecodeError,
+    })
+  })
+
+  it("returns DecodeError for a lnurl1 string with characters outside the bech32 charset", () => {
+    expect(decodeBareLnurl("lnurl1bbb")).toEqual({
+      status: BareLnurlDecodeStatus.DecodeError,
+    })
+  })
+})
+
+describe("lud17Url", () => {
+  it("returns null for non-LUD-17 input", () => {
+    expect(lud17Url("alice@example.com")).toBeNull()
+    expect(lud17Url("https://example.com/lnurl")).toBeNull()
+  })
+
+  it("maps lnurlw:// to https", () => {
+    expect(lud17Url("lnurlw://example.com/withdraw")).toBe("https://example.com/withdraw")
+  })
+
+  it("maps lnurlp:// to https", () => {
+    expect(lud17Url("lnurlp://example.com/pay")).toBe("https://example.com/pay")
+  })
+
+  it("is case-insensitive on the scheme", () => {
+    expect(lud17Url("LNURLW://example.com/withdraw")).toBe("https://example.com/withdraw")
+  })
+
+  it("maps a payload containing .onion to plain http, mirroring js-lnurl", () => {
+    expect(lud17Url("lnurlw://attacker.com/w/.onion/x")).toBe(
+      "http://attacker.com/w/.onion/x",
+    )
+    expect(lud17Url("lnurlw://hiddenservice.onion/withdraw")).toBe(
+      "http://hiddenservice.onion/withdraw",
+    )
+  })
+})
+
+describe("isHttpsUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isHttpsUrl("https://example.com/callback")).toBe(true)
+  })
+
+  it("rejects http URLs", () => {
+    expect(isHttpsUrl("http://example.com/callback")).toBe(false)
+  })
+
+  it("rejects other schemes", () => {
+    expect(isHttpsUrl("ftp://example.com/callback")).toBe(false)
+  })
+
+  it("rejects malformed input", () => {
+    expect(isHttpsUrl("not a url")).toBe(false)
+    expect(isHttpsUrl("")).toBe(false)
+  })
+})

--- a/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts
+++ b/app/screens/receive-bitcoin-screen/hooks/use-lnurl-withdraw.ts
@@ -3,6 +3,7 @@ import { Alert } from "react-native"
 import fetch from "cross-fetch"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { isHttpsUrl } from "@app/utils/lnurl"
 
 import { ReceiveDestination } from "../../send-bitcoin-screen/payment-destination/index.types"
 import { Invoice } from "../payment/index.types"
@@ -30,6 +31,13 @@ export const useLnurlWithdraw = (pr: LnurlWithdrawablePr | null | undefined) => 
       }
 
       const { callback, k1 } = destination.validDestination
+
+      // Defense in depth: resolveLnurlDestination already gates the callback to
+      // https, but this hook fetches it directly, so enforce it here too.
+      if (!isHttpsUrl(callback)) {
+        Alert.alert(LL.RedeemBitcoinScreen.redeemingError())
+        return
+      }
 
       const urlObject = new URL(callback)
       const searchParams = urlObject.searchParams

--- a/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts
+++ b/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts
@@ -6,6 +6,7 @@ import { HomeAuthedDocument, useLnInvoiceCreateMutation } from "@app/graphql/gen
 import { useLnUpdateHashPaid } from "@app/graphql/ln-update-context"
 import { usePayments } from "@app/hooks/use-payments"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { isHttpsUrl } from "@app/utils/lnurl"
 import { useTranslateSdkError } from "@app/self-custodial/hooks"
 import { PaymentResultStatus } from "@app/types/payment"
 import { AccountType } from "@app/types/wallet"
@@ -204,6 +205,13 @@ const useCustodialRedemption = ({
     if (!enabled || !withdrawalInvoice) return
 
     const submitToCallback = async () => {
+      // Defense in depth: resolveLnurlDestination already gates the callback to
+      // https, but this hook fetches it directly, so enforce it here too.
+      if (!isHttpsUrl(callback)) {
+        setErrorMessage(LL.RedeemBitcoinScreen.redeemingError())
+        return
+      }
+
       const urlObject = new URL(callback)
       urlObject.searchParams.set("k1", k1)
       urlObject.searchParams.set("pr", withdrawalInvoice.paymentRequest)

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -6,6 +6,7 @@ import {
   WalletCurrency,
 } from "@app/graphql/generated"
 import { toBtcMoneyAmount } from "@app/types/amounts"
+import { decodeBareLnurl, isHttpsUrl } from "@app/utils/lnurl"
 import { LnurlPaymentDestination, PaymentType } from "@blinkbitcoin/blink-client"
 
 import { createLnurlPaymentDetails } from "../payment-details"
@@ -37,10 +38,31 @@ export const resolveLnurlDestination = async ({
   // but lnurl withdraw is handled here
 
   if (parsedLnurlDestination.valid) {
+    // js-lnurl and lnurl-pay fetch the URL embedded in a bare bech32 LNURL
+    // without enforcing https. Reject any other scheme before any network call.
+    const decodedUrl = decodeBareLnurl(parsedLnurlDestination.lnurl)
+    if (decodedUrl !== null && !isHttpsUrl(decodedUrl)) {
+      return {
+        valid: false,
+        invalidReason: InvalidDestinationReason.LnurlError,
+        invalidPaymentDestination: parsedLnurlDestination,
+      } as const
+    }
+
     const lnurlParams = await getParams(parsedLnurlDestination.lnurl)
 
     // Check for lnurl withdraw request
     if ("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest") {
+      // The withdraw callback is fetched directly by this app or the Breez SDK;
+      // require https so a malicious or downgraded service cannot redirect the
+      // redemption (which carries the invoice) over cleartext.
+      if (!isHttpsUrl(lnurlParams.callback)) {
+        return {
+          valid: false,
+          invalidReason: InvalidDestinationReason.LnurlUnsupported,
+          invalidPaymentDestination: parsedLnurlDestination,
+        } as const
+      }
       return createLnurlWithdrawDestination({
         lnurl: parsedLnurlDestination.lnurl,
         callback: lnurlParams.callback,
@@ -59,6 +81,16 @@ export const resolveLnurlDestination = async ({
       })
 
       if (lnurlPayParams) {
+        // Same https requirement for the pay callback: the Breez SDK fetches it
+        // on self-custodial sends, and the backend on custodial ones.
+        if (!isHttpsUrl(lnurlPayParams.callback)) {
+          return {
+            valid: false,
+            invalidReason: InvalidDestinationReason.LnurlUnsupported,
+            invalidPaymentDestination: parsedLnurlDestination,
+          } as const
+        }
+
         const maybeIntraledgerDestination = await tryGetIntraLedgerDestinationFromLnurl({
           lnurlDomains,
           lnurlPayParams,

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -6,7 +6,12 @@ import {
   WalletCurrency,
 } from "@app/graphql/generated"
 import { toBtcMoneyAmount } from "@app/types/amounts"
-import { decodeBareLnurl, isHttpsUrl } from "@app/utils/lnurl"
+import {
+  BareLnurlDecodeStatus,
+  decodeBareLnurl,
+  isHttpsUrl,
+  lud17Url,
+} from "@app/utils/lnurl"
 import { LnurlPaymentDestination, PaymentType } from "@blinkbitcoin/blink-client"
 
 import { createLnurlPaymentDetails } from "../payment-details"
@@ -39,9 +44,22 @@ export const resolveLnurlDestination = async ({
 
   if (parsedLnurlDestination.valid) {
     // js-lnurl and lnurl-pay fetch the URL embedded in a bare bech32 LNURL
-    // without enforcing https. Reject any other scheme before any network call.
-    const decodedUrl = decodeBareLnurl(parsedLnurlDestination.lnurl)
-    if (decodedUrl !== null && !isHttpsUrl(decodedUrl)) {
+    // verbatim, and derive a plain http URL from LUD-17 URIs whenever ".onion"
+    // appears in the payload, without enforcing https in either case. Vet the
+    // scheme of whatever URL the input resolves to before any network call. An
+    // undecodable lnurl1 string is rejected rather than skipped: the app's
+    // bech32@2 and js-lnurl's bundled bech32@1 need not agree on every input,
+    // so a decode miss here must not wave the input through unchecked.
+    const bareLnurl = decodeBareLnurl(parsedLnurlDestination.lnurl)
+    const fetchUrl =
+      bareLnurl.status === BareLnurlDecodeStatus.Decoded
+        ? bareLnurl.url
+        : lud17Url(parsedLnurlDestination.lnurl)
+
+    if (
+      bareLnurl.status === BareLnurlDecodeStatus.DecodeError ||
+      (fetchUrl !== null && !isHttpsUrl(fetchUrl))
+    ) {
       return {
         valid: false,
         invalidReason: InvalidDestinationReason.LnurlError,
@@ -55,11 +73,14 @@ export const resolveLnurlDestination = async ({
     if ("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest") {
       // The withdraw callback is fetched directly by this app or the Breez SDK;
       // require https so a malicious or downgraded service cannot redirect the
-      // redemption (which carries the invoice) over cleartext.
+      // redemption (which carries the invoice) over cleartext. Routed through
+      // LnurlError rather than LnurlUnsupported because destination-information.tsx
+      // pattern-matches with `case LnurlError || LnurlUnsupported`, which leaves
+      // LnurlUnsupported on the generic destination error.
       if (!isHttpsUrl(lnurlParams.callback)) {
         return {
           valid: false,
-          invalidReason: InvalidDestinationReason.LnurlUnsupported,
+          invalidReason: InvalidDestinationReason.LnurlError,
           invalidPaymentDestination: parsedLnurlDestination,
         } as const
       }
@@ -82,11 +103,12 @@ export const resolveLnurlDestination = async ({
 
       if (lnurlPayParams) {
         // Same https requirement for the pay callback: the Breez SDK fetches it
-        // on self-custodial sends, and the backend on custodial ones.
+        // on self-custodial sends, and the backend on custodial ones. LnurlError
+        // rather than LnurlUnsupported for the reason given above.
         if (!isHttpsUrl(lnurlPayParams.callback)) {
           return {
             valid: false,
-            invalidReason: InvalidDestinationReason.LnurlUnsupported,
+            invalidReason: InvalidDestinationReason.LnurlError,
             invalidPaymentDestination: parsedLnurlDestination,
           } as const
         }

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -1,4 +1,9 @@
-import { requestInvoice, utils, Satoshis } from "lnurl-pay"
+import {
+  requestInvoiceWithServiceParams,
+  utils,
+  Satoshis,
+  LnUrlPayServiceResponse,
+} from "lnurl-pay"
 import React, { useEffect, useState } from "react"
 import { TouchableOpacity, TouchableWithoutFeedback, View } from "react-native"
 import ReactNativeModal from "react-native-modal"
@@ -378,12 +383,23 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
             "BTC",
           )
 
+          // Pay with the service params resolveLnurlDestination already vetted.
+          // requestInvoice(lnUrlOrAddress) would resolve the destination a second
+          // time and fetch whatever callback that response carries, which lnurl-pay
+          // does not require to be https — so the callback the app checked would
+          // not be the callback it pays.
+          if (!lnurlParams) {
+            setIsLoadingLnurl(false)
+            setAsyncErrorMessage(LL.SendBitcoinScreen.failedToFetchLnurlInvoice())
+            return
+          }
+
           const requestInvoiceParams: {
-            lnUrlOrAddress: string
+            params: LnUrlPayServiceResponse
             tokens: Satoshis
             comment?: string
           } = {
-            lnUrlOrAddress: paymentDetail.destination,
+            params: lnurlParams,
             tokens: utils.toSats(btcAmount.amount),
           }
 
@@ -391,7 +407,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
             requestInvoiceParams.comment = paymentDetail.memo
           }
 
-          const result = await requestInvoice(requestInvoiceParams)
+          const result = await requestInvoiceWithServiceParams(requestInvoiceParams)
 
           setPaymentDetail(paymentDetail.setSuccessAction(result.successAction))
 

--- a/app/utils/lnurl.ts
+++ b/app/utils/lnurl.ts
@@ -1,18 +1,50 @@
 import { bech32 } from "bech32"
 
+export const BareLnurlDecodeStatus = {
+  NotBareLnurl: "not_bare_lnurl",
+  Decoded: "decoded",
+  DecodeError: "decode_error",
+} as const
+
+export type BareLnurlDecodeResult =
+  | { status: typeof BareLnurlDecodeStatus.NotBareLnurl }
+  | { status: typeof BareLnurlDecodeStatus.Decoded; url: string }
+  | { status: typeof BareLnurlDecodeStatus.DecodeError }
+
 // A bare bech32 LNURL (lnurl1...) embeds an arbitrary URL, and the LNURL
 // libraries the app relies on (js-lnurl, lnurl-pay) fetch whatever scheme it
 // decodes to without enforcing https. Decode it here so callers can vet the
-// scheme before any network call. Returns null for non-bech32 forms (lightning
-// addresses, lnurlw://, ...) or undecodable input.
-export const decodeBareLnurl = (lnurl: string): string | null => {
+// scheme before any network call. Decode failure is reported separately from
+// non-bech32 input so callers reject instead of failing open: the app resolves
+// bech32@2 while js-lnurl bundles bech32@1, and the two decoders need not agree
+// on every input.
+export const decodeBareLnurl = (lnurl: string): BareLnurlDecodeResult => {
   const trimmed = lnurl.trim()
-  if (trimmed.toLowerCase().slice(0, 6) !== "lnurl1") return null
-  try {
-    return Buffer.from(bech32.fromWords(bech32.decode(trimmed, 20000).words)).toString()
-  } catch {
-    return null
+  if (trimmed.toLowerCase().slice(0, 6) !== "lnurl1") {
+    return { status: BareLnurlDecodeStatus.NotBareLnurl }
   }
+  try {
+    const url = Buffer.from(
+      bech32.fromWords(bech32.decode(trimmed, 20000).words),
+    ).toString()
+    return { status: BareLnurlDecodeStatus.Decoded, url }
+  } catch {
+    return { status: BareLnurlDecodeStatus.DecodeError }
+  }
+}
+
+// LUD-17 URI schemes are converted by js-lnurl to https URLs, or to plain http
+// whenever ".onion" appears anywhere in the payload (it matches /\.onion($|\W)/;
+// lnurl-pay likewise checks parsedUrl.includes(".onion")). Mirror that
+// derivation so the scheme can be vetted before any network call.
+const LUD17_SCHEME_PATTERN = /^(?:lnurlw|lnurlp|lnurlc|keyauth):\/\//i
+
+export const lud17Url = (lnurl: string): string | null => {
+  const trimmed = lnurl.trim()
+  if (!LUD17_SCHEME_PATTERN.test(trimmed)) return null
+  const payload = trimmed.split("://")[1]
+  const scheme = payload.match(/\.onion($|\W)/) ? "http" : "https"
+  return `${scheme}://${payload}`
 }
 
 export const isHttpsUrl = (url: string): boolean => {

--- a/app/utils/lnurl.ts
+++ b/app/utils/lnurl.ts
@@ -1,0 +1,24 @@
+import { bech32 } from "bech32"
+
+// A bare bech32 LNURL (lnurl1...) embeds an arbitrary URL, and the LNURL
+// libraries the app relies on (js-lnurl, lnurl-pay) fetch whatever scheme it
+// decodes to without enforcing https. Decode it here so callers can vet the
+// scheme before any network call. Returns null for non-bech32 forms (lightning
+// addresses, lnurlw://, ...) or undecodable input.
+export const decodeBareLnurl = (lnurl: string): string | null => {
+  const trimmed = lnurl.trim()
+  if (trimmed.toLowerCase().slice(0, 6) !== "lnurl1") return null
+  try {
+    return Buffer.from(bech32.fromWords(bech32.decode(trimmed, 20000).words)).toString()
+  } catch {
+    return null
+  }
+}
+
+export const isHttpsUrl = (url: string): boolean => {
+  try {
+    return new URL(url).protocol === "https:"
+  } catch {
+    return false
+  }
+}

--- a/app/utils/lnurl.ts
+++ b/app/utils/lnurl.ts
@@ -33,17 +33,19 @@ export const decodeBareLnurl = (lnurl: string): BareLnurlDecodeResult => {
   }
 }
 
-// LUD-17 URI schemes are converted by js-lnurl to https URLs, or to plain http
-// whenever ".onion" appears anywhere in the payload (it matches /\.onion($|\W)/;
-// lnurl-pay likewise checks parsedUrl.includes(".onion")). Mirror that
-// derivation so the scheme can be vetted before any network call.
+// LUD-17 URI schemes are converted to https URLs by the two libraries that fetch
+// them, or to plain http when the payload looks like an onion service. The two
+// disagree on what that means: js-lnurl matches /\.onion($|\W)/ while lnurl-pay
+// checks parsedUrl.includes(".onion"), so a payload like "host/x.onionz" is https
+// to one and http to the other. Take the wider rule, otherwise a payload can pass
+// this gate and still be fetched over cleartext by lnurl-pay.
 const LUD17_SCHEME_PATTERN = /^(?:lnurlw|lnurlp|lnurlc|keyauth):\/\//i
 
 export const lud17Url = (lnurl: string): string | null => {
   const trimmed = lnurl.trim()
   if (!LUD17_SCHEME_PATTERN.test(trimmed)) return null
   const payload = trimmed.split("://")[1]
-  const scheme = payload.match(/\.onion($|\W)/) ? "http" : "https"
+  const scheme = payload.includes(".onion") ? "http" : "https"
   return `${scheme}://${payload}`
 }
 


### PR DESCRIPTION
js-lnurl and lnurl-pay fetch the URL embedded in a bare bech32 LNURL verbatim, with no enforcement that the scheme is https, and the app added no scheme check of its own before using the decoded URL or the service-returned callback. A crafted QR/NFC tag could therefore trigger cleartext http fetches of the LNURL service and of the withdraw/pay callbacks (which carry the invoice).

Decode bare lnurl1 strings and vet the scheme in resolveLnurlDestination before any network call, reject non-https withdraw and pay callbacks returned by the service, and re-check the callback at the two direct fetch sites (redeem screen, NFC receive) as defense in depth.