### PR TITLE
fix(scan): stop the gallery picker from crashing the app

### DIFF
--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -104,6 +104,12 @@ jest.mock("@app/utils/toast", () => ({
   toastShow: (...args: unknown[]) => mockToastShow(...args),
 }))
 
+const mockReportError = jest.fn()
+jest.mock("@app/utils/error-logging", () => ({
+  ...jest.requireActual("@app/utils/error-logging"),
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
 const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {})
 
 beforeAll(() => {
@@ -355,7 +361,7 @@ describe("ScanningQRCodeScreen", () => {
     }
 
     /**
-     * The decoder allocates one integer per pixel of whatever it is handed, so an
+     * The decoder holds the decoded bitmap and one integer per pixel on top of it, so an
      * unbounded photo is an out-of-memory crash rather than a slow read.
      */
     it("bounds the picked image before the decoder ever sees it", async () => {
@@ -364,8 +370,8 @@ describe("ScanningQRCodeScreen", () => {
 
       expect(mockLaunchImageLibrary).toHaveBeenCalledWith({
         mediaType: "photo",
-        maxWidth: 4096,
-        maxHeight: 4096,
+        maxWidth: 2048,
+        maxHeight: 2048,
       })
     })
 
@@ -417,7 +423,33 @@ describe("ScanningQRCodeScreen", () => {
       const screen = await renderScreen()
       await openGallery(screen)
 
-      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      await waitFor(() =>
+        expect(alertSpy).toHaveBeenCalledWith("Unexpected error occurred"),
+      )
+      expect(mockReportError).toHaveBeenCalledWith(
+        "scanning-qrcode",
+        new Error("picker exploded"),
+      )
+    })
+
+    /**
+     * A native module can reject with something that is not an Error, and narrowing the
+     * catch on instanceof would drop those rejections with no alert and nothing reported.
+     * What it rejected with belongs in error reporting, not in a dialog.
+     */
+    it("surfaces a picker rejection that is not an Error", async () => {
+      mockLaunchImageLibrary.mockRejectedValue({ code: "E_PICKER_UNAVAILABLE" })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      await waitFor(() =>
+        expect(alertSpy).toHaveBeenCalledWith("Unexpected error occurred"),
+      )
+      expect(mockReportError).toHaveBeenCalledWith(
+        "scanning-qrcode",
+        new Error('{"code":"E_PICKER_UNAVAILABLE"}'),
+      )
     })
 
     it("tells the user when the image library permission was refused", async () => {
@@ -440,6 +472,10 @@ describe("ScanningQRCodeScreen", () => {
       await openGallery(screen)
 
       await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      expect(mockReportError).toHaveBeenCalledWith(
+        "scanning-qrcode",
+        new Error("Image library failed: others Unsupported file type"),
+      )
       expect(mockToastShow).not.toHaveBeenCalled()
       expect(mockDetect).not.toHaveBeenCalled()
     })

--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -455,6 +455,23 @@ describe("ScanningQRCodeScreen", () => {
       expect(mockResolveDestination).not.toHaveBeenCalled()
     })
 
+    /**
+     * processInvoice drops whatever it is handed while a scan is in flight, so a picker
+     * opened now would cost the user a trip through the gallery and end in silence.
+     */
+    it("stays shut while a scan is already in flight", async () => {
+      mockResolveDestination.mockReturnValue(new Promise(() => {}))
+
+      const screen = await renderScreen()
+      await act(async () => {
+        lastReadCode?.({ nativeEvent: { codeStringValue: "lnbc1inflight" } })
+      })
+
+      await openGallery(screen)
+
+      expect(mockLaunchImageLibrary).not.toHaveBeenCalled()
+    })
+
     it("surfaces a picker failure instead of dying on it", async () => {
       mockLaunchImageLibrary.mockRejectedValue(new Error("picker exploded"))
 

--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -353,6 +353,44 @@ describe("ScanningQRCodeScreen", () => {
     expect(mockResolveDestination).toHaveBeenCalledTimes(1)
   })
 
+  /**
+   * pending gates every scan and is only cleared from this alert, so a rejection that
+   * skipped the alert left the camera and the gallery button dead for the whole screen.
+   */
+  it("keeps scanning alive when resolving rejects with something that is not an Error", async () => {
+    mockResolveDestination.mockRejectedValue({ code: "E_RESOLVE" })
+
+    await renderScreen()
+    await fireScan("lnbc1first")
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Unexpected error occurred",
+        "",
+        expect.anything(),
+      ),
+    )
+    expect(mockReportError).toHaveBeenCalledWith(
+      "scanning-qrcode",
+      new Error('{"code":"E_RESOLVE"}'),
+    )
+
+    const [, , buttons] = alertSpy.mock.calls[0]
+    await act(async () => {
+      buttons?.[0].onPress?.()
+    })
+
+    mockResolveDestination.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: { paymentType: "Lightning" },
+      createPaymentDetail: jest.fn(),
+    })
+    await fireScan("lnbc1second")
+
+    expect(mockResolveDestination).toHaveBeenCalledTimes(2)
+  })
+
   describe("picking a QR from the gallery", () => {
     const openGallery = async (screen: RenderAPI) => {
       await act(async () => {

--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -1,7 +1,13 @@
 import React from "react"
 import { Alert } from "react-native"
 import { Network as mockSparkNetwork } from "@breeztech/breez-sdk-spark-react-native"
-import { act, render, waitFor } from "@testing-library/react-native"
+import {
+  act,
+  fireEvent,
+  render,
+  waitFor,
+  type RenderAPI,
+} from "@testing-library/react-native"
 
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { Network } from "@app/graphql/generated"
@@ -81,13 +87,21 @@ jest.mock("@react-native-clipboard/clipboard", () => ({
   default: { getString: jest.fn().mockResolvedValue("") },
 }))
 
+const mockDetect = jest.fn()
 jest.mock("rn-qr-generator", () => ({
   __esModule: true,
-  default: { detect: jest.fn().mockResolvedValue({ values: [] }) },
+  default: { detect: (...args: unknown[]) => mockDetect(...args) },
 }))
 
+const mockLaunchImageLibrary = jest.fn()
 jest.mock("react-native-image-picker", () => ({
-  launchImageLibrary: jest.fn().mockResolvedValue({ assets: [] }),
+  launchImageLibrary: (...args: unknown[]) => mockLaunchImageLibrary(...args),
+}))
+
+const mockToastShow = jest.fn()
+jest.mock("@app/utils/toast", () => ({
+  ...jest.requireActual("@app/utils/toast"),
+  toastShow: (...args: unknown[]) => mockToastShow(...args),
 }))
 
 const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {})
@@ -129,6 +143,8 @@ describe("ScanningQRCodeScreen", () => {
     lastReadCode = null
     mockScanContext.mockReturnValue(custodialScanContext)
     mockSelfCustodialWallet.mockReturnValue({ sdk: null })
+    mockLaunchImageLibrary.mockResolvedValue({ assets: [] })
+    mockDetect.mockResolvedValue({ values: [] })
   })
 
   it("calls resolveDestination with sdk=null when active wallet is custodial", async () => {
@@ -329,5 +345,103 @@ describe("ScanningQRCodeScreen", () => {
     await fireScan("lnbc1same")
 
     expect(mockResolveDestination).toHaveBeenCalledTimes(1)
+  })
+
+  describe("picking a QR from the gallery", () => {
+    const openGallery = async (screen: RenderAPI) => {
+      await act(async () => {
+        fireEvent.press(screen.getByTestId("open-gallery"))
+      })
+    }
+
+    /**
+     * The decoder allocates one integer per pixel of whatever it is handed, so an
+     * unbounded photo is an out-of-memory crash rather than a slow read.
+     */
+    it("bounds the picked image before the decoder ever sees it", async () => {
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      expect(mockLaunchImageLibrary).toHaveBeenCalledWith({
+        mediaType: "photo",
+        maxWidth: 4096,
+        maxHeight: 4096,
+      })
+    })
+
+    it("resolves the QR found in the picked image", async () => {
+      mockLaunchImageLibrary.mockResolvedValue({ assets: [{ uri: "file:///photo.jpg" }] })
+      mockDetect.mockResolvedValue({ values: ["lnbc1fromgallery"] })
+      mockResolveDestination.mockResolvedValue({
+        valid: true,
+        destinationDirection: DestinationDirection.Send,
+        validDestination: { paymentType: "Lightning" },
+        createPaymentDetail: jest.fn(),
+      })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      expect(mockDetect).toHaveBeenCalledWith({ uri: "file:///photo.jpg" })
+      await waitFor(() => expect(mockResolveDestination).toHaveBeenCalled())
+      const [destination] = mockResolveDestination.mock.calls[0]
+      expect(destination).toEqual(
+        expect.objectContaining({ rawInput: "lnbc1fromgallery", inputSource: "qr" }),
+      )
+    })
+
+    it("tells the user when the picked image holds no QR", async () => {
+      mockLaunchImageLibrary.mockResolvedValue({ assets: [{ uri: "file:///photo.jpg" }] })
+      mockDetect.mockResolvedValue({ values: [] })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      expect(mockResolveDestination).not.toHaveBeenCalled()
+    })
+
+    it("resolves nothing when the picker comes back empty", async () => {
+      mockLaunchImageLibrary.mockResolvedValue({ assets: [] })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      expect(mockDetect).not.toHaveBeenCalled()
+      expect(mockResolveDestination).not.toHaveBeenCalled()
+    })
+
+    it("surfaces a picker failure instead of dying on it", async () => {
+      mockLaunchImageLibrary.mockRejectedValue(new Error("picker exploded"))
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+    })
+
+    it("tells the user when the image library permission was refused", async () => {
+      mockLaunchImageLibrary.mockResolvedValue({ errorCode: "permission" })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      await waitFor(() => expect(mockToastShow).toHaveBeenCalled())
+      expect(mockDetect).not.toHaveBeenCalled()
+    })
+
+    it("does not go quiet when the picker fails for any other reason", async () => {
+      mockLaunchImageLibrary.mockResolvedValue({
+        errorCode: "others",
+        errorMessage: "Unsupported file type",
+      })
+
+      const screen = await renderScreen()
+      await openGallery(screen)
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      expect(mockToastShow).not.toHaveBeenCalled()
+      expect(mockDetect).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -276,20 +276,24 @@ export const ScanningQRCodeScreen: React.FC = () => {
             break
         }
       } catch (err: unknown) {
-        if (err instanceof Error) {
-          reportError("scanning-qrcode", err)
-          Alert.alert(err.toString(), "", [
-            {
-              text: LL.common.ok(),
-              onPress: () => setPending(false),
-            },
-          ])
-        }
+        /** Narrowing on instanceof here would drop a rejection that is not an Error
+         *  without ever reaching setPending(false), and pending gates every scan: the
+         *  camera and the gallery button would both stay dead for the rest of the screen.
+         *  What was rejected goes to error reporting rather than into the dialog, which
+         *  would otherwise show the user a serialized native payload. */
+        reportError("scanning-qrcode", toError(err))
+        Alert.alert(LL.errors.unexpectedError(), "", [
+          {
+            text: LL.common.ok(),
+            onPress: () => setPending(false),
+          },
+        ])
       }
     }
   }, [
     LL.ScanningQRCodeScreen,
     LL.common,
+    LL.errors,
     navigation,
     pending,
     bitcoinNetwork,
@@ -319,10 +323,8 @@ export const ScanningQRCodeScreen: React.FC = () => {
       const data = await Clipboard.getString()
       processInvoice(data)
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        reportError("scanning-qrcode", err)
-        Alert.alert(err.toString())
-      }
+      reportError("scanning-qrcode", toError(err))
+      Alert.alert(LL.errors.unexpectedError())
     }
   }
 

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -420,6 +420,11 @@ export const ScanningQRCodeScreen: React.FC = () => {
     )
   }
 
+  /** A scan already in flight makes processInvoice drop whatever the picker hands back,
+   *  so opening it would read as a dead button. Dimming says the same thing the guard
+   *  does, before the user spends a trip through the gallery on it. */
+  const galleryIconStyle = pending ? styles.iconGaleryPending : styles.iconGalery
+
   return (
     <Screen unsafe>
       {isFocused && (
@@ -446,12 +451,16 @@ export const ScanningQRCodeScreen: React.FC = () => {
           </View>
         </Pressable>
         <View style={styles.openGallery}>
-          <Pressable {...testProps("open-gallery")} onPress={showImagePicker}>
+          <Pressable
+            {...testProps("open-gallery")}
+            disabled={pending}
+            onPress={showImagePicker}
+          >
             <GaloyIcon
               name="image"
               size={64}
               color={colors._lightGrey}
-              style={styles.iconGalery}
+              style={galleryIconStyle}
             />
           </Pressable>
           <Pressable onPress={handleInvoicePaste}>
@@ -506,6 +515,8 @@ const useStyles = makeStyles(({ colors }) => ({
   iconClose: { position: "absolute", top: -2, color: colors._black },
 
   iconGalery: { opacity: 0.8 },
+
+  iconGaleryPending: { opacity: 0.4 },
 
   iconClipboard: { opacity: 0.8, position: "absolute", bottom: "5%", right: "15%" },
 

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -41,10 +41,21 @@ import {
   DestinationDirection,
   isMerchantChoiceDestination,
 } from "./payment-destination/index.types"
+import { testProps } from "@app/utils/testProps"
+
 import { resolveDestination } from "./payment-destination/resolve-destination"
 
 const { width: screenWidth } = Dimensions.get("window")
 const { height: screenHeight } = Dimensions.get("window")
+
+/**
+ * Longest side the picker is allowed to hand back. The QR decoder allocates one integer
+ * per pixel of what it receives, at full resolution: a 12000x12000 photo asks for 576MB
+ * against a heap that caps out around 200MB, and the app dies before reading anything.
+ * The bound sits above what a camera produces, so an ordinary photo is passed through
+ * untouched and only the extremes are subsampled, which keeps dense codes readable.
+ */
+const QR_IMAGE_MAX_DIMENSION = 4096
 
 gql`
   query scanningQRCodeScreen {
@@ -313,13 +324,33 @@ export const ScanningQRCodeScreen: React.FC = () => {
 
   const showImagePicker = async () => {
     try {
-      const result = await launchImageLibrary({ mediaType: "photo" })
+      const result = await launchImageLibrary({
+        mediaType: "photo",
+        maxWidth: QR_IMAGE_MAX_DIMENSION,
+        maxHeight: QR_IMAGE_MAX_DIMENSION,
+      })
       if (result.errorCode === "permission") {
         toastShow({
           message: (translations) =>
             translations.ScanningQRCodeScreen.imageLibraryPermissionsNotGranted(),
           LL,
         })
+        return
+      }
+      /** Every other code arrives with no assets, so without this the button reads as
+       *  dead: nothing opens, nothing is said, and nothing reaches error reporting. The
+       *  message stays generic because the picker failed before it could hand over a
+       *  photo, and saying the image holds no QR would be a claim about something the app
+       *  never got to look at. */
+      if (result.errorCode) {
+        reportError(
+          "scanning-qrcode",
+          new Error(
+            `Image library failed: ${result.errorCode} ${result.errorMessage ?? ""}`,
+          ),
+        )
+        Alert.alert(LL.errors.unexpectedError())
+        return
       }
       if (result.assets && result.assets.length > 0) {
         const { uri } = result.assets[0]
@@ -405,7 +436,7 @@ export const ScanningQRCodeScreen: React.FC = () => {
           </View>
         </Pressable>
         <View style={styles.openGallery}>
-          <Pressable onPress={showImagePicker}>
+          <Pressable {...testProps("open-gallery")} onPress={showImagePicker}>
             <GaloyIcon
               name="image"
               size={64}

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -28,6 +28,7 @@ import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { logParseDestinationResult } from "@app/utils/analytics"
 import { reportError } from "@app/utils/error-logging"
+import { toError } from "@app/utils/error-reporting"
 import { toastShow } from "@app/utils/toast"
 import Clipboard from "@react-native-clipboard/clipboard"
 import { useIsFocused, useNavigation } from "@react-navigation/native"
@@ -49,13 +50,16 @@ const { width: screenWidth } = Dimensions.get("window")
 const { height: screenHeight } = Dimensions.get("window")
 
 /**
- * Longest side the picker is allowed to hand back. The QR decoder allocates one integer
- * per pixel of what it receives, at full resolution: a 12000x12000 photo asks for 576MB
- * against a heap that caps out around 200MB, and the app dies before reading anything.
- * The bound sits above what a camera produces, so an ordinary photo is passed through
- * untouched and only the extremes are subsampled, which keeps dense codes readable.
+ * Longest side the picker is allowed to hand back. The QR decoder holds the decoded
+ * bitmap and one integer per pixel on top of it, so its peak is eight bytes per pixel of
+ * whatever it receives: a 12000x12000 photo asks for 576MB against a heap that caps out
+ * around 200MB, and the app dies before reading anything. At this bound the peak is 34MB,
+ * which the 96MB heap of a budget device survives. A code filling the frame stays well
+ * inside what the decoder needs, eight or more pixels per module even at version 40, the
+ * densest there is; a code occupying a small corner of a very large photo is the case
+ * this trades away.
  */
-const QR_IMAGE_MAX_DIMENSION = 4096
+const QR_IMAGE_MAX_DIMENSION = 2048
 
 gql`
   query scanningQRCodeScreen {
@@ -362,10 +366,14 @@ export const ScanningQRCodeScreen: React.FC = () => {
         Alert.alert(LL.ScanningQRCodeScreen.noQrCode())
       }
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        reportError("scanning-qrcode", err)
-        Alert.alert(err.toString())
-      }
+      /** A native module can reject with a plain object or a string rather than an Error,
+       *  and an Error crossing a realm boundary fails the instanceof check too. Narrowing
+       *  on that check here would leave those rejections with no alert and nothing in
+       *  error reporting, which is the dead button this change is closing. The detail goes
+       *  to error reporting rather than to the user, who would otherwise be shown whatever
+       *  the native module rejected with, serialized. */
+      reportError("scanning-qrcode", toError(err))
+      Alert.alert(LL.errors.unexpectedError())
     }
   }
 

--- a/patches/react-native-image-picker+7.1.2.patch
+++ b/patches/react-native-image-picker+7.1.2.patch
@@ -1,0 +1,102 @@
+diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
+index afe4b3e..26f4972 100644
+--- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
++++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
+@@ -166,15 +166,29 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
+     }
+ 
+     void onAssetsObtained(List<Uri> fileUris) {
++        /**
++         * The callback is claimed under a lock before this method returns, so the hand-off
++         * is single-shot. Clearing the field inside the executor task instead leaves it set
++         * until that task runs, letting a duplicate onActivityResult pass the null check
++         * and schedule a second task holding the same callback; React Native aborts the
++         * process as soon as a callback is invoked more than once.
++         */
++        final Callback cb;
++        synchronized (this) {
++            cb = this.callback;
++            this.callback = null;
++        }
++        if (cb == null) {
++            return;
++        }
++
+         ExecutorService executor = Executors.newSingleThreadExecutor();
+ 
+         executor.submit(() -> {
+             try {
+-                callback.invoke(getResponseMap(fileUris, options, reactContext));
++                cb.invoke(getResponseMap(fileUris, options, reactContext));
+             } catch (RuntimeException exception) {
+-                callback.invoke(getErrorMap(errOthers, exception.getMessage()));
+-            } finally {
+-                callback = null;
++                cb.invoke(getErrorMap(errOthers, exception.getMessage()));
+             }
+         });
+     }
+diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
+index 1e9078d..87707ae 100644
+--- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
++++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
+@@ -202,6 +202,23 @@ public class Utils {
+                 || orientation.equals(String.valueOf(ExifInterface.ORIENTATION_ROTATE_270));
+     }
+ 
++    /**
++     * Largest power-of-two subsampling factor that still leaves the decoded bitmap at or
++     * above the requested size, so the scaling that follows only ever shrinks.
++     */
++    static int calculateInSampleSize(int origWidth, int origHeight, int reqWidth, int reqHeight) {
++        if (reqWidth <= 0 || reqHeight <= 0) {
++            return 1;
++        }
++
++        int inSampleSize = 1;
++        while (origWidth / (inSampleSize * 2) >= reqWidth
++                && origHeight / (inSampleSize * 2) >= reqHeight) {
++            inSampleSize *= 2;
++        }
++        return inSampleSize;
++    }
++
+     // Resize image
+     // When decoding a jpg to bitmap all exif meta data will be lost, so make sure to copy orientation exif to new file else image might have wrong orientations
+     public static Uri resizeImage(Uri uri, Context context, Options options) {
+@@ -216,7 +233,17 @@ public class Utils {
+ 
+             try (InputStream imageStream = context.getContentResolver().openInputStream(uri)) {
+                 String mimeType = getMimeType(uri, context);
+-                Bitmap b = BitmapFactory.decodeStream(imageStream);
++                /**
++                 * Decoded straight to a size near the requested one. Reading the stream at
++                 * full resolution first allocates the entire source bitmap, four bytes per
++                 * pixel, which for a high-megapixel photo exceeds the heap and raises an
++                 * OutOfMemoryError. That is an Error rather than an Exception, so nothing
++                 * here catches it and the caller is left without a response.
++                 */
++                BitmapFactory.Options decodeOptions = new BitmapFactory.Options();
++                decodeOptions.inSampleSize =
++                        calculateInSampleSize(origDimens[0], origDimens[1], newDimens[0], newDimens[1]);
++                Bitmap b = BitmapFactory.decodeStream(imageStream, null, decodeOptions);
+                 String originalOrientation = getOrientation(uri, context);
+ 
+                 if (needToSwapDimension(originalOrientation)) {
+@@ -246,7 +273,15 @@ public class Utils {
+ 
+     static String getOrientation(Uri uri, Context context) throws IOException {
+         ExifInterface exifInterface = new ExifInterface(context.getContentResolver().openInputStream(uri));
+-        return exifInterface.getAttribute(ExifInterface.TAG_ORIENTATION);
++        String orientation = exifInterface.getAttribute(ExifInterface.TAG_ORIENTATION);
++        /**
++         * An image with no orientation tag, a screenshot for instance, reports null here,
++         * and both callers dereference this value: reading dimensions and writing the
++         * resized file each raise a NullPointerException that resizeImage swallows, so the
++         * original full-resolution image is handed back as if no resize had been asked for.
++         * Undefined is the neutral value both callers already treat as "leave it alone".
++         */
++        return orientation != null ? orientation : String.valueOf(ExifInterface.ORIENTATION_UNDEFINED);
+     }
+ 
+     // ExifInterface.saveAttributes is costly operation so don't set exif for unnecessary orientations

--- a/patches/react-native-image-picker+7.1.2.patch
+++ b/patches/react-native-image-picker+7.1.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
-index afe4b3e..2aaeb71 100644
+index afe4b3e..b39b12d 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
 +++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
 @@ -166,17 +166,47 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
@@ -55,6 +55,45 @@ index afe4b3e..2aaeb71 100644
      }
  
      @Override
+@@ -191,14 +221,32 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
+             if (requestCode == REQUEST_LAUNCH_IMAGE_CAPTURE) {
+                 deleteFile(fileUri);
+             }
+-            try {
+-                callback.invoke(getCancelMap());
++            /**
++             * Claimed under the same lock as onAssetsObtained, for the same reason: the
++             * callback is single-shot and React Native aborts the process the moment one
++             * is invoked twice. The old shape invoked it a second time from inside its own
++             * catch, so the handler for a failed hand-off was itself the crash. It also
++             * left the failure path falling through to the switch below, since its return
++             * sat inside the try. Settling the response first keeps this to one invoke on
++             * every route out.
++             */
++            final Callback cancelCallback;
++            synchronized (this) {
++                cancelCallback = this.callback;
++                this.callback = null;
++            }
++            if (cancelCallback == null) {
+                 return;
+-            } catch (RuntimeException exception) {
+-                callback.invoke(getErrorMap(errOthers, exception.getMessage()));
+-            } finally {
+-                callback = null;
+             }
++
++            ReadableMap response;
++            try {
++                response = getCancelMap();
++            } catch (Throwable throwable) {
++                response = getErrorMap(errOthers, throwable.getMessage());
++            }
++            cancelCallback.invoke(response);
++            return;
+         }
+ 
+         switch (requestCode) {
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
 index 1e9078d..87707ae 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java

--- a/patches/react-native-image-picker+7.1.2.patch
+++ b/patches/react-native-image-picker+7.1.2.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
-index afe4b3e..26f4972 100644
+index afe4b3e..2aaeb71 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
 +++ b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/ImagePickerModuleImpl.java
-@@ -166,15 +166,29 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
+@@ -166,17 +166,47 @@ public class ImagePickerModuleImpl implements ActivityEventListener {
      }
  
      void onAssetsObtained(List<Uri> fileUris) {
@@ -25,17 +25,36 @@ index afe4b3e..26f4972 100644
          ExecutorService executor = Executors.newSingleThreadExecutor();
  
          executor.submit(() -> {
++            /**
++             * The response is settled before the single invoke, and every Throwable is
++             * caught rather than only RuntimeException. Decoding the picked image can
++             * raise an OutOfMemoryError, which is an Error: catching Exception alone
++             * lets it die inside a Future nobody reads, so the callback never fires and
++             * the promise on the JS side stays pending forever.
++             */
++            ReadableMap response;
              try {
 -                callback.invoke(getResponseMap(fileUris, options, reactContext));
-+                cb.invoke(getResponseMap(fileUris, options, reactContext));
-             } catch (RuntimeException exception) {
+-            } catch (RuntimeException exception) {
 -                callback.invoke(getErrorMap(errOthers, exception.getMessage()));
 -            } finally {
 -                callback = null;
-+                cb.invoke(getErrorMap(errOthers, exception.getMessage()));
++                response = getResponseMap(fileUris, options, reactContext);
++            } catch (Throwable throwable) {
++                response = getErrorMap(errOthers, throwable.getMessage());
              }
++            cb.invoke(response);
          });
++        /**
++         * The executor is created per pick and its worker thread outlives the task that
++         * ran on it, so without this one thread and its stack leak on every gallery open,
++         * against the same heap the bounded decode above is protecting. shutdown() lets
++         * the submitted task finish and then retires the thread.
++         */
++        executor.shutdown();
      }
+ 
+     @Override
 diff --git a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java b/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
 index 1e9078d..87707ae 100644
 --- a/node_modules/react-native-image-picker/android/src/main/java/com/imagepicker/Utils.java
@@ -100,3 +119,107 @@ index 1e9078d..87707ae 100644
      }
  
      // ExifInterface.saveAttributes is costly operation so don't set exif for unnecessary orientations
+diff --git a/node_modules/react-native-image-picker/ios/ImagePickerManager.mm b/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
+index 93e99be..5157930 100644
+--- a/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
++++ b/node_modules/react-native-image-picker/ios/ImagePickerManager.mm
+@@ -165,9 +165,20 @@ NSData* extractImageData(UIImage* image){
+ 
+     UIImage* newImage = image;
+     if (![fileType isEqualToString:@"gif"]) {
+-        newImage = [ImagePickerUtils resizeImage:image
+-                                     maxWidth:[self.options[@"maxWidth"] floatValue]
+-                                    maxHeight:[self.options[@"maxHeight"] floatValue]];
++        float maxWidth = [self.options[@"maxWidth"] floatValue];
++        float maxHeight = [self.options[@"maxHeight"] floatValue];
++        /**
++         * Bounded during the decode, before the resize. Handing the picked image straight
++         * to resizeImage makes its [image drawInRect:] materialise every pixel of the
++         * source, which is the allocation a caller setting a bound is asking to avoid.
++         */
++        UIImage* sourceImage = [ImagePickerUtils boundedImage:image
++                                                         data:data
++                                                     maxWidth:maxWidth
++                                                    maxHeight:maxHeight];
++        newImage = [ImagePickerUtils resizeImage:sourceImage
++                                     maxWidth:maxWidth
++                                    maxHeight:maxHeight];
+     }
+ 
+     float quality = [self.options[@"quality"] floatValue];
+diff --git a/node_modules/react-native-image-picker/ios/ImagePickerUtils.h b/node_modules/react-native-image-picker/ios/ImagePickerUtils.h
+index 3cd8bfc..90dea80 100644
+--- a/node_modules/react-native-image-picker/ios/ImagePickerUtils.h
++++ b/node_modules/react-native-image-picker/ios/ImagePickerUtils.h
+@@ -13,6 +13,8 @@
+ 
+ + (NSString*)getFileType:(NSData*)imageData;
+ 
+++ (UIImage*)boundedImage:(UIImage*)image data:(NSData*)data maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
++
+ + (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight;
+ 
+ + (CGSize)getVideoDimensionsFromUrl:(NSURL *)url;
+diff --git a/node_modules/react-native-image-picker/ios/ImagePickerUtils.mm b/node_modules/react-native-image-picker/ios/ImagePickerUtils.mm
+index 443500d..20b213e 100644
+--- a/node_modules/react-native-image-picker/ios/ImagePickerUtils.mm
++++ b/node_modules/react-native-image-picker/ios/ImagePickerUtils.mm
+@@ -1,5 +1,6 @@
+ #import "ImagePickerUtils.h"
+ #import <CoreServices/CoreServices.h>
++#import <ImageIO/ImageIO.h>
+ #import <PhotosUI/PhotosUI.h>
+ 
+ @implementation ImagePickerUtils
+@@ -145,6 +146,51 @@
+     return CGSizeMake(0, 0);
+ }
+ 
++/**
++ * The source bitmap for a resize, read back from the data already bounded instead of
++ * decoded at full resolution first. resizeImage scales a UIImage that is in memory, and
++ * a picked image is lazy: [image drawInRect:] is what forces the source decode, so a
++ * 144MP pick allocates 576MB before the resize it was asked for can shrink anything.
++ * ImageIO reads the header, subsamples during the decode and only ever holds the bounded
++ * result. The original image is returned whenever no bound was asked for, the image is
++ * already inside it, or ImageIO cannot read the data, so those paths keep their behaviour.
++ */
+++ (UIImage*)boundedImage:(UIImage*)image data:(NSData*)data maxWidth:(float)maxWidth maxHeight:(float)maxHeight
++{
++    if ((maxWidth <= 0) || (maxHeight <= 0) || (data == nil)) {
++        return image;
++    }
++
++    if (image.size.width <= maxWidth && image.size.height <= maxHeight) {
++        return image;
++    }
++
++    CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)data, (__bridge CFDictionaryRef)@{
++        (__bridge id)kCGImageSourceShouldCache: @NO
++    });
++    if (source == NULL) {
++        return image;
++    }
++
++    NSDictionary *thumbnailOptions = @{
++        (__bridge id)kCGImageSourceCreateThumbnailFromImageAlways: @YES,
++        (__bridge id)kCGImageSourceCreateThumbnailWithTransform: @YES,
++        (__bridge id)kCGImageSourceShouldCacheImmediately: @YES,
++        (__bridge id)kCGImageSourceThumbnailMaxPixelSize: @(MAX(maxWidth, maxHeight))
++    };
++    CGImageRef boundedRef = CGImageSourceCreateThumbnailAtIndex(source, 0, (__bridge CFDictionaryRef)thumbnailOptions);
++    CFRelease(source);
++
++    if (boundedRef == NULL) {
++        return image;
++    }
++
++    UIImage *result = [UIImage imageWithCGImage:boundedRef];
++    CGImageRelease(boundedRef);
++
++    return result;
++}
++
+ + (UIImage*)resizeImage:(UIImage*)image maxWidth:(float)maxWidth maxHeight:(float)maxHeight
+ {
+     if ((maxWidth == 0) || (maxHeight == 0)) {


### PR DESCRIPTION
## Summary

Picking an image from the gallery on the scan screen could kill the app, in two unrelated ways. This fixes both, because they share a single entry point and a single test path: the gallery button on the scan screen.

The first is the crash the ticket describes. The second was found while trying to reproduce the first, and turned out to be the one that reproduces on demand.

Closes blinkbitcoin/blink-mobile#4095

## The reported crash: a callback invoked twice

`ImagePickerModuleImpl.onAssetsObtained` clears its callback field inside the executor task rather than before submitting it. A duplicate `onActivityResult` delivered before that task runs therefore passes the null check in `onActivityResult` and schedules a second task holding the same callback. React Native aborts the process the moment a callback is invoked more than once, which is the `SIGABRT` with `callback arg cannot be called more than once` in the report.

The patch claims the callback under a lock before the method returns, so the hand-off is single-shot. This also closes two smaller holes in the same method: the old `finally { callback = null }` wiped the callback belonging to a *second* pick, and the `resultCode != RESULT_OK` fall-through reached the switch with a null callback.

The cancel path had the same defect and is fixed the same way. `onActivityResult` invoked the callback inside a `try` and then invoked *the same callback again* from its own `catch`, so the handler for a failed hand-off was itself the abort it was handling. Its `return` also sat inside the `try`, leaving the failure path to fall through to the switch below. It now claims the callback under the same lock, settles the response before a single `invoke`, and returns on every route out.

Upgrading does not help. The same code is on upstream `main` at 8.2.1, verified against the source, so a patch is the only route until the upstream fix lands.

## The crash found while testing: the decoder runs out of memory

`RNQRGenerator.detect` was handed the picked image at whatever resolution the gallery returned. The decoder holds the decoded bitmap and allocates one integer per pixel on top of it to build its luminance source, so its peak is eight bytes per pixel of whatever it receives. A 12000x12000 photo asks for 576MB against a heap that caps out near 200MB, so the app dies before it can read anything:

```
java.lang.OutOfMemoryError: Failed to allocate a 576000016 byte allocation
  at RNQrGeneratorModule.createLuminanceSource(RNQrGeneratorModule.java:394)
  at RNQrGeneratorModule.scanQRImage(RNQrGeneratorModule.java:301)
```

File size is irrelevant; pixel count is what matters. The image used to reproduce this is 3.8MB on disk. Any phone shooting at 100MP or above is in range.

Four changes were needed, and none of them works without the others:

- The picker is asked for at most 2048px on the longest side, which puts the decoder's peak at 34MB and keeps it inside the 96MB heap of a budget device. This bound is below what a modern camera produces, so unlike a looser bound it does re-encode an ordinary photo rather than passing it through untouched. That is the deliberate tradeoff: a code filling the frame still lands at eleven pixels per module even on a version-40 QR, the densest there is, while a code occupying a small corner of a very large photo is the case given up. A 4096 bound would preserve those, but at a 134MB peak it is too close to the ceiling it exists to stay under.
- `Utils.resizeImage` decoded the full-resolution bitmap before scaling it down, so bounding the request alone would only have moved the same allocation from the decoder into the picker, where it is worse: `OutOfMemoryError` is an `Error`, so neither `catch (Exception)` there nor `catch (RuntimeException)` in `onAssetsObtained` catches it, the executor buries it in an unread `Future`, and the promise never settles. The gallery button would have gone dead instead of crashing. The patch subsamples during the decode, so the full bitmap is never materialised. `onAssetsObtained` now also catches `Throwable` and settles its response before the single `invoke`, so an `Error` from that decode still reaches JS instead of hanging the promise, and the per-pick executor is shut down rather than leaking a thread on every gallery open.
- The same hole existed on iOS, in the opposite direction: passing `maxWidth`/`maxHeight` at all turns on `ImagePickerUtils resizeImage`, whose `[image drawInRect:]` materialises the source at full resolution. Bounding the request would have introduced a full-resolution decode where the previous `maxWidth: 0` returned early and passed the original `NSData` through undecoded. The patch adds `ImagePickerUtils boundedImage`, which downsamples during the decode with `CGImageSourceCreateThumbnailAtIndex` before `resizeImage` runs.
- `getOrientation` returns null for an image with no EXIF orientation tag, and both callers dereference it. The resulting `NullPointerException` is swallowed by `resizeImage`, which returns the original uri as if no resize had been requested. Screenshots have no orientation tag, and a screenshot is a common way to keep a QR, so without this the fix would have skipped its most likely case. It now falls back to `ORIENTATION_UNDEFINED`, the neutral value both callers already treat as "leave it alone".

## Also fixed

Only `errorCode === "permission"` was surfaced. Every other code, including the `"others"` the native side returns when `getResponseMap` throws, arrived with no assets and fell through in silence: the button read as dead and nothing reached error reporting. Those now report and tell the user. The message stays generic rather than reusing "we could not find a QR code in the image", which would be a claim about a photo the app never got to look at.

The screen's catch narrowed on `err instanceof Error`, so a native module rejecting with a plain object or string, or an `Error` crossing a realm boundary, produced no alert and nothing reported. It now wraps whatever it caught with `toError`. The detail goes to error reporting rather than into the dialog, which would otherwise show the user a serialized native payload.

The gallery button did not check `pending`, so a QR decoded from a picked image was dropped in silence by `processInvoice`'s guard whenever a scan was already in flight: no alert, nothing reported, the same dead-button reading the rest of this change removes. It is now disabled and dimmed while a scan is in flight, which says the same thing the guard does but before the user spends a trip through the gallery on it.

## Test plan

- `yarn jest __tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx`: 20 passed. Nine are new and cover a flow that had none: the image is bounded before the decoder sees it, a QR found in the picked image resolves, an image with no QR tells the user, an empty pick resolves nothing, the picker stays shut while a scan is in flight, a picker rejection is surfaced, a rejection that is not an `Error` is surfaced, a refused permission is surfaced, and any other picker failure is reported rather than swallowed
- The in-flight test was checked against its own absence: with the guard removed it fails `Expected 0 calls, received 1`, so it pins the behaviour rather than following it
- `yarn jest __tests__/screens/send-bitcoin-screen/`: 90 passed across 10 suites, so nothing else on this screen moved
- `yarn tsc --noEmit` and `eslint` on the changed files: clean
- Device (Android emulator), against a purpose-built 12000x12000 image: the crash reproduced three times before the change, with the same 576MB allocation each time. After the change the app survives, the decoder runs to completion and reports `NotFoundException` because the test image genuinely holds no QR. `javap` on the built `Utils.class` confirms the patched method is in the installed APK rather than a cached one

- Device (Android emulator), cancel path: `cancelCallback` confirmed present in the installed dex rather than a cached class, then 24 gallery cycles (12 cancel, 6 pick, 6 rapid double-back). Logcat shows 24 `PICK_IMAGES` intents for 24 cycles, so no cycle was a no-op. PID unchanged throughout, zero `SIGABRT`, zero "called more than once", zero ANRs, and the screen ends the run with camera and gallery both live

## Not verified

The iOS half is not device-tested; there is no macOS here. It is covered only by the compile in `e2e:build ios.sim.debug`. The reasoning above is from the upstream source, not from a run.

Neither double-invoke fix has a reproduction. Triggering either needs `invoke` itself to throw, which cannot be forced by hand, and the race did not reproduce across three rounds on a physical device with "Don't keep activities" enabled. Both rest on the code path being plainly wrong and on the upstream analysis. The 24-cycle run above proves the cancel path did not regress, which was the actual risk in touching it, not that the double-invoke is closed.

## Closed findings

Raised in review, checked, and not applying here. Recorded so they are not re-opened:

- *The new error alert leaves `pending` stuck if dismissed with the back button.* It cannot: `Alert.alert` hardcodes `cancelable: false` in its Android config and overrides it only when the caller passes `options.cancelable`, which this screen does not. The dialog is not dismissible, so the button's `onPress` is the only way out. See `react-native/Libraries/Alert/Alert.js:90`.

## Follow-ups, deliberately not in this PR

Real, but in code this PR does not touch. Keeping them out keeps the diff reviewable:

- `Utils.resizeImage` catches `Exception` and returns the original uri, so a failure there hands JS an unbounded image.
- `collectUrisFromData(data)` dereferences a null `Intent` under `RESULT_OK`, which some OEM galleries return.
- GIFs skip the bound on iOS; upstream excludes them on purpose to avoid breaking the animation.

## Note for whoever bumps this dependency

`postinstall` runs `patch-package --error-on-fail` against a `^7.1.2` range, so a future 7.x release will fail installs until the patch is regenerated. Same tradeoff as the existing camera-kit and modal patches. The double-invoke half can be dropped once upstream ships its fix; the subsampling and orientation halves are not filed upstream yet.
