### PR TITLE
fix(phone-input): restore the country flags the picker stopped rendering

### DIFF
--- a/__tests__/components/phone-input/country-code-picker.spec.tsx
+++ b/__tests__/components/phone-input/country-code-picker.spec.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render } from "@testing-library/react-native"
 import { CountryCodePicker } from "@app/components/phone-input/country-code-picker"
 
 const mockPicker = jest.fn()
+const mockPickerMount = jest.fn()
 const mockFlag = jest.fn()
 const mockOnOpen = jest.fn()
 
@@ -18,19 +19,27 @@ const mockOnOpen = jest.fn()
  */
 jest.mock("react-native-country-picker-modal", () => {
   const ReactActual = jest.requireActual("react")
+
+  const CountryPickerMock = (props: Record<string, unknown>) => {
+    mockPicker(props)
+    /** Counts mounts rather than renders: an effect with no dependencies runs again only
+     *  when this subtree is a new instance, which is exactly what the key has to force. */
+    ReactActual.useEffect(() => {
+      mockPickerMount()
+    }, [])
+    const renderFlagButton = props.renderFlagButton as (args: {
+      countryCode?: string
+      onOpen: () => void
+    }) => React.ReactNode
+    return renderFlagButton({
+      countryCode: props.countryCode as string | undefined,
+      onOpen: mockOnOpen,
+    })
+  }
+
   return {
     __esModule: true,
-    default: (props: Record<string, unknown>) => {
-      mockPicker(props)
-      const renderFlagButton = props.renderFlagButton as (args: {
-        countryCode?: string
-        onOpen: () => void
-      }) => React.ReactNode
-      return renderFlagButton({
-        countryCode: props.countryCode as string | undefined,
-        onOpen: mockOnOpen,
-      })
-    },
+    default: CountryPickerMock,
     Flag: (props: Record<string, unknown>) => {
       mockFlag(props)
       return ReactActual.createElement("Flag")
@@ -46,17 +55,20 @@ jest.mock("@rn-vui/themed", () => ({
   useTheme: () => ({ theme: { mode: mockThemeMode() } }),
 }))
 
+const pickerElement = (
+  overrides: Partial<React.ComponentProps<typeof CountryCodePicker>> = {},
+) => (
+  <CountryCodePicker
+    countryCode={"SV" as never}
+    countryCodes={["SV", "US"] as never}
+    onSelect={jest.fn()}
+    {...overrides}
+  />
+)
+
 const renderPicker = (
   overrides: Partial<React.ComponentProps<typeof CountryCodePicker>> = {},
-) =>
-  render(
-    <CountryCodePicker
-      countryCode={"SV" as never}
-      countryCodes={["SV", "US"] as never}
-      onSelect={jest.fn()}
-      {...overrides}
-    />,
-  )
+) => render(pickerElement(overrides))
 
 describe("CountryCodePicker", () => {
   beforeEach(() => {
@@ -140,20 +152,26 @@ describe("CountryCodePicker", () => {
 
   it("rebuilds the picker when the supported countries finally arrive", () => {
     const { rerender } = renderPicker({ countryCodes: [] as never })
-    const keyWhileEmpty = mockPicker.mock.calls.length
+    expect(mockPickerMount).toHaveBeenCalledTimes(1)
 
-    rerender(
-      <CountryCodePicker
-        countryCode={"SV" as never}
-        countryCodes={["SV", "US"] as never}
-        onSelect={jest.fn()}
-      />,
-    )
+    rerender(pickerElement())
 
     /** A fresh mount is the point: the library reads its country list once, so reusing the
      *  instance would keep offering every country instead of the supported ones. */
-    expect(mockPicker.mock.calls.length).toBeGreaterThan(keyWhileEmpty)
+    expect(mockPickerMount).toHaveBeenCalledTimes(2)
     expect(mockPicker.mock.calls.at(-1)?.[0].countryCodes).toEqual(["SV", "US"])
+  })
+
+  it("keeps the picker it already built when only the selected country changes", () => {
+    const { rerender } = renderPicker()
+    expect(mockPickerMount).toHaveBeenCalledTimes(1)
+
+    rerender(pickerElement({ countryCode: "US" as never }))
+
+    /** The list is what the key answers to. Remounting on anything else would throw away
+     *  the modal's own state, including the filter text, while it is open. */
+    expect(mockPickerMount).toHaveBeenCalledTimes(1)
+    expect(mockPicker.mock.calls.at(-1)?.[0].countryCode).toBe("US")
   })
 
   it("follows the app theme into the picker", () => {

--- a/__tests__/components/phone-input/country-code-picker.spec.tsx
+++ b/__tests__/components/phone-input/country-code-picker.spec.tsx
@@ -1,0 +1,169 @@
+import React from "react"
+import { TouchableOpacity } from "react-native"
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { CountryCodePicker } from "@app/components/phone-input/country-code-picker"
+
+const mockPicker = jest.fn()
+const mockFlag = jest.fn()
+const mockOnOpen = jest.fn()
+
+/**
+ * The library is stubbed on purpose. What broke in production is the props contract with
+ * it: every flag prop used to arrive through `Component.defaultProps`, which React 19 no
+ * longer applies to function components, so the flags disappeared without an error. These
+ * assertions pin the props this component now sends, which is what has to stay true.
+ * Rendering the real library instead would prove nothing, because under Jest those dead
+ * defaults still resolve and the flag appears either way.
+ */
+jest.mock("react-native-country-picker-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  return {
+    __esModule: true,
+    default: (props: Record<string, unknown>) => {
+      mockPicker(props)
+      const renderFlagButton = props.renderFlagButton as (args: {
+        countryCode?: string
+        onOpen: () => void
+      }) => React.ReactNode
+      return renderFlagButton({
+        countryCode: props.countryCode as string | undefined,
+        onOpen: mockOnOpen,
+      })
+    },
+    Flag: (props: Record<string, unknown>) => {
+      mockFlag(props)
+      return ReactActual.createElement("Flag")
+    },
+    DARK_THEME: { name: "dark" },
+    DEFAULT_THEME: { name: "light" },
+  }
+})
+
+const mockThemeMode = jest.fn(() => "dark")
+jest.mock("@rn-vui/themed", () => ({
+  ...jest.requireActual("@rn-vui/themed"),
+  useTheme: () => ({ theme: { mode: mockThemeMode() } }),
+}))
+
+const renderPicker = (
+  overrides: Partial<React.ComponentProps<typeof CountryCodePicker>> = {},
+) =>
+  render(
+    <CountryCodePicker
+      countryCode={"SV" as never}
+      countryCodes={["SV", "US"] as never}
+      onSelect={jest.fn()}
+      {...overrides}
+    />,
+  )
+
+describe("CountryCodePicker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockThemeMode.mockReturnValue("dark")
+  })
+
+  it("asks the picker for the flags the library no longer defaults", () => {
+    renderPicker()
+
+    const [pickerProps] = mockPicker.mock.calls[0]
+    expect(pickerProps.withEmoji).toBe(true)
+    expect(pickerProps.withFlag).toBe(true)
+  })
+
+  it("asks the flag button for the props it needs to render at all", () => {
+    renderPicker()
+
+    const [flagProps] = mockFlag.mock.calls[0]
+    expect(flagProps.withFlagButton).toBe(true)
+    expect(flagProps.withEmoji).toBe(true)
+    expect(flagProps.countryCode).toBe("SV")
+    expect(flagProps.flagSize).toBe(24)
+  })
+
+  it("shows the calling code of the selected country", () => {
+    const { getByText } = renderPicker()
+
+    expect(getByText("+503")).toBeTruthy()
+  })
+
+  it("shows the calling code of another country", () => {
+    const { getByText } = renderPicker({ countryCode: "US" as never })
+
+    expect(getByText("+1")).toBeTruthy()
+  })
+
+  it("renders no button until the picker resolves a country", () => {
+    const { queryByText } = renderPicker({ countryCode: undefined })
+
+    expect(queryByText("+503")).toBeNull()
+    expect(mockFlag).not.toHaveBeenCalled()
+  })
+
+  it("opens the picker when the button is pressed", () => {
+    const { getByText } = renderPicker()
+
+    fireEvent.press(getByText("+503"))
+
+    expect(mockOnOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it("hands the caller's selection and close handlers to the picker", () => {
+    const onSelect = jest.fn()
+    const onClose = jest.fn()
+    renderPicker({ onSelect, onClose })
+
+    const [pickerProps] = mockPicker.mock.calls[0]
+    expect(pickerProps.onSelect).toBe(onSelect)
+    expect(pickerProps.onClose).toBe(onClose)
+    expect(pickerProps.countryCodes).toEqual(["SV", "US"])
+  })
+
+  it("applies the button style the caller supplies", () => {
+    const buttonStyle = { backgroundColor: "rebeccapurple" }
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = renderPicker({ buttonStyle })
+
+    expect(UNSAFE_getByType(TouchableOpacity).props.style).toEqual(buttonStyle)
+  })
+
+  it("keeps the picker filterable, which is how a country is found at all", () => {
+    renderPicker()
+
+    const [pickerProps] = mockPicker.mock.calls[0]
+    expect(pickerProps.withFilter).toBe(true)
+    expect(pickerProps.withCallingCode).toBe(true)
+    expect(pickerProps.withCallingCodeButton).toBe(true)
+    expect(pickerProps.filterProps).toEqual({ autoFocus: true })
+  })
+
+  it("rebuilds the picker when the supported countries finally arrive", () => {
+    const { rerender } = renderPicker({ countryCodes: [] as never })
+    const keyWhileEmpty = mockPicker.mock.calls.length
+
+    rerender(
+      <CountryCodePicker
+        countryCode={"SV" as never}
+        countryCodes={["SV", "US"] as never}
+        onSelect={jest.fn()}
+      />,
+    )
+
+    /** A fresh mount is the point: the library reads its country list once, so reusing the
+     *  instance would keep offering every country instead of the supported ones. */
+    expect(mockPicker.mock.calls.length).toBeGreaterThan(keyWhileEmpty)
+    expect(mockPicker.mock.calls.at(-1)?.[0].countryCodes).toEqual(["SV", "US"])
+  })
+
+  it("follows the app theme into the picker", () => {
+    renderPicker()
+    expect(mockPicker.mock.calls[0][0].theme).toEqual({ name: "dark" })
+
+    jest.clearAllMocks()
+    mockThemeMode.mockReturnValue("light")
+    renderPicker()
+
+    expect(mockPicker.mock.calls[0][0].theme).toEqual({ name: "light" })
+  })
+})

--- a/__tests__/components/phone-input/phone-input.spec.tsx
+++ b/__tests__/components/phone-input/phone-input.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { TextInput } from "react-native"
-import { ThemeProvider, createTheme } from "@rn-vui/themed"
+import { StyleProp, TextInput, ViewStyle } from "react-native"
+import { Input, ThemeProvider, createTheme } from "@rn-vui/themed"
 import { act, fireEvent, render } from "@testing-library/react-native"
 
 import { PhoneInput } from "@app/components/phone-input/phone-input"
@@ -29,6 +29,15 @@ jest.mock("@app/graphql/generated", () => ({
  *  full screen context would spin up providers that log act warnings for no gain here. */
 const renderInput = (node: React.ReactElement) =>
   render(<ThemeProvider theme={createTheme({})}>{node}</ThemeProvider>)
+
+/** What `disabledInput` amounts to in the stylesheet, which is all a caller can observe. */
+const DIMMED_STYLE = { opacity: 0.6 }
+
+/** The query needs a plain component type, and rn-vui types `Input`'s ref as the bare
+ *  TextInput underneath it, which does not fit one. Only the style prop is read here. */
+const ThemedInput = Input as unknown as React.ComponentType<{
+  inputContainerStyle: StyleProp<ViewStyle>
+}>
 
 describe("PhoneInput", () => {
   beforeEach(() => {
@@ -63,6 +72,19 @@ describe("PhoneInput", () => {
     renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
 
     expect(mockCountryCodePicker).not.toHaveBeenCalled()
+  })
+
+  it("dims both halves of the field when the caller disables it", () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = renderInput(
+      <PhoneInput value="" isDisabled={true} onChangeText={jest.fn()} />,
+    )
+
+    const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+    expect(props.buttonStyle).toContainEqual(DIMMED_STYLE)
+    expect(UNSAFE_getByType(ThemedInput).props.inputContainerStyle).toContainEqual(
+      DIMMED_STYLE,
+    )
   })
 
   it("reports the country and the formatted number to its caller", () => {
@@ -152,6 +174,41 @@ describe("PhoneInput", () => {
     expect(onChangeText).toHaveBeenCalledWith("+14155552671")
     expect(onChangeInfo).toHaveBeenLastCalledWith(
       expect.objectContaining({ countryCode: "US" }),
+    )
+  })
+
+  it("adopts the country of a number it is handed already written", () => {
+    const onChangeInfo = jest.fn()
+
+    renderInput(
+      <PhoneInput
+        value="+14155552671"
+        onChangeText={jest.fn()}
+        onChangeInfo={onChangeInfo}
+      />,
+    )
+
+    /** The number outranks the location here: a US number reached the field while the
+     *  device says SV, and the country has to follow the number. */
+    expect(onChangeInfo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ countryCode: "US", countryCallingCode: "1" }),
+    )
+  })
+
+  it("leaves a handed-in number's country alone when the caller pins the country", () => {
+    const onChangeInfo = jest.fn()
+
+    renderInput(
+      <PhoneInput
+        value="+14155552671"
+        keepCountryCode={true}
+        onChangeText={jest.fn()}
+        onChangeInfo={onChangeInfo}
+      />,
+    )
+
+    expect(onChangeInfo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ countryCode: "SV" }),
     )
   })
 

--- a/__tests__/components/phone-input/phone-input.spec.tsx
+++ b/__tests__/components/phone-input/phone-input.spec.tsx
@@ -1,0 +1,175 @@
+import React from "react"
+import { TextInput } from "react-native"
+import { ThemeProvider, createTheme } from "@rn-vui/themed"
+import { act, fireEvent, render } from "@testing-library/react-native"
+
+import { PhoneInput } from "@app/components/phone-input/phone-input"
+
+const mockCountryCodePicker = jest.fn()
+jest.mock("@app/components/phone-input/country-code-picker", () => ({
+  CountryCodePicker: (props: Record<string, unknown>) => {
+    mockCountryCodePicker(props)
+    return null
+  },
+}))
+
+const mockDeviceLocation = jest.fn()
+jest.mock("@app/hooks/use-device-location", () => ({
+  __esModule: true,
+  default: () => mockDeviceLocation(),
+}))
+
+const mockSupportedCountries = jest.fn()
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useSupportedCountriesQuery: () => mockSupportedCountries(),
+}))
+
+/** Only the theme is needed: every data source PhoneInput reads is mocked above, and the
+ *  full screen context would spin up providers that log act warnings for no gain here. */
+const renderInput = (node: React.ReactElement) =>
+  render(<ThemeProvider theme={createTheme({})}>{node}</ThemeProvider>)
+
+describe("PhoneInput", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeviceLocation.mockReturnValue({ countryCode: "SV", loading: false })
+    mockSupportedCountries.mockReturnValue({
+      data: { globals: { supportedCountries: [{ id: "SV" }, { id: "US" }] } },
+    })
+  })
+
+  it("delegates the country button to the shared picker", () => {
+    renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
+
+    expect(mockCountryCodePicker).toHaveBeenCalled()
+    const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+    expect(props.countryCode).toBe("SV")
+    expect(props.countryCodes).toEqual(["SV", "US"])
+  })
+
+  it("hands the picker an empty country list until the query answers", () => {
+    mockSupportedCountries.mockReturnValue({ data: undefined })
+
+    renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
+
+    const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+    expect(props.countryCodes).toEqual([])
+  })
+
+  it("shows the skeleton instead of the picker while the location resolves", () => {
+    mockDeviceLocation.mockReturnValue({ countryCode: undefined, loading: true })
+
+    renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
+
+    expect(mockCountryCodePicker).not.toHaveBeenCalled()
+  })
+
+  it("reports the country and the formatted number to its caller", () => {
+    const onChangeInfo = jest.fn()
+
+    renderInput(
+      <PhoneInput
+        value="78662557"
+        onChangeText={jest.fn()}
+        onChangeInfo={onChangeInfo}
+      />,
+    )
+
+    expect(onChangeInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        countryCode: "SV",
+        countryCallingCode: "503",
+        rawPhoneNumber: "78662557",
+      }),
+    )
+  })
+
+  it("reports nothing while there is no country to report", () => {
+    mockDeviceLocation.mockReturnValue({ countryCode: undefined, loading: false })
+    const onChangeInfo = jest.fn()
+
+    renderInput(
+      <PhoneInput value="" onChangeText={jest.fn()} onChangeInfo={onChangeInfo} />,
+    )
+
+    expect(onChangeInfo).toHaveBeenCalledWith(null)
+  })
+
+  it("adopts the country the user picks", () => {
+    const onChangeInfo = jest.fn()
+    renderInput(
+      <PhoneInput value="" onChangeText={jest.fn()} onChangeInfo={onChangeInfo} />,
+    )
+
+    const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+    act(() => {
+      ;(props.onSelect as (country: { cca2: string }) => void)({ cca2: "US" })
+    })
+
+    expect(onChangeInfo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ countryCode: "US", countryCallingCode: "1" }),
+    )
+  })
+
+  const expectRefocus = (handler: "onClose" | "onSelect", delay: number) => {
+    jest.useFakeTimers()
+    const focus = jest.spyOn(TextInput.prototype, "focus")
+    try {
+      renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
+      const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+      focus.mockClear()
+
+      act(() => {
+        ;(props[handler] as (arg?: unknown) => void)({ cca2: "US" })
+        jest.advanceTimersByTime(delay)
+      })
+
+      expect(focus).toHaveBeenCalledTimes(1)
+    } finally {
+      focus.mockRestore()
+      jest.useRealTimers()
+    }
+  }
+
+  it("returns focus to the field after the picker closes", () => {
+    expectRefocus("onClose", 300)
+  })
+
+  it("returns focus to the field after a country is chosen", () => {
+    expectRefocus("onSelect", 100)
+  })
+
+  it("adopts the country of a number typed with its international prefix", () => {
+    const onChangeText = jest.fn()
+    const onChangeInfo = jest.fn()
+    const { getByTestId } = renderInput(
+      <PhoneInput value="" onChangeText={onChangeText} onChangeInfo={onChangeInfo} />,
+    )
+
+    fireEvent.changeText(getByTestId("telephoneNumber"), "+14155552671")
+
+    expect(onChangeText).toHaveBeenCalledWith("+14155552671")
+    expect(onChangeInfo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ countryCode: "US" }),
+    )
+  })
+
+  it("keeps the chosen country when the caller pins it", () => {
+    const onChangeInfo = jest.fn()
+    const { getByTestId } = renderInput(
+      <PhoneInput
+        value=""
+        keepCountryCode={true}
+        onChangeText={jest.fn()}
+        onChangeInfo={onChangeInfo}
+      />,
+    )
+
+    fireEvent.changeText(getByTestId("telephoneNumber"), "+14155552671")
+
+    expect(onChangeInfo).toHaveBeenLastCalledWith(
+      expect.objectContaining({ countryCode: "SV" }),
+    )
+  })
+})

--- a/app/components/phone-input/country-code-picker.tsx
+++ b/app/components/phone-input/country-code-picker.tsx
@@ -1,0 +1,99 @@
+import React from "react"
+import { StyleProp, TouchableOpacity, ViewStyle } from "react-native"
+import {
+  CountryCode as PhoneNumberCountryCode,
+  getCountryCallingCode,
+} from "libphonenumber-js/mobile"
+import CountryPicker, {
+  CountryCode,
+  DARK_THEME,
+  DEFAULT_THEME,
+  Flag,
+} from "react-native-country-picker-modal"
+import { Text, useTheme } from "@rn-vui/themed"
+
+const FLAG_SIZE = 24
+
+/**
+ * Props the library declares through `Component.defaultProps`, which React 19 no longer
+ * applies to function components. Every one of them arrives undefined instead, and the
+ * flags vanish without a single error: `Flag` returns null when `withFlagButton` is unset,
+ * the country list drops its flag column without `withFlag`, and an unset `withEmoji`
+ * sends the picker to fetch flag images from a remote host rather than reading the emoji
+ * data it already ships. Declaring them here keeps the answer in one place, so a fourth
+ * caller cannot be born flagless the way the three before it were.
+ */
+const LIBRARY_FLAG_DEFAULTS = {
+  withEmoji: true,
+  withFlag: true,
+} as const
+
+const FLAG_BUTTON_DEFAULTS = {
+  withEmoji: true,
+  withFlagButton: true,
+} as const
+
+export type CountryCodePickerProps = {
+  countryCode?: CountryCode
+  countryCodes: CountryCode[]
+  onSelect: (country: { cca2: string }) => void
+  onClose?: () => void
+  buttonStyle?: StyleProp<ViewStyle>
+}
+
+/**
+ * The country code button and its picker, shared by every phone field. Callers supply
+ * what genuinely differs between them, the selection handlers and the button style, and
+ * never the flag configuration.
+ */
+export const CountryCodePicker: React.FC<CountryCodePickerProps> = ({
+  countryCode,
+  countryCodes,
+  onSelect,
+  onClose,
+  buttonStyle,
+}) => {
+  const {
+    theme: { mode: themeMode },
+  } = useTheme()
+
+  const isDarkMode = themeMode === "dark"
+
+  /**
+   * The library reads the country list once, in an effect keyed on neither the list nor
+   * the codes, and an empty list means every country. Mounting before the supported ones
+   * have arrived would therefore leave the modal offering all of them for good, so the
+   * list itself decides the identity of the subtree that reads it.
+   */
+  const countryListKey = countryCodes.join()
+
+  return (
+    <CountryPicker
+      key={countryListKey}
+      {...LIBRARY_FLAG_DEFAULTS}
+      theme={isDarkMode ? DARK_THEME : DEFAULT_THEME}
+      countryCode={countryCode as CountryCode}
+      countryCodes={countryCodes}
+      onSelect={onSelect}
+      onClose={onClose}
+      renderFlagButton={({ countryCode: buttonCountryCode, onOpen }) =>
+        buttonCountryCode ? (
+          <TouchableOpacity style={buttonStyle} onPress={onOpen}>
+            <Flag
+              {...FLAG_BUTTON_DEFAULTS}
+              countryCode={buttonCountryCode}
+              flagSize={FLAG_SIZE}
+            />
+            <Text type="p1">
+              +{getCountryCallingCode(buttonCountryCode as PhoneNumberCountryCode)}
+            </Text>
+          </TouchableOpacity>
+        ) : null
+      }
+      withCallingCodeButton={true}
+      withFilter={true}
+      filterProps={{ autoFocus: true }}
+      withCallingCode={true}
+    />
+  )
+}

--- a/app/components/phone-input/phone-input.tsx
+++ b/app/components/phone-input/phone-input.tsx
@@ -4,20 +4,16 @@ import parsePhoneNumber, {
   getCountryCallingCode,
 } from "libphonenumber-js/mobile"
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { View, TouchableOpacity, StyleProp, ViewStyle } from "react-native"
-import CountryPicker, {
-  CountryCode,
-  DARK_THEME,
-  DEFAULT_THEME,
-  Flag,
-} from "react-native-country-picker-modal"
-import { Input, makeStyles, Text, useTheme } from "@rn-vui/themed"
+import { View, StyleProp, ViewStyle } from "react-native"
+import { CountryCode } from "react-native-country-picker-modal"
+import { Input, makeStyles } from "@rn-vui/themed"
 import { testProps } from "@app/utils/testProps"
 import useDeviceLocation from "@app/hooks/use-device-location"
 import { useSupportedCountriesQuery } from "@app/graphql/generated"
 import { IconNode } from "@rn-vui/base"
 import type { InputRef } from "@app/types/themed-input"
 
+import { CountryCodePicker } from "./country-code-picker"
 import PhoneInputSkeleton from "./phone-input-skeleton"
 
 const PLACEHOLDER_PHONE_NUMBER = "123-456-7890"
@@ -58,9 +54,6 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
   countryPickerButtonStyle,
   bgColor,
 }) => {
-  const {
-    theme: { mode: themeMode },
-  } = useTheme()
   const styles = useStyles({ bgColor })
 
   const { data } = useSupportedCountriesQuery()
@@ -142,37 +135,16 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
 
   return (
     <View style={styles.inputContainer}>
-      <CountryPicker
-        theme={themeMode === "dark" ? DARK_THEME : DEFAULT_THEME}
+      <CountryCodePicker
         countryCode={phoneInputInfo?.countryCode as CountryCode}
         countryCodes={allSupportedCountries as CountryCode[]}
         onSelect={handleCountrySelect}
         onClose={handleCountryPickerClose}
-        renderFlagButton={({ countryCode, onOpen }) => {
-          return (
-            countryCode && (
-              <TouchableOpacity
-                style={[
-                  styles.countryPickerButtonStyle,
-                  isDisabled && styles.disabledInput,
-                  countryPickerButtonStyle,
-                ]}
-                onPress={onOpen}
-              >
-                <Flag countryCode={countryCode} flagSize={24} />
-                <Text type="p1">
-                  +{getCountryCallingCode(countryCode as PhoneNumberCountryCode)}
-                </Text>
-              </TouchableOpacity>
-            )
-          )
-        }}
-        withCallingCodeButton={true}
-        withFilter={true}
-        filterProps={{
-          autoFocus: true,
-        }}
-        withCallingCode={true}
+        buttonStyle={[
+          styles.countryPickerButtonStyle,
+          isDisabled && styles.disabledInput,
+          countryPickerButtonStyle,
+        ]}
       />
       <Input
         {...testProps("telephoneNumber")}

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -1,18 +1,10 @@
-import {
-  CountryCode as PhoneNumberCountryCode,
-  getCountryCallingCode,
-} from "libphonenumber-js/mobile"
+import { CountryCode as PhoneNumberCountryCode } from "libphonenumber-js/mobile"
 import * as React from "react"
 import { useEffect, useRef } from "react"
 import { ActivityIndicator, View } from "react-native"
-import CountryPicker, {
-  CountryCode,
-  DARK_THEME,
-  DEFAULT_THEME,
-  Flag,
-} from "react-native-country-picker-modal"
-import { TouchableOpacity } from "react-native-gesture-handler"
+import { CountryCode } from "react-native-country-picker-modal"
 
+import { CountryCodePicker } from "@app/components/phone-input/country-code-picker"
 import { GaloyErrorBox } from "@app/components/atomic/galoy-error-box"
 import { GaloyInfo } from "@app/components/atomic/galoy-info"
 import { ContactSupportButton } from "@app/components/contact-support-button/contact-support-button"
@@ -130,7 +122,7 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
     >()
 
   const {
-    theme: { colors, mode: themeMode },
+    theme: { colors },
   } = useTheme()
 
   const {
@@ -270,35 +262,14 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
         </View>
 
         <View style={styles.inputContainer}>
-          <CountryPicker
-            theme={themeMode === "dark" ? DARK_THEME : DEFAULT_THEME}
+          <CountryCodePicker
             countryCode={
               (phoneInputInfo?.countryCode || DEFAULT_COUNTRY_CODE) as CountryCode
             }
             countryCodes={supportedCountries as CountryCode[]}
             onSelect={handleCountrySelect}
             onClose={handleCountryPickerClose}
-            renderFlagButton={({ countryCode, onOpen }) => {
-              return (
-                countryCode && (
-                  <TouchableOpacity
-                    style={styles.countryPickerButtonStyle}
-                    onPress={onOpen}
-                  >
-                    <Flag countryCode={countryCode} flagSize={24} />
-                    <Text type="p1">
-                      +{getCountryCallingCode(countryCode as PhoneNumberCountryCode)}
-                    </Text>
-                  </TouchableOpacity>
-                )
-              )
-            }}
-            withCallingCodeButton={true}
-            withFilter={true}
-            filterProps={{
-              autoFocus: true,
-            }}
-            withCallingCode={true}
+            buttonStyle={styles.countryPickerButtonStyle}
           />
           <Input
             {...testProps("telephoneNumber")}

--- a/app/screens/phone-auth-screen/phone-registration-input.tsx
+++ b/app/screens/phone-auth-screen/phone-registration-input.tsx
@@ -1,17 +1,9 @@
-import {
-  CountryCode as PhoneNumberCountryCode,
-  getCountryCallingCode,
-} from "libphonenumber-js/mobile"
+import { CountryCode as PhoneNumberCountryCode } from "libphonenumber-js/mobile"
 import * as React from "react"
 import { ActivityIndicator, View } from "react-native"
-import CountryPicker, {
-  CountryCode,
-  DARK_THEME,
-  DEFAULT_THEME,
-  Flag,
-} from "react-native-country-picker-modal"
-import { TouchableOpacity } from "react-native-gesture-handler"
+import { CountryCode } from "react-native-country-picker-modal"
 
+import { CountryCodePicker } from "@app/components/phone-input/country-code-picker"
 import { GaloyErrorBox } from "@app/components/atomic/galoy-error-box"
 import { GaloyInfo } from "@app/components/atomic/galoy-info"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
@@ -35,7 +27,7 @@ export const PhoneRegistrationInitiateScreen: React.FC = () => {
   const styles = useStyles()
 
   const {
-    theme: { colors, mode: themeMode },
+    theme: { colors },
   } = useTheme()
 
   const {
@@ -154,34 +146,15 @@ export const PhoneRegistrationInitiateScreen: React.FC = () => {
         </View>
 
         <View style={styles.inputContainer}>
-          <CountryPicker
-            theme={themeMode === "dark" ? DARK_THEME : DEFAULT_THEME}
+          <CountryCodePicker
             countryCode={
               (phoneInputInfo?.countryCode || DEFAULT_COUNTRY_CODE) as CountryCode
             }
             countryCodes={supportedCountries as CountryCode[]}
-            onSelect={(country) => setCountryCode(country.cca2 as PhoneNumberCountryCode)}
-            renderFlagButton={({ countryCode, onOpen }) => {
-              return (
-                countryCode && (
-                  <TouchableOpacity
-                    style={styles.countryPickerButtonStyle}
-                    onPress={onOpen}
-                  >
-                    <Flag countryCode={countryCode} flagSize={24} />
-                    <Text type="p1">
-                      +{getCountryCallingCode(countryCode as PhoneNumberCountryCode)}
-                    </Text>
-                  </TouchableOpacity>
-                )
-              )
-            }}
-            withCallingCodeButton={true}
-            withFilter={true}
-            filterProps={{
-              autoFocus: true,
-            }}
-            withCallingCode={true}
+            onSelect={(country: { cca2: string }) =>
+              setCountryCode(country.cca2 as PhoneNumberCountryCode)
+            }
+            buttonStyle={styles.countryPickerButtonStyle}
           />
           <Input
             placeholder={PLACEHOLDER_PHONE_NUMBER}


### PR DESCRIPTION
## Summary

The country button in every phone field lost its flag, and so did the country list behind it. Both come from the same cause, and neither surface raised an error while it happened.

`react-native-country-picker-modal` declares its flag props through `Component.defaultProps`. React 19 no longer applies that to function components, so each one arrives `undefined` at the app boundary: `Flag` returns `null` without `withFlagButton`, the country list drops its flag column without `withFlag`, and an unset `withEmoji` sends the picker to fetch flag images from a remote host instead of reading the emoji data it already ships. That is the "after the 3.0 update" in the report: the app moved to React 19.2.3.

Upgrading is not an option. The library's last release is 2.0.0 from June 2022, which is what we are on.

Closes blinkbitcoin/blink-mobile#4132

## Changes

**One place that owns the flag configuration**

- `app/components/phone-input/country-code-picker.tsx` (new): the country button and its picker, with the props the library stopped defaulting declared once. Three call sites had the same twenty-line `renderFlagButton` inline, so the bug had to be fixed three times and a fourth caller would have been born flagless the same way. They now pass only what genuinely differs between them: the selection handlers and the button style.
- `phone-input.tsx`, `phone-login-input.tsx` and `phone-registration-input.tsx` delegate to it.

**The country list was also frozen at mount**

The library reads its country list in an effect keyed on neither the list nor the codes, and an empty list means every country. Mounting before `useSupportedCountriesQuery` answered therefore left the modal offering all of them for good, which is why Antarctica, a country with no calling code, was on the list. The list now decides the identity of the subtree that reads it, so the supported set replaces the default one as soon as it arrives.

## Test plan

- `yarn jest __tests__/components/phone-input`: 21 passed. **100% on the new component**, and `phone-input.tsx` went from no spec at all to 96.5%
- The two assertions that pin the restored props fail when those props alone are removed, so they cannot pass by coincidence. Same for the refocus assertions
- The library is stubbed in the new spec on purpose: under Jest the dead `defaultProps` still resolve, because `React.createElement` kept that legacy path, so rendering the real library would show a flag either way and prove nothing. What is pinned is the props contract, which is the thing that broke
- `yarn tsc --noEmit` and `eslint` on the changed files: clean, and no console output in the new specs
- Consumer specs still green: `send-destination.spec.tsx` and `account-type-selection`
- Device (Android emulator): flag renders on the send flow button, flags render in the country list, and Antarctica is gone from it

## Screenshots

| Before | After |
| :---: | :---: |
| <img height="320" alt="antes" src="https://github.com/user-attachments/assets/bccd5f64-6273-4bba-a4dd-931e40b227fc" /> | <img height="320" alt="despues" src="https://github.com/user-attachments/assets/ec22691a-5bc1-4b31-b153-554287663053" /> |

The country list behind the button, which had lost its flags for the same reason:

| Before | After |
| :---: | :---: |
| <img height="2400" alt="modal-antes" src="https://github.com/user-attachments/assets/b6aa518d-c895-4e23-b582-929d6391b20b" /> | <img height="2400" alt="modal-despues" src="https://github.com/user-attachments/assets/34e7ca09-16f1-44ba-a886-c6668ebf4267" /> |

## Note for whoever touches this library next

Nine other components declare defaults the same way. Only the three used from app-level JSX were losing them, because elements the library builds internally still go through `React.createElement`, which kept resolving `defaultProps` in React 19. Anything new rendered from our side should pass what it needs explicitly rather than trust a default.
