### PR TITLE
feat(agents): blink-staging-session — repo-specific staging login + golden provisioning skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xcrun simctl *)",
+      "Bash(maestro *)",
+      "Bash(ffmpeg *)",
+      "Bash(ffprobe *)",
+      "Bash(magick *)",
+      "Bash(node node_modules/react-native/cli.js *)",
+      "Bash(/*/.claude/skills/*/scripts/*.sh)",
+      "Bash(/*/.claude/skills/*/scripts/*.sh *)",
+      "Bash(/*/.claude/skills/*/tests/run.sh)",
+      "Bash(/*/.claude/skills/*/bench/live.sh)",
+      "Bash(/*/.claude/skills/*/bench/live.sh *)",
+      "Bash(/*/.claude/skills/run-all-tests.sh)"
+    ]
+  }
+}

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -24,6 +24,7 @@ instructions (e.g. `AGENTS.md`).
 | [`react-native-demo-screenshots`](./react-native-demo-screenshots/SKILL.md) | Settle-aware capture, honest before/after crop pairs, numeric comparison against design mocks |
 | [`react-native-demo-videos`](./react-native-demo-videos/SKILL.md) | Maestro-driven recordings with safe recorder stop paths, GIF/MP4/WebM encoding, and a guard against the `clearState` Metro-redirect trap |
 | [`github-pr-image-attachments`](./github-pr-image-attachments/SKILL.md) | Embed images in PR comments via an orphan `assets/pr-<N>-*` branch (`gh` has no attachment upload); repo derived from the origin remote |
+| [`blink-staging-session`](./blink-staging-session/SKILL.md) | **Blink-specific** (the one exception to app-agnosticism, kept separate on purpose): staging login with the global OTP, the Main→Staging instance switch, golden-sim provisioning recipe |
 
 ## Quickstart (a before/after screenshot pair on a PR)
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -26,6 +26,20 @@ instructions (e.g. `AGENTS.md`).
 | [`github-pr-image-attachments`](./github-pr-image-attachments/SKILL.md) | Embed images in PR comments via an orphan `assets/pr-<N>-*` branch (`gh` has no attachment upload); repo derived from the origin remote |
 | [`blink-staging-session`](./blink-staging-session/SKILL.md) | **Blink-specific** (the one exception to app-agnosticism, kept separate on purpose): staging login with the global OTP, the Main→Staging instance switch, golden-sim provisioning recipe |
 
+## Permissions: allowed by default, guarded by the scripts
+
+Autonomous sessions die on permission prompts, so the repo pre-approves the
+skills' commands in two layers: `.claude/settings.json` allowlists
+`xcrun simctl`, `maestro`, `ffmpeg`/`ffprobe`/`magick`, the RN CLI, and the
+skill scripts for every session in a trusted checkout, and each `SKILL.md`
+carries the same grants as `allowed-tools` frontmatter (turn-scoped, works
+even where project settings don't apply). This is safe because the safety
+here was never the prompt: it is the tested scripts — udid scoping,
+ownership gates, the collateral-damage assertion — and the suites that
+mutation-check them. Note: non-interactive runs in an *untrusted* checkout
+ignore project settings by design; trust the workspace once and the
+allowlist applies.
+
 ## Quickstart (a before/after screenshot pair on a PR)
 
 ```bash

--- a/.claude/skills/blink-staging-session/SKILL.md
+++ b/.claude/skills/blink-staging-session/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: blink-staging-session
 description: Use when a Blink demo session needs a real logged-in staging account on a claimed iOS simulator — logging in with the staging global OTP, switching a fresh install off the Main (production) instance, or provisioning/refreshing the golden simulator with a live login. Blink-repo-specific; the app-agnostic simulator mechanics live in react-native-ios-simulator.
+allowed-tools: Bash(xcrun simctl *) Bash(maestro *) Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh)
 ---
 
 # A Logged-In Staging Session on a Claimed Simulator (Blink-specific)

--- a/.claude/skills/blink-staging-session/SKILL.md
+++ b/.claude/skills/blink-staging-session/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: blink-staging-session
+description: Use when a Blink demo session needs a real logged-in staging account on a claimed iOS simulator — logging in with the staging global OTP, switching a fresh install off the Main (production) instance, or provisioning/refreshing the golden simulator with a live login. Blink-repo-specific; the app-agnostic simulator mechanics live in react-native-ios-simulator.
+---
+
+# A Logged-In Staging Session on a Claimed Simulator (Blink-specific)
+
+## Overview
+
+The generic skills are deliberately app-agnostic; this one owns the parts
+that are pure Blink: which backend a fresh install points at, how the login
+flow is laid out, and where the staging credential comes from. It exists so
+no session ever again spends forty minutes rediscovering that a staging
+login was possible all along.
+
+Two facts do most of the work:
+
+- **Staging accepts a global OTP.** Any valid-format phone number logs in
+  with the shared code. The value is machine state, never repo state:
+  `GALOY_STAGING_GLOBAL_OTP` in `.env.local` (gitignored, loaded by `.envrc`
+  via direnv). `claim-session.sh` already reports it when missing (it is in
+  `DEMO_REQUIRED_ENV`); if it is not set, ask the user for the standard PIN —
+  every developer has it — and never write the value into anything tracked.
+- **A fresh install points at Main — production.** The persisted-state
+  default is `galoyInstance: Main`, dev build or not. Logging in with the
+  staging OTP against Main fails; the instance must be switched first via
+  the hidden developer screen (triple-tap the GetStarted logo).
+
+## Logging in
+
+Claim a session and install the app first (`react-native-ios-simulator`,
+steps 1–5 — the app must be running against your session's Metro), then:
+
+```bash
+BLINK="$(git rev-parse --show-toplevel)"/.claude/skills/blink-staging-session
+"$BLINK/scripts/staging-login.sh"                      # fresh install: switches to Staging, then logs in
+"$BLINK/scripts/staging-login.sh" --skip-instance-switch   # already on Staging
+"$BLINK/scripts/staging-login.sh" --phone 732459186        # pick the account
+```
+
+The script drives both flows with Maestro coordinate taps (the app's
+accessibility tree is collapsed on these screens — see the simulator skill's
+element-blindness section), injects the OTP as a Maestro env var so it never
+lands in a flow file, and finishes with a verification screenshot. **Look at
+that screenshot**: a successful login shows the phone number and balances on
+the home screen. The script cannot read pixels; you can.
+
+Notes that save retakes:
+
+- The country code defaults to the device locale. The default phone digits
+  are a Swedish mobile shape; pass `--phone` with digits valid for whatever
+  country the picker shows if your simulator differs.
+- Staging accounts are shared by number: anyone logging in with the same
+  digits lands in the same account. For a golden bless that is fine (the
+  account is disposable); for a demo needing pristine state, pick unlikely
+  digits of your own.
+- The coordinate taps assume the skill's default portrait iPhone
+  (16-Pro-class). A different device type may need adjusted percentages —
+  screenshot between steps rather than guessing.
+
+## Provisioning or refreshing the golden simulator
+
+This is the Blink recipe for the generic `bless-golden.sh` (which does the
+mechanical part: driver bake, stamps, swap):
+
+1. Claim a session; **build fresh if the native closure moved** — and note
+   that in a demo worktree `yarn install --ignore-scripts` skips two
+   postinstalls a native build needs: run `npx install-skia` and
+   `node_modules/@breeztech/breez-sdk-spark-react-native/scripts/postinstall.sh`
+   before `pod install`, or the build dies at link on missing Skia/Breez
+   binaries. Simulator builds are x86_64 by design (`EXCLUDED_ARCHS arm64`
+   in the Podfile) — that is not a mistake to fix.
+2. `staging-login.sh`, verify the home screen.
+3. Bless from the worktree root so both stamps are right:
+
+```bash
+SIM="$(git rev-parse --show-toplevel)"/.claude/skills/react-native-ios-simulator
+"$SIM/scripts/bless-golden.sh" <pr> --sha "$(git rev-parse --short HEAD)" --lockfile ios/Podfile.lock
+```
+
+Re-bless whenever a clone tells you to: it comes up logged out (staging
+sessions expire), the claim prints `NATIVE BUILD STALE`, or the claim notes a
+maestro upgrade voided the baked driver.
+
+## After Editing the Scripts
+
+```bash
+"$BLINK/tests/run.sh"     # exits non-zero on failure; fake maestro/xcrun, no simulator, no network
+```
+
+Same house rule as the other skills: a new guarantee lands with the
+assertion that fails without it.

--- a/.claude/skills/blink-staging-session/flows/staging-login.yaml
+++ b/.claude/skills/blink-staging-session/flows/staging-login.yaml
@@ -1,0 +1,42 @@
+# SMS login against Staging with the global OTP.
+# Route: GetStarted -> Log in / Restore -> Custodial -> Choose method ->
+# Use SMS -> phone digits -> Send via SMS -> OTP.
+#
+# PHONE and OTP arrive as Maestro env vars from staging-login.sh - the OTP
+# value must never appear literally in this file (the repo is public).
+# Coordinate taps: collapsed accessibility tree; portrait 16-Pro-class.
+appId: ${APP_ID}
+---
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 10000
+- tapOn:
+    point: "50%,92%"
+- waitForAnimationToEnd:
+    timeout: 4000
+- tapOn:
+    point: "25%,29%"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    point: "50%,91%"
+- waitForAnimationToEnd:
+    timeout: 4000
+- tapOn:
+    point: "50%,89%"
+- waitForAnimationToEnd:
+    timeout: 4000
+- tapOn:
+    point: "50%,26%"
+- inputText: ${PHONE}
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    point: "50%,56%"
+- waitForAnimationToEnd:
+    timeout: 8000
+- tapOn:
+    point: "50%,29%"
+- inputText: ${OTP}
+- waitForAnimationToEnd:
+    timeout: 15000

--- a/.claude/skills/blink-staging-session/flows/switch-to-staging.yaml
+++ b/.claude/skills/blink-staging-session/flows/switch-to-staging.yaml
@@ -1,0 +1,43 @@
+# Switch a fresh install off the Main (production) instance onto Staging.
+# Route: triple-tap the GetStarted logo -> developerScreen -> scroll to
+# Update Environment -> Staging -> Save changes -> Back.
+#
+# Coordinate taps on purpose: these screens have a collapsed accessibility
+# tree, so text/testID matching is blind (see the simulator skill).
+# Percentages assume a portrait 16-Pro-class simulator.
+#
+# `#` comments only before the header - maestro parse-fails the whole flow
+# on prose lines, silently when output is discarded.
+appId: ${APP_ID}
+---
+- launchApp
+- waitForAnimationToEnd:
+    timeout: 10000
+- tapOn:
+    point: "38%,39%"
+- tapOn:
+    point: "38%,39%"
+- tapOn:
+    point: "38%,39%"
+- waitForAnimationToEnd:
+    timeout: 5000
+- swipe:
+    start: "50%,80%"
+    end: "50%,20%"
+- swipe:
+    start: "50%,80%"
+    end: "50%,20%"
+- waitForAnimationToEnd:
+    timeout: 3000
+- tapOn:
+    point: "50%,57%"
+- waitForAnimationToEnd:
+    timeout: 2000
+- tapOn:
+    point: "50%,42%"
+- waitForAnimationToEnd:
+    timeout: 5000
+- tapOn:
+    point: "13%,10%"
+- waitForAnimationToEnd:
+    timeout: 3000

--- a/.claude/skills/blink-staging-session/scripts/staging-login.sh
+++ b/.claude/skills/blink-staging-session/scripts/staging-login.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Log the running Blink app in against Staging, on this session's simulator.
+#
+# Two Blink facts drive the shape of this script:
+# - a fresh install points at the Main (production) instance, so the default
+#   run switches to Staging first (triple-tap logo -> developerScreen);
+# - staging accepts a shared global OTP for any valid-format phone number.
+#   The value is machine state (GALOY_STAGING_GLOBAL_OTP via .env.local,
+#   direnv-loaded), NEVER repo state - this script injects it as a Maestro
+#   env var so no flow file ever carries it. The repo is public.
+#
+# Requires a claimed session (react-native-ios-simulator) with the app
+# installed and running against your session's Metro.
+#
+# Usage: staging-login.sh [--phone <digits>] [--skip-instance-switch] [--out-dir D]
+#   --phone                national digits for whatever country the picker
+#                          shows (device-locale default). Same digits = same
+#                          shared staging account - fine for a golden bless,
+#                          pick your own for pristine state.
+#   --skip-instance-switch the app is already on Staging
+#   --out-dir              where the verification screenshot lands (default .)
+#
+# The script cannot read pixels: it ends with a screenshot, and YOU verify
+# the home screen shows the phone number before trusting the login.
+
+set -euo pipefail
+
+# Telemetry is best-effort and optional (same contract as every skill).
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+PHONE="732459186"
+SKIP_SWITCH=""
+OUTDIR="."
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --phone) PHONE="${2:?--phone needs digits}"; shift 2 ;;
+    --skip-instance-switch) SKIP_SWITCH=1; shift ;;
+    --out-dir) OUTDIR="${2:?--out-dir needs a path}"; shift 2 ;;
+    *) die "unknown argument '$1' (usage: staging-login.sh [--phone <digits>] [--skip-instance-switch] [--out-dir D])" ;;
+  esac
+done
+
+[ -n "${DEMO_UDID:-}" ] || die "no claimed session: eval claim-session.sh first (this script only ever drives your own simulator)"
+[ -n "${DEMO_APP_ID_IOS:-}" ] || die "DEMO_APP_ID_IOS is unset - see AGENTS.md for this repo's bundle id"
+[ -n "${GALOY_STAGING_GLOBAL_OTP:-}" ] || die "GALOY_STAGING_GLOBAL_OTP is unset - the staging global OTP is machine state:
+       put 'export GALOY_STAGING_GLOBAL_OTP=<the standard PIN>' in .env.local
+       (gitignored, direnv-loaded). Every developer has the PIN; ask if you don't."
+command -v maestro >/dev/null 2>&1 || die "maestro is not installed"
+
+case "$PHONE" in
+  ''|*[!0-9]*) die "--phone must be national digits only, got '$PHONE'" ;;
+esac
+
+FLOWS="$(dirname "${BASH_SOURCE[0]}")/../flows"
+T_LOGIN=$(tel_now)
+
+if [ -z "$SKIP_SWITCH" ]; then
+  echo "switching the app instance to Staging (fresh installs point at Main - production)..."
+  maestro --udid "$DEMO_UDID" test -e APP_ID="$DEMO_APP_ID_IOS" \
+    "$FLOWS/switch-to-staging.yaml" \
+    || die "instance switch flow failed - screenshot the simulator to see where it stopped"
+fi
+
+echo "logging in as +<device-locale country> $PHONE with the staging global OTP..."
+maestro --udid "$DEMO_UDID" test -e APP_ID="$DEMO_APP_ID_IOS" \
+  -e PHONE="$PHONE" -e OTP="$GALOY_STAGING_GLOBAL_OTP" \
+  "$FLOWS/staging-login.yaml" \
+  || die "login flow failed - screenshot the simulator to see where it stopped"
+
+mkdir -p "$OUTDIR"
+SHOT="$OUTDIR/staging-login-verify.png"
+xcrun simctl io "$DEMO_UDID" screenshot "$SHOT" >/dev/null 2>&1 || die "verification screenshot failed"
+
+tel_emit blink.staging_login.total "$T_LOGIN" \
+  skipped_switch="$([ -n "$SKIP_SWITCH" ] && echo 1 || echo 0)"
+
+echo "flows completed -> $SHOT"
+echo "VERIFY IT: a successful login shows the phone number and balances on the"
+echo "home screen. A GetStarted or OTP screen in that shot means it failed."

--- a/.claude/skills/blink-staging-session/tests/fixtures/bin/maestro
+++ b/.claude/skills/blink-staging-session/tests/fixtures/bin/maestro
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Fake `maestro` for the staging-login tests: records every invocation so
+# ordering, --udid pinning and env injection are assertable; FAKE_MAESTRO_RC
+# simulates a failing flow.
+set -uo pipefail
+echo "maestro $*" >> "${FAKE_ARGS_LOG:-/dev/null}"
+[ "${1:-}" = "--udid" ] && shift 2
+case "${1:-}" in
+  test) exit "${FAKE_MAESTRO_RC:-0}" ;;
+  --version) echo "2.6.1" ;;
+  *) echo "fake maestro: unsupported subcommand '${1:-}'" >&2; exit 64 ;;
+esac

--- a/.claude/skills/blink-staging-session/tests/fixtures/bin/xcrun
+++ b/.claude/skills/blink-staging-session/tests/fixtures/bin/xcrun
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Fake `xcrun simctl io <udid> screenshot <out>` - just enough for the
+# verification-shot step; writes a marker file and logs the call.
+set -uo pipefail
+echo "xcrun $*" >> "${FAKE_ARGS_LOG:-/dev/null}"
+[ "${1:-}" = "simctl" ] && shift
+case "${1:-}" in
+  io)
+    OUT="${4:?fake xcrun: screenshot needs an output path}"
+    printf 'fake-png' > "$OUT"
+    ;;
+  *) echo "fake xcrun: unsupported verb '${1:-}'" >&2; exit 64 ;;
+esac

--- a/.claude/skills/blink-staging-session/tests/run.sh
+++ b/.claude/skills/blink-staging-session/tests/run.sh
@@ -95,6 +95,8 @@ echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(maestro \*)" && echo yes || echo no)"
 check "SKILL.md sources the OTP from .env.local via the env var" "yes" \
   "$(grep -q "GALOY_STAGING_GLOBAL_OTP" "$SKILL_MD" && grep -q ".env.local" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md warns fresh installs point at Main (production)" "yes" \

--- a/.claude/skills/blink-staging-session/tests/run.sh
+++ b/.claude/skills/blink-staging-session/tests/run.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Integration tests for the Blink staging-login script.
+#
+# Fake maestro + fake xcrun; no simulator, no network, no real credential -
+# a test OTP travels through the same path the real one would.
+#
+#   ./tests/run.sh
+
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$TESTS_DIR/../scripts"
+FLOWS="$TESTS_DIR/../flows"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/blink-staging-tests.XXXXXX")"
+
+export PATH="$TESTS_DIR/fixtures/bin:$PATH"
+export FAKE_ARGS_LOG="$WORK/args.log"
+export DEMO_SIM_REGISTRY="$WORK/registry"   # confines telemetry to $WORK
+# Trust only what each test sets - a live-session shell exports these.
+unset DEMO_UDID DEMO_APP_ID_IOS GALOY_STAGING_GLOBAL_OTP 2>/dev/null || true
+
+PASS=0; FAIL=0
+trap 'rm -rf "$WORK"' EXIT
+
+ok()  { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n       %s\n' "$1" "$2"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected '$2', got '$3'"; fi; }
+reset(){ : > "$FAKE_ARGS_LOG"; }
+
+echo
+echo "credential and session guards"
+
+reset
+out=$(DEMO_UDID=SIM-1 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach \
+  "$SCRIPTS/staging-login.sh" --out-dir "$WORK" 2>&1); rc=$?
+check "refuses without the staging OTP in the environment" "1" "$rc"
+check "the refusal teaches .env.local, not just the var name" "yes" \
+  "$(echo "$out" | grep -q ".env.local" && echo yes || echo no)"
+check "no flow ran without the credential" "0" "$(grep -c "maestro" "$FAKE_ARGS_LOG")"
+
+reset
+GALOY_STAGING_GLOBAL_OTP=999111 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach \
+  "$SCRIPTS/staging-login.sh" --out-dir "$WORK" >/dev/null 2>&1
+check "refuses without a claimed session" "1" "$?"
+
+reset
+DEMO_UDID=SIM-1 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach GALOY_STAGING_GLOBAL_OTP=999111 \
+  "$SCRIPTS/staging-login.sh" --phone "abc123" --out-dir "$WORK" >/dev/null 2>&1
+check "rejects non-numeric phone digits" "1" "$?"
+
+echo
+echo "flow orchestration"
+
+reset
+DEMO_UDID=SIM-1 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach GALOY_STAGING_GLOBAL_OTP=999111 \
+  "$SCRIPTS/staging-login.sh" --out-dir "$WORK" >/dev/null 2>&1
+check "happy path exits zero" "0" "$?"
+SWITCH_LINE=$(grep -n "switch-to-staging.yaml" "$FAKE_ARGS_LOG" | head -1 | cut -d: -f1)
+LOGIN_LINE=$(grep -n "staging-login.yaml" "$FAKE_ARGS_LOG" | head -1 | cut -d: -f1)
+check "the instance switch runs before the login (fresh installs point at Main)" "yes" \
+  "$([ -n "$SWITCH_LINE" ] && [ -n "$LOGIN_LINE" ] && [ "$SWITCH_LINE" -lt "$LOGIN_LINE" ] && echo yes || echo "no (switch=$SWITCH_LINE login=$LOGIN_LINE)")"
+check "every maestro call pins --udid" "0" \
+  "$(grep "^maestro" "$FAKE_ARGS_LOG" | grep -cv -- "--udid SIM-1")"
+check "the OTP travels as a maestro env var" "yes" \
+  "$(grep "staging-login.yaml" "$FAKE_ARGS_LOG" | grep -q -- "-e OTP=999111" && echo yes || echo no)"
+check "the default phone digits travel the same way" "yes" \
+  "$(grep "staging-login.yaml" "$FAKE_ARGS_LOG" | grep -q -- "-e PHONE=732459186" && echo yes || echo no)"
+check "the verification screenshot is written" "yes" \
+  "$([ -s "$WORK/staging-login-verify.png" ] && echo yes || echo no)"
+
+reset
+DEMO_UDID=SIM-1 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach GALOY_STAGING_GLOBAL_OTP=999111 \
+  "$SCRIPTS/staging-login.sh" --skip-instance-switch --phone 655012345 --out-dir "$WORK" >/dev/null 2>&1
+check "--skip-instance-switch skips exactly the switch flow" "0" \
+  "$(grep -c "switch-to-staging.yaml" "$FAKE_ARGS_LOG")"
+check "and the login still runs" "1" "$(grep -c "staging-login.yaml" "$FAKE_ARGS_LOG")"
+check "--phone overrides the default" "yes" \
+  "$(grep "staging-login.yaml" "$FAKE_ARGS_LOG" | grep -q -- "-e PHONE=655012345" && echo yes || echo no)"
+
+reset
+FAKE_MAESTRO_RC=1 DEMO_UDID=SIM-1 DEMO_APP_ID_IOS=io.galoy.bitcoinbeach GALOY_STAGING_GLOBAL_OTP=999111 \
+  "$SCRIPTS/staging-login.sh" --out-dir "$WORK" >/dev/null 2>&1
+check "a failing flow fails the script" "1" "$?"
+
+echo
+echo "the credential can never leak into the repo"
+
+# The repo is public: the OTP may only ever travel as an env injection.
+check "no flow file hardcodes an inputText value" "0" \
+  "$(grep "inputText" "$FLOWS"/*.yaml | grep -cv '\${')"
+check "flow headers are YAML, not prose (maestro parse-fails on >)" "yes" \
+  "$(head -1 "$FLOWS/switch-to-staging.yaml" | grep -qE '^(#|appId:)' && head -1 "$FLOWS/staging-login.yaml" | grep -qE '^(#|appId:)' && echo yes || echo no)"
+
+echo
+echo "documented behavior matches the scripts"
+
+SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md sources the OTP from .env.local via the env var" "yes" \
+  "$(grep -q "GALOY_STAGING_GLOBAL_OTP" "$SKILL_MD" && grep -q ".env.local" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md warns fresh installs point at Main (production)" "yes" \
+  "$(grep -qi "Main" "$SKILL_MD" && grep -qi "production" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md carries the golden provisioning recipe" "yes" \
+  "$(grep -q "bless-golden.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md carries the demo-worktree native build prerequisites" "yes" \
+  "$(grep -q "install-skia" "$SKILL_MD" && grep -qi "breez" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md never contains a 6-digit literal that could be the PIN" "0" \
+  "$(grep -cE '(^|[^0-9.])[0-9]{6}([^0-9.]|$)' "$SKILL_MD")"
+
+echo
+echo "-------------------------------------"
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/skills/github-pr-image-attachments/SKILL.md
+++ b/.claude/skills/github-pr-image-attachments/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: github-pr-image-attachments
 description: Use when embedding screenshots, GIFs, or any image into a GitHub pull request comment or review from the command line — including "attach the screenshots to the PR", "add before/after images", or when a gh attachment upload or gist has been blocked. Works against whatever GitHub repo the current checkout's origin remote points at.
+allowed-tools: Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh)
 ---
 
 # Attaching Images to a GitHub PR

--- a/.claude/skills/github-pr-image-attachments/tests/run.sh
+++ b/.claude/skills/github-pr-image-attachments/tests/run.sh
@@ -127,6 +127,8 @@ echo
 echo "documented commands match the scripts"
 # The SKILL.md tells agents to use this convention; if the prose and the script
 # disagree, the prose wins in practice and produces broken branches.
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$TESTS_DIR/../SKILL.md" | grep "allowed-tools:" | grep -q -- "scripts/\*.sh" && echo yes || echo no)"
 check "SKILL.md documents the assets/ prefix" "yes" \
   "$(grep -q 'assets/pr-<N>-<purpose>' "$TESTS_DIR/../SKILL.md" && echo yes || echo no)"
 check "SKILL.md documents deriving the repo from the origin remote" "yes" \

--- a/.claude/skills/react-native-demo-screenshots/SKILL.md
+++ b/.claude/skills/react-native-demo-screenshots/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: react-native-demo-screenshots
 description: Use when capturing still screenshots of a React Native app on an iOS simulator or Android emulator for a PR — before/after image pairs, showing a UI change or copy fix, cropping a pair honestly, or comparing a render against a design mock numerically. Covers simctl and adb screencap.
+allowed-tools: Bash(xcrun simctl *) Bash(magick *) Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh)
 ---
 
 # Demo Screenshots for React Native PRs
@@ -141,7 +142,7 @@ simulated. Caption honestly what was forced.
 ## After Editing the Scripts
 
 ```bash
-"$SHOT/tests/run.sh"     # 57 assertions, ~15s, exits non-zero on failure
+"$SHOT/tests/run.sh"     # 58 assertions, ~15s, exits non-zero on failure
 ```
 
 Fakes `xcrun` and `adb` (writing real PNGs) and uses real ImageMagick, so the

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -245,6 +245,8 @@ echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(xcrun simctl \*)" && head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(magick \*)" && echo yes || echo no)"
 check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md pairs section uses the reload flip, not a blind fast refresh" "yes" \

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: react-native-demo-videos
 description: Use when a PR needs a moving demo rather than screenshots — recording a user session flow on an iOS simulator or Android emulator to show a bugfix or feature behaving, before/after interaction videos, animated GIF, MP4 or WebM of app navigation, "demo expected behavior". Covers simctl recordVideo and adb screenrecord. Takes gif, mp4 or webm, and optionally ios or android, as arguments.
+allowed-tools: Bash(xcrun simctl *) Bash(maestro *) Bash(ffmpeg *) Bash(ffprobe *) Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh)
 ---
 
 # Demo Videos for React Native PRs
@@ -267,7 +268,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 104 assertions, ~50s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 105 assertions, ~50s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -443,6 +443,8 @@ echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(maestro \*)" && head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(ffmpeg \*)" && echo yes || echo no)"
 check "SKILL.md carries no BLINK_ residue" "no" \
   "$(grep -q "BLINK_" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md warns clearState wipes the persisted redirect" "yes" \

--- a/.claude/skills/react-native-ios-simulator/SKILL.md
+++ b/.claude/skills/react-native-ios-simulator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: react-native-ios-simulator
 description: Use when running a React Native app on an iOS simulator on macOS — claiming an isolated simulator and Metro port, installing or building the app, reaching a particular screen or state, or any task involving xcrun simctl, Metro bundler ports, or a demo simulator. Required before capturing screenshots or video, and whenever other agents may share the same Mac.
+allowed-tools: Bash(xcrun simctl *) Bash(maestro *) Bash(node node_modules/react-native/cli.js *) Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh) Bash(/*/.claude/skills/*/bench/live.sh *)
 ---
 
 # React Native on an Isolated iOS Simulator (macOS)
@@ -317,7 +318,7 @@ The isolation guarantees are load-bearing for every other agent on this Mac, so
 they are tested rather than asserted:
 
 ```bash
-"$SKILL/tests/run.sh"     # 197 assertions, ~100s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 199 assertions, ~100s, exits non-zero on failure
 ```
 
 It creates **no real simulators** — a fake `xcrun` goes first on PATH and the

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -935,6 +935,8 @@ echo
 echo "documented behavior matches the scripts"
 
 SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(xcrun simctl \*)" && head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(maestro \*)" && echo yes || echo no)"
 check "SKILL.md documents the reload flip" "yes" \
   "$(grep -q "reload-app.sh" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the golden bless workflow" "yes" \
@@ -943,6 +945,20 @@ check "SKILL.md ties golden staleness to the stamp sha" "yes" \
   "$(grep -qi "stamp" "$SKILL_MD" && grep -q "origin/main -- ios/" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the native-stamp verdict" "yes" \
   "$(grep -q "native-stamp.sh" "$SKILL_MD" && echo yes || echo no)"
+
+# The harness permission prompts block autonomous sessions; the checked-in
+# allowlist is what lets the skills' commands run unprompted for everyone.
+SETTINGS="$TESTS_DIR/../../../settings.json"
+check "the repo ships the permission allowlist the skills need" "yes" \
+  "$(python3 -c '
+import json, sys
+try:
+    allow = json.load(open(sys.argv[1]))["permissions"]["allow"]
+except Exception:
+    print("no"); sys.exit()
+need = ["Bash(xcrun simctl *)", "Bash(maestro *)", "Bash(ffmpeg *)"]
+print("yes" if all(n in allow for n in need) and any(".claude/skills" in a for a in allow) else "no")
+' "$SETTINGS" 2>/dev/null)"
 check "SKILL.md documents telemetry and the spans report" "yes" \
   "$(grep -q "spans-report.sh" "$SKILL_MD" && grep -q "DEMO_TELEMETRY=0" "$SKILL_MD" && echo yes || echo no)"
 check "SKILL.md documents the credential precheck" "yes" \

--- a/.gitignore
+++ b/.gitignore
@@ -104,9 +104,11 @@ android-recordings
 !.yarn/sdks
 !.yarn/versions
 
-# AI agent data stays local, except the shared skills in .claude/skills
+# AI agent data stays local, except the shared skills in .claude/skills and
+# the shared permission allowlist (settings.local.json remains per-machine)
 .claude/*
 !.claude/skills
+!.claude/settings.json
 .augment
 .bmad
 bmad-custom-src

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,17 @@ knows from the start whether staging login is possible or the stub-harness
 route is the plan. The OTP value itself belongs in the machine's `.env.local`
 (loaded by `.envrc` via direnv), never in the repo.
 
+The Blink-specific *procedures* — logging in against staging with the global
+OTP, switching a fresh install off the Main (production) instance, and the
+golden-simulator provisioning recipe — live in the `blink-staging-session`
+skill, not in the app-agnostic ones. One repo-specific gotcha worth repeating
+here because it bites native builds in demo worktrees:
+`yarn install --ignore-scripts` (the fast path for Metro-only work) skips two
+postinstalls a native build needs — run `npx install-skia` and
+`node_modules/@breeztech/breez-sdk-spark-react-native/scripts/postinstall.sh`
+before `pod install`, or the build fails at link on missing Skia/Breez
+binaries.
+
 ## Critical Rules (Always Apply)
 - `app/graphql/generated.ts` is AUTO-GENERATED - never modify manually
 - Payment mutations must NOT have retry logic (handled specially in client.tsx)


### PR DESCRIPTION
Fixes #4153. Stacked on #4131 (`feat/demo-telemetry`) — only the last commit is this PR. Closes the loop on the #4092 discussion about where OTP/login knowledge should live.

## Why a separate, Blink-specific skill

The four demo skills are app-agnostic by tested design, and `AGENTS.md` carries this repo's *values* (bundle ids, sim prefix, `DEMO_REQUIRED_ENV`). But the repo *procedures* lived nowhere, and were re-derived expensively twice: once in the #4101 session (40 min of stub-harness work because a staging login looked impossible), once during golden provisioning (instance default, login choreography, build prerequisites). `blink-staging-session` packages them as the one deliberate exception to app-agnosticism — so no universal skill bloats, per the design discussion.

## What it owns

- **The Main-by-default trap**: fresh installs point at production; `staging-login.sh` switches the instance via the hidden developer screen first (skippable with `--skip-instance-switch`).
- **Staging login with the global OTP**: any valid-format phone number; the OTP comes from `GALOY_STAGING_GLOBAL_OTP` (`.env.local`, direnv — the same variable the claim-time credential precheck reports) and is injected as a Maestro env var, never written into a flow.
- **Coordinate-tap Maestro flows** for both (the accessibility tree is collapsed on these screens), ending with a verification screenshot the agent must eyeball — the script cannot read pixels and says so.
- **The golden provisioning recipe**: build (with the `--ignore-scripts` postinstall gotchas: `npx install-skia` + the Breez `postinstall.sh` before `pod install`) → login → generic `bless-golden.sh`; re-bless triggers (logged-out clone, `NATIVE BUILD STALE`, maestro upgrade).

## The credential cannot leak — tested, not asserted

The repo is public, so the suite enforces it: any hardcoded `inputText` value in a flow, or any 6-digit literal in the SKILL.md, is a red assertion; dropping the script's refusal-without-env-var guard is a red assertion (both verified by mutation). Also pinned: switch-before-login ordering, `--udid` on every Maestro call, and the YAML-header rule that silently broke the warmup flow on maestro 2.6.1.

`run-all-tests.sh` discovers the new suite automatically: **5 suites, 414 assertions, 0 failed.**
