### PR TITLE
feat(region): shape the client's region rules after the queries that will serve them

### DIFF
--- a/__tests__/components/restricted-region/restricted-region.spec.tsx
+++ b/__tests__/components/restricted-region/restricted-region.spec.tsx
@@ -13,16 +13,31 @@ jest.mock("@app/utils/ip-country-lookup")
 
 let mockIpCountry: string | undefined
 let mockIpSettled = true
-const mockUseIpCountryLookup = jest.fn<
-  { countryCode: string | undefined; isSettled: boolean },
-  [boolean]
->(() => ({ countryCode: mockIpCountry, isSettled: mockIpSettled }))
-jest.mock("@app/hooks/use-device-location", () => ({
-  ...jest.requireActual("@app/hooks/use-device-location"),
-  useIpCountryLookup: (enabled: boolean) => mockUseIpCountryLookup(enabled),
-  /** The wrapper resolves through the module-internal binding, so it must be mocked
-   *  alongside the lookup or a consumer of it would hit the real hook. */
-  useIpCountryCode: (enabled: boolean) => mockUseIpCountryLookup(enabled).countryCode,
+/** The custodial verdict is the server's now, so the region is driven through the query
+ *  the provider reads. `restricted` follows the same list the old lookup was matched
+ *  against, which is what these cases are written in terms of. */
+const CUSTODIAL_BLOCKED_COUNTRIES = ["CU", "IR"]
+const mockUseRegionCheckQuery = jest.fn((_options?: unknown) => ({
+  data: {
+    regionCheck: {
+      countryCode: mockIpCountry,
+      custodialCreationAllowed: !CUSTODIAL_BLOCKED_COUNTRIES.includes(
+        (mockIpCountry ?? "").toUpperCase(),
+      ),
+      restricted: CUSTODIAL_BLOCKED_COUNTRIES.includes(
+        (mockIpCountry ?? "").toUpperCase(),
+      ),
+    },
+  },
+  loading: !mockIpSettled,
+}))
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useRegionCheckQuery: (options: unknown) => mockUseRegionCheckQuery(options),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
+  useSelfCustodialAccountMode: () => ({ isAnonMode: false }),
 }))
 
 let mockActiveAccountType: AccountType | undefined = AccountType.SelfCustodial
@@ -37,7 +52,6 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 let mockRemoteConfigReady = true
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => ({
-    custodialCreationBlockedCountries: ["CU", "IR"],
     selfCustodialCreationBlockedCountries: ["KP"],
   }),
   useFeatureFlags: () => ({ remoteConfigReady: mockRemoteConfigReady }),
@@ -161,7 +175,9 @@ describe("RestrictedRegionProvider", () => {
     const { getByTestId } = renderWithProvider()
 
     expect(getByTestId("restricted-value").props.children).toBe("false")
-    expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
+    expect(mockUseRegionCheckQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    )
     expect(mockGateRelease).toHaveBeenCalled()
     expect(mockGateHold).not.toHaveBeenCalled()
   })
@@ -189,14 +205,26 @@ describe("RestrictedRegionProvider", () => {
     expect(getByTestId("pending-value").props.children).toBe("true")
   })
 
-  it("holds the splash while remote config has not resolved for a custodial account", () => {
+  it("releases the splash for a custodial account before remote config resolves", () => {
+    // Its verdict is the server's now, and reads no compiled-in list to wait on.
     mockActiveAccountType = AccountType.Custodial
     mockRemoteConfigReady = false
 
     renderWithProvider()
 
-    expect(mockGateHold).toHaveBeenCalledWith(2000)
-    expect(mockGateRelease).not.toHaveBeenCalled()
+    expect(mockGateRelease).toHaveBeenCalled()
+  })
+
+  it("holds a self-custodial verdict until its own list has been fetched", () => {
+    // A list still in flight would have the verdict read off the compiled-in defaults,
+    // so the evaluation stays pending and no consumer may act on it yet.
+    mockActiveAccountType = AccountType.SelfCustodial
+    mockRemoteConfigReady = false
+    mockIpCountry = "KP"
+
+    const { getByTestId } = renderWithProvider()
+
+    expect(getByTestId("pending-value").props.children).toBe("true")
   })
 
   it("never holds the splash for a known self-custodial account", () => {

--- a/__tests__/config/feature-flags-default-blocks.spec.ts
+++ b/__tests__/config/feature-flags-default-blocks.spec.ts
@@ -62,17 +62,6 @@ describe("defaultRemoteConfig: compliance country lists", () => {
     expect(defaultRemoteConfig.selfCustodialTransferBlockedCountries).toHaveLength(27)
   })
 
-  it("custodialTransferBlockedCountries contains only uppercase ISO-3166 alpha-2 codes with no duplicates", () => {
-    assertCanonical(defaultRemoteConfig.custodialTransferBlockedCountries)
-  })
-
-  it("both account-type transfer blocks default to the same 27 EU member states", () => {
-    expect(defaultRemoteConfig.custodialTransferBlockedCountries).toEqual(
-      defaultRemoteConfig.selfCustodialTransferBlockedCountries,
-    )
-    expect(defaultRemoteConfig.custodialTransferBlockedCountries).toHaveLength(27)
-  })
-
   it("selfCustodialDollarBalanceBlockedCountries contains only uppercase ISO-3166 alpha-2 codes with no duplicates", () => {
     assertCanonical(defaultRemoteConfig.selfCustodialDollarBalanceBlockedCountries)
   })
@@ -81,18 +70,21 @@ describe("defaultRemoteConfig: compliance country lists", () => {
     expect(defaultRemoteConfig.selfCustodialDollarBalanceBlockedCountries).toEqual(["HK"])
   })
 
-  it("custodialCreationBlockedCountries contains only uppercase ISO-3166 alpha-2 codes with no duplicates", () => {
-    assertCanonical(defaultRemoteConfig.custodialCreationBlockedCountries)
-  })
-
   it("selfCustodialCreationBlockedCountries contains only uppercase ISO-3166 alpha-2 codes with no duplicates", () => {
     assertCanonical(defaultRemoteConfig.selfCustodialCreationBlockedCountries)
   })
 
-  it("creation blocks default to the comprehensively sanctioned regions plus Russia and Belarus, identically for both account types", () => {
-    const expected = ["CU", "IR", "KP", "SY", "RU", "BY"]
-    expect(defaultRemoteConfig.custodialCreationBlockedCountries).toEqual(expected)
-    expect(defaultRemoteConfig.selfCustodialCreationBlockedCountries).toEqual(expected)
+  /** The custodial creation block moved to the server's own deny list with blink#756, so
+   *  only the self-custodial half is still answered from a compiled-in default. */
+  it("the self-custodial creation block defaults to the comprehensively sanctioned regions plus Russia and Belarus", () => {
+    expect(defaultRemoteConfig.selfCustodialCreationBlockedCountries).toEqual([
+      "CU",
+      "IR",
+      "KP",
+      "SY",
+      "RU",
+      "BY",
+    ])
   })
 
   it("offboardOnlyCountries contains only uppercase ISO-3166 alpha-2 codes with no duplicates", () => {

--- a/__tests__/graphql/hide-amount-component.test.tsx
+++ b/__tests__/graphql/hide-amount-component.test.tsx
@@ -16,7 +16,7 @@ jest.mock("@apollo/client", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/hooks/use-account-restrictions.spec.ts
+++ b/__tests__/hooks/use-account-restrictions.spec.ts
@@ -1,0 +1,187 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { useAccountRestrictions } from "@app/hooks/use-account-restrictions"
+import { AccountType } from "@app/types/wallet"
+
+const mockUseRemoteConfig = jest.fn()
+const mockUseActiveWallet = jest.fn()
+const mockUseDeviceLocation = jest.fn()
+const mockUseIpCountryLookup = jest.fn()
+let mockRemoteConfigReady = true
+
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => ({ remoteConfigReady: mockRemoteConfigReady }),
+}))
+
+/** Reached through use-device-location, and it warns about API keys on import. */
+jest.mock("@app/utils/ip-country-lookup", () => ({
+  resolveIpCountryCodeCached: jest.fn(),
+}))
+
+jest.mock("@app/hooks/use-device-location", () => ({
+  __esModule: true,
+  ...jest.requireActual("@app/hooks/use-device-location"),
+  default: () => mockUseDeviceLocation(),
+  useIpCountryLookup: (enabled: boolean) => mockUseIpCountryLookup(enabled),
+}))
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => mockUseActiveWallet(),
+}))
+
+const blockedCountries = {
+  custodialDollarBalanceBlockedCountries: ["HK"],
+  custodialTransferBlockedCountries: ["DE"],
+  selfCustodialDollarBalanceBlockedCountries: ["FR"],
+  selfCustodialTransferBlockedCountries: ["PK"],
+}
+
+const setUp = ({
+  accountType = AccountType.Custodial,
+  accountTypeOverride,
+  countryCode,
+  isLocationPending = false,
+  ipCountryCode,
+  isIpLookupSettled = true,
+  remoteConfigReady = true,
+}: {
+  accountType?: AccountType
+  accountTypeOverride?: AccountType
+  countryCode?: string
+  isLocationPending?: boolean
+  ipCountryCode?: string
+  isIpLookupSettled?: boolean
+  remoteConfigReady?: boolean
+}) => {
+  mockRemoteConfigReady = remoteConfigReady
+  mockUseDeviceLocation.mockReturnValue({ countryCode, loading: isLocationPending })
+  mockUseIpCountryLookup.mockReturnValue({
+    countryCode: ipCountryCode,
+    isSettled: isIpLookupSettled,
+  })
+  mockUseActiveWallet.mockReturnValue({ accountType })
+  mockUseRemoteConfig.mockReturnValue(blockedCountries)
+  return renderHook(() => useAccountRestrictions(accountTypeOverride)).result.current
+}
+
+describe("useAccountRestrictions", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe("whose lists answer", () => {
+    it("reads the custodial lists for a custodial account", () => {
+      const restrictions = setUp({ countryCode: "HK" })
+
+      expect(restrictions.dollarBalance).toBe(true)
+      expect(restrictions.transfer).toBe(false)
+    })
+
+    it("reads the self-custodial lists for a self-custodial account", () => {
+      const restrictions = setUp({
+        accountType: AccountType.SelfCustodial,
+        countryCode: "FR",
+      })
+
+      expect(restrictions.dollarBalance).toBe(true)
+    })
+
+    it("never answers one custody type from the other's lists", () => {
+      // HK blocks the custodial dollar balance only, FR the self-custodial one only.
+      expect(setUp({ countryCode: "FR" }).dollarBalance).toBe(false)
+      expect(
+        setUp({ accountType: AccountType.SelfCustodial, countryCode: "HK" })
+          .dollarBalance,
+      ).toBe(false)
+    })
+
+    it("reads each feature from its own list", () => {
+      expect(setUp({ countryCode: "DE" }).transfer).toBe(true)
+      expect(setUp({ countryCode: "DE" }).dollarBalance).toBe(false)
+    })
+
+    it("honors an override over the active account type", () => {
+      // Migration previews the self-custodial policy from a still-custodial session.
+      const restrictions = setUp({
+        accountType: AccountType.Custodial,
+        accountTypeOverride: AccountType.SelfCustodial,
+        ipCountryCode: "FR",
+      })
+
+      expect(restrictions.dollarBalance).toBe(true)
+    })
+
+    it("restricts nothing while the country is unresolved", () => {
+      const restrictions = setUp({ countryCode: undefined })
+
+      expect(restrictions.dollarBalance).toBe(false)
+      expect(restrictions.transfer).toBe(false)
+    })
+  })
+
+  describe("the country it resolves", () => {
+    it("reads the device's own country outside a prediction", () => {
+      setUp({ countryCode: "HK" })
+
+      // No IP lookup runs, so nobody is located who was not already known.
+      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
+    })
+
+    it("prefers the IP while predicting the self-custodial policy", () => {
+      const restrictions = setUp({
+        accountTypeOverride: AccountType.SelfCustodial,
+        countryCode: "SV",
+        ipCountryCode: "FR",
+      })
+
+      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(true)
+      expect(restrictions.dollarBalance).toBe(true)
+    })
+
+    it("falls back to the session country when the prediction's IP is unreachable", () => {
+      // Reading an unreachable IP as unrestricted would preview a dollar balance the new
+      // account cannot hold, in the one step the user cannot take back.
+      const restrictions = setUp({
+        accountTypeOverride: AccountType.SelfCustodial,
+        countryCode: "FR",
+        ipCountryCode: undefined,
+      })
+
+      expect(restrictions.dollarBalance).toBe(true)
+    })
+  })
+
+  describe("isSettled", () => {
+    it("is false while the device location is still resolving", () => {
+      expect(setUp({ countryCode: undefined, isLocationPending: true }).isSettled).toBe(
+        false,
+      )
+    })
+
+    it("is true once a country resolved, even while the location keeps loading", () => {
+      // The prediction's IP lookup can land first, and that already settles the region.
+      expect(setUp({ countryCode: "HK", isLocationPending: true }).isSettled).toBe(true)
+    })
+
+    it("holds a prediction until its IP lookup settles", () => {
+      // A fast phone parse would otherwise report settled-unrestricted and then flip.
+      const restrictions = setUp({
+        accountTypeOverride: AccountType.SelfCustodial,
+        countryCode: "SV",
+        isIpLookupSettled: false,
+      })
+
+      expect(restrictions.isSettled).toBe(false)
+    })
+
+    it("is false until remote config has answered", () => {
+      // An empty list mid-fetch would read as a country nothing restricts.
+      const restrictions = setUp({ countryCode: "HK", remoteConfigReady: false })
+
+      expect(restrictions.isSettled).toBe(false)
+    })
+
+    it("is true once both the region and the lists have settled", () => {
+      expect(setUp({ countryCode: "SV" }).isSettled).toBe(true)
+    })
+  })
+})

--- a/__tests__/hooks/use-account-restrictions.spec.ts
+++ b/__tests__/hooks/use-account-restrictions.spec.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react-native"
+import { act, renderHook } from "@testing-library/react-native"
 
 import { useAccountRestrictions } from "@app/hooks/use-account-restrictions"
 import { AccountType } from "@app/types/wallet"
@@ -8,6 +8,7 @@ const mockUseActiveWallet = jest.fn()
 const mockUseDeviceLocation = jest.fn()
 const mockUseIpCountryLookup = jest.fn()
 const mockUseCustodialRestrictionsQuery = jest.fn()
+const mockRefetch = jest.fn()
 let mockRemoteConfigReady = true
 let mockIsAuthed = true
 let mockIsRegistryHydrating = false
@@ -58,7 +59,7 @@ const UNRESTRICTED: ServerRestrictions = { dollarBalance: false, transfer: false
 
 /** null stands for "the query answered nothing", which `undefined` cannot: it would take
  *  the parameter default instead. */
-const setUp = ({
+const renderRestrictions = ({
   accountType = AccountType.Custodial,
   accountTypeOverride,
   countryCode,
@@ -70,6 +71,7 @@ const setUp = ({
   isRegistryHydrating = false,
   custodialRestrictions = UNRESTRICTED,
   isQueryLoading = false,
+  queryError,
 }: {
   accountType?: AccountType
   accountTypeOverride?: AccountType
@@ -82,6 +84,7 @@ const setUp = ({
   isRegistryHydrating?: boolean
   custodialRestrictions?: ServerRestrictions | null
   isQueryLoading?: boolean
+  queryError?: Error
 }) => {
   mockRemoteConfigReady = remoteConfigReady
   mockIsAuthed = isAuthed
@@ -96,9 +99,16 @@ const setUp = ({
   mockUseCustodialRestrictionsQuery.mockReturnValue({
     data: custodialRestrictions ? { custodialRestrictions } : undefined,
     loading: isQueryLoading,
+    error: queryError,
+    refetch: mockRefetch,
   })
-  return renderHook(() => useAccountRestrictions(accountTypeOverride)).result.current
+  return renderHook(() => useAccountRestrictions(accountTypeOverride))
 }
+
+/** The reading a test asserts on. Retry tests keep the render instead, since they have to
+ *  advance time and re-read. */
+const setUp = (options: Parameters<typeof renderRestrictions>[0]) =>
+  renderRestrictions(options).result.current
 
 /** What the query hook was told, so the skip decision can be read directly. */
 const lastQueryOptions = () => mockUseCustodialRestrictionsQuery.mock.calls.at(-1)?.[0]
@@ -194,6 +204,136 @@ describe("useAccountRestrictions", () => {
       expect(restrictions.dollarBalance).toBe(false)
       expect(restrictions.transfer).toBe(false)
       expect(restrictions.isSettled).toBe(true)
+    })
+  })
+
+  /**
+   * A request that never arrived and a served "no verdict" are the same absence of data,
+   * and the hook used to answer both with FAIL_CLOSED. One is the server speaking; the
+   * other is a lost packet, and `no-cache` leaves nothing to re-read, so the failure would
+   * govern the whole session until the user backgrounded the app and came back.
+   */
+  describe("a request that never arrived", () => {
+    const transportFailure = new Error("network request failed")
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      mockRefetch.mockResolvedValue({})
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it("asks again instead of taking the failure for a verdict", () => {
+      renderRestrictions({ custodialRestrictions: null, queryError: transportFailure })
+
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      expect(mockRefetch).toHaveBeenCalledTimes(1)
+    })
+
+    /** Gating on a lost packet is the latch; waiting is what a slow answer already gets. */
+    it("gates nothing while a retry is still owed", () => {
+      const { result } = renderRestrictions({
+        custodialRestrictions: null,
+        queryError: transportFailure,
+      })
+
+      expect(result.current.dollarBalance).toBe(false)
+      expect(result.current.transfer).toBe(false)
+      expect(result.current.isSettled).toBe(false)
+    })
+
+    it("takes the verdict a retry finally brings", () => {
+      const { result, rerender } = renderRestrictions({
+        custodialRestrictions: null,
+        queryError: transportFailure,
+      })
+
+      mockUseCustodialRestrictionsQuery.mockReturnValue({
+        data: { custodialRestrictions: { dollarBalance: false, transfer: true } },
+        loading: false,
+        error: undefined,
+        refetch: mockRefetch,
+      })
+      rerender(undefined)
+
+      expect(result.current).toEqual({
+        dollarBalance: false,
+        transfer: true,
+        isSettled: true,
+      })
+    })
+
+    /** Asking has stopped working, which is a determined absence of region rather than a
+     *  moment of one, so FAIL_CLOSED governs from here. */
+    it("gates every feature once the retries are spent", () => {
+      const { result } = renderRestrictions({
+        custodialRestrictions: null,
+        queryError: transportFailure,
+      })
+
+      /** One per commit: each retry is scheduled by the render that follows the last one,
+       *  and the delay doubles. */
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      act(() => {
+        jest.advanceTimersByTime(2000)
+      })
+      act(() => {
+        jest.advanceTimersByTime(4000)
+      })
+      act(() => {
+        jest.advanceTimersByTime(60_000)
+      })
+
+      expect(mockRefetch).toHaveBeenCalledTimes(3)
+      expect(result.current).toEqual({
+        dollarBalance: true,
+        transfer: true,
+        isSettled: true,
+      })
+    })
+
+    /** Every mounted consumer runs this hook, so an unbacked-off retry would turn one
+     *  unreachable server into a burst of requests per screen. */
+    it("backs off rather than asking again at once", () => {
+      renderRestrictions({ custodialRestrictions: null, queryError: transportFailure })
+
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      expect(mockRefetch).toHaveBeenCalledTimes(2)
+    })
+
+    /** The server answering "no verdict" is an answer, and the PRD gates on it. */
+    it("never asks again about a verdict the server actually served", () => {
+      const { result } = renderRestrictions({ custodialRestrictions: null })
+
+      act(() => {
+        jest.advanceTimersByTime(60_000)
+      })
+
+      expect(mockRefetch).not.toHaveBeenCalled()
+      expect(result.current).toEqual({
+        dollarBalance: true,
+        transfer: true,
+        isSettled: true,
+      })
     })
   })
 

--- a/__tests__/hooks/use-account-restrictions.spec.ts
+++ b/__tests__/hooks/use-account-restrictions.spec.ts
@@ -7,11 +7,24 @@ const mockUseRemoteConfig = jest.fn()
 const mockUseActiveWallet = jest.fn()
 const mockUseDeviceLocation = jest.fn()
 const mockUseIpCountryLookup = jest.fn()
+const mockUseCustodialRestrictionsQuery = jest.fn()
 let mockRemoteConfigReady = true
+let mockIsAuthed = true
+let mockIsRegistryHydrating = false
 
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => mockUseRemoteConfig(),
   useFeatureFlags: () => ({ remoteConfigReady: mockRemoteConfigReady }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => mockIsAuthed,
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useCustodialRestrictionsQuery: (options: unknown) =>
+    mockUseCustodialRestrictionsQuery(options),
 }))
 
 /** Reached through use-device-location, and it warns about API keys on import. */
@@ -30,13 +43,21 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => mockUseActiveWallet(),
 }))
 
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ loading: mockIsRegistryHydrating }),
+}))
+
 const blockedCountries = {
-  custodialDollarBalanceBlockedCountries: ["HK"],
-  custodialTransferBlockedCountries: ["DE"],
   selfCustodialDollarBalanceBlockedCountries: ["FR"],
   selfCustodialTransferBlockedCountries: ["PK"],
 }
 
+type ServerRestrictions = { dollarBalance: boolean; transfer: boolean }
+
+const UNRESTRICTED: ServerRestrictions = { dollarBalance: false, transfer: false }
+
+/** null stands for "the query answered nothing", which `undefined` cannot: it would take
+ *  the parameter default instead. */
 const setUp = ({
   accountType = AccountType.Custodial,
   accountTypeOverride,
@@ -45,6 +66,10 @@ const setUp = ({
   ipCountryCode,
   isIpLookupSettled = true,
   remoteConfigReady = true,
+  isAuthed = true,
+  isRegistryHydrating = false,
+  custodialRestrictions = UNRESTRICTED,
+  isQueryLoading = false,
 }: {
   accountType?: AccountType
   accountTypeOverride?: AccountType
@@ -53,8 +78,14 @@ const setUp = ({
   ipCountryCode?: string
   isIpLookupSettled?: boolean
   remoteConfigReady?: boolean
+  isAuthed?: boolean
+  isRegistryHydrating?: boolean
+  custodialRestrictions?: ServerRestrictions | null
+  isQueryLoading?: boolean
 }) => {
   mockRemoteConfigReady = remoteConfigReady
+  mockIsAuthed = isAuthed
+  mockIsRegistryHydrating = isRegistryHydrating
   mockUseDeviceLocation.mockReturnValue({ countryCode, loading: isLocationPending })
   mockUseIpCountryLookup.mockReturnValue({
     countryCode: ipCountryCode,
@@ -62,45 +93,113 @@ const setUp = ({
   })
   mockUseActiveWallet.mockReturnValue({ accountType })
   mockUseRemoteConfig.mockReturnValue(blockedCountries)
+  mockUseCustodialRestrictionsQuery.mockReturnValue({
+    data: custodialRestrictions ? { custodialRestrictions } : undefined,
+    loading: isQueryLoading,
+  })
   return renderHook(() => useAccountRestrictions(accountTypeOverride)).result.current
 }
+
+/** What the query hook was told, so the skip decision can be read directly. */
+const lastQueryOptions = () => mockUseCustodialRestrictionsQuery.mock.calls.at(-1)?.[0]
 
 describe("useAccountRestrictions", () => {
   beforeEach(() => jest.clearAllMocks())
 
-  describe("whose lists answer", () => {
-    it("reads the custodial lists for a custodial account", () => {
-      const restrictions = setUp({ countryCode: "HK" })
+  describe("who answers for the account", () => {
+    it("takes the server's verdict for a custodial account", () => {
+      const restrictions = setUp({
+        custodialRestrictions: { dollarBalance: true, transfer: true },
+      })
 
       expect(restrictions.dollarBalance).toBe(true)
-      expect(restrictions.transfer).toBe(false)
+      expect(restrictions.transfer).toBe(true)
     })
 
     it("reads the self-custodial lists for a self-custodial account", () => {
+      // A self-custodial wallet has no Blink account behind it, so no server verdict
+      // covers it and its own lists answer.
       const restrictions = setUp({
         accountType: AccountType.SelfCustodial,
         countryCode: "FR",
       })
 
       expect(restrictions.dollarBalance).toBe(true)
+      expect(restrictions.transfer).toBe(false)
     })
 
-    it("never answers one custody type from the other's lists", () => {
-      // HK blocks the custodial dollar balance only, FR the self-custodial one only.
-      expect(setUp({ countryCode: "FR" }).dollarBalance).toBe(false)
-      expect(
-        setUp({ accountType: AccountType.SelfCustodial, countryCode: "HK" })
-          .dollarBalance,
-      ).toBe(false)
+    it("asks the server nothing on behalf of a self-custodial account", () => {
+      setUp({ accountType: AccountType.SelfCustodial, countryCode: "FR" })
+
+      expect(lastQueryOptions()).toMatchObject({ skip: true })
     })
 
-    it("reads each feature from its own list", () => {
-      expect(setUp({ countryCode: "DE" }).transfer).toBe(true)
-      expect(setUp({ countryCode: "DE" }).dollarBalance).toBe(false)
+    it("asks the server nothing without an account to ask about", () => {
+      setUp({ isAuthed: false })
+
+      expect(lastQueryOptions()).toMatchObject({ skip: true })
     })
 
-    it("honors an override over the active account type", () => {
-      // Migration previews the self-custodial policy from a still-custodial session.
+    it("asks the server for an authed custodial account", () => {
+      setUp({ isAuthed: true })
+
+      expect(lastQueryOptions()).toMatchObject({ skip: false })
+    })
+
+    it("never reads a cached verdict, which would outlive the session that earned it", () => {
+      setUp({})
+
+      expect(lastQueryOptions()).toMatchObject({ fetchPolicy: "no-cache" })
+    })
+
+    it("reads each field the server answers on its own", () => {
+      // A dollar-balance block does not imply a transfer block, and the reverse.
+      const restrictions = setUp({
+        custodialRestrictions: { dollarBalance: true, transfer: false },
+      })
+
+      expect(restrictions.dollarBalance).toBe(true)
+      expect(restrictions.transfer).toBe(false)
+    })
+  })
+
+  describe("an unanswered query", () => {
+    it("gates every feature when the server gave no verdict", () => {
+      // No region determined, no gated feature — UnknownRegionPolicy = FAIL_CLOSED.
+      const restrictions = setUp({ custodialRestrictions: null })
+
+      expect(restrictions.dollarBalance).toBe(true)
+      expect(restrictions.transfer).toBe(true)
+    })
+
+    it("still settles, so no surface waits on an answer that is not coming", () => {
+      // The server enforces its own rules per request regardless, and it serves every
+      // other custodial feature, so an unreachable one leaves nothing to protect.
+      expect(setUp({ custodialRestrictions: null }).isSettled).toBe(true)
+    })
+
+    /** `useActiveWallet` answers Custodial while the registry hydrates, so a self-custodial
+     *  device reads as custodial-unauthed for those first renders. Settling there would
+     *  offer the dollar balance and then withdraw it. */
+    it("stays unsettled while the registry has not named the account", () => {
+      const restrictions = setUp({ isAuthed: false, isRegistryHydrating: true })
+
+      expect(restrictions.isSettled).toBe(false)
+      expect(restrictions.dollarBalance).toBe(false)
+    })
+
+    it("restricts nothing for a session with no account", () => {
+      const restrictions = setUp({ isAuthed: false, custodialRestrictions: null })
+
+      expect(restrictions.dollarBalance).toBe(false)
+      expect(restrictions.transfer).toBe(false)
+      expect(restrictions.isSettled).toBe(true)
+    })
+  })
+
+  describe("the self-custodial prediction", () => {
+    it("evaluates the overridden type rather than the active one", () => {
+      // A still-custodial session predicting the self-custodial policy during migration.
       const restrictions = setUp({
         accountType: AccountType.Custodial,
         accountTypeOverride: AccountType.SelfCustodial,
@@ -110,36 +209,18 @@ describe("useAccountRestrictions", () => {
       expect(restrictions.dollarBalance).toBe(true)
     })
 
-    it("restricts nothing while the country is unresolved", () => {
-      const restrictions = setUp({ countryCode: undefined })
-
-      expect(restrictions.dollarBalance).toBe(false)
-      expect(restrictions.transfer).toBe(false)
-    })
-  })
-
-  describe("the country it resolves", () => {
-    it("reads the device's own country outside a prediction", () => {
-      setUp({ countryCode: "HK" })
-
-      // No IP lookup runs, so nobody is located who was not already known.
-      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
-    })
-
-    it("prefers the IP while predicting the self-custodial policy", () => {
-      const restrictions = setUp({
+    it("resolves by IP, since the predicted account has no phone", () => {
+      setUp({
         accountTypeOverride: AccountType.SelfCustodial,
-        countryCode: "SV",
         ipCountryCode: "FR",
       })
 
       expect(mockUseIpCountryLookup).toHaveBeenCalledWith(true)
-      expect(restrictions.dollarBalance).toBe(true)
     })
 
-    it("falls back to the session country when the prediction's IP is unreachable", () => {
-      // Reading an unreachable IP as unrestricted would preview a dollar balance the new
-      // account cannot hold, in the one step the user cannot take back.
+    it("falls back to the session country when the IP does not resolve", () => {
+      // A failed lookup must not read as unrestricted and preview a dollar balance the
+      // account cannot hold.
       const restrictions = setUp({
         accountTypeOverride: AccountType.SelfCustodial,
         countryCode: "FR",
@@ -148,40 +229,90 @@ describe("useAccountRestrictions", () => {
 
       expect(restrictions.dollarBalance).toBe(true)
     })
+
+    it("prefers the IP over the session country when both resolve", () => {
+      const restrictions = setUp({
+        accountTypeOverride: AccountType.SelfCustodial,
+        countryCode: "FR",
+        ipCountryCode: "SV",
+      })
+
+      expect(restrictions.dollarBalance).toBe(false)
+    })
+
+    it("runs no IP lookup when no prediction was asked for", () => {
+      setUp({ accountType: AccountType.SelfCustodial })
+
+      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
+    })
+
+    it("takes the server's verdict when the override names the custodial type", () => {
+      const restrictions = setUp({
+        accountType: AccountType.SelfCustodial,
+        accountTypeOverride: AccountType.Custodial,
+        custodialRestrictions: { dollarBalance: true, transfer: false },
+      })
+
+      expect(restrictions.dollarBalance).toBe(true)
+    })
   })
 
   describe("isSettled", () => {
-    it("is false while the device location is still resolving", () => {
-      expect(setUp({ countryCode: undefined, isLocationPending: true }).isSettled).toBe(
-        false,
-      )
+    it("is false while the server has not answered", () => {
+      expect(setUp({ isQueryLoading: true }).isSettled).toBe(false)
     })
 
-    it("is true once a country resolved, even while the location keeps loading", () => {
-      // The prediction's IP lookup can land first, and that already settles the region.
-      expect(setUp({ countryCode: "HK", isLocationPending: true }).isSettled).toBe(true)
+    it("is true once the server has answered", () => {
+      expect(setUp({ isQueryLoading: false }).isSettled).toBe(true)
     })
 
-    it("holds a prediction until its IP lookup settles", () => {
-      // A fast phone parse would otherwise report settled-unrestricted and then flip.
-      const restrictions = setUp({
-        accountTypeOverride: AccountType.SelfCustodial,
-        countryCode: "SV",
-        isIpLookupSettled: false,
-      })
-
-      expect(restrictions.isSettled).toBe(false)
+    it("is true for a session with no account, which has nothing to wait for", () => {
+      expect(setUp({ isAuthed: false, isQueryLoading: true }).isSettled).toBe(true)
     })
 
-    it("is false until remote config has answered", () => {
+    it("holds a self-custodial account while its device location resolves", () => {
+      expect(
+        setUp({
+          accountType: AccountType.SelfCustodial,
+          isLocationPending: true,
+        }).isSettled,
+      ).toBe(false)
+    })
+
+    it("settles a self-custodial account on a country, even mid-lookup", () => {
+      expect(
+        setUp({
+          accountType: AccountType.SelfCustodial,
+          countryCode: "FR",
+          isLocationPending: true,
+        }).isSettled,
+      ).toBe(true)
+    })
+
+    it("holds a self-custodial account until its lists have been fetched", () => {
       // An empty list mid-fetch would read as a country nothing restricts.
-      const restrictions = setUp({ countryCode: "HK", remoteConfigReady: false })
-
-      expect(restrictions.isSettled).toBe(false)
+      expect(
+        setUp({
+          accountType: AccountType.SelfCustodial,
+          countryCode: "FR",
+          remoteConfigReady: false,
+        }).isSettled,
+      ).toBe(false)
     })
 
-    it("is true once both the region and the lists have settled", () => {
-      expect(setUp({ countryCode: "SV" }).isSettled).toBe(true)
+    it("holds the prediction until the IP lookup settles", () => {
+      // A fast phone parse would otherwise report settled-unrestricted and then flip.
+      expect(
+        setUp({
+          accountTypeOverride: AccountType.SelfCustodial,
+          countryCode: "FR",
+          isIpLookupSettled: false,
+        }).isSettled,
+      ).toBe(false)
+    })
+
+    it("ignores remote config for a custodial account, whose lists are gone", () => {
+      expect(setUp({ remoteConfigReady: false }).isSettled).toBe(true)
     })
   })
 })

--- a/__tests__/hooks/use-creation-block.spec.ts
+++ b/__tests__/hooks/use-creation-block.spec.ts
@@ -6,12 +6,12 @@ import { CreationBlockReason } from "@app/types/account"
 
 const mockUseRemoteConfig = jest.fn()
 const mockUseAccountRegistry = jest.fn()
-const mockResolveIpCountryCodeCached = jest.fn()
+const mockClientQuery = jest.fn()
 const mockUpdateCountryCode = jest.fn()
 
 jest.mock("@apollo/client", () => ({
   ...jest.requireActual("@apollo/client"),
-  useApolloClient: () => ({}),
+  useApolloClient: () => ({ query: (options: unknown) => mockClientQuery(options) }),
 }))
 
 jest.mock("@app/graphql/client-only-query", () => ({
@@ -31,31 +31,49 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 jest.mock("@app/utils/ip-country-lookup", () => ({
-  resolveIpCountryCodeCached: () => mockResolveIpCountryCodeCached(),
+  resolveIpCountryCodeCached: jest.fn(),
 }))
 
+/**
+ * The custodial half of the verdict is the server's own answer now, so it is stated rather
+ * than derived from a list; the self-custodial half still comes from a compiled-in list,
+ * since no Blink account stands behind that wallet.
+ */
 const setUp = ({
-  ipCountryCode,
+  countryCode,
+  custodialCreationAllowed = true,
+  hasServerAnswer = true,
   accountCount = 1,
   isRegistryHydrating = false,
-  custodialCreationBlockedCountries = ["CU", "IR"],
   selfCustodialCreationBlockedCountries = ["KP", "SY"],
   custodialFirstSignupBlockedCountries = [],
 }: {
-  ipCountryCode?: string
+  countryCode?: string
+  custodialCreationAllowed?: boolean
+  hasServerAnswer?: boolean
   accountCount?: number
   isRegistryHydrating?: boolean
-  custodialCreationBlockedCountries?: string[]
   selfCustodialCreationBlockedCountries?: string[]
   custodialFirstSignupBlockedCountries?: string[]
 }) => {
-  mockResolveIpCountryCodeCached.mockResolvedValue(ipCountryCode)
+  mockClientQuery.mockResolvedValue(
+    hasServerAnswer
+      ? {
+          data: {
+            regionCheck: {
+              countryCode,
+              custodialCreationAllowed,
+              restricted: !custodialCreationAllowed,
+            },
+          },
+        }
+      : { data: undefined },
+  )
   mockUseAccountRegistry.mockReturnValue({
     accounts: new Array(accountCount).fill({}),
     loading: isRegistryHydrating,
   })
   mockUseRemoteConfig.mockReturnValue({
-    custodialCreationBlockedCountries,
     selfCustodialCreationBlockedCountries,
     custodialFirstSignupBlockedCountries,
   })
@@ -78,15 +96,15 @@ describe("useCreationBlock", () => {
   beforeEach(() => jest.clearAllMocks())
 
   it("looks up nothing until an option is submitted", () => {
-    setUp({ ipCountryCode: "CU" })
+    setUp({ countryCode: "CU", custodialCreationAllowed: false })
 
     // Merely opening the screen must not locate anyone.
-    expect(mockResolveIpCountryCodeCached).not.toHaveBeenCalled()
+    expect(mockClientQuery).not.toHaveBeenCalled()
   })
 
   describe("regional rules", () => {
     it("refuses the custodial option from its own list", async () => {
-      const { result } = setUp({ ipCountryCode: "CU" })
+      const { result } = setUp({ countryCode: "CU", custodialCreationAllowed: false })
 
       expect(await check(result, AccountOption.Custodial)).toBe(
         CreationBlockReason.Region,
@@ -94,7 +112,7 @@ describe("useCreationBlock", () => {
     })
 
     it("refuses the self-custodial option from its own list", async () => {
-      const { result } = setUp({ ipCountryCode: "KP" })
+      const { result } = setUp({ countryCode: "KP" })
 
       expect(await check(result, AccountOption.SelfCustodial)).toBe(
         CreationBlockReason.Region,
@@ -103,8 +121,8 @@ describe("useCreationBlock", () => {
 
     it("reads each option from its own list, so the lists can diverge", async () => {
       const { result } = setUp({
-        ipCountryCode: "CU",
-        custodialCreationBlockedCountries: ["CU"],
+        countryCode: "CU",
+        custodialCreationAllowed: false,
         selfCustodialCreationBlockedCountries: ["KP"],
       })
 
@@ -115,7 +133,7 @@ describe("useCreationBlock", () => {
     })
 
     it("allows an option whose list does not carry the country", async () => {
-      const { result } = setUp({ ipCountryCode: "SV" })
+      const { result } = setUp({ countryCode: "SV" })
 
       expect(await check(result, AccountOption.Custodial)).toBeNull()
       expect(await check(result, AccountOption.SelfCustodial)).toBeNull()
@@ -123,8 +141,8 @@ describe("useCreationBlock", () => {
 
     it("matches case-insensitively", async () => {
       const { result } = setUp({
-        ipCountryCode: "cu",
-        custodialCreationBlockedCountries: ["CU"],
+        countryCode: "cu",
+        custodialCreationAllowed: false,
       })
 
       expect(await check(result, AccountOption.Custodial)).toBe(
@@ -136,7 +154,7 @@ describe("useCreationBlock", () => {
   describe("the first custodial signup", () => {
     it("is refused in a listed country when the device holds no account", async () => {
       const { result } = setUp({
-        ipCountryCode: "PK",
+        countryCode: "PK",
         accountCount: 0,
         custodialFirstSignupBlockedCountries: ["PK"],
       })
@@ -148,7 +166,7 @@ describe("useCreationBlock", () => {
 
     it("is allowed in that same country once an account exists", async () => {
       const { result } = setUp({
-        ipCountryCode: "PK",
+        countryCode: "PK",
         accountCount: 1,
         custodialFirstSignupBlockedCountries: ["PK"],
       })
@@ -159,7 +177,7 @@ describe("useCreationBlock", () => {
 
     it("never refuses the self-custodial option, which the rule does not govern", async () => {
       const { result } = setUp({
-        ipCountryCode: "PK",
+        countryCode: "PK",
         accountCount: 0,
         custodialFirstSignupBlockedCountries: ["PK"],
       })
@@ -169,9 +187,9 @@ describe("useCreationBlock", () => {
 
     it("yields to the regional rule, which is the stronger refusal", async () => {
       const { result } = setUp({
-        ipCountryCode: "CU",
+        countryCode: "CU",
         accountCount: 0,
-        custodialCreationBlockedCountries: ["CU"],
+        custodialCreationAllowed: false,
         custodialFirstSignupBlockedCountries: ["CU"],
       })
 
@@ -185,7 +203,7 @@ describe("useCreationBlock", () => {
   describe("the country it reads", () => {
     it("uppercases what the provider returned before matching any list", async () => {
       const { result } = setUp({
-        ipCountryCode: "pk",
+        countryCode: "pk",
         accountCount: 0,
         custodialFirstSignupBlockedCountries: ["PK"],
       })
@@ -197,7 +215,7 @@ describe("useCreationBlock", () => {
     })
 
     it("records the answer, so the rest of the app shares the country it read", async () => {
-      const { result } = setUp({ ipCountryCode: "SV" })
+      const { result } = setUp({ countryCode: "SV" })
 
       await check(result, AccountOption.Custodial)
 
@@ -205,7 +223,7 @@ describe("useCreationBlock", () => {
     })
 
     it("reports an unreadable location as such, rather than blaming the region", async () => {
-      const { result } = setUp({ ipCountryCode: undefined, accountCount: 5 })
+      const { result } = setUp({ countryCode: undefined, accountCount: 5 })
 
       // Someone who already holds accounts is not refused for a first signup.
       expect(await check(result, AccountOption.Custodial)).toBe(
@@ -216,33 +234,43 @@ describe("useCreationBlock", () => {
       )
     })
 
-    it("reads the connection and never an account's registered phone", async () => {
-      const { result } = setUp({ ipCountryCode: "CU" })
+    it("asks the server, which reads the connection and never a registered phone", async () => {
+      const { result } = setUp({ countryCode: "CU" })
 
       // Which account happens to be open must not decide who may create a new one.
       await check(result, AccountOption.Custodial)
 
-      expect(mockResolveIpCountryCodeCached).toHaveBeenCalled()
+      expect(mockClientQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ fetchPolicy: "no-cache" }),
+      )
     })
   })
 
   describe("the flags a submit button waits on", () => {
     const setUpPending = () => {
-      let resolveLookup: (code: string) => void = () => undefined
-      mockResolveIpCountryCodeCached.mockReturnValue(
-        new Promise<string>((resolve) => {
-          resolveLookup = resolve
+      let resolveQuery: (result: unknown) => void = () => undefined
+      mockClientQuery.mockReturnValue(
+        new Promise((resolve) => {
+          resolveQuery = resolve
         }),
       )
       mockUseAccountRegistry.mockReturnValue({ accounts: [], loading: false })
       mockUseRemoteConfig.mockReturnValue({
-        custodialCreationBlockedCountries: [],
         selfCustodialCreationBlockedCountries: [],
         custodialFirstSignupBlockedCountries: [],
       })
       return {
         render: renderHook(() => useCreationBlock()),
-        resolve: () => resolveLookup("SV"),
+        resolve: () =>
+          resolveQuery({
+            data: {
+              regionCheck: {
+                countryCode: "SV",
+                custodialCreationAllowed: true,
+                restricted: false,
+              },
+            },
+          }),
       }
     }
 
@@ -266,7 +294,7 @@ describe("useCreationBlock", () => {
     })
 
     it("reports the first-signup rule unready while the account registry hydrates", () => {
-      const { result } = setUp({ ipCountryCode: "SV", isRegistryHydrating: true })
+      const { result } = setUp({ countryCode: "SV", isRegistryHydrating: true })
 
       // An empty registry mid-hydration would refuse a device that already holds accounts.
       expect(result.current.isFirstSignupRuleReady).toBe(false)
@@ -275,7 +303,7 @@ describe("useCreationBlock", () => {
     })
 
     it("reports the rule ready once the registry has settled", () => {
-      const { result } = setUp({ ipCountryCode: "SV" })
+      const { result } = setUp({ countryCode: "SV" })
 
       expect(result.current.isFirstSignupRuleReady).toBe(true)
     })

--- a/__tests__/hooks/use-default-account-modal-shown.spec.ts
+++ b/__tests__/hooks/use-default-account-modal-shown.spec.ts
@@ -14,7 +14,7 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -17,12 +17,26 @@ jest.mock("libphonenumber-js/mobile", () => ({
 }))
 
 const mockResolveIpCountryCode = jest.fn()
+let mockLookupGeneration = 0
+let mockNotifyLookupReset: (() => void) | null = null
 jest.mock("@app/utils/ip-country-lookup", () => ({
   resolveIpCountryCodeCached: (...args: unknown[]) => mockResolveIpCountryCode(...args),
-  /** The hook subscribes to the session-start reset; this spec never fires one. */
-  subscribeToIpCountryLookup: () => () => undefined,
-  getIpCountryLookupGeneration: () => 0,
+  /** The hook subscribes to the session-start reset; `resetLookupGeneration` fires one. */
+  subscribeToIpCountryLookup: (listener: () => void) => {
+    mockNotifyLookupReset = listener
+    return () => {
+      mockNotifyLookupReset = null
+    }
+  },
+  getIpCountryLookupGeneration: () => mockLookupGeneration,
 }))
+
+/** Stands in for a session start dropping the shared lookup, which is what makes an
+ *  already-mounted consumer resolve again instead of keeping the last country. */
+const resetLookupGeneration = () => {
+  mockLookupGeneration += 1
+  mockNotifyLookupReset?.()
+}
 
 jest.mock("@app/utils/log-error", () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
@@ -514,6 +528,54 @@ describe("useIpCountryLookup", () => {
     await act(async () => {})
 
     expect(result.current).toEqual({ countryCode: undefined, isSettled: true })
+  })
+
+  describe("a session-start reset", () => {
+    /**
+     * The reset exists to drop the previous session's answer. Reporting the old country as
+     * settled when the fresh lookup comes back empty is the cross-session latch it was added
+     * to remove, and the consumers that gate on `isSettled` cannot tell the two apart.
+     */
+    it("drops the previous country when the re-lookup finds none", async () => {
+      mockResolveIpCountryCode.mockResolvedValue("HK")
+      const { result } = renderHook(() => useIpCountryLookup(true))
+      await act(async () => {})
+      expect(result.current).toEqual({ countryCode: "HK", isSettled: true })
+
+      mockResolveIpCountryCode.mockResolvedValue(undefined)
+      await act(async () => {
+        resetLookupGeneration()
+      })
+
+      expect(result.current).toEqual({ countryCode: undefined, isSettled: true })
+    })
+
+    it("takes the new country when the re-lookup finds one", async () => {
+      mockResolveIpCountryCode.mockResolvedValue("HK")
+      const { result } = renderHook(() => useIpCountryLookup(true))
+      await act(async () => {})
+
+      mockResolveIpCountryCode.mockResolvedValue("SV")
+      await act(async () => {
+        resetLookupGeneration()
+      })
+
+      expect(result.current).toEqual({ countryCode: "SV", isSettled: true })
+    })
+
+    /** Unsettling is what makes the gates wait rather than answer from the old country. */
+    it("goes back to unsettled while the re-lookup is in flight", async () => {
+      mockResolveIpCountryCode.mockResolvedValue("HK")
+      const { result } = renderHook(() => useIpCountryLookup(true))
+      await act(async () => {})
+
+      mockResolveIpCountryCode.mockReturnValue(new Promise(() => {}))
+      act(() => {
+        resetLookupGeneration()
+      })
+
+      expect(result.current.isSettled).toBe(false)
+    })
   })
 
   it("discards a lookup still in flight when it gets disabled and relooks up on re-enable", async () => {

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -19,6 +19,9 @@ jest.mock("libphonenumber-js/mobile", () => ({
 const mockResolveIpCountryCode = jest.fn()
 jest.mock("@app/utils/ip-country-lookup", () => ({
   resolveIpCountryCodeCached: (...args: unknown[]) => mockResolveIpCountryCode(...args),
+  /** The hook subscribes to the session-start reset; this spec never fires one. */
+  subscribeToIpCountryLookup: () => () => undefined,
+  getIpCountryLookupGeneration: () => 0,
 }))
 
 jest.mock("@app/utils/log-error", () => ({

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -4,6 +4,7 @@ import { AccountType } from "@app/types/wallet"
 
 const mockUseDeviceLocation = jest.fn()
 const mockUseRemoteConfig = jest.fn()
+let mockRemoteConfigReady = true
 const mockUseActiveWallet = jest.fn()
 const mockUseIpCountryLookup = jest.fn()
 
@@ -23,6 +24,7 @@ jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
 
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => ({ remoteConfigReady: mockRemoteConfigReady }),
 }))
 
 jest.mock("@app/hooks/use-active-wallet", () => ({
@@ -37,7 +39,9 @@ import {
 } from "@app/hooks/use-dollar-balance-restricted"
 
 const remoteConfig = {
+  custodialTransferBlockedCountries: [],
   custodialDollarBalanceBlockedCountries: ["HK"],
+  selfCustodialTransferBlockedCountries: [],
   selfCustodialDollarBalanceBlockedCountries: ["FR"],
 }
 
@@ -48,6 +52,7 @@ const setIpLookup = (countryCode: string | undefined, isSettled = true): void =>
 
 const setup = (accountType: AccountType): void => {
   jest.clearAllMocks()
+  mockRemoteConfigReady = true
   mockIsAnonMode = false
   mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
   mockUseRemoteConfig.mockReturnValue(remoteConfig)
@@ -250,6 +255,20 @@ describe("useDollarBalanceRestricted", () => {
       setIpLookup(undefined, false)
 
       expect(readRestriction()).toEqual({ isRestricted: false, isRegionPending: false })
+    })
+  })
+
+  describe("before the block-lists have arrived", () => {
+    it("reports the region pending rather than a verdict off the compiled defaults", () => {
+      mockRemoteConfigReady = false
+
+      const { isRegionPending, isGated } = renderHook(() => useDollarBalanceGate()).result
+        .current
+
+      // A list still being fetched would read as a country nothing restricts, and the
+      // surface would settle on it and then flip once the real list lands.
+      expect(isRegionPending).toBe(true)
+      expect(isGated).toBe(false)
     })
   })
 })

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -7,6 +7,8 @@ const mockUseRemoteConfig = jest.fn()
 let mockRemoteConfigReady = true
 const mockUseActiveWallet = jest.fn()
 const mockUseIpCountryLookup = jest.fn()
+const mockUseCustodialRestrictionsQuery = jest.fn()
+let mockIsAuthed = true
 
 jest.mock("@app/utils/ip-country-lookup")
 
@@ -30,6 +32,19 @@ jest.mock("@app/config/feature-flags-context", () => ({
 jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => mockUseActiveWallet(),
 }))
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ loading: false }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => mockIsAuthed,
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useCustodialRestrictionsQuery: (options: unknown) =>
+    mockUseCustodialRestrictionsQuery(options),
+}))
 
 import {
   useDollarBalanceGate,
@@ -39,8 +54,6 @@ import {
 } from "@app/hooks/use-dollar-balance-restricted"
 
 const remoteConfig = {
-  custodialTransferBlockedCountries: [],
-  custodialDollarBalanceBlockedCountries: ["HK"],
   selfCustodialTransferBlockedCountries: [],
   selfCustodialDollarBalanceBlockedCountries: ["FR"],
 }
@@ -50,14 +63,29 @@ const setIpLookup = (countryCode: string | undefined, isSettled = true): void =>
   mockUseIpCountryLookup.mockReturnValue({ countryCode, isSettled })
 }
 
+/** The server's answer, which is what a custodial account is judged by. */
+const serverAnswers = (dollarBalance: boolean, loading = false): void => {
+  mockUseCustodialRestrictionsQuery.mockReturnValue({
+    data: { custodialRestrictions: { dollarBalance, transfer: false } },
+    loading,
+  })
+}
+
+/** No answer at all: an unreachable server, or a session with no account to ask about. */
+const serverSilent = (loading = false): void => {
+  mockUseCustodialRestrictionsQuery.mockReturnValue({ data: undefined, loading })
+}
+
 const setup = (accountType: AccountType): void => {
   jest.clearAllMocks()
   mockRemoteConfigReady = true
   mockIsAnonMode = false
+  mockIsAuthed = true
   mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
   mockUseRemoteConfig.mockReturnValue(remoteConfig)
   mockUseActiveWallet.mockReturnValue({ accountType })
   setIpLookup(undefined)
+  serverAnswers(false)
 }
 
 const read = () => renderHook(() => useDollarBalanceRestricted()).result.current
@@ -69,23 +97,32 @@ describe("useDollarBalanceRestricted", () => {
   describe("custodial", () => {
     beforeEach(() => setup(AccountType.Custodial))
 
-    it("is restricted in a Stablesats-blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+    it("is restricted when the server blocks the dollar balance", () => {
+      serverAnswers(true)
       expect(read()).toBe(true)
     })
 
-    it("is case-insensitive on the device country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "hk" })
-      expect(read()).toBe(true)
-    })
-
-    it("is not restricted in a country that only the stable-token list blocks", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+    it("is not restricted when the server clears it", () => {
+      serverAnswers(false)
       expect(read()).toBe(false)
     })
 
-    it("is not restricted without a resolved country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+    it("ignores the device country, which the server resolves for itself", () => {
+      // The server picks phone or IP by account level, so the client never chooses.
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+      serverAnswers(false)
+      expect(read()).toBe(false)
+    })
+
+    it("is restricted when the server gave no answer", () => {
+      // No region determined, no gated feature — UnknownRegionPolicy = FAIL_CLOSED.
+      serverSilent()
+      expect(read()).toBe(true)
+    })
+
+    it("is not restricted without an account to ask about", () => {
+      mockIsAuthed = false
+      serverSilent()
       expect(read()).toBe(false)
     })
   })
@@ -98,7 +135,24 @@ describe("useDollarBalanceRestricted", () => {
       expect(read()).toBe(true)
     })
 
-    it("is not restricted in a country that only blocks custodial Stablesats", () => {
+    it("is case-insensitive on the device country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "fr" })
+      expect(read()).toBe(true)
+    })
+
+    it("is not restricted in a country its own list does not carry", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+      expect(read()).toBe(false)
+    })
+
+    it("is not restricted without a resolved country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      expect(read()).toBe(false)
+    })
+
+    it("is unaffected by a custodial verdict the server gave", () => {
+      // No server verdict covers a wallet with no Blink account behind it.
+      serverAnswers(true)
       mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
       expect(read()).toBe(false)
     })
@@ -129,7 +183,8 @@ describe("useDollarBalanceRestricted", () => {
       expect(readOverride(AccountType.SelfCustodial)).toBe(false)
     })
 
-    it("uses the self-custodial blocked list, not the custodial one", () => {
+    it("uses the self-custodial list, not the server's custodial verdict", () => {
+      serverAnswers(true)
       setIpLookup("HK")
       expect(readOverride(AccountType.SelfCustodial)).toBe(false)
     })
@@ -168,31 +223,31 @@ describe("useDollarBalanceRestricted", () => {
     })
   })
 
-  describe("while the region is still resolving", () => {
+  describe("while the verdict is still resolving", () => {
     beforeEach(() => setup(AccountType.Custodial))
 
     it("reports the region as pending without claiming a restriction", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, loading: true })
+      serverAnswers(false, true)
 
       expect(readRestriction()).toEqual({ isRestricted: false, isRegionPending: true })
     })
 
-    it("restricts once the region resolves to a blocked country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", loading: false })
+    it("restricts once the server answers that it is blocked", () => {
+      serverAnswers(true)
 
       expect(readRestriction()).toEqual({ isRestricted: true, isRegionPending: false })
     })
 
-    it("settles unrestricted once the region resolves to an allowed country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: "US", loading: false })
+    it("settles unrestricted once the server clears it", () => {
+      serverAnswers(false)
 
       expect(readRestriction()).toEqual({ isRestricted: false, isRegionPending: false })
     })
 
-    it("settles on a finished lookup that produced no country", () => {
-      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, loading: false })
+    it("settles restricted on an unreachable server rather than holding for good", () => {
+      serverSilent()
 
-      expect(readRestriction()).toEqual({ isRestricted: false, isRegionPending: false })
+      expect(readRestriction()).toEqual({ isRestricted: true, isRegionPending: false })
     })
 
     it("settles the self-custodial prediction on the IP even while the device keeps loading", () => {
@@ -208,6 +263,7 @@ describe("useDollarBalanceRestricted", () => {
     /** Anon gates on the mode alone, so no region resolves and nothing pends. */
     it("never pends in Anon mode", () => {
       mockIsAnonMode = true
+      mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
       mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, loading: false })
 
       expect(renderHook(() => useDollarBalanceGate()).result.current).toEqual({
@@ -258,7 +314,9 @@ describe("useDollarBalanceRestricted", () => {
     })
   })
 
-  describe("before the block-lists have arrived", () => {
+  describe("before the self-custodial block-lists have arrived", () => {
+    beforeEach(() => setup(AccountType.SelfCustodial))
+
     it("reports the region pending rather than a verdict off the compiled defaults", () => {
       mockRemoteConfigReady = false
 
@@ -269,6 +327,13 @@ describe("useDollarBalanceRestricted", () => {
       // surface would settle on it and then flip once the real list lands.
       expect(isRegionPending).toBe(true)
       expect(isGated).toBe(false)
+    })
+
+    it("leaves the custodial evaluation settled, whose lists are gone", () => {
+      mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
+      mockRemoteConfigReady = false
+
+      expect(readRestriction()).toEqual({ isRestricted: false, isRegionPending: false })
     })
   })
 })

--- a/__tests__/hooks/use-quiz-completions.spec.ts
+++ b/__tests__/hooks/use-quiz-completions.spec.ts
@@ -14,7 +14,7 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/hooks/use-region-check.spec.ts
+++ b/__tests__/hooks/use-region-check.spec.ts
@@ -2,185 +2,277 @@ import { renderHook } from "@testing-library/react-native"
 
 import { useRegionCheck, useRegionCheckLazy } from "@app/hooks/use-region-check"
 
-const mockUseRemoteConfig = jest.fn()
-const mockUseFeatureFlags = jest.fn()
-const mockUseIpCountryLookup = jest.fn()
-const mockResolveIpCountryCodeCached = jest.fn()
+const mockUseRegionCheckQuery = jest.fn()
+const mockClientQuery = jest.fn()
 const mockUpdateCountryCode = jest.fn()
+const mockUseSelfCustodialAccountMode = jest.fn()
 
-jest.mock("@app/config/feature-flags-context", () => ({
-  useRemoteConfig: () => mockUseRemoteConfig(),
-  useFeatureFlags: () => mockUseFeatureFlags(),
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useRegionCheckQuery: (options: unknown) => mockUseRegionCheckQuery(options),
 }))
 
 jest.mock("@apollo/client", () => ({
   ...jest.requireActual("@apollo/client"),
-  useApolloClient: () => ({}),
+  useApolloClient: () => ({ query: (options: unknown) => mockClientQuery(options) }),
 }))
 
 jest.mock("@app/graphql/client-only-query", () => ({
   updateCountryCode: (...args: unknown[]) => mockUpdateCountryCode(...args),
 }))
 
-/** Reached through use-device-location, and it warns about API keys on import. */
-jest.mock("@app/utils/ip-country-lookup", () => ({
-  resolveIpCountryCodeCached: () => mockResolveIpCountryCodeCached(),
+jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
+  useSelfCustodialAccountMode: () => mockUseSelfCustodialAccountMode(),
 }))
 
-jest.mock("@app/hooks/use-device-location", () => ({
-  __esModule: true,
-  ...jest.requireActual("@app/hooks/use-device-location"),
-  useIpCountryLookup: (enabled: boolean) => mockUseIpCountryLookup(enabled),
-}))
+type ServerVerdict = {
+  countryCode?: string | null
+  custodialCreationAllowed: boolean
+  restricted: boolean
+}
 
+const ALLOWED: ServerVerdict = {
+  countryCode: "SV",
+  custodialCreationAllowed: true,
+  restricted: false,
+}
+
+/** null stands for "the query answered nothing", which `undefined` cannot: it would take
+ *  the parameter default instead. */
 const setUp = ({
   enabled = true,
-  countryCode,
-  isLookupSettled = true,
-  remoteConfigReady = true,
-  custodialCreationBlockedCountries = ["CU", "IR"],
+  isAnonMode = false,
+  regionCheck = ALLOWED,
+  loading = false,
 }: {
   enabled?: boolean
-  countryCode?: string
-  isLookupSettled?: boolean
-  remoteConfigReady?: boolean
-  custodialCreationBlockedCountries?: string[]
+  isAnonMode?: boolean
+  regionCheck?: ServerVerdict | null
+  loading?: boolean
 }) => {
-  mockUseIpCountryLookup.mockReturnValue({ countryCode, isSettled: isLookupSettled })
-  mockUseFeatureFlags.mockReturnValue({ remoteConfigReady })
-  mockUseRemoteConfig.mockReturnValue({ custodialCreationBlockedCountries })
+  mockUseSelfCustodialAccountMode.mockReturnValue({ isAnonMode })
+  mockUseRegionCheckQuery.mockReturnValue({
+    data: regionCheck ? { regionCheck } : undefined,
+    loading,
+  })
   return renderHook(() => useRegionCheck(enabled)).result.current
 }
+
+/** What the query hook was told, so the skip decision can be read directly. */
+const lastQueryOptions = () => mockUseRegionCheckQuery.mock.calls.at(-1)?.[0]
 
 describe("useRegionCheck", () => {
   beforeEach(() => jest.clearAllMocks())
 
   describe("the verdict", () => {
-    it("refuses creation and reports the session restricted in a listed country", () => {
-      const verdict = setUp({ countryCode: "CU" })
+    it("reports the refusal the server gave, rather than deriving one", () => {
+      const verdict = setUp({
+        regionCheck: {
+          countryCode: "CU",
+          custodialCreationAllowed: false,
+          restricted: true,
+        },
+      })
 
       expect(verdict.custodialCreationAllowed).toBe(false)
       expect(verdict.restricted).toBe(true)
     })
 
-    it("allows both where the list does not carry the country", () => {
-      const verdict = setUp({ countryCode: "SV" })
+    it("carries the two fields separately, since the server separates them", () => {
+      // A country closed to new accounts is not necessarily a sanctioned session.
+      const verdict = setUp({
+        regionCheck: {
+          countryCode: "PK",
+          custodialCreationAllowed: false,
+          restricted: false,
+        },
+      })
+
+      expect(verdict.custodialCreationAllowed).toBe(false)
+      expect(verdict.restricted).toBe(false)
+    })
+
+    it("allows both where the server restricts nothing", () => {
+      const verdict = setUp({ regionCheck: ALLOWED })
 
       expect(verdict.custodialCreationAllowed).toBe(true)
       expect(verdict.restricted).toBe(false)
     })
 
-    it("allows both while the country is unresolved", () => {
-      // Nothing was read, so nothing may be held against the user.
-      const verdict = setUp({ countryCode: undefined })
+    it("holds nothing against the user when the query answered nothing", () => {
+      const verdict = setUp({ regionCheck: null })
 
+      expect(verdict.countryCode).toBeUndefined()
       expect(verdict.custodialCreationAllowed).toBe(true)
       expect(verdict.restricted).toBe(false)
     })
 
-    it("matches case-insensitively, since the list is stored uppercase", () => {
-      expect(setUp({ countryCode: "cu" }).restricted).toBe(true)
+    it("reports the country the server resolved", () => {
+      expect(setUp({ regionCheck: ALLOWED }).countryCode).toBe("SV")
     })
 
-    it("reports the country it resolved", () => {
-      expect(setUp({ countryCode: "SV" }).countryCode).toBe("SV")
+    it("uppercases the country, so every caller reads one casing", () => {
+      expect(setUp({ regionCheck: { ...ALLOWED, countryCode: "sv" } }).countryCode).toBe(
+        "SV",
+      )
+    })
+
+    it("reports a verdict the server could not attach a country to", () => {
+      const verdict = setUp({
+        regionCheck: {
+          countryCode: null,
+          custodialCreationAllowed: true,
+          restricted: false,
+        },
+      })
+
+      expect(verdict.countryCode).toBeUndefined()
+      expect(verdict.restricted).toBe(false)
     })
   })
 
   describe("locating the user", () => {
-    it("resolves nothing for a caller that did not ask", () => {
-      // Reading the region is the act of locating someone. Anon is the standing case.
+    it("asks nothing for a caller that did not ask", () => {
+      // Reading the region is the act of locating someone.
       setUp({ enabled: false })
 
-      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
+      expect(lastQueryOptions()).toMatchObject({ skip: true })
     })
 
-    it("passes the caller's intent through to the lookup", () => {
+    it("asks nothing in Anon, which spoke for an account that declined to be located", () => {
+      setUp({ enabled: true, isAnonMode: true })
+
+      expect(lastQueryOptions()).toMatchObject({ skip: true })
+    })
+
+    it("asks once the caller has a reason to", () => {
       setUp({ enabled: true })
 
-      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(true)
+      expect(lastQueryOptions()).toMatchObject({ skip: false })
+    })
+
+    it("never reads a cached verdict, which could speak for a network already left", () => {
+      setUp({ enabled: true })
+
+      expect(lastQueryOptions()).toMatchObject({ fetchPolicy: "no-cache" })
+    })
+
+    it("withholds a verdict left over from before Anon was entered", () => {
+      // The skip keeps Apollo's last data around; returning it would leak a country the
+      // account asked not to have read.
+      const verdict = setUp({ isAnonMode: true, regionCheck: ALLOWED })
+
+      expect(verdict.countryCode).toBeUndefined()
+      expect(verdict.restricted).toBe(false)
     })
   })
 
   describe("isSettled", () => {
     it("is settled at once for a caller that asks nothing", () => {
       // There is no answer coming, so waiting on one would never end.
-      expect(setUp({ enabled: false, isLookupSettled: false }).isSettled).toBe(true)
+      expect(setUp({ enabled: false, loading: true }).isSettled).toBe(true)
     })
 
-    it("is false while the lookup is still running", () => {
-      expect(setUp({ isLookupSettled: false }).isSettled).toBe(false)
+    it("is settled at once in Anon", () => {
+      expect(setUp({ isAnonMode: true, loading: true }).isSettled).toBe(true)
     })
 
-    it("is false until remote config has answered", () => {
-      // An empty list mid-fetch would read as a country nothing restricts.
-      expect(setUp({ countryCode: "CU", remoteConfigReady: false }).isSettled).toBe(false)
+    it("is false while the query is in flight", () => {
+      expect(setUp({ loading: true }).isSettled).toBe(false)
     })
 
-    it("is true once both have settled, resolved country or not", () => {
-      expect(setUp({ countryCode: "SV" }).isSettled).toBe(true)
-      expect(setUp({ countryCode: undefined }).isSettled).toBe(true)
+    it("settles on an answer, and on the absence of one", () => {
+      // An unreachable server is not a verdict, and holding the UI on it would strand a
+      // user the app has no service left to protect anyway.
+      expect(setUp({ regionCheck: ALLOWED }).isSettled).toBe(true)
+      expect(setUp({ regionCheck: null }).isSettled).toBe(true)
     })
   })
 })
 
 describe("useRegionCheckLazy", () => {
-  const setUpLazy = ({
-    ipCountryCode,
-    custodialCreationBlockedCountries = ["CU", "IR"],
-  }: {
-    ipCountryCode?: string
-    custodialCreationBlockedCountries?: string[]
-  }) => {
-    mockResolveIpCountryCodeCached.mockResolvedValue(ipCountryCode)
-    mockUseRemoteConfig.mockReturnValue({ custodialCreationBlockedCountries })
+  const setUpLazy = (result: { data?: { regionCheck: ServerVerdict } } | Error) => {
+    if (result instanceof Error) mockClientQuery.mockRejectedValue(result)
+    else mockClientQuery.mockResolvedValue(result)
     return renderHook(() => useRegionCheckLazy()).result.current
   }
 
   beforeEach(() => jest.clearAllMocks())
 
   it("locates nobody until it is called", () => {
-    setUpLazy({ ipCountryCode: "CU" })
+    setUpLazy({ data: { regionCheck: ALLOWED } })
 
     // The creation screens hold this hook while the user is still only browsing.
-    expect(mockResolveIpCountryCodeCached).not.toHaveBeenCalled()
+    expect(mockClientQuery).not.toHaveBeenCalled()
   })
 
-  it("refuses creation and reports restricted in a listed country", async () => {
-    const verdict = await setUpLazy({ ipCountryCode: "CU" })()
+  it("reports the refusal the server gave", async () => {
+    const verdict = await setUpLazy({
+      data: {
+        regionCheck: {
+          countryCode: "CU",
+          custodialCreationAllowed: false,
+          restricted: true,
+        },
+      },
+    })()
 
     expect(verdict.custodialCreationAllowed).toBe(false)
     expect(verdict.restricted).toBe(true)
     expect(verdict.countryCode).toBe("CU")
   })
 
-  it("allows both where the list does not carry the country", async () => {
-    const verdict = await setUpLazy({ ipCountryCode: "SV" })()
+  it("allows both where the server restricts nothing", async () => {
+    const verdict = await setUpLazy({ data: { regionCheck: ALLOWED } })()
 
     expect(verdict.custodialCreationAllowed).toBe(true)
     expect(verdict.restricted).toBe(false)
   })
 
-  it("uppercases what the provider returned before matching the list", async () => {
-    const verdict = await setUpLazy({ ipCountryCode: "cu" })()
+  it("uppercases what the server returned", async () => {
+    const verdict = await setUpLazy({
+      data: { regionCheck: { ...ALLOWED, countryCode: "sv" } },
+    })()
 
-    expect(verdict.countryCode).toBe("CU")
-    expect(verdict.restricted).toBe(true)
+    expect(verdict.countryCode).toBe("SV")
   })
 
-  it("answers an unresolved country as such, with nothing held against the user", async () => {
-    const verdict = await setUpLazy({ ipCountryCode: undefined })()
+  it("never reads a cached verdict", async () => {
+    await setUpLazy({ data: { regionCheck: ALLOWED } })()
 
-    // No local fallback: the country-code cache answers "SV" for an unset value, and
-    // reading it would turn "could not resolve" into a country nobody read.
+    expect(mockClientQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ fetchPolicy: "no-cache" }),
+    )
+  })
+
+  it("answers an unreachable server as an unread region", async () => {
+    // Account creation refuses on this rather than guessing; it is the one caller that
+    // must not proceed without a region.
+    const verdict = await setUpLazy(new Error("network down"))()
+
     expect(verdict.countryCode).toBeUndefined()
     expect(verdict.custodialCreationAllowed).toBe(true)
     expect(verdict.restricted).toBe(false)
     expect(mockUpdateCountryCode).not.toHaveBeenCalled()
   })
 
+  it("answers a verdict with no country as an unread region", async () => {
+    const verdict = await setUpLazy({
+      data: {
+        regionCheck: {
+          countryCode: null,
+          custodialCreationAllowed: true,
+          restricted: false,
+        },
+      },
+    })()
+
+    expect(verdict.countryCode).toBeUndefined()
+    expect(mockUpdateCountryCode).not.toHaveBeenCalled()
+  })
+
   it("records the answer, so the rest of the app shares the country it read", async () => {
-    await setUpLazy({ ipCountryCode: "SV" })()
+    await setUpLazy({ data: { regionCheck: ALLOWED } })()
 
     expect(mockUpdateCountryCode).toHaveBeenCalledWith(expect.anything(), "SV")
   })

--- a/__tests__/hooks/use-region-check.spec.ts
+++ b/__tests__/hooks/use-region-check.spec.ts
@@ -1,0 +1,187 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { useRegionCheck, useRegionCheckLazy } from "@app/hooks/use-region-check"
+
+const mockUseRemoteConfig = jest.fn()
+const mockUseFeatureFlags = jest.fn()
+const mockUseIpCountryLookup = jest.fn()
+const mockResolveIpCountryCodeCached = jest.fn()
+const mockUpdateCountryCode = jest.fn()
+
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => mockUseFeatureFlags(),
+}))
+
+jest.mock("@apollo/client", () => ({
+  ...jest.requireActual("@apollo/client"),
+  useApolloClient: () => ({}),
+}))
+
+jest.mock("@app/graphql/client-only-query", () => ({
+  updateCountryCode: (...args: unknown[]) => mockUpdateCountryCode(...args),
+}))
+
+/** Reached through use-device-location, and it warns about API keys on import. */
+jest.mock("@app/utils/ip-country-lookup", () => ({
+  resolveIpCountryCodeCached: () => mockResolveIpCountryCodeCached(),
+}))
+
+jest.mock("@app/hooks/use-device-location", () => ({
+  __esModule: true,
+  ...jest.requireActual("@app/hooks/use-device-location"),
+  useIpCountryLookup: (enabled: boolean) => mockUseIpCountryLookup(enabled),
+}))
+
+const setUp = ({
+  enabled = true,
+  countryCode,
+  isLookupSettled = true,
+  remoteConfigReady = true,
+  custodialCreationBlockedCountries = ["CU", "IR"],
+}: {
+  enabled?: boolean
+  countryCode?: string
+  isLookupSettled?: boolean
+  remoteConfigReady?: boolean
+  custodialCreationBlockedCountries?: string[]
+}) => {
+  mockUseIpCountryLookup.mockReturnValue({ countryCode, isSettled: isLookupSettled })
+  mockUseFeatureFlags.mockReturnValue({ remoteConfigReady })
+  mockUseRemoteConfig.mockReturnValue({ custodialCreationBlockedCountries })
+  return renderHook(() => useRegionCheck(enabled)).result.current
+}
+
+describe("useRegionCheck", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  describe("the verdict", () => {
+    it("refuses creation and reports the session restricted in a listed country", () => {
+      const verdict = setUp({ countryCode: "CU" })
+
+      expect(verdict.custodialCreationAllowed).toBe(false)
+      expect(verdict.restricted).toBe(true)
+    })
+
+    it("allows both where the list does not carry the country", () => {
+      const verdict = setUp({ countryCode: "SV" })
+
+      expect(verdict.custodialCreationAllowed).toBe(true)
+      expect(verdict.restricted).toBe(false)
+    })
+
+    it("allows both while the country is unresolved", () => {
+      // Nothing was read, so nothing may be held against the user.
+      const verdict = setUp({ countryCode: undefined })
+
+      expect(verdict.custodialCreationAllowed).toBe(true)
+      expect(verdict.restricted).toBe(false)
+    })
+
+    it("matches case-insensitively, since the list is stored uppercase", () => {
+      expect(setUp({ countryCode: "cu" }).restricted).toBe(true)
+    })
+
+    it("reports the country it resolved", () => {
+      expect(setUp({ countryCode: "SV" }).countryCode).toBe("SV")
+    })
+  })
+
+  describe("locating the user", () => {
+    it("resolves nothing for a caller that did not ask", () => {
+      // Reading the region is the act of locating someone. Anon is the standing case.
+      setUp({ enabled: false })
+
+      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(false)
+    })
+
+    it("passes the caller's intent through to the lookup", () => {
+      setUp({ enabled: true })
+
+      expect(mockUseIpCountryLookup).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe("isSettled", () => {
+    it("is settled at once for a caller that asks nothing", () => {
+      // There is no answer coming, so waiting on one would never end.
+      expect(setUp({ enabled: false, isLookupSettled: false }).isSettled).toBe(true)
+    })
+
+    it("is false while the lookup is still running", () => {
+      expect(setUp({ isLookupSettled: false }).isSettled).toBe(false)
+    })
+
+    it("is false until remote config has answered", () => {
+      // An empty list mid-fetch would read as a country nothing restricts.
+      expect(setUp({ countryCode: "CU", remoteConfigReady: false }).isSettled).toBe(false)
+    })
+
+    it("is true once both have settled, resolved country or not", () => {
+      expect(setUp({ countryCode: "SV" }).isSettled).toBe(true)
+      expect(setUp({ countryCode: undefined }).isSettled).toBe(true)
+    })
+  })
+})
+
+describe("useRegionCheckLazy", () => {
+  const setUpLazy = ({
+    ipCountryCode,
+    custodialCreationBlockedCountries = ["CU", "IR"],
+  }: {
+    ipCountryCode?: string
+    custodialCreationBlockedCountries?: string[]
+  }) => {
+    mockResolveIpCountryCodeCached.mockResolvedValue(ipCountryCode)
+    mockUseRemoteConfig.mockReturnValue({ custodialCreationBlockedCountries })
+    return renderHook(() => useRegionCheckLazy()).result.current
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it("locates nobody until it is called", () => {
+    setUpLazy({ ipCountryCode: "CU" })
+
+    // The creation screens hold this hook while the user is still only browsing.
+    expect(mockResolveIpCountryCodeCached).not.toHaveBeenCalled()
+  })
+
+  it("refuses creation and reports restricted in a listed country", async () => {
+    const verdict = await setUpLazy({ ipCountryCode: "CU" })()
+
+    expect(verdict.custodialCreationAllowed).toBe(false)
+    expect(verdict.restricted).toBe(true)
+    expect(verdict.countryCode).toBe("CU")
+  })
+
+  it("allows both where the list does not carry the country", async () => {
+    const verdict = await setUpLazy({ ipCountryCode: "SV" })()
+
+    expect(verdict.custodialCreationAllowed).toBe(true)
+    expect(verdict.restricted).toBe(false)
+  })
+
+  it("uppercases what the provider returned before matching the list", async () => {
+    const verdict = await setUpLazy({ ipCountryCode: "cu" })()
+
+    expect(verdict.countryCode).toBe("CU")
+    expect(verdict.restricted).toBe(true)
+  })
+
+  it("answers an unresolved country as such, with nothing held against the user", async () => {
+    const verdict = await setUpLazy({ ipCountryCode: undefined })()
+
+    // No local fallback: the country-code cache answers "SV" for an unset value, and
+    // reading it would turn "could not resolve" into a country nobody read.
+    expect(verdict.countryCode).toBeUndefined()
+    expect(verdict.custodialCreationAllowed).toBe(true)
+    expect(verdict.restricted).toBe(false)
+    expect(mockUpdateCountryCode).not.toHaveBeenCalled()
+  })
+
+  it("records the answer, so the rest of the app shares the country it read", async () => {
+    await setUpLazy({ ipCountryCode: "SV" })()
+
+    expect(mockUpdateCountryCode).toHaveBeenCalledWith(expect.anything(), "SV")
+  })
+})

--- a/__tests__/hooks/use-transfer-blocked.spec.ts
+++ b/__tests__/hooks/use-transfer-blocked.spec.ts
@@ -4,6 +4,7 @@ import { AccountType } from "@app/types/wallet"
 
 const mockUseDeviceLocation = jest.fn()
 const mockUseRemoteConfig = jest.fn()
+let mockRemoteConfigReady = true
 const mockUseActiveWallet = jest.fn()
 
 jest.mock("@app/utils/ip-country-lookup")
@@ -21,6 +22,7 @@ jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
 
 jest.mock("@app/config/feature-flags-context", () => ({
   useRemoteConfig: () => mockUseRemoteConfig(),
+  useFeatureFlags: () => ({ remoteConfigReady: mockRemoteConfigReady }),
 }))
 
 jest.mock("@app/hooks/use-active-wallet", () => ({
@@ -31,10 +33,13 @@ import { useTransferGate, useTransferGated } from "@app/hooks/use-transfer-block
 
 const setup = (): void => {
   jest.clearAllMocks()
+  mockRemoteConfigReady = true
   mockIsAnonMode = false
   mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
   mockUseRemoteConfig.mockReturnValue({
+    custodialDollarBalanceBlockedCountries: [],
     custodialTransferBlockedCountries: ["DE"],
+    selfCustodialDollarBalanceBlockedCountries: [],
     selfCustodialTransferBlockedCountries: ["FR"],
   })
   mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
@@ -128,6 +133,20 @@ describe("useTransferGated — region policy", () => {
       mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, loading: false })
 
       expect(readGate()).toEqual({ isGated: true, isRegionPending: false })
+    })
+  })
+
+  describe("before the block-lists have arrived", () => {
+    it("reports the region pending rather than a verdict off the compiled defaults", () => {
+      mockRemoteConfigReady = false
+
+      const { isRegionPending, isGated } = renderHook(() => useTransferGate()).result
+        .current
+
+      // A list still being fetched would read as a country nothing restricts, and the
+      // surface would settle on it and then flip once the real list lands.
+      expect(isRegionPending).toBe(true)
+      expect(isGated).toBe(false)
     })
   })
 })

--- a/__tests__/hooks/use-transfer-blocked.spec.ts
+++ b/__tests__/hooks/use-transfer-blocked.spec.ts
@@ -6,6 +6,8 @@ const mockUseDeviceLocation = jest.fn()
 const mockUseRemoteConfig = jest.fn()
 let mockRemoteConfigReady = true
 const mockUseActiveWallet = jest.fn()
+const mockUseCustodialRestrictionsQuery = jest.fn()
+let mockIsAuthed = true
 
 jest.mock("@app/utils/ip-country-lookup")
 
@@ -28,21 +30,42 @@ jest.mock("@app/config/feature-flags-context", () => ({
 jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => mockUseActiveWallet(),
 }))
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => ({ loading: false }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => mockIsAuthed,
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useCustodialRestrictionsQuery: (options: unknown) =>
+    mockUseCustodialRestrictionsQuery(options),
+}))
 
 import { useTransferGate, useTransferGated } from "@app/hooks/use-transfer-blocked"
+
+/** The server's answer, for the custodial cases. Self-custodial is the setup default and
+ *  never reaches the query. */
+const serverAnswers = (transfer: boolean, loading = false) =>
+  mockUseCustodialRestrictionsQuery.mockReturnValue({
+    data: { custodialRestrictions: { dollarBalance: false, transfer } },
+    loading,
+  })
 
 const setup = (): void => {
   jest.clearAllMocks()
   mockRemoteConfigReady = true
   mockIsAnonMode = false
+  mockIsAuthed = true
   mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, source: undefined })
   mockUseRemoteConfig.mockReturnValue({
-    custodialDollarBalanceBlockedCountries: [],
-    custodialTransferBlockedCountries: ["DE"],
     selfCustodialDollarBalanceBlockedCountries: [],
     selfCustodialTransferBlockedCountries: ["FR"],
   })
   mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
+  serverAnswers(false)
 }
 
 /** Outside Anon (the setup default), the gate reduces to the region policy. */
@@ -56,23 +79,25 @@ describe("useTransferGated — region policy", () => {
     expect(read()).toBe(true)
   })
 
-  it("blocks a custodial transfer when the country is in the custodial list", () => {
+  it("blocks a custodial transfer when the server says so", () => {
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
-    mockUseDeviceLocation.mockReturnValue({ countryCode: "DE" })
+    serverAnswers(true)
     expect(read()).toBe(true)
   })
 
-  it("reads each account type from its own list, so the lists can diverge", () => {
+  it("answers each account type from its own source, so the two can diverge", () => {
+    // The self-custodial list carries FR; the server clears the custodial account.
     mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
 
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
     expect(read()).toBe(true)
 
     mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
+    serverAnswers(false)
     expect(read()).toBe(false)
   })
 
-  it("returns false when the country is in neither list", () => {
+  it("returns false when the self-custodial list does not carry the country", () => {
     mockUseDeviceLocation.mockReturnValue({ countryCode: "AR" })
     expect(read()).toBe(false)
   })
@@ -85,6 +110,14 @@ describe("useTransferGated — region policy", () => {
   it("returns false without a resolved country", () => {
     mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
     expect(read()).toBe(false)
+  })
+
+  it("gates a custodial account the server did not answer for", () => {
+    // No region determined, no gated feature — UnknownRegionPolicy = FAIL_CLOSED.
+    mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
+    mockUseCustodialRestrictionsQuery.mockReturnValue({ data: undefined, loading: false })
+
+    expect(read()).toBe(true)
   })
 
   describe("useTransferGated", () => {
@@ -133,6 +166,13 @@ describe("useTransferGated — region policy", () => {
       mockUseDeviceLocation.mockReturnValue({ countryCode: undefined, loading: false })
 
       expect(readGate()).toEqual({ isGated: true, isRegionPending: false })
+    })
+
+    it("pends a custodial account while the server has not answered", () => {
+      mockUseActiveWallet.mockReturnValue({ accountType: AccountType.Custodial })
+      serverAnswers(false, true)
+
+      expect(readGate()).toEqual({ isGated: false, isRegionPending: true })
     })
   })
 

--- a/__tests__/navigation/app-state.spec.tsx
+++ b/__tests__/navigation/app-state.spec.tsx
@@ -13,6 +13,8 @@ const mockRefetchQueries = jest.fn()
 
 let mockGracePeriodSeconds = 60
 let mockIsAuthed = true
+let mockIsAnonMode = false
+const mockResetIpCountryLookup = jest.fn()
 let mockIsAppLocked = false
 
 jest.mock("@react-navigation/native", () => ({
@@ -33,6 +35,14 @@ jest.mock("@app/config/feature-flags-context", () => ({
 
 jest.mock("@app/graphql/is-authed-context", () => ({
   useIsAuthed: () => mockIsAuthed,
+}))
+
+jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
+  useSelfCustodialAccountMode: () => ({ isAnonMode: mockIsAnonMode }),
+}))
+
+jest.mock("@app/utils/ip-country-lookup", () => ({
+  resetIpCountryLookup: () => mockResetIpCountryLookup(),
 }))
 
 jest.mock("@apollo/client", () => ({
@@ -87,6 +97,7 @@ describe("AppStateWrapper", () => {
 
     mockGracePeriodSeconds = GRACE_PERIOD_SECONDS
     mockIsAuthed = true
+    mockIsAnonMode = false
     mockIsAppLocked = false
     setLock({ pin: true, biometrics: false })
 
@@ -276,23 +287,69 @@ describe("AppStateWrapper", () => {
   })
 
   describe("existing foreground behavior", () => {
+    /** The document a refetch call named, so the two batches can be told apart. */
+    const refetchedOperations = () =>
+      mockRefetchQueries.mock.calls.flatMap((call) =>
+        (call[0]?.include ?? []).map(
+          (document: { definitions: { name?: { value: string } }[] }) =>
+            document.definitions[0]?.name?.value,
+        ),
+      )
+
     it("refetches the home query when the app returns", async () => {
       renderWrapper()
       await flushEffects()
 
       await leaveAndReturn(1)
 
-      expect(mockRefetchQueries).toHaveBeenCalledTimes(1)
+      expect(refetchedOperations()).toContain("homeAuthed")
     })
 
-    it("does not refetch for a signed-out user", async () => {
+    /** Sanctions ride the live connection and are evaluated at every session start, so
+     *  the verdict is re-asked for on return regardless of who is signed in. */
+    it("re-asks for the region verdict when the app returns", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(1)
+
+      expect(refetchedOperations()).toContain("regionCheck")
+    })
+
+    /** The self-custodial half resolves its own country through a lookup shared for the
+     *  whole JS process; keeping it across a session start is the latch this removes. */
+    it("drops the shared country lookup when the app returns", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(1)
+
+      expect(mockResetIpCountryLookup).toHaveBeenCalled()
+    })
+
+    /** Anon exists so that nothing about the user is read, the connection included. The
+     *  guard is asserted here rather than left to the query's own skip. */
+    it("asks for no region verdict in Anon mode", async () => {
+      mockIsAnonMode = true
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(1)
+
+      expect(refetchedOperations()).not.toContain("regionCheck")
+    })
+
+    it("refetches nothing account-bound for a signed-out user", async () => {
       mockIsAuthed = false
       renderWrapper()
       await flushEffects()
 
       await leaveAndReturn(1)
 
-      expect(mockRefetchQueries).not.toHaveBeenCalled()
+      const operations = refetchedOperations()
+      expect(operations).toContain("regionCheck")
+      expect(operations).not.toContain("homeAuthed")
+      expect(operations).not.toContain("custodialRestrictions")
     })
   })
 })

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -43,7 +43,7 @@ it("migration from 5 to current returns ok with the migrated state", async () =>
   expect(result).toEqual({
     status: MigrationStatus.Ok,
     state: {
-      schemaVersion: 19,
+      schemaVersion: 20,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "myToken",
     },

--- a/__tests__/screens/account-migration/hooks/use-seed-migrated-account-settings.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-seed-migrated-account-settings.spec.ts
@@ -32,7 +32,7 @@ import { DisplayCurrencyDocument, LanguageDocument } from "@app/graphql/generate
 import { useSeedMigratedAccountSettings } from "@app/screens/account-migration/hooks/use-seed-migrated-account-settings"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: DefaultAccountId.Custodial,

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -50,6 +50,16 @@ jest.mock("@app/config/feature-flags-context", () => ({
   useFeatureFlags: () => ({ remoteConfigReady: true }),
 }))
 
+/** The custodial verdict is the server's, and an unanswered query gates every feature
+ *  that needs a region, so this screen needs one served to be reachable at all. */
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useCustodialRestrictionsQuery: () => ({
+    data: { custodialRestrictions: { dollarBalance: false, transfer: false } },
+    loading: false,
+  }),
+}))
+
 jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -43,6 +43,13 @@ import { withDeviceLocale } from "../helpers/device-locale"
  */
 withDeviceLocale("en-US")
 
+/** The dollar-balance guard now holds the screen until remote config lands, and the
+ *  context default outside a provider is never-ready, which would hide it for good. */
+jest.mock("@app/config/feature-flags-context", () => ({
+  ...jest.requireActual("@app/config/feature-flags-context"),
+  useFeatureFlags: () => ({ remoteConfigReady: true }),
+}))
+
 jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -20,7 +20,7 @@ const PersistentStateWrapper: React.FC<PropsWithChildren> = ({ children }) => (
   <PersistentStateContext.Provider
     value={{
       persistentState: {
-        schemaVersion: 19,
+        schemaVersion: 20,
         galoyInstance: {
           id: "Main",
         },

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -122,7 +122,6 @@ jest.mock("@app/config/feature-flags-context", () => {
    */
   const remoteConfig: ReturnType<typeof actual.useRemoteConfig> = {
     ...actual.defaultRemoteConfig,
-    custodialDollarBalanceBlockedCountries: [],
     selfCustodialDollarBalanceBlockedCountries: [],
   }
   return {

--- a/__tests__/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.spec.ts
+++ b/__tests__/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.spec.ts
@@ -5,6 +5,10 @@ import {
   useRestoreWallet,
   RestoreWalletStatus,
 } from "@app/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet"
+import { getSelfCustodialAccountMode } from "@app/store/persistent-state/self-custodial-account-mode"
+import { getSelfCustodialServerAccountMode } from "@app/store/persistent-state/self-custodial-server-account-mode"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import { AccountMode } from "@app/types/account"
 
 const TEST_ACCOUNT_ID = "test-account-id-123"
 
@@ -97,7 +101,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
 describe("useRestoreWallet", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockRestore.mockResolvedValue(undefined)
+    mockRestore.mockResolvedValue({ serverMode: null, isServerModeKnown: true })
     mockReloadSelfCustodialAccounts.mockResolvedValue(undefined)
     mockFindSelfCustodialAccountByMnemonic.mockResolvedValue({ status: "ok", id: null })
     mockValidateMnemonic.mockReturnValue(true)
@@ -123,12 +127,10 @@ describe("useRestoreWallet", () => {
       leewaySatPerVbyte: 5,
     })
     expect(mockReloadSelfCustodialAccounts).toHaveBeenCalledTimes(1)
-    expect(mockUpdateState).toHaveBeenCalledTimes(1)
+    expect(mockUpdateState).toHaveBeenCalledTimes(2)
     expect(mockReinitSdk).toHaveBeenCalledTimes(1)
     expect(mockMarkBackupCompletedFor).toHaveBeenCalledWith(TEST_ACCOUNT_ID, "manual")
-    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialChooseExperience", {
-      onContinue: { route: "selfCustodialBackupSuccess", accountId: TEST_ACCOUNT_ID },
-    })
+    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupSuccess")
   })
 
   it("activates an existing account when the mnemonic is already imported", async () => {
@@ -146,8 +148,141 @@ describe("useRestoreWallet", () => {
     expect(mockRestore).not.toHaveBeenCalled()
     expect(mockUpdateState).toHaveBeenCalledTimes(1)
     expect(mockReinitSdk).toHaveBeenCalledTimes(1)
-    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialChooseExperience", {
-      onContinue: { route: "selfCustodialBackupSuccess", accountId: "existing-id" },
+    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupSuccess")
+  })
+
+  /**
+   * A restored wallet gets its mode from the server, never from a fresh question: it was
+   * chosen on a device this one may never have been, so asking again could only overwrite
+   * a deliberate answer with a default.
+   */
+  describe("the mode a restored wallet comes back with", () => {
+    const baseState: PersistentState = {
+      schemaVersion: 20,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "",
+      activeAccountId: TEST_ACCOUNT_ID,
+    }
+
+    const restoreAndReadState = async (serverMode: AccountMode | null) => {
+      mockRestore.mockResolvedValue({ serverMode, isServerModeKnown: true })
+      const { result } = renderHook(() => useRestoreWallet())
+
+      await act(async () => {
+        await result.current.restore("word1 word2 word3")
+      })
+
+      /** Applied in the order the hook queued them, which is what the store does. */
+      return mockUpdateState.mock.calls.reduce(
+        (state, [updater]) => updater(state) as PersistentState,
+        baseState,
+      )
+    }
+
+    it("adopts the Anon the server holds instead of asking", async () => {
+      const state = await restoreAndReadState(AccountMode.Anon)
+
+      expect(getSelfCustodialAccountMode(state)).toBe(AccountMode.Anon)
+      expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupSuccess")
+    })
+
+    it("adopts the Enhanced the server holds", async () => {
+      const state = await restoreAndReadState(AccountMode.Enhanced)
+
+      expect(getSelfCustodialAccountMode(state)).toBe(AccountMode.Enhanced)
+    })
+
+    /** Already on the server, so re-pushing it would spend a paid country lookup to say
+     *  what it just told us. */
+    it("records a recovered mode as already confirmed", async () => {
+      const state = await restoreAndReadState(AccountMode.Anon)
+
+      expect(getSelfCustodialServerAccountMode(state, TEST_ACCOUNT_ID)).toBe(
+        AccountMode.Anon,
+      )
+    })
+
+    it("falls back to Enhanced when the server holds no mode", async () => {
+      const state = await restoreAndReadState(null)
+
+      expect(getSelfCustodialAccountMode(state)).toBe(AccountMode.Enhanced)
+    })
+
+    /** Left unconfirmed on purpose: the server never said Enhanced, so the sync still
+     *  owes it that push. */
+    it("leaves an assumed Enhanced unconfirmed so the sync pushes it", async () => {
+      const state = await restoreAndReadState(null)
+
+      expect(getSelfCustodialServerAccountMode(state, TEST_ACCOUNT_ID)).toBeNull()
+    })
+
+    /** The one case that still asks. Defaulting here would push Enhanced back and
+     *  overwrite an Anon the server holds but could not report. */
+    it("asks when the server could not be reached at all", async () => {
+      mockRestore.mockResolvedValue({ serverMode: null, isServerModeKnown: false })
+      const { result } = renderHook(() => useRestoreWallet())
+
+      await act(async () => {
+        await result.current.restore("word1 word2 word3")
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith("selfCustodialChooseExperience", {
+        onContinue: {
+          route: "selfCustodialBackupSuccess",
+          accountId: TEST_ACCOUNT_ID,
+        },
+      })
+    })
+
+    it("writes no mode at all when the server could not be reached", async () => {
+      mockRestore.mockResolvedValue({ serverMode: null, isServerModeKnown: false })
+      const { result } = renderHook(() => useRestoreWallet())
+
+      await act(async () => {
+        await result.current.restore("word1 word2 word3")
+      })
+
+      /** Only the activation write; nothing claims a mode the server never reported. */
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+    })
+
+    it("never sends a restore to the mode picker", async () => {
+      await restoreAndReadState(AccountMode.Anon)
+
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        "selfCustodialChooseExperience",
+        expect.anything(),
+      )
+    })
+
+    it("makes the restored account the active one", async () => {
+      mockRestore.mockResolvedValue({ serverMode: null, isServerModeKnown: true })
+      const { result } = renderHook(() => useRestoreWallet())
+
+      await act(async () => {
+        await result.current.restore("word1 word2 word3")
+      })
+
+      const activate = mockUpdateState.mock.calls[0][0]
+      expect(
+        (activate({ ...baseState, activeAccountId: undefined }) as PersistentState)
+          .activeAccountId,
+      ).toBe(TEST_ACCOUNT_ID)
+      expect(activate(undefined)).toBeUndefined()
+    })
+
+    it("leaves the state alone when there is none to update", async () => {
+      mockRestore.mockResolvedValue({
+        serverMode: AccountMode.Anon,
+        isServerModeKnown: true,
+      })
+      const { result } = renderHook(() => useRestoreWallet())
+
+      await act(async () => {
+        await result.current.restore("word1 word2 word3")
+      })
+
+      expect(mockUpdateState.mock.calls[1][0](undefined)).toBeUndefined()
     })
   })
 
@@ -246,8 +381,8 @@ describe("useRestoreWallet", () => {
     let resolveFirst: () => void
     mockRestore.mockImplementationOnce(
       () =>
-        new Promise<void>((resolve) => {
-          resolveFirst = resolve
+        new Promise<{ serverMode: null; isServerModeKnown: boolean }>((resolve) => {
+          resolveFirst = () => resolve({ serverMode: null, isServerModeKnown: true })
         }),
     )
 
@@ -273,8 +408,8 @@ describe("useRestoreWallet", () => {
   it("sets restoring status during restore", async () => {
     let resolveRestore: () => void
     mockRestore.mockReturnValue(
-      new Promise<void>((resolve) => {
-        resolveRestore = resolve
+      new Promise<{ serverMode: null; isServerModeKnown: boolean }>((resolve) => {
+        resolveRestore = () => resolve({ serverMode: null, isServerModeKnown: true })
       }),
     )
 

--- a/__tests__/screens/settings-screen/security-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/security-screen.spec.tsx
@@ -146,7 +146,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/self-custodial/bridge.spec.ts
+++ b/__tests__/self-custodial/bridge.spec.ts
@@ -15,6 +15,11 @@ const mockDisconnect = jest.fn()
 const mockUpdateUserSettings = jest.fn()
 const mockRecordError = jest.fn()
 
+const mockRecoverLnurlServerMode = jest.fn()
+jest.mock("@app/self-custodial/lnurl-server-mode", () => ({
+  recoverLnurlServerMode: (...args: unknown[]) => mockRecoverLnurlServerMode(...args),
+}))
+
 jest.mock("bip39", () => ({
   generateMnemonic: (...args: unknown[]) => mockGenerateMnemonic(...args),
   validateMnemonic: jest.fn().mockReturnValue(true),
@@ -83,6 +88,7 @@ jest.mock("@app/self-custodial/storage/account-index", () => ({
 
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
   recordError: (...args: Error[]) => mockRecordError(...args),
+  log: jest.fn(),
 }))
 
 jest.mock("@app/self-custodial/logging", () => ({
@@ -144,11 +150,20 @@ describe("selfCustodialCreateWallet", () => {
 })
 
 describe("selfCustodialRestoreWallet", () => {
+  const restoreWallet = () =>
+    selfCustodialRestoreWallet({
+      accountId: "test-account-id",
+      mnemonic: "restore word1 word2 word3",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockSetMnemonicForAccount.mockResolvedValue(true)
     mockSetMnemonicNetworkForAccount.mockResolvedValue(true)
     mockConnect.mockResolvedValue({ disconnect: jest.fn().mockResolvedValue(undefined) })
+    mockRecoverLnurlServerMode.mockResolvedValue(null)
   })
 
   it("stores provided mnemonic and network", async () => {
@@ -167,6 +182,35 @@ describe("selfCustodialRestoreWallet", () => {
       "test-account-id",
       "regtest",
     )
+  })
+
+  /** Read while the wallet is connected and able to sign, the one moment the restore
+   *  has. */
+  it("hands back the mode the LNURL server already holds", async () => {
+    mockRecoverLnurlServerMode.mockResolvedValue("anon")
+
+    expect(await restoreWallet()).toEqual({ serverMode: "anon", isServerModeKnown: true })
+  })
+
+  it("hands back no mode when the server holds none", async () => {
+    expect(await restoreWallet()).toEqual({ serverMode: null, isServerModeKnown: true })
+  })
+
+  /** The wallet itself is whole; an unreachable server must not undo a restore that
+   *  otherwise succeeded. */
+  it("completes the restore when the mode cannot be recovered", async () => {
+    mockRecoverLnurlServerMode.mockRejectedValue(new Error("server down"))
+
+    expect(await restoreWallet()).toEqual({ serverMode: null, isServerModeKnown: false })
+    expect(mockDeleteMnemonicForAccount).not.toHaveBeenCalled()
+  })
+
+  /** An unanswered server is not the server answering "none": a stored Anon may be
+   *  sitting behind it, and reporting none would push it away. */
+  it("marks the mode as unknown rather than absent when the server never answered", async () => {
+    mockRecoverLnurlServerMode.mockRejectedValue(new Error("server down"))
+
+    expect((await restoreWallet()).isServerModeKnown).toBe(false)
   })
 
   it("throws if keychain storage fails", async () => {

--- a/__tests__/self-custodial/components/account-mode-sync-mount.spec.tsx
+++ b/__tests__/self-custodial/components/account-mode-sync-mount.spec.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+// React 19 react-test-renderer calls window.dispatchEvent for error
+// reporting which doesn't exist in React Native jest environment.
+if (typeof window !== "undefined" && !window.dispatchEvent) {
+  window.dispatchEvent = jest.fn()
+}
+
+import { AccountModeSyncMount } from "@app/self-custodial/components/account-mode-sync-mount"
+
+const mockAccountModeSync = jest.fn()
+jest.mock("@app/self-custodial/hooks/use-account-mode-sync", () => ({
+  useAccountModeSync: () => mockAccountModeSync(),
+}))
+
+describe("AccountModeSyncMount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("mounts the mode sync hook exactly once per render", () => {
+    render(<AccountModeSyncMount />)
+
+    expect(mockAccountModeSync).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders null so it contributes no UI to the tree", () => {
+    const { toJSON } = render(<AccountModeSyncMount />)
+
+    expect(toJSON()).toBeNull()
+  })
+})

--- a/__tests__/self-custodial/config.spec.ts
+++ b/__tests__/self-custodial/config.spec.ts
@@ -4,6 +4,7 @@ import {
   hasSparkAddressShape,
   isRegtestNetwork,
   lnurlDomainFor,
+  lnurlServerUrlFor,
   mismatchedNetworkLabel,
   networkForInstance,
   networkLabelFor,
@@ -126,6 +127,42 @@ describe("lnurlDomainFor", () => {
 
   it("uses the staging Blink LNURL host on regtest", () => {
     expect(lnurlDomainFor(Network.Regtest)).toBe("staging.blink.sv")
+  })
+})
+
+/**
+ * The guard on the host the mode requests reach. It has to be the host the account's
+ * address is spelled with, which is what serves the authenticated `/lnurlpay/{pubkey}`
+ * routes the mode endpoint sits beside. The custodial `lnAddressHostname` is a different
+ * service (`pay.staging.blink.sv` fronts the payment app) and answers those routes with
+ * its own 404, so pointing there would look like a healthy request that never lands.
+ */
+describe("lnurlServerUrlFor", () => {
+  it("reaches the production LNURL server on mainnet", () => {
+    expect(lnurlServerUrlFor(Network.Mainnet)).toBe("https://blink.sv")
+  })
+
+  it("reaches the staging LNURL server on regtest", () => {
+    expect(lnurlServerUrlFor(Network.Regtest)).toBe("https://staging.blink.sv")
+  })
+
+  it("keeps mainnet and regtest on separate servers", () => {
+    expect(lnurlServerUrlFor(Network.Mainnet)).not.toBe(
+      lnurlServerUrlFor(Network.Regtest),
+    )
+  })
+
+  /** Both deployments are public and TLS-terminated; a plain-http request would be
+   *  sending a signed pubkey in the clear. */
+  it("always speaks https", () => {
+    expect(lnurlServerUrlFor(Network.Mainnet)).toMatch(/^https:\/\//)
+    expect(lnurlServerUrlFor(Network.Regtest)).toMatch(/^https:\/\//)
+  })
+
+  it("stays on the exact host the address is spelled with", () => {
+    for (const network of [Network.Mainnet, Network.Regtest]) {
+      expect(lnurlServerUrlFor(network)).toBe(`https://${lnurlDomainFor(network)}`)
+    }
   })
 })
 

--- a/__tests__/self-custodial/hooks/use-account-mode-sync.spec.ts
+++ b/__tests__/self-custodial/hooks/use-account-mode-sync.spec.ts
@@ -1,0 +1,285 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+
+import { useAccountModeSync } from "@app/self-custodial/hooks/use-account-mode-sync"
+import { getSelfCustodialAccountMode } from "@app/store/persistent-state/self-custodial-account-mode"
+import { getSelfCustodialServerAccountMode } from "@app/store/persistent-state/self-custodial-server-account-mode"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import { AccountMode } from "@app/types/account"
+
+const mockSetLnurlServerMode = jest.fn()
+const mockRecoverLnurlServerMode = jest.fn()
+jest.mock("@app/self-custodial/lnurl-server-mode", () => ({
+  setLnurlServerMode: (...args: unknown[]) => mockSetLnurlServerMode(...args),
+  recoverLnurlServerMode: (...args: unknown[]) => mockRecoverLnurlServerMode(...args),
+}))
+
+let mockPersistentState: PersistentState = {
+  schemaVersion: 20,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+  activeAccountId: "sc-1",
+}
+const mockUpdateState = jest.fn()
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: mockPersistentState,
+    updateState: mockUpdateState,
+  }),
+}))
+
+let mockAccountMode: AccountMode | null = AccountMode.Enhanced
+jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
+  useSelfCustodialAccountMode: () => ({ accountMode: mockAccountMode }),
+}))
+
+const sdk = { id: "sdk" }
+let mockSdk: typeof sdk | null = sdk
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => ({ sdk: mockSdk }),
+}))
+
+/** The host of the self-custodial address, which is the LNURL server. */
+const SERVER_URL = "https://staging.blink.sv"
+jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
+  useSparkNetwork: () => "regtest",
+}))
+
+const mockReportError = jest.fn()
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
+const withConfirmedMode = (mode: AccountMode) => {
+  mockPersistentState = {
+    ...mockPersistentState,
+    selfCustodialServerAccountModeByAccountId: { "sc-1": mode },
+  }
+}
+
+describe("useAccountModeSync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAccountMode = AccountMode.Enhanced
+    mockSdk = sdk
+    mockPersistentState = {
+      schemaVersion: 20,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "",
+      activeAccountId: "sc-1",
+    }
+    mockSetLnurlServerMode.mockResolvedValue(undefined)
+    mockRecoverLnurlServerMode.mockResolvedValue(null)
+  })
+
+  it("pushes the chosen mode the server has never been told about", async () => {
+    renderHook(() => useAccountModeSync())
+
+    await waitFor(() => {
+      expect(mockSetLnurlServerMode).toHaveBeenCalledWith({
+        sdk,
+        serverUrl: SERVER_URL,
+        mode: AccountMode.Enhanced,
+      })
+    })
+  })
+
+  it("pushes Anon when the account switches away from a confirmed Enhanced", async () => {
+    withConfirmedMode(AccountMode.Enhanced)
+    mockAccountMode = AccountMode.Anon
+
+    renderHook(() => useAccountModeSync())
+
+    await waitFor(() => {
+      expect(mockSetLnurlServerMode).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: AccountMode.Anon }),
+      )
+    })
+  })
+
+  /** Each Enhanced push spends a paid country lookup against a per-IP budget, so telling
+   *  the server what it already stores would burn that budget for nothing. */
+  it("stays quiet when the server already holds the chosen mode", async () => {
+    withConfirmedMode(AccountMode.Enhanced)
+
+    renderHook(() => useAccountModeSync())
+    await Promise.resolve()
+
+    expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  it("does nothing for a custodial account, which has no mode", async () => {
+    mockAccountMode = null
+
+    renderHook(() => useAccountModeSync())
+    await Promise.resolve()
+
+    expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  /** The mode is chosen on screens with no wallet yet (creation picks one before the
+   *  wallet exists), so there is nothing to sign with until the SDK connects. */
+  it("waits for a connected SDK before pushing", async () => {
+    mockSdk = null
+
+    renderHook(() => useAccountModeSync())
+    await Promise.resolve()
+
+    expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  it("does nothing while no self-custodial account is active", async () => {
+    mockPersistentState = { ...mockPersistentState, activeAccountId: undefined }
+
+    renderHook(() => useAccountModeSync())
+    await Promise.resolve()
+
+    expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  it("records the confirmed mode against the account", async () => {
+    renderHook(() => useAccountModeSync())
+
+    await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+    const updater = mockUpdateState.mock.calls[0][0]
+    expect(getSelfCustodialServerAccountMode(updater(mockPersistentState), "sc-1")).toBe(
+      AccountMode.Enhanced,
+    )
+    expect(updater(undefined)).toBeUndefined()
+  })
+
+  /** A push that never landed has to stay owed, or the next launch would take the
+   *  server's silence for agreement. */
+  it("leaves the account unconfirmed when the push fails", async () => {
+    const failure = new Error("server refused")
+    mockSetLnurlServerMode.mockRejectedValue(failure)
+
+    renderHook(() => useAccountModeSync())
+
+    await waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledWith("lnurl server mode sync", failure)
+    })
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  /**
+   * An account can reach a connected wallet holding no mode at all: created before the
+   * modes existed, or provisioned on another device. The server is asked before anything
+   * is assumed, because the same wallet may already be Anon somewhere else.
+   */
+  describe("an account that holds no mode yet", () => {
+    beforeEach(() => {
+      mockAccountMode = null
+    })
+
+    it("asks the server what it holds instead of assuming", async () => {
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => {
+        expect(mockRecoverLnurlServerMode).toHaveBeenCalledWith({
+          sdk,
+          serverUrl: SERVER_URL,
+        })
+      })
+    })
+
+    it("adopts the Anon the server holds rather than defaulting it away", async () => {
+      mockRecoverLnurlServerMode.mockResolvedValue(AccountMode.Anon)
+
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+      const state = mockUpdateState.mock.calls[0][0](mockPersistentState)
+      expect(getSelfCustodialAccountMode(state)).toBe(AccountMode.Anon)
+      expect(getSelfCustodialServerAccountMode(state, "sc-1")).toBe(AccountMode.Anon)
+    })
+
+    it("settles on Enhanced when the server holds none", async () => {
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+      const state = mockUpdateState.mock.calls[0][0](mockPersistentState)
+      expect(getSelfCustodialAccountMode(state)).toBe(AccountMode.Enhanced)
+    })
+
+    /** Left unconfirmed on purpose: the server never said Enhanced, so it is still owed
+     *  that push. */
+    it("leaves an assumed Enhanced unconfirmed so the push still happens", async () => {
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+      const state = mockUpdateState.mock.calls[0][0](mockPersistentState)
+      expect(getSelfCustodialServerAccountMode(state, "sc-1")).toBeNull()
+    })
+
+    it("pushes nothing while the mode is still unknown", async () => {
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+    })
+
+    /** An unanswered server must leave the account exactly as it was: writing a default
+     *  would push it over whatever the server really holds. */
+    it("writes nothing when the server cannot be asked", async () => {
+      const failure = new Error("server down")
+      mockRecoverLnurlServerMode.mockRejectedValue(failure)
+
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => {
+        expect(mockReportError).toHaveBeenCalledWith("lnurl server mode resolve", failure)
+      })
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("leaves the state alone when there is none to settle", async () => {
+      renderHook(() => useAccountModeSync())
+
+      await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+      expect(mockUpdateState.mock.calls[0][0](undefined)).toBeUndefined()
+    })
+
+    it("does nothing while no self-custodial account is active", async () => {
+      mockPersistentState = { ...mockPersistentState, activeAccountId: undefined }
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockRecoverLnurlServerMode).not.toHaveBeenCalled()
+    })
+
+    it("waits for a connected SDK", async () => {
+      mockSdk = null
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockRecoverLnurlServerMode).not.toHaveBeenCalled()
+    })
+  })
+
+  /** Already settled, so there is nothing to ask: asking anyway would spend a paid
+   *  country lookup per launch. */
+  it("never asks the server about an account that already holds a mode", async () => {
+    withConfirmedMode(AccountMode.Enhanced)
+
+    renderHook(() => useAccountModeSync())
+    await Promise.resolve()
+
+    expect(mockRecoverLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  it("pushes once rather than on every render", async () => {
+    const { rerender } = renderHook(() => useAccountModeSync())
+
+    await waitFor(() => expect(mockSetLnurlServerMode).toHaveBeenCalledTimes(1))
+    rerender(undefined)
+
+    expect(mockSetLnurlServerMode).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/self-custodial/hooks/use-account-mode-sync.spec.ts
+++ b/__tests__/self-custodial/hooks/use-account-mode-sync.spec.ts
@@ -34,8 +34,14 @@ jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
 
 const sdk = { id: "sdk" }
 let mockSdk: typeof sdk | null = sdk
+/** The account the connected SDK signs as, which the switch window makes differ from the
+ *  active one. */
+let mockConnectedAccountId: string | null = "sc-1"
 jest.mock("@app/self-custodial/providers/wallet", () => ({
-  useSelfCustodialWallet: () => ({ sdk: mockSdk }),
+  useSelfCustodialWallet: () => ({
+    sdk: mockSdk,
+    connectedAccountId: mockConnectedAccountId,
+  }),
 }))
 
 /** The host of the self-custodial address, which is the LNURL server. */
@@ -61,6 +67,7 @@ describe("useAccountModeSync", () => {
     jest.clearAllMocks()
     mockAccountMode = AccountMode.Enhanced
     mockSdk = sdk
+    mockConnectedAccountId = "sc-1"
     mockPersistentState = {
       schemaVersion: 20,
       galoyInstance: { id: "Main" },
@@ -272,6 +279,85 @@ describe("useAccountModeSync", () => {
     await Promise.resolve()
 
     expect(mockRecoverLnurlServerMode).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The provider tears down its SDK in an effect cleanup, which runs after the effects of
+   * its descendants. So for one commit on every account switch this hook sees the incoming
+   * account id beside the outgoing account's connection, and both effects would act on the
+   * wrong pairing: signing as the old account while filing the answer under the new one.
+   */
+  describe("the commit where the account switches", () => {
+    const switchToAccountWithOldConnection = () => {
+      mockPersistentState = {
+        ...mockPersistentState,
+        activeAccountId: "sc-2",
+      }
+      mockConnectedAccountId = "sc-1"
+    }
+
+    it("pushes nothing while the connection still belongs to the previous account", async () => {
+      mockAccountMode = AccountMode.Anon
+      switchToAccountWithOldConnection()
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+    })
+
+    /** The confirmation is what stops the next launch from pushing again, so recording it
+     *  against an account that was never pushed would silence that account for good. */
+    it("records no confirmation against the account it did not push", async () => {
+      mockAccountMode = AccountMode.Anon
+      switchToAccountWithOldConnection()
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("asks the server nothing while the connection belongs to the previous account", async () => {
+      mockAccountMode = null
+      switchToAccountWithOldConnection()
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockRecoverLnurlServerMode).not.toHaveBeenCalled()
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("pushes once the connection catches up with the active account", async () => {
+      mockAccountMode = AccountMode.Anon
+      switchToAccountWithOldConnection()
+
+      const { rerender } = renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+      expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+
+      mockConnectedAccountId = "sc-2"
+      rerender(undefined)
+
+      await waitFor(() =>
+        expect(mockSetLnurlServerMode).toHaveBeenCalledWith({
+          sdk,
+          serverUrl: SERVER_URL,
+          mode: AccountMode.Anon,
+        }),
+      )
+    })
+
+    /** A connection that names no account cannot be shown to be the active one's. */
+    it("stays quiet while the connection names no account", async () => {
+      mockConnectedAccountId = null
+
+      renderHook(() => useAccountModeSync())
+      await Promise.resolve()
+
+      expect(mockSetLnurlServerMode).not.toHaveBeenCalled()
+    })
   })
 
   it("pushes once rather than on every render", async () => {

--- a/__tests__/self-custodial/hooks/use-anon-stable-balance-deactivation.spec.ts
+++ b/__tests__/self-custodial/hooks/use-anon-stable-balance-deactivation.spec.ts
@@ -15,7 +15,7 @@ jest.mock("@app/self-custodial/bridge", () => ({
 }))
 
 let mockPersistentState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: "sc-1",
@@ -81,7 +81,7 @@ describe("useAnonStableBalanceDeactivation", () => {
     mockIsAnonMode = true
     mockStableBalanceEnabled = true
     mockPersistentState = {
-      schemaVersion: 19,
+      schemaVersion: 20,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
       activeAccountId: "sc-1",

--- a/__tests__/self-custodial/hooks/use-self-custodial-account-mode.spec.ts
+++ b/__tests__/self-custodial/hooks/use-self-custodial-account-mode.spec.ts
@@ -15,7 +15,7 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/self-custodial/lnurl-server-mode.spec.ts
+++ b/__tests__/self-custodial/lnurl-server-mode.spec.ts
@@ -1,0 +1,241 @@
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
+import {
+  recoverLnurlServerMode,
+  setLnurlServerMode,
+} from "@app/self-custodial/lnurl-server-mode"
+import { AccountMode } from "@app/types/account"
+
+const mockGetWalletInfo = jest.fn()
+jest.mock("@app/self-custodial/bridge/wallet", () => ({
+  getWalletInfo: (...args: unknown[]) => mockGetWalletInfo(...args),
+}))
+
+const PUBKEY = "02ab".padEnd(66, "c")
+const SERVER_URL = "https://pay.example.test"
+const NOW_SECONDS = 1_710_000_000
+
+const mockSignMessage = jest.fn()
+const sdk = { signMessage: mockSignMessage } as unknown as BreezSdkInterface
+
+const mockFetch = jest.fn()
+
+const setup = (mode: AccountMode = AccountMode.Enhanced) =>
+  setLnurlServerMode({ sdk, serverUrl: SERVER_URL, mode })
+
+const lastRequest = () => {
+  const [url, init] = mockFetch.mock.calls[0]
+  return { url, init, body: JSON.parse(init.body) }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.useFakeTimers()
+  jest.setSystemTime(NOW_SECONDS * 1000)
+  global.fetch = mockFetch as unknown as typeof fetch
+  mockGetWalletInfo.mockResolvedValue({ identityPubkey: PUBKEY })
+  mockSignMessage.mockResolvedValue({ pubkey: PUBKEY, signature: "3045-der-hex" })
+  mockFetch.mockResolvedValue({ ok: true, status: 200 })
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe("setLnurlServerMode", () => {
+  it("posts to the mode endpoint of the account's own pubkey", async () => {
+    await setup()
+
+    expect(lastRequest().url).toBe(`${SERVER_URL}/lnurlpay/${PUBKEY}/mode`)
+    expect(lastRequest().init.method).toBe("POST")
+  })
+
+  it("sends the mode, its signature and the timestamp that was signed", async () => {
+    await setup()
+
+    expect(lastRequest().body).toEqual({
+      mode: AccountMode.Enhanced,
+      signature: "3045-der-hex",
+      timestamp: NOW_SECONDS,
+    })
+  })
+
+  /** `mode:` is what keeps a register or transfer signature, made with the same key, from
+   *  being replayed as a mode change. */
+  it("signs the domain-separated challenge the server rebuilds", async () => {
+    await setup(AccountMode.Anon)
+
+    expect(mockSignMessage).toHaveBeenCalledWith({
+      message: `mode:${AccountMode.Anon}:${PUBKEY}-${NOW_SECONDS}`,
+      compact: false,
+    })
+  })
+
+  /** The server parses DER; a compact signature would be refused as invalid. */
+  it("asks for a DER signature rather than a compact one", async () => {
+    await setup()
+
+    expect(mockSignMessage.mock.calls[0][0].compact).toBe(false)
+  })
+
+  it("sends the timestamp in seconds, not milliseconds", async () => {
+    jest.setSystemTime(NOW_SECONDS * 1000 + 750)
+
+    await setup()
+
+    expect(lastRequest().body.timestamp).toBe(NOW_SECONDS)
+  })
+
+  it("throws with the refusal status when the server rejects the mode", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 409 })
+
+    await expect(setup(AccountMode.Anon)).rejects.toThrow(
+      "LNURL server refused mode 'anon' with 409",
+    )
+  })
+
+  it("surfaces a transport failure rather than reporting the mode as stored", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"))
+
+    await expect(setup()).rejects.toThrow("network down")
+  })
+
+  it("does not sign anything when the wallet cannot state its pubkey", async () => {
+    mockGetWalletInfo.mockRejectedValue(new Error("sdk not connected"))
+
+    await expect(setup()).rejects.toThrow("sdk not connected")
+    expect(mockSignMessage).not.toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("aborts a request the server leaves hanging", async () => {
+    let abortSignal: AbortSignal | undefined
+    mockFetch.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          abortSignal = init.signal ?? undefined
+          init.signal?.addEventListener("abort", () => reject(new Error("Aborted")))
+        }),
+    )
+
+    /** Caught before the clock moves: the abort rejects inside the tick itself, which
+     *  would otherwise land as an unhandled rejection. */
+    const settled = setup().catch((err: Error) => err)
+    /** Async so the pubkey and signature awaits settle first: the timer is only armed
+     *  once the request is actually in flight. */
+    await jest.advanceTimersByTimeAsync(15_000)
+
+    expect(await settled).toEqual(new Error("Aborted"))
+    expect(abortSignal?.aborted).toBe(true)
+  })
+
+  it("clears the abort timer once the server answers", async () => {
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    await setup()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+  })
+})
+
+describe("recoverLnurlServerMode", () => {
+  const recover = () => recoverLnurlServerMode({ sdk, serverUrl: SERVER_URL })
+
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ mode: AccountMode.Anon }),
+    })
+  })
+
+  it("posts to the recover endpoint of the account's own pubkey", async () => {
+    await recover()
+
+    expect(lastRequest().url).toBe(`${SERVER_URL}/lnurlpay/${PUBKEY}/recover`)
+    expect(lastRequest().init.method).toBe("POST")
+  })
+
+  /** Recover signs the bare pubkey; a `mode:` prefix here would be a message the server
+   *  rebuilds differently and refuses. */
+  it("signs the bare pubkey challenge, undomain-separated", async () => {
+    await recover()
+
+    expect(mockSignMessage).toHaveBeenCalledWith({
+      message: `${PUBKEY}-${NOW_SECONDS}`,
+      compact: false,
+    })
+  })
+
+  it("sends only the signature and the timestamp", async () => {
+    await recover()
+
+    expect(lastRequest().body).toEqual({
+      signature: "3045-der-hex",
+      timestamp: NOW_SECONDS,
+    })
+  })
+
+  it("returns the mode the server holds", async () => {
+    expect(await recover()).toBe(AccountMode.Anon)
+  })
+
+  it("returns Enhanced when that is what the server holds", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ mode: AccountMode.Enhanced }),
+    })
+
+    expect(await recover()).toBe(AccountMode.Enhanced)
+  })
+
+  /** An account the server knows but that never chose a mode. */
+  it("returns null when the server holds no mode", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ mode: null }),
+    })
+
+    expect(await recover()).toBeNull()
+  })
+
+  /** The server has never heard of this wallet, which is the same as holding no mode. */
+  it("returns null when the account is unknown", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 })
+
+    expect(await recover()).toBeNull()
+  })
+
+  /** A variant this app does not know cannot be honored, and calling it one of ours would
+   *  misreport what the account holds. */
+  it("returns null for a mode value it does not recognize", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ mode: "something-else" }),
+    })
+
+    expect(await recover()).toBeNull()
+  })
+
+  it("returns null when the field is absent altogether", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    expect(await recover()).toBeNull()
+  })
+
+  /** Distinguishable from "no mode": a refusal must not read as an answer. */
+  it("throws when the server refuses the recover", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 400 })
+
+    await expect(recover()).rejects.toThrow("LNURL server refused recover with 400")
+  })
+
+  it("surfaces a transport failure", async () => {
+    mockFetch.mockRejectedValue(new Error("network down"))
+
+    await expect(recover()).rejects.toThrow("network down")
+  })
+})

--- a/__tests__/store/persistent-state/active-self-custodial-account.spec.ts
+++ b/__tests__/store/persistent-state/active-self-custodial-account.spec.ts
@@ -3,7 +3,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
+++ b/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/hide-balance.spec.ts
+++ b/__tests__/store/persistent-state/hide-balance.spec.ts
@@ -8,7 +8,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/migrated-account-settings.spec.ts
+++ b/__tests__/store/persistent-state/migrated-account-settings.spec.ts
@@ -6,7 +6,7 @@ import { getThemePreference } from "@app/store/persistent-state/theme-preference
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/quiz-completions.spec.ts
+++ b/__tests__/store/persistent-state/quiz-completions.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-account-mode.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-account-mode.spec.ts
@@ -7,7 +7,7 @@ import { AccountMode } from "@app/types/account"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
@@ -7,7 +7,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-language.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-language.spec.ts
@@ -7,7 +7,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-server-account-mode.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-server-account-mode.spec.ts
@@ -1,0 +1,116 @@
+import { getSelfCustodialAccountMode } from "@app/store/persistent-state/self-custodial-account-mode"
+import {
+  getSelfCustodialServerAccountMode,
+  withSelfCustodialModeFromServer,
+  withSelfCustodialServerAccountMode,
+} from "@app/store/persistent-state/self-custodial-server-account-mode"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import { AccountMode } from "@app/types/account"
+
+const baseState: PersistentState = {
+  schemaVersion: 20,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+describe("withSelfCustodialServerAccountMode", () => {
+  it("records the mode the server confirmed for the given account", () => {
+    const next = withSelfCustodialServerAccountMode(
+      baseState,
+      "sc-1",
+      AccountMode.Enhanced,
+    )
+
+    expect(next.selfCustodialServerAccountModeByAccountId).toEqual({
+      "sc-1": AccountMode.Enhanced,
+    })
+  })
+
+  it("overwrites a previously confirmed mode when the account switches", () => {
+    const state: PersistentState = {
+      ...baseState,
+      selfCustodialServerAccountModeByAccountId: { "sc-1": AccountMode.Enhanced },
+    }
+
+    const next = withSelfCustodialServerAccountMode(state, "sc-1", AccountMode.Anon)
+
+    expect(getSelfCustodialServerAccountMode(next, "sc-1")).toBe(AccountMode.Anon)
+  })
+
+  /** Each account holds its own posture, so one confirming a mode must not speak for
+   *  another the server has never heard from. */
+  it("preserves the confirmations of other accounts", () => {
+    const state: PersistentState = {
+      ...baseState,
+      selfCustodialServerAccountModeByAccountId: { "sc-1": AccountMode.Anon },
+    }
+
+    const next = withSelfCustodialServerAccountMode(state, "sc-2", AccountMode.Enhanced)
+
+    expect(next.selfCustodialServerAccountModeByAccountId).toEqual({
+      "sc-1": AccountMode.Anon,
+      "sc-2": AccountMode.Enhanced,
+    })
+  })
+})
+
+describe("getSelfCustodialServerAccountMode", () => {
+  it("reads back what the writer stored", () => {
+    const next = withSelfCustodialServerAccountMode(baseState, "sc-1", AccountMode.Anon)
+
+    expect(getSelfCustodialServerAccountMode(next, "sc-1")).toBe(AccountMode.Anon)
+  })
+
+  /** Null is what makes the first push happen: an account the server has never been told
+   *  about must not read as already agreeing with whatever mode is chosen. */
+  it("reports null for an account with no confirmation", () => {
+    const state: PersistentState = {
+      ...baseState,
+      selfCustodialServerAccountModeByAccountId: { "sc-1": AccountMode.Enhanced },
+    }
+
+    expect(getSelfCustodialServerAccountMode(state, "sc-2")).toBeNull()
+  })
+
+  it("reports null when no account has been confirmed at all", () => {
+    expect(getSelfCustodialServerAccountMode(baseState, "sc-1")).toBeNull()
+  })
+})
+
+describe("withSelfCustodialModeFromServer", () => {
+  const activeState: PersistentState = { ...baseState, activeAccountId: "sc-1" }
+
+  it("adopts the mode the server reported", () => {
+    const next = withSelfCustodialModeFromServer(activeState, "sc-1", AccountMode.Anon)
+
+    expect(getSelfCustodialAccountMode(next)).toBe(AccountMode.Anon)
+  })
+
+  /** Already on the server, so pushing it back would spend a paid country lookup to say
+   *  what it just told us. */
+  it("records a reported mode as confirmed", () => {
+    const next = withSelfCustodialModeFromServer(activeState, "sc-1", AccountMode.Anon)
+
+    expect(getSelfCustodialServerAccountMode(next, "sc-1")).toBe(AccountMode.Anon)
+  })
+
+  it("settles on Enhanced when the server reported no mode", () => {
+    const next = withSelfCustodialModeFromServer(activeState, "sc-1", null)
+
+    expect(getSelfCustodialAccountMode(next)).toBe(AccountMode.Enhanced)
+  })
+
+  /** The server never said Enhanced, so it is still owed that push. */
+  it("leaves an assumed Enhanced unconfirmed", () => {
+    const next = withSelfCustodialModeFromServer(activeState, "sc-1", null)
+
+    expect(getSelfCustodialServerAccountMode(next, "sc-1")).toBeNull()
+  })
+
+  it("settles the account it was given, not whichever is active", () => {
+    const next = withSelfCustodialModeFromServer(activeState, "sc-2", AccountMode.Anon)
+
+    expect(next.selfCustodialAccountModeByAccountId).toEqual({ "sc-2": AccountMode.Anon })
+    expect(getSelfCustodialAccountMode(next)).toBeNull()
+  })
+})

--- a/__tests__/store/persistent-state/stable-balance-anon-pause.spec.ts
+++ b/__tests__/store/persistent-state/stable-balance-anon-pause.spec.ts
@@ -5,7 +5,7 @@ import {
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -24,7 +24,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state6)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.galoyAuthToken).toBe("test-token")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -40,7 +40,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state7)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.activeAccountId).toBe("custodial-default")
   })
 
@@ -53,7 +53,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state5)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.galoyAuthToken).toBe("old-token")
     expect(result.activeAccountId).toBeUndefined()
   })
@@ -69,7 +69,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -90,7 +90,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "USD",
       "self-custodial-id-2": "BTC",
@@ -106,7 +106,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toBeUndefined()
     expect(result.selfCustodialLanguageByAccountId).toBeUndefined()
   })
@@ -129,7 +129,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state12)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "EUR",
       "self-custodial-id-2": "JPY",
@@ -154,7 +154,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state12)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.themeByAccountId).toEqual({
       "self-custodial-id-1": "dark",
       "self-custodial-id-2": "light",
@@ -175,7 +175,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state13)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.defaultAccountModalShownByAccountId).toEqual({
       "self-custodial-id-1": true,
       "self-custodial-id-2": false,
@@ -195,7 +195,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state14)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result).not.toHaveProperty("stablesatsRestrictedCustodial")
     expect(result).not.toHaveProperty("stableTokenRestricted")
     expect(result).not.toHaveProperty("stablesatsTransferBlocked")
@@ -216,7 +216,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state15)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result).not.toHaveProperty("stablesatsRestrictedCustodial")
     expect(result.completedQuizIdsByAccountId).toEqual({
       "self-custodial-id-1": ["whatIsBitcoin", "sat"],
@@ -236,7 +236,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state16)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.completedQuizIdsByAccountId).toEqual({
       "self-custodial-id-1": ["whatIsBitcoin", "sat"],
     })
@@ -251,7 +251,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state15)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.alwaysHideBalance).toBeUndefined()
     expect(result.balanceHidden).toBeUndefined()
   })
@@ -267,7 +267,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state16)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.alwaysHideBalance).toBe(true)
     expect(result.balanceHidden).toBe(true)
   })
@@ -285,7 +285,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state16)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result).not.toHaveProperty("stablesatsRestrictedCustodial")
     expect(result).not.toHaveProperty("stableTokenRestricted")
     expect(result).not.toHaveProperty("stablesatsTransferBlocked")
@@ -310,7 +310,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state18)
 
-    expect(result).toEqual({ ...state18, schemaVersion: 19 })
+    expect(result).toEqual({ ...state18, schemaVersion: 20 })
   })
 
   it("leaves completedQuizIdsByAccountId undefined when migrating from v14", async () => {
@@ -322,7 +322,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state14)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.completedQuizIdsByAccountId).toBeUndefined()
   })
 
@@ -335,7 +335,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state13)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result).not.toHaveProperty("stablesatsRestrictedCustodial")
   })
 
@@ -349,7 +349,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state16)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialAccountModeByAccountId).toBeUndefined()
   })
 
@@ -364,14 +364,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state18)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialAccountModeByAccountId).toEqual({
       "self-custodial-id-1": "anon",
     })
     expect(result.stableBalanceAnonPausedByAccountId).toBeUndefined()
   })
 
-  it("v19 identity migration preserves the stored account modes untouched", async () => {
+  it("carries a v19 state to current, preserving the stored account modes", async () => {
     const state19 = {
       schemaVersion: 19,
       galoyInstance: { id: "Main" },
@@ -388,7 +388,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state19)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialAccountModeByAccountId).toEqual({
       "self-custodial-id-1": "anon",
       "self-custodial-id-2": "enhanced",
@@ -396,6 +396,45 @@ describe("state-migrations schema 10", () => {
     expect(result.completedQuizIdsByAccountId).toEqual({
       "self-custodial-id-1": ["whatIsBitcoin", "sat"],
     })
+  })
+
+  /** Deliberately not backfilled from the chosen mode: an account that picked one before
+   *  this version has never told the server, and claiming otherwise would suppress the
+   *  push it is still owed. */
+  it("migrates a v19 state to current leaving the server-confirmed mode unset", async () => {
+    const state19 = {
+      schemaVersion: 19,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "token",
+      activeAccountId: "self-custodial-id-1",
+      selfCustodialAccountModeByAccountId: {
+        "self-custodial-id-1": AccountMode.Enhanced,
+      },
+    }
+
+    const result = await migrateAndGetPersistentState(state19)
+
+    expect(result.selfCustodialServerAccountModeByAccountId).toBeUndefined()
+  })
+
+  it("carries a whole v20 state to current untouched", async () => {
+    const state20 = {
+      schemaVersion: 20,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "token",
+      activeAccountId: "self-custodial-id-1",
+      selfCustodialAccountModeByAccountId: {
+        "self-custodial-id-1": AccountMode.Anon,
+      },
+      selfCustodialServerAccountModeByAccountId: {
+        "self-custodial-id-1": AccountMode.Enhanced,
+      },
+      stableBalanceAnonPausedByAccountId: { "self-custodial-id-1": true },
+    }
+
+    const result = await migrateAndGetPersistentState(state20)
+
+    expect(result).toEqual(state20)
   })
 
   it("returns default state for invalid data", async () => {
@@ -434,7 +473,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state4)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.galoyAuthToken).toBe("token-v4")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -464,14 +503,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state3)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.galoyAuthToken).toBe("token-v3")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
   })
 
   it("default state has the current schema version", () => {
-    expect(defaultPersistentState.schemaVersion).toBe(19)
+    expect(defaultPersistentState.schemaVersion).toBe(20)
     expect(defaultPersistentState.activeAccountId).toBeUndefined()
     expect(
       defaultPersistentState.selfCustodialDefaultWalletCurrencyByAccountId,
@@ -489,7 +528,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -508,7 +547,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "BTC",
@@ -524,7 +563,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -539,7 +578,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -555,7 +594,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -575,7 +614,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(19)
+    expect(result.schemaVersion).toBe(20)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "BTC",

--- a/__tests__/store/persistent-state/theme-preference.spec.ts
+++ b/__tests__/store/persistent-state/theme-preference.spec.ts
@@ -7,7 +7,7 @@ import {
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -7,6 +7,9 @@ import {
   DEFAULT_ADAPTERS,
   resolveIpCountryCode,
   resolveIpCountryCodeCached,
+  resetIpCountryLookup,
+  getIpCountryLookupGeneration,
+  subscribeToIpCountryLookup,
 } from "@app/utils/ip-country-lookup"
 
 import { reportError } from "@app/utils/error-logging"
@@ -115,6 +118,62 @@ describe("resolveIpCountryCodeCached", () => {
 
     mockedAxios.get.mockClear()
     await expect(resolveIpCountryCodeCached()).resolves.toBe("DE")
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  /** The country a session runs under is the one its connection resolves to, so the
+   *  shared lookup cannot outlive the session that filled it. */
+  it("resolves against the connection again once the session is reset", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { country: "DE" } })
+    await expect(resolveIpCountryCodeCached()).resolves.toBe("DE")
+
+    mockedAxios.get.mockClear()
+    mockedAxios.get.mockResolvedValue({ data: { country: "FR" } })
+
+    resetIpCountryLookup()
+
+    await expect(resolveIpCountryCodeCached()).resolves.toBe("FR")
+    expect(mockedAxios.get).toHaveBeenCalled()
+  })
+
+  it("notifies subscribers so a mounted consumer can resolve again", () => {
+    // Clearing the promise alone would only serve whatever mounts next.
+    const onChange = jest.fn()
+    const unsubscribe = subscribeToIpCountryLookup(onChange)
+    const before = getIpCountryLookupGeneration()
+
+    resetIpCountryLookup()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(getIpCountryLookupGeneration()).toBe(before + 1)
+
+    unsubscribe()
+    resetIpCountryLookup()
+    expect(onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it("lets a lookup that was in flight across a reset keep its successor", async () => {
+    // The stale lookup settling must not clear the promise the next session installed,
+    // or that session spends another round of rate-limited calls.
+    let resolveStale: (value: { data: { country: string } }) => void = () => undefined
+    mockedAxios.get.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve
+      }),
+    )
+    const stale = resolveIpCountryCodeCached()
+
+    resetIpCountryLookup()
+
+    mockedAxios.get.mockResolvedValue({ data: { country: "FR" } })
+    const fresh = resolveIpCountryCodeCached()
+
+    resolveStale({ data: { country: "" } })
+    await stale
+    await expect(fresh).resolves.toBe("FR")
+
+    mockedAxios.get.mockClear()
+    await expect(resolveIpCountryCodeCached()).resolves.toBe("FR")
     expect(mockedAxios.get).not.toHaveBeenCalled()
   })
 })

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -22,7 +22,10 @@ import { NotificationsProvider } from "./components/notifications/index"
 import { PushNotificationComponent } from "./components/push-notification"
 import { FeatureFlagContextProvider } from "./config/feature-flags-context"
 import { CustodialWalletProvider } from "./custodial/providers/wallet"
-import { AutoConvertListenerMount } from "./self-custodial/components"
+import {
+  AccountModeSyncMount,
+  AutoConvertListenerMount,
+} from "./self-custodial/components"
 import { AutoConvertStatusProvider } from "./self-custodial/providers/auto-convert-status"
 import { BackupStateProvider } from "./self-custodial/providers/backup-state"
 import { SelfCustodialWalletProvider } from "./self-custodial/providers/wallet"
@@ -76,6 +79,7 @@ export const App = () => (
                                       <AppStateWrapper />
                                       <PushNotificationComponent />
                                       <AutoConvertListenerMount />
+                                      <AccountModeSyncMount />
                                       <RootStack />
                                       <NetworkErrorComponent />
                                       <ActionModals />

--- a/app/components/restricted-region/restricted-region.tsx
+++ b/app/components/restricted-region/restricted-region.tsx
@@ -8,10 +8,11 @@ import React, {
   useState,
 } from "react"
 
-import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
+import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
-import { isBlockedCountry, useIpCountryLookup } from "@app/hooks/use-device-location"
 import { RestrictedRegionScreen } from "@app/custodial/components/restricted-region-screen"
+import { isBlockedCountry } from "@app/hooks/use-device-location"
+import { useRegionCheck } from "@app/hooks/use-region-check"
 import { bootSplashGate } from "@app/navigation/boot-splash-gate"
 import { RestrictedRegionModal } from "@app/self-custodial/components/restricted-region-modal"
 import { AccountType } from "@app/types/wallet"
@@ -55,14 +56,18 @@ type RestrictedRegionEvaluation = {
 const useEvaluateRestrictedRegion = (): RestrictedRegionEvaluation => {
   const { activeAccount, loading: isRegistryHydrating } = useAccountRegistry()
   const accountType = activeAccount?.type
-  const { custodialCreationBlockedCountries, selfCustodialCreationBlockedCountries } =
-    useRemoteConfig()
-  const { remoteConfigReady } = useFeatureFlags()
-  const { countryCode: ipCountryCode, isSettled } = useIpCountryLookup(
-    accountType !== undefined,
-  )
+  const { selfCustodialCreationBlockedCountries } = useRemoteConfig()
+  /** Custodial answers through the hook the server will serve; a self-custodial wallet has
+   *  no Blink account behind it and keeps its own list. `isSettled` already spans the
+   *  remote-config fetch, so both branches wait on it. */
+  const hasAccountToEvaluate = accountType !== undefined
+  const {
+    countryCode,
+    restricted: isCustodialRestricted,
+    isSettled,
+  } = useRegionCheck(hasAccountToEvaluate)
 
-  if (accountType === undefined) {
+  if (!hasAccountToEvaluate) {
     return {
       isRestrictedRegion: false,
       isEvaluationPending: isRegistryHydrating,
@@ -70,18 +75,17 @@ const useEvaluateRestrictedRegion = (): RestrictedRegionEvaluation => {
     }
   }
 
-  const blockedCountries =
-    accountType === AccountType.SelfCustodial
-      ? selfCustodialCreationBlockedCountries
-      : custodialCreationBlockedCountries
+  const isSelfCustodial = accountType === AccountType.SelfCustodial
+  const isSelfCustodialRestricted = isBlockedCountry(
+    countryCode,
+    selfCustodialCreationBlockedCountries,
+  )
+  const isRestrictedRegion = isSelfCustodial
+    ? isSelfCustodialRestricted
+    : isCustodialRestricted
+  const isEvaluationPending = isRegistryHydrating || !isSettled
 
-  const isEvaluationPending = isRegistryHydrating || !isSettled || !remoteConfigReady
-
-  return {
-    isRestrictedRegion: isBlockedCountry(ipCountryCode, blockedCountries),
-    isEvaluationPending,
-    accountType,
-  }
+  return { isRestrictedRegion, isEvaluationPending, accountType }
 }
 
 /** Hosts the sanctions surfaces: the custodial one blocks the whole session, since

--- a/app/components/restricted-region/restricted-region.tsx
+++ b/app/components/restricted-region/restricted-region.tsx
@@ -8,7 +8,7 @@ import React, {
   useState,
 } from "react"
 
-import { useRemoteConfig } from "@app/config/feature-flags-context"
+import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { RestrictedRegionScreen } from "@app/custodial/components/restricted-region-screen"
 import { isBlockedCountry } from "@app/hooks/use-device-location"
@@ -57,9 +57,9 @@ const useEvaluateRestrictedRegion = (): RestrictedRegionEvaluation => {
   const { activeAccount, loading: isRegistryHydrating } = useAccountRegistry()
   const accountType = activeAccount?.type
   const { selfCustodialCreationBlockedCountries } = useRemoteConfig()
-  /** Custodial answers through the hook the server will serve; a self-custodial wallet has
-   *  no Blink account behind it and keeps its own list. `isSettled` already spans the
-   *  remote-config fetch, so both branches wait on it. */
+  const { remoteConfigReady } = useFeatureFlags()
+  /** Custodial answers through the server's own verdict; a self-custodial wallet has no
+   *  Blink account behind it and keeps its own list. */
   const hasAccountToEvaluate = accountType !== undefined
   const {
     countryCode,
@@ -83,7 +83,11 @@ const useEvaluateRestrictedRegion = (): RestrictedRegionEvaluation => {
   const isRestrictedRegion = isSelfCustodial
     ? isSelfCustodialRestricted
     : isCustodialRestricted
-  const isEvaluationPending = isRegistryHydrating || !isSettled
+  /** Only the self-custodial branch still reads a compiled-in list, so only it waits on
+   *  the fetch: an empty list mid-flight would read as a country nothing restricts. The
+   *  custodial verdict is the server's and needs no list at all. */
+  const isListPending = isSelfCustodial && !remoteConfigReady
+  const isEvaluationPending = isRegistryHydrating || !isSettled || isListPending
 
   return { isRestrictedRegion, isEvaluationPending, accountType }
 }

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -47,12 +47,9 @@ const AutoConvertPollMaxAttemptsKey = "autoConvertPollMaxAttempts"
 const AutoConvertPollIntervalMsKey = "autoConvertPollIntervalMs"
 const AutoConvertAmountMatchToleranceBpsKey = "autoConvertAmountMatchToleranceBps"
 const CustodialFirstSignupBlockedCountriesKey = "custodialFirstSignupBlockedCountries"
-const CustodialDollarBalanceBlockedCountriesKey = "custodialDollarBalanceBlockedCountries"
 const SelfCustodialDollarBalanceBlockedCountriesKey =
   "selfCustodialDollarBalanceBlockedCountries"
 const SelfCustodialTransferBlockedCountriesKey = "selfCustodialTransferBlockedCountries"
-const CustodialTransferBlockedCountriesKey = "custodialTransferBlockedCountries"
-const CustodialCreationBlockedCountriesKey = "custodialCreationBlockedCountries"
 const SelfCustodialCreationBlockedCountriesKey = "selfCustodialCreationBlockedCountries"
 const OffboardOnlyCountriesKey = "offboardOnlyCountries"
 const SelfCustodialDepositClaimLeewayVbyteKey = "selfCustodialDepositClaimLeewayVbyte"
@@ -118,11 +115,8 @@ type RemoteConfig = {
   [AutoConvertPollIntervalMsKey]: number
   [AutoConvertAmountMatchToleranceBpsKey]: number
   [CustodialFirstSignupBlockedCountriesKey]: string[]
-  [CustodialDollarBalanceBlockedCountriesKey]: string[]
   [SelfCustodialDollarBalanceBlockedCountriesKey]: string[]
   [SelfCustodialTransferBlockedCountriesKey]: string[]
-  [CustodialTransferBlockedCountriesKey]: string[]
-  [CustodialCreationBlockedCountriesKey]: string[]
   [SelfCustodialCreationBlockedCountriesKey]: string[]
   [OffboardOnlyCountriesKey]: string[]
   [SelfCustodialDepositClaimLeewayVbyteKey]: number
@@ -229,11 +223,8 @@ export const defaultRemoteConfig: RemoteConfig = {
   autoConvertPollIntervalMs: 500,
   autoConvertAmountMatchToleranceBps: 500,
   custodialFirstSignupBlockedCountries: custodialFirstSignupBlockedDefault,
-  custodialDollarBalanceBlockedCountries: ["HK"],
   selfCustodialDollarBalanceBlockedCountries: ["HK"],
   selfCustodialTransferBlockedCountries: transferBlockedDefault,
-  custodialTransferBlockedCountries: transferBlockedDefault,
-  custodialCreationBlockedCountries: creationBlockedDefault,
   selfCustodialCreationBlockedCountries: creationBlockedDefault,
   offboardOnlyCountries: offboardOnlyDefault,
   selfCustodialDepositClaimLeewayVbyte: 1,
@@ -263,20 +254,11 @@ remoteConfigInstance().setDefaults({
   custodialFirstSignupBlockedCountries: serializeRemoteConfigDefault(
     custodialFirstSignupBlockedDefault,
   ),
-  custodialDollarBalanceBlockedCountries: serializeRemoteConfigDefault(
-    defaultRemoteConfig.custodialDollarBalanceBlockedCountries,
-  ),
   selfCustodialDollarBalanceBlockedCountries: serializeRemoteConfigDefault(
     defaultRemoteConfig.selfCustodialDollarBalanceBlockedCountries,
   ),
   selfCustodialTransferBlockedCountries: serializeRemoteConfigDefault(
     defaultRemoteConfig.selfCustodialTransferBlockedCountries,
-  ),
-  custodialTransferBlockedCountries: serializeRemoteConfigDefault(
-    defaultRemoteConfig.custodialTransferBlockedCountries,
-  ),
-  custodialCreationBlockedCountries: serializeRemoteConfigDefault(
-    defaultRemoteConfig.custodialCreationBlockedCountries,
   ),
   selfCustodialCreationBlockedCountries: serializeRemoteConfigDefault(
     defaultRemoteConfig.selfCustodialCreationBlockedCountries,
@@ -457,11 +439,6 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           custodialFirstSignupBlockedDefault,
         )
 
-        const custodialDollarBalanceBlockedCountries = getRemoteConfigStringList(
-          CustodialDollarBalanceBlockedCountriesKey,
-          defaultRemoteConfig.custodialDollarBalanceBlockedCountries,
-        )
-
         const selfCustodialDollarBalanceBlockedCountries = getRemoteConfigStringList(
           SelfCustodialDollarBalanceBlockedCountriesKey,
           defaultRemoteConfig.selfCustodialDollarBalanceBlockedCountries,
@@ -470,16 +447,6 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
         const selfCustodialTransferBlockedCountries = getRemoteConfigStringList(
           SelfCustodialTransferBlockedCountriesKey,
           defaultRemoteConfig.selfCustodialTransferBlockedCountries,
-        )
-
-        const custodialTransferBlockedCountries = getRemoteConfigStringList(
-          CustodialTransferBlockedCountriesKey,
-          defaultRemoteConfig.custodialTransferBlockedCountries,
-        )
-
-        const custodialCreationBlockedCountries = getRemoteConfigStringList(
-          CustodialCreationBlockedCountriesKey,
-          defaultRemoteConfig.custodialCreationBlockedCountries,
         )
 
         const selfCustodialCreationBlockedCountries = getRemoteConfigStringList(
@@ -544,11 +511,8 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           autoConvertPollIntervalMs,
           autoConvertAmountMatchToleranceBps,
           custodialFirstSignupBlockedCountries,
-          custodialDollarBalanceBlockedCountries,
           selfCustodialDollarBalanceBlockedCountries,
           selfCustodialTransferBlockedCountries,
-          custodialTransferBlockedCountries,
-          custodialCreationBlockedCountries,
           selfCustodialCreationBlockedCountries,
           offboardOnlyCountries,
           selfCustodialDepositClaimLeewayVbyte,

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1334,6 +1334,14 @@ query currencyList {
   }
 }
 
+query custodialRestrictions {
+  custodialRestrictions {
+    dollarBalance
+    transfer
+    __typename
+  }
+}
+
 query debugScreen {
   me {
     id
@@ -1881,6 +1889,15 @@ query realtimePriceUnauthed($currency: DisplayCurrency) {
       offset
       __typename
     }
+    __typename
+  }
+}
+
+query regionCheck {
+  regionCheck {
+    countryCode
+    custodialCreationAllowed
+    restricted
     __typename
   }
 }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -3377,6 +3377,11 @@ export type LevelQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type LevelQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly level: AccountLevel } } | null };
 
+export type CustodialRestrictionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CustodialRestrictionsQuery = { readonly __typename: 'Query', readonly custodialRestrictions: { readonly __typename: 'CustodialRestrictions', readonly dollarBalance: boolean, readonly transfer: boolean } };
+
 export type DisplayCurrencyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -3422,6 +3427,11 @@ export type UserLogoutMutationVariables = Exact<{
 
 
 export type UserLogoutMutation = { readonly __typename: 'Mutation', readonly userLogout: { readonly __typename: 'SuccessPayload', readonly success?: boolean | null } };
+
+export type RegionCheckQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type RegionCheckQuery = { readonly __typename: 'Query', readonly regionCheck: { readonly __typename: 'RegionCheck', readonly countryCode?: string | null, readonly custodialCreationAllowed: boolean, readonly restricted: boolean } };
 
 export type TransactionOwnershipProbeQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -5149,6 +5159,46 @@ export type LevelQueryHookResult = ReturnType<typeof useLevelQuery>;
 export type LevelLazyQueryHookResult = ReturnType<typeof useLevelLazyQuery>;
 export type LevelSuspenseQueryHookResult = ReturnType<typeof useLevelSuspenseQuery>;
 export type LevelQueryResult = Apollo.QueryResult<LevelQuery, LevelQueryVariables>;
+export const CustodialRestrictionsDocument = gql`
+    query custodialRestrictions {
+  custodialRestrictions {
+    dollarBalance
+    transfer
+  }
+}
+    `;
+
+/**
+ * __useCustodialRestrictionsQuery__
+ *
+ * To run a query within a React component, call `useCustodialRestrictionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCustodialRestrictionsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCustodialRestrictionsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCustodialRestrictionsQuery(baseOptions?: Apollo.QueryHookOptions<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>(CustodialRestrictionsDocument, options);
+      }
+export function useCustodialRestrictionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>(CustodialRestrictionsDocument, options);
+        }
+export function useCustodialRestrictionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>(CustodialRestrictionsDocument, options);
+        }
+export type CustodialRestrictionsQueryHookResult = ReturnType<typeof useCustodialRestrictionsQuery>;
+export type CustodialRestrictionsLazyQueryHookResult = ReturnType<typeof useCustodialRestrictionsLazyQuery>;
+export type CustodialRestrictionsSuspenseQueryHookResult = ReturnType<typeof useCustodialRestrictionsSuspenseQuery>;
+export type CustodialRestrictionsQueryResult = Apollo.QueryResult<CustodialRestrictionsQuery, CustodialRestrictionsQueryVariables>;
 export const DisplayCurrencyDocument = gql`
     query displayCurrency {
   me {
@@ -5471,6 +5521,47 @@ export function useUserLogoutMutation(baseOptions?: Apollo.MutationHookOptions<U
 export type UserLogoutMutationHookResult = ReturnType<typeof useUserLogoutMutation>;
 export type UserLogoutMutationResult = Apollo.MutationResult<UserLogoutMutation>;
 export type UserLogoutMutationOptions = Apollo.BaseMutationOptions<UserLogoutMutation, UserLogoutMutationVariables>;
+export const RegionCheckDocument = gql`
+    query regionCheck {
+  regionCheck {
+    countryCode
+    custodialCreationAllowed
+    restricted
+  }
+}
+    `;
+
+/**
+ * __useRegionCheckQuery__
+ *
+ * To run a query within a React component, call `useRegionCheckQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRegionCheckQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useRegionCheckQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useRegionCheckQuery(baseOptions?: Apollo.QueryHookOptions<RegionCheckQuery, RegionCheckQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<RegionCheckQuery, RegionCheckQueryVariables>(RegionCheckDocument, options);
+      }
+export function useRegionCheckLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RegionCheckQuery, RegionCheckQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<RegionCheckQuery, RegionCheckQueryVariables>(RegionCheckDocument, options);
+        }
+export function useRegionCheckSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<RegionCheckQuery, RegionCheckQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<RegionCheckQuery, RegionCheckQueryVariables>(RegionCheckDocument, options);
+        }
+export type RegionCheckQueryHookResult = ReturnType<typeof useRegionCheckQuery>;
+export type RegionCheckLazyQueryHookResult = ReturnType<typeof useRegionCheckLazyQuery>;
+export type RegionCheckSuspenseQueryHookResult = ReturnType<typeof useRegionCheckSuspenseQuery>;
+export type RegionCheckQueryResult = Apollo.QueryResult<RegionCheckQuery, RegionCheckQueryVariables>;
 export const TransactionOwnershipProbeDocument = gql`
     query transactionOwnershipProbe($first: Int) {
   me {

--- a/app/hooks/use-account-restrictions.ts
+++ b/app/hooks/use-account-restrictions.ts
@@ -1,0 +1,124 @@
+import { CountryCode } from "libphonenumber-js/mobile"
+
+import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
+import { AccountType } from "@app/types/wallet"
+
+import useDeviceLocation, {
+  isBlockedCountry,
+  useIpCountryLookup,
+} from "./use-device-location"
+import { useActiveWallet } from "./use-active-wallet"
+
+/**
+ * What an account may not do where it is. The field names are the ones the
+ * `custodialRestrictions` query answers, so adopting it later replaces one branch below
+ * rather than any caller.
+ */
+export type Restrictions = {
+  dollarBalance: boolean
+  transfer: boolean
+}
+
+export type AccountRestrictions = Restrictions & {
+  /** True once waiting is pointless: the verdict is in, or nothing is left to resolve. */
+  isSettled: boolean
+}
+
+type BlockedCountries = {
+  dollarBalance: string[]
+  transfer: string[]
+}
+
+/**
+ * Pure so the policy can be read without a render, and so both custody types answer to the
+ * same rule with only their lists differing. An unresolved country restricts nothing, which
+ * is the server's answer too; callers wait on `isSettled` rather than read that as a verdict.
+ */
+const toRestrictions = (
+  countryCode: CountryCode | undefined,
+  blockedCountries: BlockedCountries,
+): Restrictions => ({
+  dollarBalance: isBlockedCountry(countryCode, blockedCountries.dollarBalance),
+  transfer: isBlockedCountry(countryCode, blockedCountries.transfer),
+})
+
+type RestrictionRegion = {
+  countryCode: CountryCode | undefined
+  isPending: boolean
+}
+
+/**
+ * The country whose block-list decides the restriction, resolved once for every feature so
+ * a verdict and the flag describing it can never come from different reads.
+ *
+ * A self-custodial account has no phone, so evaluating its policy resolves by IP; every
+ * other case reads the device's own country. The IP wins whenever it resolves, but while
+ * predicting the self-custodial policy from a still-custodial session an unreachable IP
+ * falls back to the session country, so a failed IP lookup does not read as unrestricted
+ * and preview a dollar balance the account cannot hold. A country that already resolved
+ * settles the region even while the device location keeps loading, since the prediction's
+ * IP lookup can land first. The prediction also holds until the IP lookup settles, or a
+ * fast phone parse would report settled-unrestricted and then flip once the IP lands.
+ */
+const useRestrictionRegion = (isSelfCustodialPrediction: boolean): RestrictionRegion => {
+  const { countryCode: deviceCountryCode, loading: isDeviceLocationLoading } =
+    useDeviceLocation()
+  const { countryCode: ipCountryCode, isSettled: isIpLookupSettled } = useIpCountryLookup(
+    isSelfCustodialPrediction,
+  )
+
+  const countryCode = isSelfCustodialPrediction
+    ? ipCountryCode ?? deviceCountryCode
+    : deviceCountryCode
+
+  const isDeviceRegionPending = isDeviceLocationLoading && !countryCode
+  const isPredictedRegionPending = isSelfCustodialPrediction && !isIpLookupSettled
+
+  return { countryCode, isPending: isDeviceRegionPending || isPredictedRegionPending }
+}
+
+/**
+ * Every regional restriction an account answers to, from one resolution of one country.
+ *
+ * Gating on accountType (not isSelfCustodial) keeps the restriction stable through the
+ * self-custodial cold-start window while the SDK connects; passing `accountTypeOverride`
+ * evaluates a specific type instead (e.g. predicting the self-custodial dollar restriction
+ * from the still-custodial session during migration).
+ */
+export const useAccountRestrictions = (
+  accountTypeOverride?: AccountType,
+): AccountRestrictions => {
+  const { accountType: activeAccountType } = useActiveWallet()
+  const {
+    custodialDollarBalanceBlockedCountries,
+    selfCustodialDollarBalanceBlockedCountries,
+    custodialTransferBlockedCountries,
+    selfCustodialTransferBlockedCountries,
+  } = useRemoteConfig()
+  const { remoteConfigReady } = useFeatureFlags()
+
+  const isSelfCustodial =
+    (accountTypeOverride ?? activeAccountType) === AccountType.SelfCustodial
+  const isSelfCustodialPrediction = accountTypeOverride === AccountType.SelfCustodial
+  const { countryCode, isPending: isRegionPending } = useRestrictionRegion(
+    isSelfCustodialPrediction,
+  )
+
+  /** The custodial half is the server's to answer; a self-custodial wallet has no Blink
+   *  account behind it and keeps its own lists. */
+  const blockedCountries: BlockedCountries = isSelfCustodial
+    ? {
+        dollarBalance: selfCustodialDollarBalanceBlockedCountries,
+        transfer: selfCustodialTransferBlockedCountries,
+      }
+    : {
+        dollarBalance: custodialDollarBalanceBlockedCountries,
+        transfer: custodialTransferBlockedCountries,
+      }
+
+  /** An empty list mid-fetch would read as a country nothing restricts, so the fetch is
+   *  part of the wait rather than a verdict of its own. */
+  const isSettled = !isRegionPending && remoteConfigReady
+
+  return { ...toRestrictions(countryCode, blockedCountries), isSettled }
+}

--- a/app/hooks/use-account-restrictions.ts
+++ b/app/hooks/use-account-restrictions.ts
@@ -1,18 +1,30 @@
 import { CountryCode } from "libphonenumber-js/mobile"
 
+import { gql } from "@apollo/client"
 import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
+import { useCustodialRestrictionsQuery } from "@app/graphql/generated"
+import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { AccountType } from "@app/types/wallet"
 
 import useDeviceLocation, {
   isBlockedCountry,
   useIpCountryLookup,
 } from "./use-device-location"
+import { useAccountRegistry } from "./use-account-registry"
 import { useActiveWallet } from "./use-active-wallet"
 
+gql`
+  query custodialRestrictions {
+    custodialRestrictions {
+      dollarBalance
+      transfer
+    }
+  }
+`
+
 /**
- * What an account may not do where it is. The field names are the ones the
- * `custodialRestrictions` query answers, so adopting it later replaces one branch below
- * rather than any caller.
+ * What an account may not do where it is. The custodial half is the server's own answer;
+ * the field names are its.
  */
 export type Restrictions = {
   dollarBalance: boolean
@@ -28,6 +40,20 @@ type BlockedCountries = {
   dollarBalance: string[]
   transfer: string[]
 }
+
+/** What a session with no Blink account behind it answers to: there is nothing to gate. */
+const UNRESTRICTED: Restrictions = Object.freeze({
+  dollarBalance: false,
+  transfer: false,
+})
+
+/** A gated feature requires a determined region, and an unanswered query determined none.
+ *  `UnknownRegionPolicy = FAIL_CLOSED` per the PRD's P0 values: no region, no gated
+ *  feature, regardless of why there is no region. */
+const RESTRICTED_UNKNOWN_REGION: Restrictions = Object.freeze({
+  dollarBalance: true,
+  transfer: true,
+})
 
 /**
  * Pure so the policy can be read without a render, and so both custody types answer to the
@@ -90,12 +116,16 @@ export const useAccountRestrictions = (
 ): AccountRestrictions => {
   const { accountType: activeAccountType } = useActiveWallet()
   const {
-    custodialDollarBalanceBlockedCountries,
     selfCustodialDollarBalanceBlockedCountries,
-    custodialTransferBlockedCountries,
     selfCustodialTransferBlockedCountries,
   } = useRemoteConfig()
   const { remoteConfigReady } = useFeatureFlags()
+  const isAuthed = useIsAuthed()
+  /** `useActiveWallet` answers Custodial while the registry hydrates, so a self-custodial
+   *  device reads as an unauthed custodial one for those first renders. Reporting settled
+   *  there would offer the dollar balance and the transfer button, then withdraw both once
+   *  the real account lands. */
+  const { loading: isRegistryHydrating } = useAccountRegistry()
 
   const isSelfCustodial =
     (accountTypeOverride ?? activeAccountType) === AccountType.SelfCustodial
@@ -104,21 +134,49 @@ export const useAccountRestrictions = (
     isSelfCustodialPrediction,
   )
 
-  /** The custodial half is the server's to answer; a self-custodial wallet has no Blink
-   *  account behind it and keeps its own lists. */
-  const blockedCountries: BlockedCountries = isSelfCustodial
-    ? {
-        dollarBalance: selfCustodialDollarBalanceBlockedCountries,
-        transfer: selfCustodialTransferBlockedCountries,
-      }
-    : {
-        dollarBalance: custodialDollarBalanceBlockedCountries,
-        transfer: custodialTransferBlockedCountries,
-      }
+  /**
+   * The server picks the country this answers for by account level (verified phone for a
+   * level 1-2 account, request IP for level 0), so the client never chooses between
+   * sources. It speaks only for a Blink account, so a session without one asks nothing.
+   */
+  const isQueryEnabled = !isSelfCustodial && isAuthed
+  const { data, loading: isQueryLoading } = useCustodialRestrictionsQuery({
+    skip: !isQueryEnabled,
+    /** The verdict follows the account's current standing, and the app re-asks on
+     *  foreground, so a cached answer would outlive the session that earned it. */
+    fetchPolicy: "no-cache",
+  })
 
-  /** An empty list mid-fetch would read as a country nothing restricts, so the fetch is
-   *  part of the wait rather than a verdict of its own. */
-  const isSettled = !isRegionPending && remoteConfigReady
+  /** A self-custodial wallet has no Blink account behind it, so no server verdict covers
+   *  it and it keeps its own lists. */
+  const selfCustodialBlockedCountries: BlockedCountries = {
+    dollarBalance: selfCustodialDollarBalanceBlockedCountries,
+    transfer: selfCustodialTransferBlockedCountries,
+  }
 
-  return { ...toRestrictions(countryCode, blockedCountries), isSettled }
+  if (isSelfCustodial) {
+    /** An empty list mid-fetch would read as a country nothing restricts, so the fetch is
+     *  part of the wait rather than a verdict of its own. */
+    return {
+      ...toRestrictions(countryCode, selfCustodialBlockedCountries),
+      isSettled: !isRegionPending && remoteConfigReady,
+    }
+  }
+
+  /** A session with no Blink account has no custodial verdict to receive, so nothing is
+   *  gated. It only settles once the registry has named the account, since until then
+   *  this reads as custodial-unauthed whatever the account really is. */
+  if (!isQueryEnabled) return { ...UNRESTRICTED, isSettled: !isRegistryHydrating }
+
+  /** Held rather than judged while the answer is in flight: the surfaces read
+   *  `isRegionPending` and wait, so this value is never shown. */
+  if (isQueryLoading) return { ...UNRESTRICTED, isSettled: false }
+
+  const restrictions = data?.custodialRestrictions ?? RESTRICTED_UNKNOWN_REGION
+
+  return {
+    dollarBalance: restrictions.dollarBalance,
+    transfer: restrictions.transfer,
+    isSettled: true,
+  }
 }

--- a/app/hooks/use-account-restrictions.ts
+++ b/app/hooks/use-account-restrictions.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react"
+
 import { CountryCode } from "libphonenumber-js/mobile"
 
 import { gql } from "@apollo/client"
@@ -54,6 +56,12 @@ const RESTRICTED_UNKNOWN_REGION: Restrictions = Object.freeze({
   dollarBalance: true,
   transfer: true,
 })
+
+/** A request that never arrived carries no verdict, but FAIL_CLOSED still has to govern
+ *  once asking has genuinely stopped working, so the retries are bounded rather than
+ *  endless. Backed off so a server that is down is not hammered by every mounted consumer. */
+const RESTRICTION_RETRY_LIMIT = 3
+const RESTRICTION_RETRY_BASE_DELAY_MS = 1000
 
 /**
  * Pure so the policy can be read without a render, and so both custody types answer to the
@@ -140,12 +148,43 @@ export const useAccountRestrictions = (
    * sources. It speaks only for a Blink account, so a session without one asks nothing.
    */
   const isQueryEnabled = !isSelfCustodial && isAuthed
-  const { data, loading: isQueryLoading } = useCustodialRestrictionsQuery({
+  const {
+    data,
+    loading: isQueryLoading,
+    error: queryError,
+    refetch,
+  } = useCustodialRestrictionsQuery({
     skip: !isQueryEnabled,
     /** The verdict follows the account's current standing, and the app re-asks on
      *  foreground, so a cached answer would outlive the session that earned it. */
     fetchPolicy: "no-cache",
   })
+
+  const [retryCount, setRetryCount] = useState(0)
+  const hasRetriesLeft = retryCount < RESTRICTION_RETRY_LIMIT
+
+  /**
+   * A dropped request and a served "no verdict" are not the same answer, and only the
+   * second one is the server speaking. Nothing else re-issues this query inside a session
+   * (`no-cache` leaves nothing to re-read, and the only refetch is on foreground), so
+   * without this a single lost request would hold its failure until the user backgrounded
+   * the app and came back.
+   */
+  useEffect(() => {
+    if (!queryError) {
+      setRetryCount(0)
+      return undefined
+    }
+    if (!hasRetriesLeft) return undefined
+    const timer = setTimeout(
+      () => {
+        setRetryCount((count) => count + 1)
+        refetch().catch(() => undefined)
+      },
+      RESTRICTION_RETRY_BASE_DELAY_MS * 2 ** retryCount,
+    )
+    return () => clearTimeout(timer)
+  }, [queryError, hasRetriesLeft, retryCount, refetch])
 
   /** A self-custodial wallet has no Blink account behind it, so no server verdict covers
    *  it and it keeps its own lists. */
@@ -171,6 +210,12 @@ export const useAccountRestrictions = (
   /** Held rather than judged while the answer is in flight: the surfaces read
    *  `isRegionPending` and wait, so this value is never shown. */
   if (isQueryLoading) return { ...UNRESTRICTED, isSettled: false }
+
+  /** Still being asked, so still unanswered: the surfaces wait exactly as they do for a
+   *  slow reply rather than being told the region is unknown. FAIL_CLOSED applies below,
+   *  once the retries are spent and asking has stopped working. */
+  const isRetryPending = Boolean(queryError) && hasRetriesLeft
+  if (isRetryPending) return { ...UNRESTRICTED, isSettled: false }
 
   const restrictions = data?.custodialRestrictions ?? RESTRICTED_UNKNOWN_REGION
 

--- a/app/hooks/use-creation-block.ts
+++ b/app/hooks/use-creation-block.ts
@@ -1,15 +1,13 @@
 import { useCallback, useState } from "react"
 
-import { useApolloClient } from "@apollo/client"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
-import { updateCountryCode } from "@app/graphql/client-only-query"
 import { CreationBlockReason } from "@app/types/account"
 import { decideCustodialEligibility } from "@app/utils/custodial-eligibility"
-import { resolveIpCountryCodeCached } from "@app/utils/ip-country-lookup"
 
 import { AccountOption } from "./use-account-type-options"
 import { useAccountRegistry } from "./use-account-registry"
 import { isBlockedCountry } from "./use-device-location"
+import { useRegionCheckLazy } from "./use-region-check"
 
 type CreationBlock = {
   checkBlockReason: (option: AccountOption) => Promise<CreationBlockReason | null>
@@ -27,49 +25,39 @@ type CreationBlock = {
  */
 export const useCreationBlock = (): CreationBlock => {
   const { accounts, loading: isRegistryHydrating } = useAccountRegistry()
-  const {
-    custodialCreationBlockedCountries,
-    selfCustodialCreationBlockedCountries,
-    custodialFirstSignupBlockedCountries,
-  } = useRemoteConfig()
-  const client = useApolloClient()
+  const { selfCustodialCreationBlockedCountries, custodialFirstSignupBlockedCountries } =
+    useRemoteConfig()
   const [isResolving, setIsResolving] = useState(false)
-
   /**
-   * The connection alone, matching the `regionCheck` query this will hand over to: an
-   * account being created has no phone of its own, and borrowing another account's would
-   * make the verdict depend on which one happens to be open. There is no local fallback
-   * either, since the country-code cache answers "SV" for an unset value and would turn
-   * "could not resolve" into a country nobody read.
+   * Asked for on submit, never subscribed to: browsing the creation screens locates nobody.
+   * The custodial verdict is the server's to give, and a self-custodial wallet has no Blink
+   * account behind it, so its own list answers for it.
    */
-  const resolveCountry = useCallback(async (): Promise<string | undefined> => {
-    const resolved = await resolveIpCountryCodeCached()
-    if (!resolved) return undefined
-
-    updateCountryCode(client, resolved)
-    return resolved.toUpperCase()
-  }, [client])
+  const resolveRegionCheck = useRegionCheckLazy()
 
   const checkBlockReason = useCallback(
     async (option: AccountOption): Promise<CreationBlockReason | null> => {
       setIsResolving(true)
       try {
-        const country = await resolveCountry()
-        if (country === undefined) return CreationBlockReason.UnknownRegion
+        const { countryCode, custodialCreationAllowed } = await resolveRegionCheck()
+        if (countryCode === undefined) return CreationBlockReason.UnknownRegion
 
-        const blockedCountriesByOption: Record<AccountOption, string[]> = {
-          [AccountOption.Custodial]: custodialCreationBlockedCountries,
-          [AccountOption.SelfCustodial]: selfCustodialCreationBlockedCountries,
+        /** Exhaustive on purpose: a third option fails to compile until it declares who
+         *  answers for it, rather than silently inheriting another type's rule. */
+        const isOptionAllowedByRegion: Record<AccountOption, boolean> = {
+          [AccountOption.Custodial]: custodialCreationAllowed,
+          [AccountOption.SelfCustodial]: !isBlockedCountry(
+            countryCode,
+            selfCustodialCreationBlockedCountries,
+          ),
         }
-        if (isBlockedCountry(country, blockedCountriesByOption[option])) {
-          return CreationBlockReason.Region
-        }
+        if (!isOptionAllowedByRegion[option]) return CreationBlockReason.Region
 
         /** Only Blink accounts answer to this rule; a self-custodial wallet is the user's own. */
         if (option !== AccountOption.Custodial) return null
 
         const isSignupAllowed = decideCustodialEligibility({
-          country,
+          country: countryCode,
           accountCount: accounts.length,
           custodialFirstSignupBlockedCountries,
         })
@@ -81,8 +69,7 @@ export const useCreationBlock = (): CreationBlock => {
     },
     [
       accounts.length,
-      resolveCountry,
-      custodialCreationBlockedCountries,
+      resolveRegionCheck,
       selfCustodialCreationBlockedCountries,
       custodialFirstSignupBlockedCountries,
     ],

--- a/app/hooks/use-device-location.ts
+++ b/app/hooks/use-device-location.ts
@@ -215,7 +215,11 @@ export const useIpCountryLookup = (enabled: boolean): IpCountryLookup => {
     setHasLookupFinished(false)
     resolveIpCountryCodeCached().then((code) => {
       if (!active) return
-      if (code) setIpCountryCode(code)
+      /** Written even when the lookup comes back empty. A re-lookup that fails has to report
+       *  unresolved: holding the previous answer would settle this session on the country the
+       *  last connection resolved, which is the cross-session latch the generation exists to
+       *  drop. */
+      setIpCountryCode(code)
       setHasLookupFinished(true)
     })
     return () => {

--- a/app/hooks/use-device-location.ts
+++ b/app/hooks/use-device-location.ts
@@ -1,10 +1,14 @@
 import { CountryCode, parsePhoneNumber } from "libphonenumber-js/mobile"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react"
 
 import { useApolloClient } from "@apollo/client"
 import { updateCountryCode } from "@app/graphql/client-only-query"
 import { useCountryCodeQuery, useSettingsScreenQuery } from "@app/graphql/generated"
-import { resolveIpCountryCodeCached } from "@app/utils/ip-country-lookup"
+import {
+  getIpCountryLookupGeneration,
+  resolveIpCountryCodeCached,
+  subscribeToIpCountryLookup,
+} from "@app/utils/ip-country-lookup"
 import { logError } from "@app/utils/log-error"
 
 import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
@@ -60,6 +64,13 @@ const useDeviceLocation = ({
   const [countryCode, setCountryCode] = useState<CountryCode | undefined>()
   const [detectionFailed, setDetectionFailed] = useState(false)
   const [source, setSource] = useState<LocationSource | undefined>()
+
+  /** Re-read at each session start so the IP branch resolves against the connection the
+   *  session actually runs on, rather than the one the screen mounted under. */
+  const lookupGeneration = useSyncExternalStore(
+    subscribeToIpCountryLookup,
+    getIpCountryLookupGeneration,
+  )
 
   const userPhone = settingsData?.me?.phone
 
@@ -144,7 +155,7 @@ const useDeviceLocation = ({
     return () => {
       active = false
     }
-  }, [isDetectionBlocked, data, client, userPhone])
+  }, [isDetectionBlocked, data, client, userPhone, lookupGeneration])
 
   if (isDetectionBlocked) return NO_LOCATION
 
@@ -187,6 +198,13 @@ export const useIpCountryLookup = (enabled: boolean): IpCountryLookup => {
   const [ipCountryCode, setIpCountryCode] = useState<CountryCode | undefined>()
   const [hasLookupFinished, setHasLookupFinished] = useState(false)
 
+  /** A session start drops the shared lookup; re-reading the generation here is what makes
+   *  an already-mounted consumer resolve again rather than keep last session's country. */
+  const lookupGeneration = useSyncExternalStore(
+    subscribeToIpCountryLookup,
+    getIpCountryLookupGeneration,
+  )
+
   useEffect(() => {
     if (!isLookupEnabled) {
       setIpCountryCode(undefined)
@@ -194,6 +212,7 @@ export const useIpCountryLookup = (enabled: boolean): IpCountryLookup => {
       return undefined
     }
     let active = true
+    setHasLookupFinished(false)
     resolveIpCountryCodeCached().then((code) => {
       if (!active) return
       if (code) setIpCountryCode(code)
@@ -202,7 +221,7 @@ export const useIpCountryLookup = (enabled: boolean): IpCountryLookup => {
     return () => {
       active = false
     }
-  }, [isLookupEnabled])
+  }, [isLookupEnabled, lookupGeneration])
 
   const isLookupSettled = !isLookupEnabled || hasLookupFinished
 

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -1,70 +1,7 @@
-import { CountryCode } from "libphonenumber-js/mobile"
-
-import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { AccountType } from "@app/types/wallet"
 
-import useDeviceLocation, {
-  isBlockedCountry,
-  useIpCountryLookup,
-} from "./use-device-location"
-import { useActiveWallet } from "./use-active-wallet"
+import { useAccountRestrictions } from "./use-account-restrictions"
 import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
-
-/**
- * Gating on accountType (not isSelfCustodial) keeps the restriction stable through the
- * self-custodial cold-start window while the SDK connects; passing `accountTypeOverride`
- * evaluates a specific account type's block-list (e.g. predicting the self-custodial
- * dollar restriction from the still-custodial session during migration).
- */
-const useDollarBalanceBlockedCountries = (
-  accountTypeOverride?: AccountType,
-): string[] => {
-  const { accountType: activeAccountType } = useActiveWallet()
-  const accountType = accountTypeOverride ?? activeAccountType
-  const {
-    custodialDollarBalanceBlockedCountries,
-    selfCustodialDollarBalanceBlockedCountries,
-  } = useRemoteConfig()
-
-  return accountType === AccountType.SelfCustodial
-    ? selfCustodialDollarBalanceBlockedCountries
-    : custodialDollarBalanceBlockedCountries
-}
-
-type RestrictionRegion = {
-  countryCode: CountryCode | undefined
-  isPending: boolean
-}
-
-/**
- * The country whose block-list decides the restriction. A self-custodial account has no
- * phone, so evaluating its policy resolves by IP; every other case reads the device's own
- * country. The IP wins whenever it resolves, but while predicting the self-custodial policy
- * from a still-custodial session an unreachable IP falls back to the session country, so a
- * failed IP lookup does not read as unrestricted and preview a dollar balance the account
- * cannot hold. A country that already resolved settles the region even while the device
- * location keeps loading, since the prediction's IP lookup can land first. The prediction
- * also holds until the IP lookup settles, or a fast phone parse would report
- * settled-unrestricted and then flip once the IP lands.
- */
-const useRestrictionRegion = (accountTypeOverride?: AccountType): RestrictionRegion => {
-  const { countryCode: deviceCountryCode, loading: isDeviceLocationLoading } =
-    useDeviceLocation()
-
-  const isSelfCustodialPrediction = accountTypeOverride === AccountType.SelfCustodial
-  const { countryCode: ipCountryCode, isSettled: isIpLookupSettled } = useIpCountryLookup(
-    isSelfCustodialPrediction,
-  )
-
-  const countryCode = isSelfCustodialPrediction
-    ? ipCountryCode ?? deviceCountryCode
-    : deviceCountryCode
-
-  const isDeviceRegionPending = isDeviceLocationLoading && !countryCode
-  const isPredictedRegionPending = isSelfCustodialPrediction && !isIpLookupSettled
-
-  return { countryCode, isPending: isDeviceRegionPending || isPredictedRegionPending }
-}
 
 /** `isRestricted` needs a resolved country, so it never accuses an unrestricted user.
  *  Surfaces hold on `isRegionPending` instead of reading the unresolved region as
@@ -79,14 +16,9 @@ type DollarBalanceRestriction = {
 export const useDollarBalanceRestriction = (
   accountTypeOverride?: AccountType,
 ): DollarBalanceRestriction => {
-  const blockedCountries = useDollarBalanceBlockedCountries(accountTypeOverride)
-  const { countryCode, isPending: isRegionPending } =
-    useRestrictionRegion(accountTypeOverride)
+  const { dollarBalance, isSettled } = useAccountRestrictions(accountTypeOverride)
 
-  return {
-    isRestricted: isBlockedCountry(countryCode, blockedCountries),
-    isRegionPending,
-  }
+  return { isRestricted: dollarBalance, isRegionPending: !isSettled }
 }
 
 export const useDollarBalanceRestricted = (accountTypeOverride?: AccountType): boolean =>

--- a/app/hooks/use-region-check.ts
+++ b/app/hooks/use-region-check.ts
@@ -1,11 +1,25 @@
 import { useCallback } from "react"
 
-import { useApolloClient } from "@apollo/client"
-import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
+import { gql, useApolloClient } from "@apollo/client"
 import { updateCountryCode } from "@app/graphql/client-only-query"
-import { resolveIpCountryCodeCached } from "@app/utils/ip-country-lookup"
+import {
+  RegionCheckDocument,
+  RegionCheckQuery,
+  useRegionCheckQuery,
+} from "@app/graphql/generated"
+import { CountryCode } from "libphonenumber-js/mobile"
 
-import { isBlockedCountry, useIpCountryLookup } from "./use-device-location"
+import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
+
+gql`
+  query regionCheck {
+    regionCheck {
+      countryCode
+      custodialCreationAllowed
+      restricted
+    }
+  }
+`
 
 /**
  * The session's region verdict, shaped after the `regionCheck` query that will serve it.
@@ -37,46 +51,48 @@ const UNRESOLVED_VERDICT: RegionCheckVerdict = Object.freeze({
 })
 
 /**
- * One list answers both today, so a country closed to new accounts is also read as
- * sanctioned. The server separates them, and this shape already carries the two fields
- * that will hold the difference.
+ * The server separates "closed to new accounts" from "sanctioned", so the two fields are
+ * read as given rather than derived from one another. A verdict with no country is one the
+ * server could not resolve, which restricts nothing.
  */
 const toVerdict = (
-  resolvedCountry: string,
-  custodialCreationBlockedCountries: string[],
-): RegionCheckVerdict => {
-  /** Uppercased once here, so both access modes answer the same casing and the lists,
-   *  which are stored uppercase, are matched the same way. */
-  const countryCode = resolvedCountry.toUpperCase()
-  const isCountryBlocked = isBlockedCountry(
-    countryCode,
-    custodialCreationBlockedCountries,
-  )
+  regionCheck: RegionCheckQuery["regionCheck"] | undefined,
+): RegionCheckVerdict | undefined => {
+  if (!regionCheck) return undefined
 
   return {
-    countryCode,
-    custodialCreationAllowed: !isCountryBlocked,
-    restricted: isCountryBlocked,
+    /** Uppercased once here, so both access modes answer the same casing. */
+    countryCode: regionCheck.countryCode?.toUpperCase(),
+    custodialCreationAllowed: regionCheck.custodialCreationAllowed,
+    restricted: regionCheck.restricted,
   }
 }
 
 /**
  * Reading the region is the act of locating the user, so a caller with no reason to ask
- * passes false and nothing is resolved. Anon is the standing case.
+ * passes false and nothing is resolved. Anon is the standing case: it speaks for an account
+ * that exists and asked not to be located, so the query is never issued there.
  */
 export const useRegionCheck = (enabled: boolean): RegionCheck => {
-  const { custodialCreationBlockedCountries } = useRemoteConfig()
-  const { remoteConfigReady } = useFeatureFlags()
-  const { countryCode, isSettled: isLookupSettled } = useIpCountryLookup(enabled)
+  const { isAnonMode } = useSelfCustodialAccountMode()
+  const isQueryEnabled = enabled && !isAnonMode
 
-  const verdict = countryCode
-    ? toVerdict(countryCode, custodialCreationBlockedCountries)
-    : UNRESOLVED_VERDICT
+  const { data, loading } = useRegionCheckQuery({
+    skip: !isQueryEnabled,
+    /** The verdict follows the connection the request went out on, so a cached answer
+     *  could speak for a network the user has since left. */
+    fetchPolicy: "no-cache",
+  })
 
-  /** An empty list mid-fetch would read as a country nothing restricts, so the fetch is
-   *  part of the wait. A caller that asks nothing has no answer coming, so it never waits. */
-  const isVerdictSettled = isLookupSettled && remoteConfigReady
-  const isSettled = !enabled || isVerdictSettled
+  /** Read only while the query is live: a skip keeps Apollo's last data around, and
+   *  returning it would leak a verdict from before the caller stopped asking. */
+  const servedVerdict = isQueryEnabled ? toVerdict(data?.regionCheck) : undefined
+  const verdict = servedVerdict ?? UNRESOLVED_VERDICT
+
+  /** An unreachable server is not a verdict, so nothing is held against the user and the
+   *  wait ends: `regionCheck` shares an API with every other custodial feature, so there is
+   *  no service left to protect. A caller that asks nothing never waits at all. */
+  const isSettled = !isQueryEnabled || !loading
 
   return { ...verdict, isSettled }
 }
@@ -93,16 +109,24 @@ export const useRegionCheck = (enabled: boolean): RegionCheck => {
  * account being created, which has no mode of its own yet and cannot inherit another's.
  */
 export const useRegionCheckLazy = (): (() => Promise<RegionCheckVerdict>) => {
-  const { custodialCreationBlockedCountries } = useRemoteConfig()
   const client = useApolloClient()
 
   return useCallback(async () => {
-    const resolved = await resolveIpCountryCodeCached()
-    if (!resolved) return UNRESOLVED_VERDICT
+    /** An unreachable server leaves the region unread, which account creation refuses on
+     *  rather than guesses at: it is the one caller that must not proceed without one. */
+    const verdict = await client
+      .query<RegionCheckQuery>({
+        query: RegionCheckDocument,
+        fetchPolicy: "no-cache",
+      })
+      .then(({ data }) => toVerdict(data?.regionCheck))
+      .catch(() => undefined)
+
+    if (!verdict?.countryCode) return UNRESOLVED_VERDICT
 
     /** Shared with every other consumer of the country, so one read serves them all. */
-    updateCountryCode(client, resolved)
+    updateCountryCode(client, verdict.countryCode as CountryCode)
 
-    return toVerdict(resolved, custodialCreationBlockedCountries)
-  }, [client, custodialCreationBlockedCountries])
+    return verdict
+  }, [client])
 }

--- a/app/hooks/use-region-check.ts
+++ b/app/hooks/use-region-check.ts
@@ -1,0 +1,108 @@
+import { useCallback } from "react"
+
+import { useApolloClient } from "@apollo/client"
+import { useFeatureFlags, useRemoteConfig } from "@app/config/feature-flags-context"
+import { updateCountryCode } from "@app/graphql/client-only-query"
+import { resolveIpCountryCodeCached } from "@app/utils/ip-country-lookup"
+
+import { isBlockedCountry, useIpCountryLookup } from "./use-device-location"
+
+/**
+ * The session's region verdict, shaped after the `regionCheck` query that will serve it.
+ * Every field here is one the server answers, so adopting it later replaces this body
+ * rather than its callers.
+ *
+ * It speaks only for custodial rules, as that query does: it is resolved from the request
+ * IP with no account attached, so it cannot know an account type. A caller that also has a
+ * self-custodial rule keeps reading that one for itself.
+ */
+export type RegionCheckVerdict = {
+  /** Undefined until resolved, and in a session that resolves nothing. */
+  countryCode: string | undefined
+  custodialCreationAllowed: boolean
+  restricted: boolean
+}
+
+export type RegionCheck = RegionCheckVerdict & {
+  /** True once waiting is pointless: the verdict is in, or it will never be asked for. */
+  isSettled: boolean
+}
+
+/** Nothing was read, so nothing may be held against the user. The server answers the same
+ *  way when it cannot resolve a country. */
+const UNRESOLVED_VERDICT: RegionCheckVerdict = Object.freeze({
+  countryCode: undefined,
+  custodialCreationAllowed: true,
+  restricted: false,
+})
+
+/**
+ * One list answers both today, so a country closed to new accounts is also read as
+ * sanctioned. The server separates them, and this shape already carries the two fields
+ * that will hold the difference.
+ */
+const toVerdict = (
+  resolvedCountry: string,
+  custodialCreationBlockedCountries: string[],
+): RegionCheckVerdict => {
+  /** Uppercased once here, so both access modes answer the same casing and the lists,
+   *  which are stored uppercase, are matched the same way. */
+  const countryCode = resolvedCountry.toUpperCase()
+  const isCountryBlocked = isBlockedCountry(
+    countryCode,
+    custodialCreationBlockedCountries,
+  )
+
+  return {
+    countryCode,
+    custodialCreationAllowed: !isCountryBlocked,
+    restricted: isCountryBlocked,
+  }
+}
+
+/**
+ * Reading the region is the act of locating the user, so a caller with no reason to ask
+ * passes false and nothing is resolved. Anon is the standing case.
+ */
+export const useRegionCheck = (enabled: boolean): RegionCheck => {
+  const { custodialCreationBlockedCountries } = useRemoteConfig()
+  const { remoteConfigReady } = useFeatureFlags()
+  const { countryCode, isSettled: isLookupSettled } = useIpCountryLookup(enabled)
+
+  const verdict = countryCode
+    ? toVerdict(countryCode, custodialCreationBlockedCountries)
+    : UNRESOLVED_VERDICT
+
+  /** An empty list mid-fetch would read as a country nothing restricts, so the fetch is
+   *  part of the wait. A caller that asks nothing has no answer coming, so it never waits. */
+  const isVerdictSettled = isLookupSettled && remoteConfigReady
+  const isSettled = !enabled || isVerdictSettled
+
+  return { ...verdict, isSettled }
+}
+
+/**
+ * The same verdict asked for on demand rather than subscribed to, for a caller that must
+ * not locate anyone until the user acts. Account creation is the case: the screens it
+ * spans read nothing until an option is submitted.
+ *
+ * The split mirrors the query's own two access modes, so each caller keeps the one it has.
+ *
+ * One difference is deliberate: the subscribed mode withholds the lookup in Anon, since it
+ * speaks for an account that exists and asked not to be located. This one speaks for an
+ * account being created, which has no mode of its own yet and cannot inherit another's.
+ */
+export const useRegionCheckLazy = (): (() => Promise<RegionCheckVerdict>) => {
+  const { custodialCreationBlockedCountries } = useRemoteConfig()
+  const client = useApolloClient()
+
+  return useCallback(async () => {
+    const resolved = await resolveIpCountryCodeCached()
+    if (!resolved) return UNRESOLVED_VERDICT
+
+    /** Shared with every other consumer of the country, so one read serves them all. */
+    updateCountryCode(client, resolved)
+
+    return toVerdict(resolved, custodialCreationBlockedCountries)
+  }, [client, custodialCreationBlockedCountries])
+}

--- a/app/hooks/use-transfer-blocked.ts
+++ b/app/hooks/use-transfer-blocked.ts
@@ -1,20 +1,5 @@
-import { useRemoteConfig } from "@app/config/feature-flags-context"
-import { AccountType } from "@app/types/wallet"
-
-import useDeviceLocation, { isBlockedCountry } from "./use-device-location"
-import { useActiveWallet } from "./use-active-wallet"
+import { useAccountRestrictions } from "./use-account-restrictions"
 import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
-
-/** Gating on accountType (not isSelfCustodial) stays stable through the self-custodial cold-start. */
-const useTransferBlockedCountries = (): string[] => {
-  const { accountType } = useActiveWallet()
-  const { custodialTransferBlockedCountries, selfCustodialTransferBlockedCountries } =
-    useRemoteConfig()
-
-  return accountType === AccountType.SelfCustodial
-    ? selfCustodialTransferBlockedCountries
-    : custodialTransferBlockedCountries
-}
 
 /** `isGated` needs a resolved country, so it never ejects an allowed user. Surfaces hold
  *  on `isRegionPending` instead of reading the unresolved region as allowed, which is what
@@ -29,13 +14,9 @@ type TransferGate = {
  *  surfaces and guards read this, the sole public gate. */
 export const useTransferGate = (): TransferGate => {
   const { isAnonMode } = useSelfCustodialAccountMode()
-  const blockedCountries = useTransferBlockedCountries()
-  const { countryCode, loading: isRegionPending } = useDeviceLocation()
+  const { transfer, isSettled } = useAccountRestrictions()
 
-  return {
-    isGated: isAnonMode || isBlockedCountry(countryCode, blockedCountries),
-    isRegionPending,
-  }
+  return { isGated: isAnonMode || transfer, isRegionPending: !isSettled }
 }
 
 export const useTransferGated = (): boolean => useTransferGate().isGated

--- a/app/navigation/app-state.tsx
+++ b/app/navigation/app-state.tsx
@@ -6,11 +6,17 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 
 import { useApolloClient } from "@apollo/client"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
-import { HomeAuthedDocument } from "@app/graphql/generated"
+import {
+  CustodialRestrictionsDocument,
+  HomeAuthedDocument,
+  RegionCheckDocument,
+} from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
+import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
 import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { logEnterBackground, logEnterForeground } from "@app/utils/analytics"
+import { resetIpCountryLookup } from "@app/utils/ip-country-lookup"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 const MILLISECONDS_PER_SECOND = 1000
@@ -22,6 +28,7 @@ export const AppStateWrapper: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const { isAppLocked, setAppLocked } = useAuthenticationContext()
   const { appLockGracePeriodSeconds } = useRemoteConfig()
+  const { isAnonMode } = useSelfCustodialAccountMode()
 
   /** When the app left the foreground, or null while it has not. A ref rather than state
    *  because nothing renders from it, and losing it to a killed process is harmless: that
@@ -88,7 +95,24 @@ export const AppStateWrapper: React.FC = () => {
         nextAppState === "background"
 
       if (isEnteringForeground) {
-        isAuthed && client.refetchQueries({ include: [HomeAuthedDocument] })
+        /** Sanctions ride the live connection and are evaluated at every session start,
+         *  so the verdict is re-asked for on return rather than kept from wherever the
+         *  session was backgrounded. It carries no account, so it runs unauthed too.
+         *
+         *  Anon is excluded here rather than left to the query's own `skip`: Apollo parks
+         *  a skipped query in `standby` and would not refetch it, but the promise that an
+         *  Anon account is never located must not rest on that. */
+        isAnonMode || client.refetchQueries({ include: [RegionCheckDocument] })
+
+        /** The self-custodial half still resolves its own country, and its shared lookup
+         *  outlives a session unless dropped here: without this the region a user
+         *  launched on would govern until they killed the app, which is the latch this
+         *  work exists to remove. */
+        resetIpCountryLookup()
+        isAuthed &&
+          client.refetchQueries({
+            include: [HomeAuthedDocument, CustodialRestrictionsDocument],
+          })
 
         console.info("App has come to the foreground!")
         logEnterForeground()
@@ -101,7 +125,7 @@ export const AppStateWrapper: React.FC = () => {
         logEnterBackground()
       }
     },
-    [client, isAuthed, relockIfGracePeriodExpired],
+    [client, isAuthed, isAnonMode, relockIfGracePeriodExpired],
   )
 
   useEffect(() => {

--- a/app/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.ts
+++ b/app/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.ts
@@ -26,6 +26,8 @@ import {
   StorageReadStatus,
 } from "@app/self-custodial/storage/account-index"
 import { usePersistentStateContext } from "@app/store/persistent-state"
+import { withSelfCustodialModeFromServer } from "@app/store/persistent-state/self-custodial-server-account-mode"
+import { AccountMode } from "@app/types/account"
 import { reportError } from "@app/utils/error-logging"
 import { normalizeMnemonic } from "@app/utils/mnemonic"
 import { toastShow } from "@app/utils/toast"
@@ -59,6 +61,17 @@ export const useRestoreWallet = () => {
     [updateState],
   )
 
+  /** A restored account takes its mode from the server, never from a fresh question: it
+   *  was chosen on a device this one may never have been. */
+  const adoptServerMode = useCallback(
+    (accountId: string, serverMode: AccountMode | null) => {
+      updateState(
+        (prev) => prev && withSelfCustodialModeFromServer(prev, accountId, serverMode),
+      )
+    },
+    [updateState],
+  )
+
   const restore = useCallback(
     async (mnemonic: string) => {
       await guard.run(async () => {
@@ -75,21 +88,18 @@ export const useRestoreWallet = () => {
           const lookup = await findSelfCustodialAccountByMnemonic(normalized)
           if (lookup.status === StorageReadStatus.ReadFailed) throw lookup.error
 
+          /** Already on this device, so its mode is already stored: re-entering the
+           *  phrase is not a new answer about how the account should behave. */
           if (lookup.id) {
             activateAccount(lookup.id)
             reinitSdk()
             logSelfCustodialRestoreCompleted()
-            navigation.navigate("selfCustodialChooseExperience", {
-              onContinue: {
-                route: ChooseExperienceContinueRoute.BackupSuccess,
-                accountId: lookup.id,
-              },
-            })
+            navigation.navigate("selfCustodialBackupSuccess")
             return
           }
 
           const accountId = Crypto.randomUUID()
-          await selfCustodialRestoreWallet({
+          const { serverMode, isServerModeKnown } = await selfCustodialRestoreWallet({
             accountId,
             mnemonic: normalized,
             network,
@@ -101,9 +111,21 @@ export const useRestoreWallet = () => {
           activateAccount(accountId)
           reinitSdk()
           logSelfCustodialRestoreCompleted()
-          navigation.navigate("selfCustodialChooseExperience", {
-            onContinue: { route: ChooseExperienceContinueRoute.BackupSuccess, accountId },
-          })
+
+          /** Only an unanswered server leaves the question open. Assuming a default here
+           *  would push it back and overwrite whatever the account really holds. */
+          if (!isServerModeKnown) {
+            navigation.navigate("selfCustodialChooseExperience", {
+              onContinue: {
+                route: ChooseExperienceContinueRoute.BackupSuccess,
+                accountId,
+              },
+            })
+            return
+          }
+
+          adoptServerMode(accountId, serverMode)
+          navigation.navigate("selfCustodialBackupSuccess")
         } catch (err) {
           reportError("Wallet restore", err)
           setStatus(RestoreWalletStatus.Error)
@@ -115,6 +137,7 @@ export const useRestoreWallet = () => {
     [
       guard,
       activateAccount,
+      adoptServerMode,
       reinitSdk,
       reloadSelfCustodialAccounts,
       navigation,

--- a/app/self-custodial/bridge/lifecycle.ts
+++ b/app/self-custodial/bridge/lifecycle.ts
@@ -11,12 +11,14 @@ import {
 import { generateMnemonic, validateMnemonic } from "bip39"
 import Crypto from "react-native-quick-crypto"
 
+import { AccountMode } from "@app/types/account"
 import { reportError } from "@app/utils/error-logging"
 import { normalizeMnemonic } from "@app/utils/mnemonic"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 import {
   lnurlDomainFor,
+  lnurlServerUrlFor,
   MAX_SLIPPAGE_BPS,
   networkLabelFor,
   requireBreezApiKey,
@@ -24,6 +26,7 @@ import {
   SparkToken,
   storageDirFor,
 } from "../config"
+import { recoverLnurlServerMode } from "../lnurl-server-mode"
 import { createSdkLogListener } from "../logging"
 import { addSelfCustodialAccountId } from "../storage/account-index"
 
@@ -133,12 +136,22 @@ type RestoreWalletParams = {
   leewaySatPerVbyte: number
 }
 
+type RestoredWallet = {
+  /** The mode the LNURL server holds for this wallet, or null when it holds none. Read
+   *  here because this is the one moment the wallet is connected and able to sign. */
+  serverMode: AccountMode | null
+  /** False when the server could not be asked at all, which is not the same as it
+   *  answering "none": a stored Anon may be sitting behind an unanswered request, and
+   *  assuming Enhanced would push it away. */
+  isServerModeKnown: boolean
+}
+
 export const selfCustodialRestoreWallet = async ({
   accountId,
   mnemonic,
   network,
   leewaySatPerVbyte,
-}: RestoreWalletParams): Promise<void> => {
+}: RestoreWalletParams): Promise<RestoredWallet> => {
   const normalized = normalizeMnemonic(mnemonic)
   if (!validateMnemonic(normalized)) {
     throw new Error("Invalid BIP39 mnemonic")
@@ -159,8 +172,19 @@ export const selfCustodialRestoreWallet = async ({
       network,
       leewaySatPerVbyte,
     })
+    /** An unreachable server must not fail the restore: the wallet itself is whole. */
+    const recovered = await recoverLnurlServerMode({
+      sdk,
+      serverUrl: lnurlServerUrlFor(network),
+    })
+      .then((serverMode) => ({ serverMode, isServerModeKnown: true }))
+      .catch((err) => {
+        reportError("Wallet restore mode recovery", err)
+        return { serverMode: null, isServerModeKnown: false }
+      })
     await disconnectSdk(sdk)
     await addSelfCustodialAccountId(accountId)
+    return recovered
   } catch (err) {
     await KeyStoreWrapper.deleteMnemonicForAccount(accountId)
     reportError("Wallet restore", err)

--- a/app/self-custodial/components/account-mode-sync-mount.tsx
+++ b/app/self-custodial/components/account-mode-sync-mount.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+
+import { useAccountModeSync } from "../hooks/use-account-mode-sync"
+
+/**
+ * Root-level host: the push often becomes possible long after the mode was chosen, once
+ * the SDK connects or the network returns, and no single screen is up for that.
+ */
+export const AccountModeSyncMount: React.FC = () => {
+  useAccountModeSync()
+  return null
+}

--- a/app/self-custodial/components/index.ts
+++ b/app/self-custodial/components/index.ts
@@ -1,3 +1,4 @@
+export { AccountModeSyncMount } from "./account-mode-sync-mount"
 export { AutoConvertListenerMount } from "./auto-convert-listener-mount"
 export { OfflineGate } from "./offline-gate"
 export { PaymentOfflineNotice } from "./payment-offline-notice"

--- a/app/self-custodial/config.ts
+++ b/app/self-custodial/config.ts
@@ -40,6 +40,14 @@ export const lnurlDomainFor = (network: Network): string =>
   network === Network.Mainnet ? MAINNET_LNURL_DOMAIN : REGTEST_LNURL_DOMAIN
 
 /**
+ * Base URL of the LNURL server for a self-custodial account: the same host its address is
+ * spelled with, which is what serves the authenticated `/lnurlpay/{pubkey}` routes. Not
+ * the custodial `lnAddressHostname` — `pay.*` fronts the payment app and 404s them.
+ */
+export const lnurlServerUrlFor = (network: Network): string =>
+  `https://${lnurlDomainFor(network)}`
+
+/**
  * Returns the wallet's stored network label when it conflicts with the current
  * network, or null when there is no stored label or it matches. Single source
  * of the mismatch rule shared by the SDK connect gate and the mismatch toast.

--- a/app/self-custodial/hooks/use-account-mode-sync.ts
+++ b/app/self-custodial/hooks/use-account-mode-sync.ts
@@ -1,0 +1,71 @@
+import { useEffect } from "react"
+
+import { useSelfCustodialAccountMode } from "@app/self-custodial/hooks/use-self-custodial-account-mode"
+import { usePersistentStateContext } from "@app/store/persistent-state"
+import { resolveActiveSelfCustodialId } from "@app/store/persistent-state/active-self-custodial-account"
+import {
+  getSelfCustodialServerAccountMode,
+  withSelfCustodialModeFromServer,
+  withSelfCustodialServerAccountMode,
+} from "@app/store/persistent-state/self-custodial-server-account-mode"
+import { reportError } from "@app/utils/error-logging"
+
+import { lnurlServerUrlFor } from "../config"
+import { recoverLnurlServerMode, setLnurlServerMode } from "../lnurl-server-mode"
+import { useSelfCustodialWallet } from "../providers/wallet"
+
+import { useSparkNetwork } from "./use-spark-network"
+
+/**
+ * Keeps an account's mode and the LNURL server's copy of it in agreement, which is what
+ * activates or silences its Lightning Address.
+ *
+ * An account holding no mode is settled from the server before anything is pushed: the
+ * same wallet may already be Anon on another device, and assuming Enhanced would push
+ * that away. Only once a mode is known does a disagreement become a push.
+ *
+ * Both are driven off stored state rather than off the moment the user picks a mode: the
+ * choice is made on screens with no connected SDK to sign with, and a push that fails
+ * offline has to happen later anyway. What lands is recorded so the next launch stays
+ * quiet, since each Enhanced push costs the server a paid country lookup.
+ */
+export const useAccountModeSync = (): void => {
+  const { accountMode } = useSelfCustodialAccountMode()
+  const { persistentState, updateState } = usePersistentStateContext()
+  const { sdk } = useSelfCustodialWallet()
+  const lnurlServerUrl = lnurlServerUrlFor(useSparkNetwork())
+
+  const activeAccountId = resolveActiveSelfCustodialId(persistentState)
+  const serverMode = activeAccountId
+    ? getSelfCustodialServerAccountMode(persistentState, activeAccountId)
+    : null
+  const isPushDue = Boolean(accountMode) && accountMode !== serverMode
+  /** An account that has never held a mode, whatever the reason: created before the modes
+   *  existed, or provisioned on another device. */
+  const isResolveDue = Boolean(activeAccountId) && !accountMode
+
+  useEffect(() => {
+    if (!sdk || !isResolveDue || !activeAccountId) return
+    recoverLnurlServerMode({ sdk, serverUrl: lnurlServerUrl })
+      .then((recovered) => {
+        updateState(
+          (prev) =>
+            prev && withSelfCustodialModeFromServer(prev, activeAccountId, recovered),
+        )
+      })
+      .catch((err) => reportError("lnurl server mode resolve", err))
+  }, [sdk, isResolveDue, activeAccountId, lnurlServerUrl, updateState])
+
+  useEffect(() => {
+    if (!sdk || !isPushDue || !activeAccountId || !accountMode) return
+    setLnurlServerMode({ sdk, serverUrl: lnurlServerUrl, mode: accountMode })
+      .then(() => {
+        updateState(
+          (prev) =>
+            prev &&
+            withSelfCustodialServerAccountMode(prev, activeAccountId, accountMode),
+        )
+      })
+      .catch((err) => reportError("lnurl server mode sync", err))
+  }, [sdk, isPushDue, activeAccountId, accountMode, lnurlServerUrl, updateState])
+}

--- a/app/self-custodial/hooks/use-account-mode-sync.ts
+++ b/app/self-custodial/hooks/use-account-mode-sync.ts
@@ -32,17 +32,29 @@ import { useSparkNetwork } from "./use-spark-network"
 export const useAccountModeSync = (): void => {
   const { accountMode } = useSelfCustodialAccountMode()
   const { persistentState, updateState } = usePersistentStateContext()
-  const { sdk } = useSelfCustodialWallet()
+  const { sdk, connectedAccountId } = useSelfCustodialWallet()
   const lnurlServerUrl = lnurlServerUrlFor(useSparkNetwork())
 
   const activeAccountId = resolveActiveSelfCustodialId(persistentState)
   const serverMode = activeAccountId
     ? getSelfCustodialServerAccountMode(persistentState, activeAccountId)
     : null
-  const isPushDue = Boolean(accountMode) && accountMode !== serverMode
+  /**
+   * The SDK signs as whichever account it connected for, while the mode and the record are
+   * read from persistent state. Those two disagree for a commit on every account switch,
+   * since the provider's teardown runs after this hook's effects: acting then would sign as
+   * the previous account, push its Lightning Address away, and file the confirmation under
+   * the new one, which would then never be pushed at all. Neither effect is due until the
+   * connection and the active account are the same account.
+   */
+  const isSdkOnActiveAccount =
+    Boolean(activeAccountId) && connectedAccountId === activeAccountId
+
+  const isPushDue =
+    isSdkOnActiveAccount && Boolean(accountMode) && accountMode !== serverMode
   /** An account that has never held a mode, whatever the reason: created before the modes
    *  existed, or provisioned on another device. */
-  const isResolveDue = Boolean(activeAccountId) && !accountMode
+  const isResolveDue = isSdkOnActiveAccount && !accountMode
 
   useEffect(() => {
     if (!sdk || !isResolveDue || !activeAccountId) return

--- a/app/self-custodial/lnurl-server-mode.ts
+++ b/app/self-custodial/lnurl-server-mode.ts
@@ -1,0 +1,113 @@
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
+import { AccountMode } from "@app/types/account"
+
+import { getWalletInfo } from "./bridge/wallet"
+
+/** The server refuses a request whose timestamp is further than this from its own clock,
+ *  so a stalled request is dropped rather than sent to be rejected. */
+const MODE_REQUEST_TIMEOUT_MS = 15_000
+
+/** The server answers this when it holds no account for the pubkey at all. */
+const NOT_FOUND_STATUS = 404
+
+type LnurlServerRequestArgs = {
+  sdk: BreezSdkInterface
+  serverUrl: string
+}
+
+type SetLnurlServerModeArgs = LnurlServerRequestArgs & {
+  mode: AccountMode
+}
+
+/**
+ * Tells the LNURL server which region posture an account holds. Enhanced is what lets the
+ * server mint invoices for the account's Lightning Address and record the country it saw;
+ * Anon stops both, which is how the address goes dormant without the username being given
+ * up. The address is therefore never registered or deleted from here: the mode alone
+ * decides whether it answers, so a switch cannot cost the user their name.
+ *
+ * Authorization is the signature and nothing else, so the pubkey in the path is the one
+ * the wallet signed with. `mode:` domain-separates the message from the register and
+ * transfer signatures, which the server verifies against the same key.
+ */
+export const setLnurlServerMode = async ({
+  sdk,
+  serverUrl,
+  mode,
+}: SetLnurlServerModeArgs): Promise<void> => {
+  const { identityPubkey } = await getWalletInfo(sdk)
+  /** The server's anti-rollback anchor: it stores this verbatim and refuses anything not
+   *  strictly newer, so it is read as late as possible. */
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  /** DER, not compact: the server parses the signature in DER. */
+  const { signature } = await sdk.signMessage({
+    message: `mode:${mode}:${identityPubkey}-${timestamp}`,
+    compact: false,
+  })
+
+  const response = await postSigned(`${serverUrl}/lnurlpay/${identityPubkey}/mode`, {
+    mode,
+    signature,
+    timestamp,
+  })
+
+  if (!response.ok) {
+    throw new Error(`LNURL server refused mode '${mode}' with ${response.status}`)
+  }
+}
+
+/**
+ * Reads back the mode the server holds, which is what a restored wallet has instead of an
+ * answer from the user: the mode was chosen on a device this one may never have been.
+ *
+ * Null means no mode is held — the server was never told, or has never heard of the
+ * wallet. Both leave the caller nothing to honor. A refusal throws instead, so "could not
+ * ask" stays distinguishable from "holds none".
+ */
+export const recoverLnurlServerMode = async ({
+  sdk,
+  serverUrl,
+}: LnurlServerRequestArgs): Promise<AccountMode | null> => {
+  const { identityPubkey } = await getWalletInfo(sdk)
+  const timestamp = Math.floor(Date.now() / 1000)
+
+  /** No `mode:` prefix: recover signs the bare pubkey, like register and unregister. */
+  const { signature } = await sdk.signMessage({
+    message: `${identityPubkey}-${timestamp}`,
+    compact: false,
+  })
+
+  const response = await postSigned(`${serverUrl}/lnurlpay/${identityPubkey}/recover`, {
+    signature,
+    timestamp,
+  })
+
+  if (response.status === NOT_FOUND_STATUS) return null
+  if (!response.ok) {
+    throw new Error(`LNURL server refused recover with ${response.status}`)
+  }
+
+  const { mode } = (await response.json()) as { mode?: string | null }
+  return toAccountMode(mode)
+}
+
+/** Unknown values read as "no mode": a variant this app does not know cannot be honored,
+ *  and treating it as one of ours would misreport what the account holds. */
+const toAccountMode = (mode: string | null | undefined): AccountMode | null => {
+  if (mode === AccountMode.Enhanced) return AccountMode.Enhanced
+  if (mode === AccountMode.Anon) return AccountMode.Anon
+  return null
+}
+
+const postSigned = (url: string, body: unknown): Promise<Response> => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), MODE_REQUEST_TIMEOUT_MS)
+  return fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  }).finally(() => clearTimeout(timeout))
+}

--- a/app/self-custodial/providers/wallet.tsx
+++ b/app/self-custodial/providers/wallet.tsx
@@ -48,6 +48,11 @@ type SelfCustodialWalletContextValue = ActiveWalletState & {
   allTransactions: NormalizedTransaction[]
   retry: () => void
   sdk: BreezSdkInterface | null
+  /** The account the connected `sdk` belongs to, which is not always the active one: the
+   *  provider's teardown runs after its descendants' effects, so on the commit where the
+   *  user switches accounts a consumer sees the new active id beside the old connection.
+   *  Anything that signs with the SDK and records the result elsewhere has to compare. */
+  connectedAccountId: string | null
   lightningAddress: string | null
   isStableBalanceActive?: boolean
   lastReceivedPaymentId: string | null
@@ -68,6 +73,7 @@ const defaultState: SelfCustodialWalletContextValue = {
   accountType: AccountType.SelfCustodial,
   retry: () => {},
   sdk: null,
+  connectedAccountId: null,
   lightningAddress: null,
   lastReceivedPaymentId: null,
   hasMoreTransactions: false,
@@ -166,6 +172,7 @@ export const SelfCustodialWalletProvider: React.FC<React.PropsWithChildren> = ({
       accountType: AccountType.SelfCustodial,
       retry,
       sdk,
+      connectedAccountId,
       lightningAddress,
       isStableBalanceActive,
       lastReceivedPaymentId,
@@ -182,6 +189,7 @@ export const SelfCustodialWalletProvider: React.FC<React.PropsWithChildren> = ({
       status,
       retry,
       sdk,
+      connectedAccountId,
       lightningAddress,
       isStableBalanceActive,
       lastReceivedPaymentId,

--- a/app/store/persistent-state/self-custodial-server-account-mode.ts
+++ b/app/store/persistent-state/self-custodial-server-account-mode.ts
@@ -1,0 +1,49 @@
+import { AccountMode } from "@app/types/account"
+
+import { withSelfCustodialAccountMode } from "./self-custodial-account-mode"
+import { PersistentState } from "./state-migrations"
+
+/**
+ * The mode the LNURL server last confirmed, kept beside the chosen mode rather than folded
+ * into it so a push that never landed stays visible as work still owed: the two
+ * disagreeing is the signal to push again.
+ */
+export const getSelfCustodialServerAccountMode = (
+  state: PersistentState,
+  accountId: string,
+): AccountMode | null =>
+  state.selfCustodialServerAccountModeByAccountId?.[accountId] ?? null
+
+export const withSelfCustodialServerAccountMode = (
+  state: PersistentState,
+  accountId: string,
+  mode: AccountMode,
+): PersistentState => ({
+  ...state,
+  selfCustodialServerAccountModeByAccountId: {
+    ...state.selfCustodialServerAccountModeByAccountId,
+    [accountId]: mode,
+  },
+})
+
+/**
+ * Settles an account's mode from what the server reported. A mode it holds is adopted and
+ * recorded as confirmed, so nothing is pushed back at it. No mode leaves the Enhanced
+ * default unconfirmed, which is what makes the sync push it.
+ *
+ * Only ever called with an answer the server actually gave: assuming one it never gave
+ * would push Enhanced over an Anon it holds but could not report.
+ */
+export const withSelfCustodialModeFromServer = (
+  state: PersistentState,
+  accountId: string,
+  serverMode: AccountMode | null,
+): PersistentState => {
+  const withMode = withSelfCustodialAccountMode(
+    state,
+    accountId,
+    serverMode ?? AccountMode.Enhanced,
+  )
+  if (!serverMode) return withMode
+  return withSelfCustodialServerAccountMode(withMode, accountId, serverMode)
+}

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -233,8 +233,42 @@ type PersistentState_19 = {
   stableBalanceAnonPausedByAccountId?: Record<string, boolean>
 }
 
-const migrate19ToCurrent = (state: PersistentState_19): Promise<PersistentState> =>
+type PersistentState_20 = {
+  schemaVersion: 20
+  galoyInstance: GaloyInstanceInput
+  galoyAuthToken: string
+  activeAccountId?: string
+  selfCustodialDefaultWalletCurrency?: "BTC" | "USD"
+  selfCustodialDefaultWalletCurrencyByAccountId?: Record<string, "BTC" | "USD">
+  selfCustodialDisplayCurrencyByAccountId?: Record<string, string>
+  selfCustodialLanguageByAccountId?: Record<string, string>
+  themeByAccountId?: Record<string, "system" | "light" | "dark">
+  defaultAccountModalShownByAccountId?: Record<string, boolean>
+  // Quiz progress for accounts the backend keeps no quiz record for (self-custodial).
+  completedQuizIdsByAccountId?: Record<string, string[]>
+  // "Always hide balance" setting. It used to live on the Apollo cache, which only
+  // restores when an auth token is present and is purged on logout, so the setting
+  // silently reset for self-custodial users.
+  alwaysHideBalance?: boolean
+  // The visibility the user last left the app in, consulted only when alwaysHideBalance
+  // is off. Device-wide, not per-account: hiding is about who can see the screen.
+  balanceHidden?: boolean
+  selfCustodialAccountModeByAccountId?: Record<string, AccountMode>
+  // Accounts whose Stable Balance was switched off by Anon Mode, not by the user.
+  stableBalanceAnonPausedByAccountId?: Record<string, boolean>
+  // The mode the LNURL server last confirmed, so a mode is pushed once rather than on
+  // every launch: each Enhanced push costs the server a paid country lookup.
+  selfCustodialServerAccountModeByAccountId?: Record<string, AccountMode>
+}
+
+const migrate20ToCurrent = (state: PersistentState_20): Promise<PersistentState> =>
   Promise.resolve(state)
+
+/** Adds the optional per-account server-confirmed mode. Deliberately not backfilled from
+ *  the local mode: an account that chose one before this version has never told the
+ *  server, so leaving it empty is what makes the first push happen. */
+const migrate19ToCurrent = (state: PersistentState_19): Promise<PersistentState> =>
+  migrate20ToCurrent({ ...state, schemaVersion: 20 })
 
 /** Adds the optional per-account Anon pause marker; nothing to backfill. */
 const migrate18ToCurrent = (state: PersistentState_18): Promise<PersistentState> =>
@@ -393,6 +427,7 @@ type StateMigrations = {
   17: (state: PersistentState_17) => Promise<PersistentState>
   18: (state: PersistentState_18) => Promise<PersistentState>
   19: (state: PersistentState_19) => Promise<PersistentState>
+  20: (state: PersistentState_20) => Promise<PersistentState>
 }
 
 const stateMigrations: StateMigrations = {
@@ -413,12 +448,13 @@ const stateMigrations: StateMigrations = {
   17: migrate17ToCurrent,
   18: migrate18ToCurrent,
   19: migrate19ToCurrent,
+  20: migrate20ToCurrent,
 }
 
-export type PersistentState = PersistentState_19
+export type PersistentState = PersistentState_20
 
 export const defaultPersistentState: PersistentState = {
-  schemaVersion: 19,
+  schemaVersion: 20,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/app/utils/__mocks__/ip-country-lookup.ts
+++ b/app/utils/__mocks__/ip-country-lookup.ts
@@ -5,3 +5,12 @@ export const DEFAULT_ADAPTERS = []
 export const resolveIpCountryCode = jest.fn(async () => undefined)
 
 export const resolveIpCountryCodeCached = jest.fn(async () => undefined)
+
+/** The lookup hooks subscribe to the session-start reset through these, so both must be
+ *  callable: `useSyncExternalStore` invokes the snapshot during render. A spec that
+ *  exercises a reset drives it through its own mock rather than this one. */
+export const subscribeToIpCountryLookup = jest.fn(() => () => undefined)
+
+export const getIpCountryLookupGeneration = jest.fn(() => 0)
+
+export const resetIpCountryLookup = jest.fn()

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -92,25 +92,69 @@ export const resolveIpCountryCode = async (
 }
 
 /**
- * One shared lookup per app session: the device's country rarely changes
- * mid-session and several screens mount hooks that need it, so the external
- * services are hit once instead of once per mount. A failed lookup is not
- * cached, so a later mount can retry (e.g. the app started offline).
+ * One shared lookup per session: the device's country rarely changes within one, and
+ * several screens mount hooks that need it, so the external services are hit once
+ * instead of once per mount. A failed lookup is not cached, so a later mount can retry
+ * (e.g. the app started offline).
+ *
+ * A session is not the JS process. The region a session runs under is the one its
+ * connection resolves to, so this is dropped whenever a new session starts
+ * (`resetIpCountryLookup`) and the next consumer resolves afresh. Held for the process
+ * instead, a user who changed network would keep the country they launched on until they
+ * killed the app.
  */
 let sharedLookup: Promise<CountryCode | undefined> | null = null
 
+/**
+ * Bumped by every reset. Hooks read it so a reset re-runs their effect: clearing the
+ * promise alone only serves consumers that mount afterwards, and a screen already on
+ * display would keep the country it resolved a session ago.
+ */
+let lookupGeneration = 0
+
+const generationSubscribers = new Set<() => void>()
+
+/** `useSyncExternalStore` pair, so a reset re-renders the hooks reading the country
+ *  rather than only affecting whatever mounts next. */
+export const subscribeToIpCountryLookup = (onChange: () => void): (() => void) => {
+  generationSubscribers.add(onChange)
+  return () => {
+    generationSubscribers.delete(onChange)
+  }
+}
+
+export const getIpCountryLookupGeneration = (): number => lookupGeneration
+
+/**
+ * Drops the shared lookup so the next consumer resolves against the current connection.
+ * Called at each session start; it issues no request of its own, so a mode that resolves
+ * nothing (Anon) stays unaffected.
+ */
+export const resetIpCountryLookup = (): void => {
+  sharedLookup = null
+  lookupGeneration += 1
+  generationSubscribers.forEach((onChange) => onChange())
+}
+
 export const resolveIpCountryCodeCached = (): Promise<CountryCode | undefined> => {
   if (!sharedLookup) {
+    /** Captured so a lookup still in flight when a reset lands cannot clear the promise
+     *  its successor installed, which would spend another round of rate-limited calls. */
+    const generation = lookupGeneration
+    const clearIfCurrent = () => {
+      if (generation === lookupGeneration) sharedLookup = null
+    }
+
     sharedLookup = resolveIpCountryCode()
       .then((countryCode) => {
-        if (!countryCode) sharedLookup = null
+        if (!countryCode) clearIfCurrent()
         return countryCode
       })
       /** resolveIpCountryCode only rejects if error reporting itself throws, but a
        *  rejection must never stay cached: consumers gate UI on this promise settling,
        *  and a cached rejection would poison every later mount for the whole session. */
       .catch(() => {
-        sharedLookup = null
+        clearIfCurrent()
         return undefined
       })
   }


### PR DESCRIPTION
## What

Moves the client's custodial region rules onto the two queries that now serve them, and carries the self-custodial account mode to the LNURL server that acts on it. [blink#756](https://github.com/blinkbitcoin/blink/pull/756) is merged and live on staging, so this no longer only shapes the client after those queries — it reads them.

Backend:
- [blink#756](https://github.com/blinkbitcoin/blink/pull/756) — `regionCheck` and `custodialRestrictions`. **Merged and integrated here.**
- [blink-lnurl-server#36](https://github.com/blinkbitcoin/blink-lnurl-server/pull/36) — account mode persisted server-side. **Merged and integrated here.**

Ticket: [blink-wip#1035](https://github.com/blinkbitcoin/blink-wip/issues/1035).

## Where each rule is answered

| Rule | Before | Now |
|---|---|---|
| Custodial creation, session sanctions | `custodialCreationBlockedCountries` + IP | `regionCheck` |
| Custodial dollar balance, transfers | `custodial*BlockedCountries` + phone or IP | `custodialRestrictions` |
| First custodial signup | Device account count | Unchanged. The count is on the device and the server cannot see it |
| Every self-custodial rule | Firebase lists | Unchanged. A self-custodial wallet has no Blink account behind it |

**The server picks the country it answers for.** `custodialRestrictions` selects by account level — verified phone for level 1-2, request IP for level 0 — so the client never chooses between sources. That removes the phone-versus-IP waterfall from the custodial path entirely: an authenticated custodial session now performs **zero** client-side IP lookups.

**The three custodial lists are deleted**, along with their compiled-in defaults: `custodialCreationBlockedCountries`, `custodialDollarBalanceBlockedCountries`, `custodialTransferBlockedCountries`. The four that survive are the ones no server verdict covers.

**Verdicts are re-asked for at each session start.** Both queries are `no-cache` and refetch on foreground, and the shared IP lookup — memoised for the whole JS process — is dropped there too, through a generation counter the lookup hooks subscribe to. Clearing the promise alone only served consumers mounting afterwards, so a screen already on display kept the country it resolved a session ago. That was the latch this work exists to remove.

**Anon is excluded explicitly**, not left to the query's own `skip`. Apollo parks a skipped query in `standby` and would not refetch it, but the promise that an Anon account is never located should not rest on that.

## Policy on an unanswered verdict

`custodialRestrictions` **fails closed**: no verdict, no gated feature, matching `UnknownRegionPolicy = FAIL_CLOSED` in the PRD's P0 values.

`regionCheck` **fails open**: an unreachable server does not raise the sanctions blocker. Deliberate — `regionCheck` shares an API with every other custodial feature, so if it cannot be reached neither can sending, receiving or converting, and blocking the whole session on an outage helps nobody. Flagged here because the two policies differ on the same failure.

## The account mode on the LNURL server

The mode is the LNURL server's business too: it decides whether the server mints invoices for a self-custodial account's Lightning Address. Enhanced lets it answer and records the country it saw; Anon stops both.

**The address is never registered or deleted from here.** Only the mode is written. Deleting the address would free the username, and a later re-registration could lose it to someone else — so a switch can never cost the user their name.

**The push is driven off disagreement, not off the moment the user picks.** The choice is made on screens with no connected SDK to sign with, so the chosen mode and the server-confirmed one are stored separately (schema 20) and the gap between them is the work owed. What lands is recorded, so a launch with nothing to say stays silent: each Enhanced push costs the server a paid country lookup against a per-IP budget.

**An account holding no mode is settled from the server before anything is assumed.** Accounts predating the modes, and abandoned migrations, reach a connected wallet with nothing stored. The same wallet may already be Anon on another device, so the server is asked first; only a server that answers "none" gets the Enhanced default pushed at it.

**A restored wallet takes its mode from the server, not from a fresh question.** It was chosen on a device this one may never have been. The picker now appears only when the server could not be asked at all — assuming a default there would push it over whatever the account really holds.

Requests are signed with the wallet's own key and DER-encoded: `mode:{mode}:{pubkey}-{timestamp}` to write, the bare `{pubkey}-{timestamp}` to read. They go to the host the account's address is spelled with — `blink.sv` or `staging.blink.sv` — which is what serves the authenticated `/lnurlpay/{pubkey}` routes. Not the custodial `lnAddressHostname`: `pay.*` fronts the payment app and 404s them.

## Verification

Typecheck, lint and `graphql-check` (against the live staging endpoint) all clean. **100% statements, branches, functions and lines** on every file this PR adds or touches.

Walked on an Android emulator against staging, on a custodial account:

| Case | Result |
|---|---|
| Backend answers | `{"dollarBalance":false,"transfer":false}` — the real query |
| Unrestricted | Dollar balance visible, transfer and send enabled, nothing broken |
| Restricted verdict | Blocker presents, and the USD→BTC divest stays available — the remediation path the backend contract requires |
| `dollarBalance` alone | Dollar row greyed with its amount still shown, transfer disabled, receive/send/scan untouched |
| Client-side IP reads, authed custodial session | **0** |

Region reads across account creation, traced on device:

| Step | Reads |
|---|---|
| Get Started, account type, mode selection | 0 |
| Submit Anon | **0** |
| Submit Enhanced | 1 |

Anon resolves nothing at any point, and even Enhanced resolves only on submit — never on mount.

The mode, walked on the same emulator against staging with a registered address (`esaumodetest01@staging.blink.sv`):

| Case | Result |
|---|---|
| Custodial session | **0** requests to the LNURL server |
| Self-custodial holding no mode | Nothing pushed until a mode is known |
| Enhanced chosen | `200`; the signature verifies as ECDSA over `sha256(message)` against the wallet pubkey |
| Switched to Anon | `200`, with a timestamp strictly newer than the previous one |
| Relaunch | **0** repeat requests — the stored confirmation holds |
| Server answers `500` | Nothing confirmed; the next launch retries and confirms |
| Invoice while Enhanced | bolt11 minted |
| Invoice while Incognito | Refused: `recipient not accepting payments` |
| Invoice back on Enhanced | minted again, with no re-registration |
