### PR TITLE
fix(migration): stop the armed gate from restarting an unlock already in progress

### DIFF
--- a/__tests__/navigation/migration-flow-registration.spec.ts
+++ b/__tests__/navigation/migration-flow-registration.spec.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "fs"
 
+import { isMigrationRoute } from "@app/navigation/migration-routes"
+
 // The flow's screens navigate to each other by route name, and every screen spec mocks
 // navigation, so a route that was never registered still passes everywhere else and only
 // fails on device. Pinned with source-level assertions for the same reason the developer
@@ -19,6 +21,21 @@ describe("migration flow registration in root-navigator", () => {
   it("registers every step of the flow", () => {
     FLOW_ROUTES.forEach((route) => {
       expect(navigatorSource).toContain(`name="${route}"`)
+    })
+  })
+
+  it("keeps every registered migration screen inside the armed gate's allowance", () => {
+    /** The armed-gate reset pops whatever it does not recognise as the gate's own, and an
+     *  enumerated allowance is exactly what went wrong there: it named the deeplink entry
+     *  and missed the screens the gate opens itself. Read off the navigator so a screen
+     *  registered later is covered without anyone remembering to add it. */
+    const registeredRoutes = [
+      ...navigatorSource.matchAll(/name="(accountMigration\w+)"/g),
+    ].map(([, routeName]) => routeName)
+
+    expect(registeredRoutes.length).toBeGreaterThan(FLOW_ROUTES.length)
+    registeredRoutes.forEach((routeName) => {
+      expect(isMigrationRoute(routeName)).toBe(true)
     })
   })
 

--- a/__tests__/navigation/migration-routes.spec.ts
+++ b/__tests__/navigation/migration-routes.spec.ts
@@ -1,0 +1,27 @@
+import { isMigrationRoute } from "@app/navigation/migration-routes"
+
+describe("isMigrationRoute", () => {
+  it("recognises the deeplink entry the armed gate lets through", () => {
+    expect(isMigrationRoute("accountMigrationEntry")).toBe(true)
+  })
+
+  it("recognises the screens the armed gate opens itself, which the entry alone missed", () => {
+    /** Where a gate resuming a locked migration actually sends the user: a checkpoint step,
+     *  or contact support when there is nothing to resume. Coverage of every registered
+     *  screen is anchored on the navigator source, in migration-flow-registration.spec. */
+    expect(isMigrationRoute("accountMigrationContactSupport")).toBe(true)
+    expect(isMigrationRoute("accountMigrationTransferringFunds")).toBe(true)
+  })
+
+  it("rejects the screens the armed-gate reset exists to pop", () => {
+    expect(isMigrationRoute("Primary")).toBe(false)
+    expect(isMigrationRoute("scanningQRCode")).toBe(false)
+    expect(isMigrationRoute("conversionDetails")).toBe(false)
+  })
+
+  it("rejects the unlock routes, which must never be preserved above the blocker", () => {
+    expect(isMigrationRoute("authenticationCheck")).toBe(false)
+    expect(isMigrationRoute("authentication")).toBe(false)
+    expect(isMigrationRoute("pin")).toBe(false)
+  })
+})

--- a/__tests__/navigation/navigation-container-wrapper.spec.tsx
+++ b/__tests__/navigation/navigation-container-wrapper.spec.tsx
@@ -36,9 +36,9 @@ let mockOnStateChange: ((state: unknown) => void) | undefined
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   createNavigationContainerRef: () => ({
-    reset: (state: { routes: { name: string }[] }) => {
+    reset: (state: { index: number; routes: { name: string; params?: object }[] }) => {
       mockReset(state)
-      mockRootState = { index: 0, routes: state.routes }
+      mockRootState = { index: state.index, routes: state.routes }
     },
     isReady: () => mockIsReady,
     getRootState: () => mockRootState,
@@ -92,6 +92,7 @@ import {
   processLinkForAction,
   useAuthenticationContext,
 } from "@app/navigation/navigation-container-wrapper"
+import { MigrationSupportOrigin, MigrationSupportReason } from "@app/types/migration"
 import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
 
 describe("processLinkForAction", () => {
@@ -241,6 +242,31 @@ const STACK_AT_BIOMETRIC_PIN_FALLBACK = {
   ],
 }
 
+/** Where the gate sends a locked migration it has no checkpoint to resume, and one of the
+ *  checkpoint steps it resumes to. Neither is the deeplink entry: the gate never navigates
+ *  there, so an allowance naming only the entry misses everything it does open. */
+const GATE_CONTACT_SUPPORT_ROUTE = {
+  name: "accountMigrationContactSupport",
+  params: {
+    reason: MigrationSupportReason.LockedWithoutCheckpoint,
+    origin: MigrationSupportOrigin.Gate,
+  },
+}
+const GATE_CHECKPOINT_ROUTE = { name: "accountMigrationTransferringFunds" }
+
+/** The gate is mounted under the unlock screen, so it resumes and navigates there while the
+ *  user has not typed anything into the PIN pad yet. */
+const STACK_WITH_GATE_SCREEN_OVER_UNLOCK = {
+  index: 3,
+  routes: [...STACK_AT_RESUME_UNLOCK.routes, GATE_CONTACT_SUPPORT_ROUTE],
+}
+
+/** The same screen once the unlock has stepped back off the stack. */
+const STACK_WITH_GATE_SCREEN_ABOVE = {
+  index: 2,
+  routes: [{ name: "Primary" }, { name: "scanningQRCode" }, GATE_CONTACT_SUPPORT_ROUTE],
+}
+
 /** Settings reuses the pin route to SET a PIN, with the app already unlocked. */
 const STACK_AT_SETTINGS_PIN = {
   index: 2,
@@ -386,17 +412,68 @@ describe("NavigationContainerWrapper armed-gate reset", () => {
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("lands a retry on the blocker itself, never back on the unlock", async () => {
-    /** Only arming owes a still-locked session a trip through the unlock. A retry that
-     *  routed there would bounce the user off the screen it was only meant to pop. */
+  it("lands a retry on the blocker once the unlock it waited for has run", async () => {
     mockBlockerVisible = true
     mockRootState = STACK_AT_RESUME_UNLOCK
 
-    renderWrapper(<Text testID="child">child</Text>)
+    renderWrapper(<UnlockProbe />)
 
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
     navigateTo(STACK_WITH_SCREEN_ABOVE)
 
     expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY)
+  })
+
+  it("routes a retry through the unlock when the lock is still up", async () => {
+    /** Where a reset lands is the lock's call, not the trigger's. Deriving it from the
+     *  trigger let a retry land on Primary with the lock raised, and the user reached the
+     *  app without ever entering a PIN. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    navigateTo(STACK_WITH_SCREEN_ABOVE)
+
+    expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK)
+  })
+
+  it("routes a retry the armed gate itself set off through the unlock", async () => {
+    /** The gate is mounted under the unlock screen, so a locked migration resumes and
+     *  navigates while the PIN pad is still up and empty. That navigation is what runs the
+     *  pending retry, which used to tear the unlock down and land on Primary. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+    expect(mockReset).not.toHaveBeenCalled()
+
+    navigateTo(STACK_WITH_GATE_SCREEN_OVER_UNLOCK)
+
+    expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK)
+    expect(screen.getByTestId("lock-state").props.children).toBe("locked")
+  })
+
+  it("does not preserve a gate screen above the unlock, which would skip the PIN", async () => {
+    /** The unlock outranks the allowance: anything stacked over it is reachable without a
+     *  PIN. The gate opens the screen again from the mount the unlock returns to. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    navigateTo(STACK_WITH_GATE_SCREEN_OVER_UNLOCK)
+
+    expect(mockReset).toHaveBeenCalledTimes(1)
+    expect(mockReset.mock.calls[0][0].routes).toHaveLength(1)
   })
 
   it("does not come back for a reset the arming had already declined", async () => {
@@ -448,9 +525,11 @@ describe("NavigationContainerWrapper armed-gate reset", () => {
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("never pops the migration entry the armed gate lets through", async () => {
+  it("keeps the migration entry the armed gate lets through, and pops what is under it", async () => {
     /** The one deeplink the gate allows can only land after the gate armed, so a retry
-     *  finishing an older job must leave it alone. */
+     *  finishing an older job must leave it alone. Returning early instead abandoned the
+     *  pop, and the pre-arming screen underneath stayed reachable by back-navigation over
+     *  a closed account. */
     mockBlockerVisible = true
     mockRootState = STACK_AT_RESUME_UNLOCK
 
@@ -468,7 +547,116 @@ describe("NavigationContainerWrapper armed-gate reset", () => {
       ],
     })
 
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 1,
+      routes: [{ name: "Primary" }, { name: "accountMigrationEntry" }],
+    })
+  })
+
+  it("keeps a screen the armed gate opened itself, not just the deeplink entry", async () => {
+    /** The gate navigates to contact support and to the checkpoint steps, never to the
+     *  entry, so an allowance naming the entry alone popped the gate's own choice back off
+     *  and left it to navigate there again from a fresh mount. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
+    navigateTo(STACK_WITH_GATE_SCREEN_ABOVE)
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 1,
+      routes: [{ name: "Primary" }, GATE_CONTACT_SUPPORT_ROUTE],
+    })
+  })
+
+  it("carries the preserved screen's params, so it reopens on the same case", async () => {
+    /** The support screen reads its reason and origin from the params; dropping them would
+     *  land the user on a blank ticket. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
+    navigateTo(STACK_WITH_GATE_SCREEN_ABOVE)
+
+    expect(mockReset.mock.calls[0][0].routes[1].params).toEqual(
+      GATE_CONTACT_SUPPORT_ROUTE.params,
+    )
+  })
+
+  it("pops everything above the blocker when the gate arms, migration screens included", async () => {
+    /** Arming has no allowance to make: whatever is on the stack was opened before the gate
+     *  existed, a migration screen reached from Settings included. */
+    mockRootState = {
+      index: 1,
+      routes: [{ name: "Primary" }, GATE_CHECKPOINT_ROUTE],
+    }
+
+    const { rerender } = renderWrapper(<UnlockProbe />)
+
+    unlock()
+    await waitFor(() =>
+      expect(screen.getByTestId("lock-state").props.children).toBe("unlocked"),
+    )
+
+    mockBlockerVisible = true
+    rerender(
+      <NavigationContainerWrapper>
+        <UnlockProbe />
+      </NavigationContainerWrapper>,
+    )
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY))
+  })
+
+  it("does not remount a gate screen that already sits on the blocker", async () => {
+    /** Preserving it would lay down the stack that is already there. Dispatching that
+     *  anyway remounts the screen and restarts whatever it had in flight, and the transfer
+     *  step is the worst place for that. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
+    navigateTo({ index: 1, routes: [{ name: "Primary" }, GATE_CHECKPOINT_ROUTE] })
+
     expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("spends the deferral on the gate screen, rather than saving it for what comes next", async () => {
+    /** The dollar transfer the gate opens is not a migration route, so a deferral still
+     *  armed when the user taps Transfer would reset the conversion away mid-flow. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
+    navigateTo(STACK_WITH_GATE_SCREEN_ABOVE)
+    expect(mockReset).toHaveBeenCalledTimes(1)
+
+    navigateTo({
+      index: 2,
+      routes: [
+        { name: "Primary" },
+        GATE_CONTACT_SUPPORT_ROUTE,
+        { name: "conversionDetails" },
+      ],
+    })
+
+    expect(mockReset).toHaveBeenCalledTimes(1)
   })
 
   it("stops retrying once the kill-switch hides the blocker", async () => {

--- a/__tests__/navigation/navigation-container-wrapper.spec.tsx
+++ b/__tests__/navigation/navigation-container-wrapper.spec.tsx
@@ -21,16 +21,20 @@ jest.mock("@app/components/upgrade-account-modal", () => ({
 }))
 
 const mockReset = jest.fn()
+const mockGetRootState = jest.fn()
 let mockBlockerVisible = false
+let mockIsReady = true
 
-/** The navigationRef is module-level, so the container ref is stubbed to observe reset()
- *  and the container itself just renders its children (its onReady is not needed: the same
- *  reset runs from the mid-session effect, which fires on mount once isReady() is true). */
+/** The navigationRef is module-level, so the container ref is stubbed to observe reset(),
+ *  to serve the root stack the pop decides on, and to report readiness; the container itself
+ *  just renders its children (its onReady is not needed: the pop runs from the effect, which
+ *  fires once isReady() is true). */
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   createNavigationContainerRef: () => ({
     reset: (...args: unknown[]) => mockReset(...args),
-    isReady: () => true,
+    isReady: () => mockIsReady,
+    getRootState: () => mockGetRootState(),
   }),
   NavigationContainer: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }))
@@ -59,11 +63,10 @@ jest.mock("@rn-vui/themed", () => ({
 
 import * as React from "react"
 import { Text } from "react-native"
-import { render, screen, waitFor } from "@testing-library/react-native"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react-native"
 
 import { Action } from "@app/components/actions"
 import {
-  blockerEntryRoute,
   isMigrationDeeplink,
   NavigationContainerWrapper,
   processLinkForAction,
@@ -152,89 +155,171 @@ describe("isMigrationDeeplink", () => {
   })
 })
 
-describe("blockerEntryRoute", () => {
-  it("routes a still-locked armed start through authenticationCheck so the PIN/biometric unlock is not skipped", () => {
-    expect(blockerEntryRoute(true)).toBe("authenticationCheck")
-  })
-
-  it("routes an already-unlocked mid-session arming straight to the blocker under Primary, with no re-prompt", () => {
-    expect(blockerEntryRoute(false)).toBe("Primary")
-  })
-})
-
-/** Unlocks the app through the real AuthenticationContext (the same path the auth screens
- *  use) and renders the current lock state so a test can wait for it to settle. */
-const LockStateProbe: React.FC = () => {
+/** Unlocks through the real AuthenticationContext, the same path the unlock screens take,
+ *  when pressed; the lock state renders so a test can wait for it to settle. */
+const UnlockProbe: React.FC = () => {
   const { isAppLocked, setAppUnlocked } = useAuthenticationContext()
-  React.useEffect(() => {
-    setAppUnlocked()
-  }, [setAppUnlocked])
-  return <Text testID="lock-state">{isAppLocked ? "locked" : "unlocked"}</Text>
+  return (
+    <Text testID="lock-state" onPress={setAppUnlocked}>
+      {isAppLocked ? "locked" : "unlocked"}
+    </Text>
+  )
 }
 
-describe("NavigationContainerWrapper armed-gate reset", () => {
+const RESET_TO_BLOCKER = { index: 0, routes: [{ name: "Primary" }] }
+
+/** A deeplinked screen above the blocker, which is the only thing the pop exists for. */
+const STACK_WITH_SCREEN_ABOVE = {
+  routes: [{ name: "Primary" }, { name: "scanningQRCode" }],
+}
+const STACK_AT_BLOCKER = { routes: [{ name: "Primary" }] }
+/** A resume lock, which pushes the unlock on top of whatever the user had open. */
+const STACK_AT_RESUME_UNLOCK = { routes: [{ name: "Primary" }, { name: "pin" }] }
+/** A cold start, whose whole stack is the unlock flow. */
+const STACK_AT_COLD_START_UNLOCK = { routes: [{ name: "authenticationCheck" }] }
+
+const unlock = () => fireEvent.press(screen.getByTestId("lock-state"))
+
+const renderWrapper = (children: React.ReactNode) =>
+  render(<NavigationContainerWrapper>{children}</NavigationContainerWrapper>)
+
+describe("NavigationContainerWrapper armed-gate pop", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockBlockerVisible = false
+    mockIsReady = true
+    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
   })
 
-  it("resets a still-locked armed launch to authenticationCheck so the unlock is not skipped", async () => {
+  it("leaves an unlock in progress alone rather than restarting it", async () => {
+    /** The blocker turns visible on a server answer that lands while the user is already
+     *  typing their PIN. Popping there tore that screen down and served an identical empty
+     *  one, on every single launch (#4150). */
+    mockBlockerVisible = true
+    mockGetRootState.mockReturnValue(STACK_AT_COLD_START_UNLOCK)
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("pops what an unlock was standing in front of once that unlock finishes", async () => {
+    mockBlockerVisible = true
+    mockGetRootState.mockReturnValue(STACK_AT_RESUME_UNLOCK)
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    expect(mockReset).not.toHaveBeenCalled()
+
+    /** The resume unlock steps back, uncovering the screen that was underneath it. */
+    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
+    unlock()
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
+  })
+
+  it("pops in a session that signs in without ever unlocking", async () => {
+    /** Signing in from getStarted lands on Primary without touching an unlock screen, so
+     *  the lock state stays raised for the whole session and the pop must not wait on it. */
     mockBlockerVisible = true
 
-    render(
-      <NavigationContainerWrapper>
-        <Text testID="child">child</Text>
-      </NavigationContainerWrapper>,
-    )
+    renderWrapper(<Text testID="child">child</Text>)
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
+  })
+
+  it("does not pop a second time on a later unlock, when no pop was waiting", async () => {
+    /** The pop already ran when the gate armed. A resume lock and unlock over a screen the
+     *  gate itself opened (the dollar transfer) must not throw that screen away. */
+    mockBlockerVisible = true
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledTimes(1))
+
+    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
+    unlock()
 
     await waitFor(() =>
-      expect(mockReset).toHaveBeenCalledWith({
-        index: 0,
-        routes: [{ name: "authenticationCheck" }],
-      }),
+      expect(screen.getByTestId("lock-state").props.children).toBe("unlocked"),
     )
+    expect(mockReset).toHaveBeenCalledTimes(1)
+  })
+
+  it("leaves a stack that is already just the blocker alone, rather than remounting it", async () => {
+    mockBlockerVisible = true
+    mockGetRootState.mockReturnValue(STACK_AT_BLOCKER)
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("leaves the stack alone when the container has no state to read", async () => {
+    /** Nothing to pop that can be proven, so nothing is thrown away on a guess. */
+    mockBlockerVisible = true
+    mockGetRootState.mockReturnValue(undefined)
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("leaves the stack alone when the container reports no routes", async () => {
+    mockBlockerVisible = true
+    mockGetRootState.mockReturnValue({ routes: [] })
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("reads nothing and pops nothing while the container is not ready", async () => {
+    /** onReady runs the pop again, so bailing out here loses nothing. */
+    mockBlockerVisible = true
+    mockIsReady = false
+
+    renderWrapper(<Text testID="child">child</Text>)
+
+    await waitFor(() => expect(screen.getByTestId("child")).toBeTruthy())
+    expect(mockGetRootState).not.toHaveBeenCalled()
+    expect(mockReset).not.toHaveBeenCalled()
   })
 
   it("takes no armed action while the blocker is hidden (incl. the kill-switch case)", async () => {
     /** useMigrationBlocker returns isVisible=false both when the gate is not armed and when
-     *  the kill-switch hides an armed gate. The wrapper keys the stack reset AND the deeplink
+     *  the kill-switch hides an armed gate. The wrapper keys the stack pop AND the deeplink
      *  drop on that same visibility, so neither fires here: payment deeplinks keep flowing. */
     mockBlockerVisible = false
-    render(
-      <NavigationContainerWrapper>
-        <Text testID="child">child</Text>
-      </NavigationContainerWrapper>,
-    )
+
+    renderWrapper(<Text testID="child">child</Text>)
 
     await waitFor(() => expect(screen.getByTestId("child")).toBeTruthy())
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("resets to Primary (no re-prompt) when the gate arms after the app is already unlocked", async () => {
-    const { rerender } = render(
-      <NavigationContainerWrapper>
-        <LockStateProbe />
-      </NavigationContainerWrapper>,
-    )
+  it("pops when the gate arms after the app is already unlocked", async () => {
+    const { rerender } = renderWrapper(<UnlockProbe />)
 
+    unlock()
     await waitFor(() =>
       expect(screen.getByTestId("lock-state").props.children).toBe("unlocked"),
     )
     expect(mockReset).not.toHaveBeenCalled()
 
-    // Arm the gate on the same, already-unlocked instance so the reset reads isAppLocked=false.
+    // Arm the gate on the same, already-unlocked instance.
     mockBlockerVisible = true
     rerender(
       <NavigationContainerWrapper>
-        <LockStateProbe />
+        <UnlockProbe />
       </NavigationContainerWrapper>,
     )
 
-    await waitFor(() =>
-      expect(mockReset).toHaveBeenCalledWith({
-        index: 0,
-        routes: [{ name: "Primary" }],
-      }),
-    )
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
   })
 })

--- a/__tests__/navigation/navigation-container-wrapper.spec.tsx
+++ b/__tests__/navigation/navigation-container-wrapper.spec.tsx
@@ -21,22 +21,41 @@ jest.mock("@app/components/upgrade-account-modal", () => ({
 }))
 
 const mockReset = jest.fn()
-const mockGetRootState = jest.fn()
 let mockBlockerVisible = false
 let mockIsReady = true
+let mockRootState:
+  | { index: number; routes: { name: string; params?: object }[] }
+  | undefined
+let mockOnReady: (() => void) | undefined
+let mockOnStateChange: ((state: unknown) => void) | undefined
 
-/** The navigationRef is module-level, so the container ref is stubbed to observe reset(),
- *  to serve the root stack the pop decides on, and to report readiness; the container itself
- *  just renders its children (its onReady is not needed: the pop runs from the effect, which
- *  fires once isReady() is true). */
+/** The navigationRef is module-level, so the container ref is stubbed. The stub APPLIES the
+ *  reset to the stack it serves, as the real container does, so a second evaluation sees the
+ *  popped stack rather than the one that prompted the pop. The container itself renders its
+ *  children and hands onReady to the test, which fires it where the app would. */
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   createNavigationContainerRef: () => ({
-    reset: (...args: unknown[]) => mockReset(...args),
+    reset: (state: { routes: { name: string }[] }) => {
+      mockReset(state)
+      mockRootState = { index: 0, routes: state.routes }
+    },
     isReady: () => mockIsReady,
-    getRootState: () => mockGetRootState(),
+    getRootState: () => mockRootState,
   }),
-  NavigationContainer: ({ children }: { children?: React.ReactNode }) => children ?? null,
+  NavigationContainer: ({
+    children,
+    onReady,
+    onStateChange,
+  }: {
+    children?: React.ReactNode
+    onReady?: () => void
+    onStateChange?: (state: unknown) => void
+  }) => {
+    mockOnReady = onReady
+    mockOnStateChange = onStateChange
+    return children ?? null
+  },
 }))
 
 jest.mock("@app/screens/account-migration/hooks/use-migration-blocker", () => ({
@@ -63,15 +82,17 @@ jest.mock("@rn-vui/themed", () => ({
 
 import * as React from "react"
 import { Text } from "react-native"
-import { fireEvent, render, screen, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native"
 
 import { Action } from "@app/components/actions"
 import {
+  blockerEntryRoute,
   isMigrationDeeplink,
   NavigationContainerWrapper,
   processLinkForAction,
   useAuthenticationContext,
 } from "@app/navigation/navigation-container-wrapper"
+import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
 
 describe("processLinkForAction", () => {
   it("returns null when no action query parameter is present", () => {
@@ -155,6 +176,16 @@ describe("isMigrationDeeplink", () => {
   })
 })
 
+describe("blockerEntryRoute", () => {
+  it("routes a still-locked armed start through authenticationCheck so the PIN/biometric unlock is not skipped", () => {
+    expect(blockerEntryRoute(true)).toBe("authenticationCheck")
+  })
+
+  it("routes an already-unlocked mid-session arming straight to the blocker under Primary, with no re-prompt", () => {
+    expect(blockerEntryRoute(false)).toBe("Primary")
+  })
+})
+
 /** Unlocks through the real AuthenticationContext, the same path the unlock screens take,
  *  when pressed; the lock state renders so a test can wait for it to settle. */
 const UnlockProbe: React.FC = () => {
@@ -166,80 +197,359 @@ const UnlockProbe: React.FC = () => {
   )
 }
 
-const RESET_TO_BLOCKER = { index: 0, routes: [{ name: "Primary" }] }
+const RESET_TO_PRIMARY = { index: 0, routes: [{ name: "Primary" }] }
+const RESET_TO_UNLOCK = { index: 0, routes: [{ name: "authenticationCheck" }] }
 
-/** A deeplinked screen above the blocker, which is the only thing the pop exists for. */
+/** A deeplinked screen above the blocker, which is the only thing the reset exists for. */
 const STACK_WITH_SCREEN_ABOVE = {
+  index: 1,
   routes: [{ name: "Primary" }, { name: "scanningQRCode" }],
 }
-const STACK_AT_BLOCKER = { routes: [{ name: "Primary" }] }
+const STACK_AT_BLOCKER = { index: 0, routes: [{ name: "Primary" }] }
+/** A cold start at the moment the bug struck: authenticationCheck has already replaced
+ *  itself with the PIN pad, so the whole stack is the screen the user is typing into. */
+const STACK_AT_COLD_START_UNLOCK = {
+  index: 0,
+  routes: [{ name: "pin", params: { screenPurpose: PinScreenPurpose.AuthenticatePin } }],
+}
 /** A resume lock, which pushes the unlock on top of whatever the user had open. */
-const STACK_AT_RESUME_UNLOCK = { routes: [{ name: "Primary" }, { name: "pin" }] }
-/** A cold start, whose whole stack is the unlock flow. */
-const STACK_AT_COLD_START_UNLOCK = { routes: [{ name: "authenticationCheck" }] }
+const STACK_AT_RESUME_UNLOCK = {
+  index: 2,
+  routes: [
+    { name: "Primary" },
+    { name: "scanningQRCode" },
+    { name: "pin", params: { screenPurpose: PinScreenPurpose.AuthenticatePin } },
+  ],
+}
+/** A resume lock on a device with biometrics, and the PIN pad its fallback pushes over it. */
+const STACK_AT_RESUME_BIOMETRICS = {
+  index: 2,
+  routes: [
+    { name: "Primary" },
+    { name: "scanningQRCode" },
+    {
+      name: "authentication",
+      params: { screenPurpose: AuthenticationScreenPurpose.Authenticate },
+    },
+  ],
+}
+const STACK_AT_BIOMETRIC_PIN_FALLBACK = {
+  index: 3,
+  routes: [
+    ...STACK_AT_RESUME_BIOMETRICS.routes,
+    { name: "pin", params: { screenPurpose: PinScreenPurpose.AuthenticatePin } },
+  ],
+}
+
+/** Settings reuses the pin route to SET a PIN, with the app already unlocked. */
+const STACK_AT_SETTINGS_PIN = {
+  index: 2,
+  routes: [
+    { name: "Primary" },
+    { name: "security" },
+    { name: "pin", params: { screenPurpose: PinScreenPurpose.SetPin } },
+  ],
+}
 
 const unlock = () => fireEvent.press(screen.getByTestId("lock-state"))
+
+/** Moves the stack and tells the container, the way a real navigation would. */
+const navigateTo = (state: typeof mockRootState) => {
+  mockRootState = state
+  act(() => mockOnStateChange?.(state))
+}
 
 const renderWrapper = (children: React.ReactNode) =>
   render(<NavigationContainerWrapper>{children}</NavigationContainerWrapper>)
 
-describe("NavigationContainerWrapper armed-gate pop", () => {
+describe("NavigationContainerWrapper armed-gate reset", () => {
+  /** onReady logs on the way past, which would print a console block from every spec that
+   *  fires it. */
+  const consoleLogSpy = jest.spyOn(console, "log")
+  beforeAll(() => consoleLogSpy.mockImplementation(() => {}))
+  afterAll(() => consoleLogSpy.mockRestore())
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockBlockerVisible = false
     mockIsReady = true
-    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
+    mockOnReady = undefined
+    mockOnStateChange = undefined
+    mockRootState = STACK_WITH_SCREEN_ABOVE
   })
 
   it("leaves an unlock in progress alone rather than restarting it", async () => {
     /** The blocker turns visible on a server answer that lands while the user is already
-     *  typing their PIN. Popping there tore that screen down and served an identical empty
-     *  one, on every single launch (#4150). */
+     *  typing their PIN. Resetting there tore that screen down and served an identical
+     *  empty one, on every single launch (#4150). */
     mockBlockerVisible = true
-    mockGetRootState.mockReturnValue(STACK_AT_COLD_START_UNLOCK)
+    mockRootState = STACK_AT_COLD_START_UNLOCK
 
     renderWrapper(<UnlockProbe />)
 
-    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("pops what an unlock was standing in front of once that unlock finishes", async () => {
+  it("resets once the unlock it was waiting on gets out of the way", async () => {
     mockBlockerVisible = true
-    mockGetRootState.mockReturnValue(STACK_AT_RESUME_UNLOCK)
+    mockRootState = STACK_AT_RESUME_UNLOCK
 
     renderWrapper(<UnlockProbe />)
 
-    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
     expect(mockReset).not.toHaveBeenCalled()
 
     /** The resume unlock steps back, uncovering the screen that was underneath it. */
-    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
     unlock()
+    navigateTo(STACK_WITH_SCREEN_ABOVE)
 
-    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
+    expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY)
   })
 
-  it("pops in a session that signs in without ever unlocking", async () => {
+  it("keeps waiting while an unlock is still on screen, lock down or not", async () => {
+    /** Biometrics with a PIN fallback: "Use PIN" pushes the pad over the prompt, and the
+     *  unlock steps back onto the prompt it came from with the lock already released. The
+     *  way is not clear yet, so a retry keyed on the lock would spend itself here. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_BIOMETRICS
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    navigateTo(STACK_AT_BIOMETRIC_PIN_FALLBACK)
+    unlock()
+    navigateTo(STACK_AT_RESUME_BIOMETRICS)
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("resets a still-locked session sitting at the blocker, so the unlock can run", async () => {
+    /** Signing in through a path that never passes an unlock screen leaves the lock raised
+     *  for the whole session, and only the unlock entry lowers it and drains the queued
+     *  deeplink, so there is a reason to reset even with nothing stacked above. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_BLOCKER
+
+    renderWrapper(<Text testID="child">child</Text>)
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK))
+  })
+
+  it("pops a screen above a blocker that is not at the root of the stack", async () => {
+    /** Signing in from getStarted replaces the last route, leaving the sign-in screens
+     *  underneath Primary rather than the blocker at index 0. */
+    mockBlockerVisible = true
+    mockRootState = {
+      index: 3,
+      routes: [
+        { name: "getStarted" },
+        { name: "login" },
+        { name: "Primary" },
+        { name: "scanningQRCode" },
+      ],
+    }
+
+    renderWrapper(<Text testID="child">child</Text>)
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK))
+  })
+
+  it("leaves a stack the blocker is not even part of alone", async () => {
+    /** Logging out of the unlock screen lands on the sign-in screen, which runs nothing over
+     *  the closed account and reaches the blocker on its own once the user signs back in. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_COLD_START_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    navigateTo({ index: 0, routes: [{ name: "getStarted" }] })
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("does not bounce a logout that reset the stack without lowering the lock", async () => {
+    /** Three wrong PINs log the user out and reset the stack themselves, never unlocking.
+     *  A retry exists to finish a pop, not to route that session through the unlock. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    navigateTo(STACK_AT_BLOCKER)
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("lands a retry on the blocker itself, never back on the unlock", async () => {
+    /** Only arming owes a still-locked session a trip through the unlock. A retry that
+     *  routed there would bounce the user off the screen it was only meant to pop. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<Text testID="child">child</Text>)
+
+    navigateTo(STACK_WITH_SCREEN_ABOVE)
+
+    expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY)
+  })
+
+  it("does not come back for a reset the arming had already declined", async () => {
+    /** A cold start has no blocker in its stack at all, so there is nothing to pop and no
+     *  reason to keep watching for the unlock to end. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_COLD_START_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    unlock()
+    navigateTo(STACK_WITH_SCREEN_ABOVE)
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("drops a deferral the kill-switch outlived, rather than spending it on re-arming", async () => {
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    const { rerender } = renderWrapper(<UnlockProbe />)
+    const rerenderWrapper = () =>
+      rerender(
+        <NavigationContainerWrapper>
+          <UnlockProbe />
+        </NavigationContainerWrapper>,
+      )
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    /** The kill-switch hides the gate, and the user gets on with the unlocked app. */
+    mockBlockerVisible = false
+    rerenderWrapper()
+    unlock()
+    navigateTo(STACK_AT_BLOCKER)
+
+    /** Re-armed later, with nothing above the blocker, so nothing is owed. */
+    mockBlockerVisible = true
+    rerenderWrapper()
+    expect(mockReset).not.toHaveBeenCalled()
+
+    /** The migration deeplink the armed gate allows through opens. A deferral left over
+     *  from the kill-switched round would pop it right back off. */
+    navigateTo({
+      index: 1,
+      routes: [{ name: "Primary" }, { name: "accountMigrationEntry" }],
+    })
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("never pops the migration entry the armed gate lets through", async () => {
+    /** The one deeplink the gate allows can only land after the gate armed, so a retry
+     *  finishing an older job must leave it alone. */
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    unlock()
+    navigateTo({
+      index: 2,
+      routes: [
+        { name: "Primary" },
+        { name: "scanningQRCode" },
+        { name: "accountMigrationEntry" },
+      ],
+    })
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("stops retrying once the kill-switch hides the blocker", async () => {
+    mockBlockerVisible = true
+    mockRootState = STACK_AT_RESUME_UNLOCK
+
+    const { rerender } = renderWrapper(<UnlockProbe />)
+
+    await waitFor(() => expect(screen.getByTestId("lock-state")).toBeTruthy())
+
+    mockBlockerVisible = false
+    rerender(
+      <NavigationContainerWrapper>
+        <UnlockProbe />
+      </NavigationContainerWrapper>,
+    )
+    unlock()
+    navigateTo(STACK_WITH_SCREEN_ABOVE)
+
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("treats the Settings PIN screen as no unlock at all", async () => {
+    /** Settings pushes the same route to SET a PIN while the app is already unlocked, so
+     *  the purpose decides; reading the name alone would strand the reset behind it. */
+    mockRootState = STACK_AT_SETTINGS_PIN
+    const { rerender } = renderWrapper(<UnlockProbe />)
+
+    unlock()
+    await waitFor(() =>
+      expect(screen.getByTestId("lock-state").props.children).toBe("unlocked"),
+    )
+
+    mockBlockerVisible = true
+    rerender(
+      <NavigationContainerWrapper>
+        <UnlockProbe />
+      </NavigationContainerWrapper>,
+    )
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY))
+  })
+
+  it("judges the route the user is looking at, not the last one on the stack", async () => {
+    /** A reset can leave the focus somewhere other than the tail, and an unlock the user
+     *  cannot see is not one to wait for. */
+    mockBlockerVisible = true
+    mockRootState = {
+      index: 0,
+      routes: [
+        { name: "Primary" },
+        { name: "pin", params: { screenPurpose: PinScreenPurpose.AuthenticatePin } },
+      ],
+    }
+
+    renderWrapper(<Text testID="child">child</Text>)
+
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK))
+  })
+
+  it("resets in a session that signs in without ever unlocking", async () => {
     /** Signing in from getStarted lands on Primary without touching an unlock screen, so
-     *  the lock state stays raised for the whole session and the pop must not wait on it. */
+     *  the lock state stays raised for the whole session and the reset must not wait on it.
+     *  It routes through the unlock entry, which releases that lock on the way past. */
     mockBlockerVisible = true
 
     renderWrapper(<Text testID="child">child</Text>)
 
-    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK))
   })
 
-  it("does not pop a second time on a later unlock, when no pop was waiting", async () => {
-    /** The pop already ran when the gate armed. A resume lock and unlock over a screen the
-     *  gate itself opened (the dollar transfer) must not throw that screen away. */
+  it("does not reset a second time on a later unlock, when nothing was waiting", async () => {
+    /** The reset already ran when the gate armed. A resume lock and unlock over a screen
+     *  the gate itself opened must not throw that screen away. */
     mockBlockerVisible = true
 
     renderWrapper(<UnlockProbe />)
 
     await waitFor(() => expect(mockReset).toHaveBeenCalledTimes(1))
 
-    mockGetRootState.mockReturnValue(STACK_WITH_SCREEN_ABOVE)
+    mockRootState = STACK_WITH_SCREEN_ABOVE
     unlock()
 
     await waitFor(() =>
@@ -248,62 +558,65 @@ describe("NavigationContainerWrapper armed-gate pop", () => {
     expect(mockReset).toHaveBeenCalledTimes(1)
   })
 
-  it("leaves a stack that is already just the blocker alone, rather than remounting it", async () => {
+  it("leaves a stack with nothing above the blocker alone, rather than remounting it", async () => {
+    mockRootState = STACK_AT_BLOCKER
+    const { rerender } = renderWrapper(<UnlockProbe />)
+
+    unlock()
+    await waitFor(() =>
+      expect(screen.getByTestId("lock-state").props.children).toBe("unlocked"),
+    )
+
     mockBlockerVisible = true
-    mockGetRootState.mockReturnValue(STACK_AT_BLOCKER)
+    rerender(
+      <NavigationContainerWrapper>
+        <UnlockProbe />
+      </NavigationContainerWrapper>,
+    )
 
-    renderWrapper(<UnlockProbe />)
-
-    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
     expect(mockReset).not.toHaveBeenCalled()
   })
 
   it("leaves the stack alone when the container has no state to read", async () => {
-    /** Nothing to pop that can be proven, so nothing is thrown away on a guess. */
+    /** Nothing proven either way: neither an unlock to protect nor a route to pop. */
     mockBlockerVisible = true
-    mockGetRootState.mockReturnValue(undefined)
+    mockRootState = undefined
 
-    renderWrapper(<UnlockProbe />)
+    renderWrapper(<Text testID="child">child</Text>)
 
-    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByTestId("child")).toBeTruthy())
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("leaves the stack alone when the container reports no routes", async () => {
-    mockBlockerVisible = true
-    mockGetRootState.mockReturnValue({ routes: [] })
-
-    renderWrapper(<UnlockProbe />)
-
-    await waitFor(() => expect(mockGetRootState).toHaveBeenCalled())
-    expect(mockReset).not.toHaveBeenCalled()
-  })
-
-  it("reads nothing and pops nothing while the container is not ready", async () => {
-    /** onReady runs the pop again, so bailing out here loses nothing. */
+  it("resets from onReady when the effect ran before the container was ready", async () => {
     mockBlockerVisible = true
     mockIsReady = false
 
     renderWrapper(<Text testID="child">child</Text>)
 
     await waitFor(() => expect(screen.getByTestId("child")).toBeTruthy())
-    expect(mockGetRootState).not.toHaveBeenCalled()
     expect(mockReset).not.toHaveBeenCalled()
+
+    mockIsReady = true
+    act(() => mockOnReady?.())
+
+    expect(mockReset).toHaveBeenCalledWith(RESET_TO_UNLOCK)
   })
 
   it("takes no armed action while the blocker is hidden (incl. the kill-switch case)", async () => {
     /** useMigrationBlocker returns isVisible=false both when the gate is not armed and when
-     *  the kill-switch hides an armed gate. The wrapper keys the stack pop AND the deeplink
+     *  the kill-switch hides an armed gate. The wrapper keys the stack reset AND the deeplink
      *  drop on that same visibility, so neither fires here: payment deeplinks keep flowing. */
     mockBlockerVisible = false
 
     renderWrapper(<Text testID="child">child</Text>)
 
     await waitFor(() => expect(screen.getByTestId("child")).toBeTruthy())
+    act(() => mockOnReady?.())
     expect(mockReset).not.toHaveBeenCalled()
   })
 
-  it("pops when the gate arms after the app is already unlocked", async () => {
+  it("resets to Primary (no re-prompt) when the gate arms after the app is already unlocked", async () => {
     const { rerender } = renderWrapper(<UnlockProbe />)
 
     unlock()
@@ -312,7 +625,6 @@ describe("NavigationContainerWrapper armed-gate pop", () => {
     )
     expect(mockReset).not.toHaveBeenCalled()
 
-    // Arm the gate on the same, already-unlocked instance.
     mockBlockerVisible = true
     rerender(
       <NavigationContainerWrapper>
@@ -320,6 +632,6 @@ describe("NavigationContainerWrapper armed-gate pop", () => {
       </NavigationContainerWrapper>,
     )
 
-    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_BLOCKER))
+    await waitFor(() => expect(mockReset).toHaveBeenCalledWith(RESET_TO_PRIMARY))
   })
 })

--- a/__tests__/navigation/unlock-routes.spec.ts
+++ b/__tests__/navigation/unlock-routes.spec.ts
@@ -1,0 +1,52 @@
+import { isUnlockInProgress } from "@app/navigation/unlock-routes"
+import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
+
+describe("isUnlockInProgress", () => {
+  it("counts the unlock check, which exists for nothing else", () => {
+    expect(isUnlockInProgress({ name: "authenticationCheck" })).toBe(true)
+  })
+
+  it("counts a PIN pad that is authenticating", () => {
+    expect(
+      isUnlockInProgress({
+        name: "pin",
+        params: { screenPurpose: PinScreenPurpose.AuthenticatePin },
+      }),
+    ).toBe(true)
+  })
+
+  it("does not count the same PIN pad when Settings is setting a PIN", () => {
+    expect(
+      isUnlockInProgress({
+        name: "pin",
+        params: { screenPurpose: PinScreenPurpose.SetPin },
+      }),
+    ).toBe(false)
+  })
+
+  it("counts a biometric prompt that is authenticating", () => {
+    expect(
+      isUnlockInProgress({
+        name: "authentication",
+        params: { screenPurpose: AuthenticationScreenPurpose.Authenticate },
+      }),
+    ).toBe(true)
+  })
+
+  it("does not count the same prompt when Settings is turning biometrics on", () => {
+    expect(
+      isUnlockInProgress({
+        name: "authentication",
+        params: { screenPurpose: AuthenticationScreenPurpose.TurnOnAuthentication },
+      }),
+    ).toBe(false)
+  })
+
+  it("does not count a shared route that arrived without a purpose", () => {
+    expect(isUnlockInProgress({ name: "pin" })).toBe(false)
+  })
+
+  it("does not count a route the unlock flow does not use", () => {
+    expect(isUnlockInProgress({ name: "Primary" })).toBe(false)
+  })
+})

--- a/app/navigation/migration-routes.ts
+++ b/app/navigation/migration-routes.ts
@@ -1,0 +1,22 @@
+import { RootStackParamList } from "./stack-param-lists"
+
+/**
+ * The prefix every screen in the migration flow is named with, and the single source of
+ * truth for recognising one. Matched as a prefix rather than an enumerated list because the
+ * list is what went wrong: the armed gate's reset once allowed the deeplink entry by name
+ * and popped everything else, which left out the screens the gate opens ITSELF, and those
+ * are the ones a reset is most likely to land on. A gate resuming a locked migration
+ * navigates to a checkpoint step, or to contact support when there is nothing to resume,
+ * and never to the entry.
+ */
+const MIGRATION_ROUTE_PREFIX = "accountMigration"
+
+export type MigrationRouteName = Extract<
+  keyof RootStackParamList,
+  `${typeof MIGRATION_ROUTE_PREFIX}${string}`
+>
+
+/** Whether the migration flow is what put this screen on the stack: either the one deeplink
+ *  the armed gate lets through, or a screen the gate navigated to itself. */
+export const isMigrationRoute = (name: string): name is MigrationRouteName =>
+  name.startsWith(MIGRATION_ROUTE_PREFIX)

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -40,14 +40,36 @@ export const isMigrationDeeplink = (url: string): boolean => {
   }
 }
 
-/** The armed-gate reset is lock-aware: while the app is still locked it must land on
- *  authenticationCheck so the PIN/biometric unlock is never skipped. Jumping straight to
- *  Primary would strand isAppLocked at true, hiding the gate behind an app that never
- *  unlocked and freezing the queued migration deeplink (which waits on !isAppLocked). Once
- *  unlocked, Primary is correct: the blocker renders the gate with no jarring re-prompt. */
-export const blockerEntryRoute = (
-  isAppLocked: boolean,
-): "authenticationCheck" | "Primary" => (isAppLocked ? "authenticationCheck" : "Primary")
+/** The root route the blocker renders under: PrimaryNavigator swaps its tabs for the gate. */
+const BLOCKER_ROUTE = "Primary" as const
+
+/** The unlock flow's own screens. Resetting the stack while one of them is in front tears
+ *  down an unlock the user is halfway through and serves them an identical empty one, which
+ *  is the PIN screen that kept reappearing on every launch (#4150). */
+const UNLOCK_ROUTES = new Set<string>([
+  "authenticationCheck",
+  "authentication",
+  "pin",
+] satisfies (keyof RootStackParamList)[])
+
+type RootRoutes = NavigationState["routes"]
+
+/** Whether the root stack holds anything for the blocker to pop. The blocker renders inside
+ *  its own route, so a stack that is already just that route needs nothing, and resetting it
+ *  anyway would remount the gate for no reason. A stack with no routes to read is judged the
+ *  same way an unreadable one is: nothing proven, nothing thrown away. */
+const hasRoutesAboveBlocker = (routes: RootRoutes): boolean => {
+  if (routes.length === 0) return false
+  const hasStackedRoutes = routes.length > 1
+  const isBlockerAtRoot = routes[0].name === BLOCKER_ROUTE
+  return hasStackedRoutes || !isBlockerAtRoot
+}
+
+/** Whether an unlock stands in front of the pop, which only the topmost route can. */
+const isUnlockInProgress = (routes: RootRoutes): boolean => {
+  const topRoute = routes[routes.length - 1]
+  return topRoute !== undefined && UNLOCK_ROUTES.has(topRoute.name)
+}
 
 export type AuthenticationContextType = {
   isAppLocked: boolean
@@ -102,27 +124,41 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
     isBlockerVisibleRef.current = isBlockerVisible
   }, [isBlockerVisible])
 
-  /** Kept current for resetToBlocker, which reads the lock state from a stable callback
-   *  and from onReady, both of which would otherwise close over a stale value. */
-  const isAppLockedRef = useRef(isAppLocked)
-  useEffect(() => {
-    isAppLockedRef.current = isAppLocked
-  }, [isAppLocked])
+  /** Set when a pop found an unlock in front of it, so the pop runs the moment that unlock
+   *  finishes instead of being lost. Only that case waits: keying the pop on the lock state
+   *  itself would re-run it on every resume unlock, throwing away whatever the gate had
+   *  opened, and would never run at all in a session that signed in without ever unlocking. */
+  const isPopDeferredRef = useRef(false)
 
   /** Pop anything a deeplink opened above the blocker so nothing keeps working over the
-   *  closed account, landing on the lock-aware entry so arming never skips the unlock. */
-  const resetToBlocker = useCallback(() => {
-    navigationRef.reset({
-      index: 0,
-      routes: [{ name: blockerEntryRoute(isAppLockedRef.current) }],
-    })
+   *  closed account. */
+  const popRoutesAboveBlocker = useCallback(() => {
+    if (!navigationRef.isReady()) return
+
+    const routes = navigationRef.getRootState()?.routes ?? []
+    const isUnlockInTheWay = isUnlockInProgress(routes)
+    isPopDeferredRef.current = isUnlockInTheWay
+
+    if (isUnlockInTheWay) return
+    if (!hasRoutesAboveBlocker(routes)) return
+    navigationRef.reset({ index: 0, routes: [{ name: BLOCKER_ROUTE }] })
   }, [])
 
   /** Covers arming mid-session. The container-not-ready-yet case (armed at cold start) is
    *  handled from onReady below, since this effect can fire before isReady() is true. */
   useEffect(() => {
-    if (isBlockerVisible && navigationRef.isReady()) resetToBlocker()
-  }, [isBlockerVisible, resetToBlocker])
+    if (!isBlockerVisible) return
+    popRoutesAboveBlocker()
+  }, [isBlockerVisible, popRoutesAboveBlocker])
+
+  /** The waiting half: the unlock that stood in front of a pop has finished. */
+  const hasUnlockFinished = isBlockerVisible && !isAppLocked
+
+  useEffect(() => {
+    if (!hasUnlockFinished) return
+    if (!isPopDeferredRef.current) return
+    popRoutesAboveBlocker()
+  }, [hasUnlockFinished, popRoutesAboveBlocker])
 
   useEffect(() => {
     if (canHandlePayments && !isAppLocked && urlAfterUnlockAndAuth) {
@@ -269,9 +305,9 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
         onReady={() => {
           RNBootSplash.hide({ fade: true })
           console.log("NavigationContainer onReady")
-          /** Cold-started already gated: reset now that the container is ready, since the
+          /** Cold-started already gated: pop now that the container is ready, since the
            *  effect above may have run before isReady() turned true. */
-          if (isBlockerVisibleRef.current) resetToBlocker()
+          if (isBlockerVisibleRef.current) popRoutesAboveBlocker()
         }}
         onStateChange={(state) => {
           const currentRouteName = getActiveRouteName(state)

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -21,6 +21,7 @@ import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useMigrationBlocker } from "@app/screens/account-migration/hooks/use-migration-blocker"
 
 import { RootStackParamList } from "./stack-param-lists"
+import { isUnlockInProgress } from "./unlock-routes"
 
 const navigationRef = createNavigationContainerRef<RootStackParamList>()
 
@@ -40,36 +41,55 @@ export const isMigrationDeeplink = (url: string): boolean => {
   }
 }
 
-/** The root route the blocker renders under: PrimaryNavigator swaps its tabs for the gate. */
-const BLOCKER_ROUTE = "Primary" as const
+/** Where the blocker lives: PrimaryNavigator swaps its tabs for the gate. */
+const BLOCKER_ROUTE = "Primary" satisfies keyof RootStackParamList
 
-/** The unlock flow's own screens. Resetting the stack while one of them is in front tears
- *  down an unlock the user is halfway through and serves them an identical empty one, which
- *  is the PIN screen that kept reappearing on every launch (#4150). */
-const UNLOCK_ROUTES = new Set<string>([
-  "authenticationCheck",
-  "authentication",
-  "pin",
-] satisfies (keyof RootStackParamList)[])
+/** Where a still-locked session has to pass through first. */
+const UNLOCK_ENTRY_ROUTE = "authenticationCheck" satisfies keyof RootStackParamList
 
-type RootRoutes = NavigationState["routes"]
+/** What the migration deeplink above opens. The armed gate lets that one link through, so
+ *  it is the one thing that can legitimately appear above the blocker after the gate armed,
+ *  and a retry finishing an older job must not pop the screen it just opened. */
+const MIGRATION_ENTRY_ROUTE = "accountMigrationEntry" satisfies keyof RootStackParamList
 
-/** Whether the root stack holds anything for the blocker to pop. The blocker renders inside
- *  its own route, so a stack that is already just that route needs nothing, and resetting it
- *  anyway would remount the gate for no reason. A stack with no routes to read is judged the
- *  same way an unreadable one is: nothing proven, nothing thrown away. */
-const hasRoutesAboveBlocker = (routes: RootRoutes): boolean => {
-  if (routes.length === 0) return false
-  const hasStackedRoutes = routes.length > 1
-  const isBlockerAtRoot = routes[0].name === BLOCKER_ROUTE
-  return hasStackedRoutes || !isBlockerAtRoot
+/** The armed-gate reset is lock-aware: while the app is still locked it must land on
+ *  authenticationCheck so the PIN/biometric unlock is never skipped. Jumping straight to
+ *  Primary would strand isAppLocked at true, hiding the gate behind an app that never
+ *  unlocked and freezing the queued migration deeplink (which waits on !isAppLocked). Once
+ *  unlocked, Primary is correct: the blocker renders the gate with no jarring re-prompt. */
+export const blockerEntryRoute = (mustRouteThroughUnlock: boolean) =>
+  mustRouteThroughUnlock ? UNLOCK_ENTRY_ROUTE : BLOCKER_ROUTE
+
+/** The route the user is looking at, which is the only one an unlock can be blocking from,
+ *  read off the state's own index rather than the tail of the list. */
+const focusedRoute = (state: NavigationState | undefined) =>
+  state ? state.routes[state.index] : undefined
+
+/**
+ * Whether resetting this stack would achieve anything. Two separate jobs qualify: popping
+ * whatever is stacked on top of the blocker, and routing a session that is still locked
+ * through the unlock entry, which is the only thing that lowers the lock and so the only
+ * thing that drains the queued deeplink. A stack the blocker is not part of at all belongs
+ * to another flow — signing in, unlocking, the landing screen a logout returns to — which
+ * runs nothing over the closed account and reaches the blocker on its own.
+ */
+const isResetWarranted = (
+  state: NavigationState | undefined,
+  mustRouteThroughUnlock: boolean,
+): boolean => {
+  const routes = state?.routes ?? []
+  const blockerIndex = routes.findIndex((route) => route.name === BLOCKER_ROUTE)
+  if (blockerIndex === -1) return false
+
+  const hasRoutesAboveBlocker = blockerIndex < routes.length - 1
+  return hasRoutesAboveBlocker || mustRouteThroughUnlock
 }
 
-/** Whether an unlock stands in front of the pop, which only the topmost route can. */
-const isUnlockInProgress = (routes: RootRoutes): boolean => {
-  const topRoute = routes[routes.length - 1]
-  return topRoute !== undefined && UNLOCK_ROUTES.has(topRoute.name)
-}
+/** Why the stack is being judged. The two triggers do not carry the same authority: arming
+ *  owns both of the jobs above, while a retry exists only to finish the pop an unlock stood
+ *  in front of, and must not bounce a session elsewhere on the strength of a lock its own
+ *  flow never lowered (the three-strikes logout resets the stack without unlocking). */
+type ResetTrigger = "gate-armed" | "unlock-cleared"
 
 export type AuthenticationContextType = {
   isAppLocked: boolean
@@ -124,41 +144,69 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
     isBlockerVisibleRef.current = isBlockerVisible
   }, [isBlockerVisible])
 
-  /** Set when a pop found an unlock in front of it, so the pop runs the moment that unlock
-   *  finishes instead of being lost. Only that case waits: keying the pop on the lock state
-   *  itself would re-run it on every resume unlock, throwing away whatever the gate had
-   *  opened, and would never run at all in a session that signed in without ever unlocking. */
-  const isPopDeferredRef = useRef(false)
+  /** Mirrors the lock for the readers that run outside a render: the state is a commit
+   *  behind, and the retry below runs during a navigation dispatch, before that commit
+   *  lands. Written by the two setters so it is never the stale one. */
+  const isAppLockedRef = useRef(isAppLocked)
+
+  /** Set when the reset found an unlock in front of it, so it retries instead of being
+   *  lost. Cleared by the next attempt that finds the way clear. */
+  const isResetDeferredRef = useRef(false)
 
   /** Pop anything a deeplink opened above the blocker so nothing keeps working over the
-   *  closed account. */
-  const popRoutesAboveBlocker = useCallback(() => {
+   *  closed account, landing on the lock-aware entry so arming never skips the unlock.
+   *  An unlock already on screen is the one thing it will not do that to: resetting there
+   *  tore the screen down mid-PIN and served an identical empty one (#4150). */
+  const resetToBlocker = useCallback((trigger: ResetTrigger) => {
+    /** Guarded here rather than at each caller: the retry below fires on navigations the
+     *  kill-switch may have made harmless in the meantime. A deferral does not outlive the
+     *  blocker it was waiting for, or a re-arming would inherit a verdict about a stack
+     *  that has since moved on. Readiness is different: it is transient, and onReady runs
+     *  the arming again, so a deferral survives it. */
+    if (!isBlockerVisibleRef.current) {
+      isResetDeferredRef.current = false
+      return
+    }
     if (!navigationRef.isReady()) return
 
-    const routes = navigationRef.getRootState()?.routes ?? []
-    const isUnlockInTheWay = isUnlockInProgress(routes)
-    isPopDeferredRef.current = isUnlockInTheWay
+    const rootState = navigationRef.getRootState()
+    const routeInFront = focusedRoute(rootState)
+    if (!routeInFront) return
 
-    if (isUnlockInTheWay) return
-    if (!hasRoutesAboveBlocker(routes)) return
-    navigationRef.reset({ index: 0, routes: [{ name: BLOCKER_ROUTE }] })
+    const isArming = trigger === "gate-armed"
+
+    /** Only a retry has to make this allowance. Arming pops everything above the blocker,
+     *  as it always has: those screens were opened before the gate existed. */
+    const isOnSanctionedEntry = routeInFront.name === MIGRATION_ENTRY_ROUTE
+    if (!isArming && isOnSanctionedEntry) {
+      isResetDeferredRef.current = false
+      return
+    }
+
+    const mustRouteThroughUnlock = isAppLockedRef.current && isArming
+
+    /** Judged before the unlock is: a reset that would achieve nothing has nothing to come
+     *  back for either, so it must not leave a retry armed behind it. */
+    if (!isResetWarranted(rootState, mustRouteThroughUnlock)) {
+      isResetDeferredRef.current = false
+      return
+    }
+
+    isResetDeferredRef.current = isUnlockInProgress(routeInFront)
+    if (isResetDeferredRef.current) return
+
+    navigationRef.reset({
+      index: 0,
+      routes: [{ name: blockerEntryRoute(mustRouteThroughUnlock) }],
+    })
   }, [])
 
   /** Covers arming mid-session. The container-not-ready-yet case (armed at cold start) is
    *  handled from onReady below, since this effect can fire before isReady() is true. */
   useEffect(() => {
     if (!isBlockerVisible) return
-    popRoutesAboveBlocker()
-  }, [isBlockerVisible, popRoutesAboveBlocker])
-
-  /** The waiting half: the unlock that stood in front of a pop has finished. */
-  const hasUnlockFinished = isBlockerVisible && !isAppLocked
-
-  useEffect(() => {
-    if (!hasUnlockFinished) return
-    if (!isPopDeferredRef.current) return
-    popRoutesAboveBlocker()
-  }, [hasUnlockFinished, popRoutesAboveBlocker])
+    resetToBlocker("gate-armed")
+  }, [isBlockerVisible, resetToBlocker])
 
   useEffect(() => {
     if (canHandlePayments && !isAppLocked && urlAfterUnlockAndAuth) {
@@ -169,12 +217,19 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
 
   const setAppUnlocked = React.useMemo(
     () => async () => {
+      isAppLockedRef.current = false
       setIsAppLocked(false)
     },
     [],
   )
 
-  const setAppLocked = React.useMemo(() => () => setIsAppLocked(true), [])
+  const setAppLocked = React.useMemo(
+    () => () => {
+      isAppLockedRef.current = true
+      setIsAppLocked(true)
+    },
+    [],
+  )
 
   const routeName = useRef("Initial")
 
@@ -305,9 +360,9 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
         onReady={() => {
           RNBootSplash.hide({ fade: true })
           console.log("NavigationContainer onReady")
-          /** Cold-started already gated: pop now that the container is ready, since the
+          /** Cold-started already gated: reset now that the container is ready, since the
            *  effect above may have run before isReady() turned true. */
-          if (isBlockerVisibleRef.current) popRoutesAboveBlocker()
+          if (isBlockerVisibleRef.current) resetToBlocker("gate-armed")
         }}
         onStateChange={(state) => {
           const currentRouteName = getActiveRouteName(state)
@@ -321,6 +376,14 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
             })
             routeName.current = currentRouteName
           }
+
+          /** A reset an unlock held back retries on every navigation until the way is
+           *  clear. The visibility comes from this render rather than the ref, which a
+           *  passive effect may not have caught up to yet. Releasing the lock is not the same event as leaving the unlock: the
+           *  biometric prompt falls back to the PIN pad and steps back onto itself with the
+           *  lock already down, so keying the retry on the lock would spend it too early. */
+          const isRetryPending = isBlockerVisible && isResetDeferredRef.current
+          if (isRetryPending) resetToBlocker("unlock-cleared")
         }}
       >
         {children}

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -20,6 +20,7 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useMigrationBlocker } from "@app/screens/account-migration/hooks/use-migration-blocker"
 
+import { isMigrationRoute } from "./migration-routes"
 import { RootStackParamList } from "./stack-param-lists"
 import { isUnlockInProgress } from "./unlock-routes"
 
@@ -47,11 +48,6 @@ const BLOCKER_ROUTE = "Primary" satisfies keyof RootStackParamList
 /** Where a still-locked session has to pass through first. */
 const UNLOCK_ENTRY_ROUTE = "authenticationCheck" satisfies keyof RootStackParamList
 
-/** What the migration deeplink above opens. The armed gate lets that one link through, so
- *  it is the one thing that can legitimately appear above the blocker after the gate armed,
- *  and a retry finishing an older job must not pop the screen it just opened. */
-const MIGRATION_ENTRY_ROUTE = "accountMigrationEntry" satisfies keyof RootStackParamList
-
 /** The armed-gate reset is lock-aware: while the app is still locked it must land on
  *  authenticationCheck so the PIN/biometric unlock is never skipped. Jumping straight to
  *  Primary would strand isAppLocked at true, hiding the gate behind an app that never
@@ -75,20 +71,22 @@ const focusedRoute = (state: NavigationState | undefined) =>
  */
 const isResetWarranted = (
   state: NavigationState | undefined,
-  mustRouteThroughUnlock: boolean,
+  canResetOnLockAlone: boolean,
 ): boolean => {
   const routes = state?.routes ?? []
   const blockerIndex = routes.findIndex((route) => route.name === BLOCKER_ROUTE)
   if (blockerIndex === -1) return false
 
   const hasRoutesAboveBlocker = blockerIndex < routes.length - 1
-  return hasRoutesAboveBlocker || mustRouteThroughUnlock
+  return hasRoutesAboveBlocker || canResetOnLockAlone
 }
 
-/** Why the stack is being judged. The two triggers do not carry the same authority: arming
- *  owns both of the jobs above, while a retry exists only to finish the pop an unlock stood
- *  in front of, and must not bounce a session elsewhere on the strength of a lock its own
- *  flow never lowered (the three-strikes logout resets the stack without unlocking). */
+/** Why the stack is being judged. The triggers differ on WHETHER a reset is owed, not on
+ *  where one lands: arming owns both of the jobs above, while a retry exists only to finish
+ *  the pop an unlock stood in front of, so it must not reset a session it finds already at
+ *  the blocker on the strength of a lock its own flow never lowered (the three-strikes
+ *  logout resets the stack without unlocking). Where a reset that IS owed lands is the
+ *  lock's call and no trigger's: see mustRouteThroughUnlock below. */
 type ResetTrigger = "gate-armed" | "unlock-cleared"
 
 export type AuthenticationContextType = {
@@ -154,7 +152,7 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
   const isResetDeferredRef = useRef(false)
 
   /** Pop anything a deeplink opened above the blocker so nothing keeps working over the
-   *  closed account, landing on the lock-aware entry so arming never skips the unlock.
+   *  closed account, landing on the lock-aware entry so no reset ever skips the unlock.
    *  An unlock already on screen is the one thing it will not do that to: resetting there
    *  tore the screen down mid-PIN and served an identical empty one (#4150). */
   const resetToBlocker = useCallback((trigger: ResetTrigger) => {
@@ -175,19 +173,15 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
 
     const isArming = trigger === "gate-armed"
 
-    /** Only a retry has to make this allowance. Arming pops everything above the blocker,
-     *  as it always has: those screens were opened before the gate existed. */
-    const isOnSanctionedEntry = routeInFront.name === MIGRATION_ENTRY_ROUTE
-    if (!isArming && isOnSanctionedEntry) {
-      isResetDeferredRef.current = false
-      return
-    }
-
-    const mustRouteThroughUnlock = isAppLockedRef.current && isArming
-
-    /** Judged before the unlock is: a reset that would achieve nothing has nothing to come
+    /** Resetting a stack with nothing above the blocker, purely to route a locked session
+     *  through the unlock, is arming's job alone. A retry doing it would bounce the
+     *  three-strikes logout, which resets to the blocker itself without ever unlocking,
+     *  back onto a PIN its own flow never owed.
+     *
+     *  Judged before the unlock is: a reset that would achieve nothing has nothing to come
      *  back for either, so it must not leave a retry armed behind it. */
-    if (!isResetWarranted(rootState, mustRouteThroughUnlock)) {
+    const canResetOnLockAlone = isAppLockedRef.current && isArming
+    if (!isResetWarranted(rootState, canResetOnLockAlone)) {
       isResetDeferredRef.current = false
       return
     }
@@ -195,10 +189,35 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
     isResetDeferredRef.current = isUnlockInProgress(routeInFront)
     if (isResetDeferredRef.current) return
 
-    navigationRef.reset({
-      index: 0,
-      routes: [{ name: blockerEntryRoute(mustRouteThroughUnlock) }],
-    })
+    /** Where a reset that is owed lands is the lock's call, whichever trigger asked for it.
+     *  Deriving this from the trigger let a retry land on Primary with the lock still up:
+     *  the gate, mounted under the unlock screen, navigates to its resume target, which
+     *  fires the pending retry, which then tore the unlock down and skipped the PIN
+     *  entirely, stranding isAppLocked at true and freezing the queued migration deeplink
+     *  (which waits on !isAppLocked). */
+    const mustRouteThroughUnlock = isAppLockedRef.current
+
+    /** A screen the armed gate opened rides along rather than being popped with the rest,
+     *  so the pop that was owed does not throw away the gate's own choice and leave it to
+     *  navigate there again from a fresh mount. Never above an unlock, which anything
+     *  stacked over it would skip; the gate reopens it once the unlock steps aside. */
+    const isOnGateOpenedScreen = !isArming && isMigrationRoute(routeInFront.name)
+    const shouldPreserveGateScreen = isOnGateOpenedScreen && !mustRouteThroughUnlock
+
+    const entryRoute = { name: blockerEntryRoute(mustRouteThroughUnlock) }
+    const preservedRoute = { name: routeInFront.name, params: routeInFront.params }
+    const routes = shouldPreserveGateScreen ? [entryRoute, preservedRoute] : [entryRoute]
+
+    /** Preserving can leave nothing to pop: a gate screen sitting directly on the blocker
+     *  already IS the stack this would lay down, and dispatching it anyway would remount
+     *  the screen and restart whatever it had in flight. */
+    const routesInStack = rootState?.routes ?? []
+    const isStackAlreadyReset =
+      routesInStack.length === routes.length &&
+      routesInStack.every((route, index) => route.name === routes[index].name)
+    if (isStackAlreadyReset) return
+
+    navigationRef.reset({ index: routes.length - 1, routes })
   }, [])
 
   /** Covers arming mid-session. The container-not-ready-yet case (armed at cold start) is

--- a/app/navigation/unlock-routes.ts
+++ b/app/navigation/unlock-routes.ts
@@ -1,0 +1,49 @@
+import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
+
+import { RootStackParamList } from "./stack-param-lists"
+
+/**
+ * The routes the unlock flow runs on, and the single source of truth for them: the unlock
+ * screens type their own options against this list, and the armed migration gate reads it
+ * to know which screen it must never tear down, so a fourth unlock step cannot be added to
+ * one and forgotten in the other.
+ */
+const UNLOCK_ROUTE_NAMES = [
+  "authenticationCheck",
+  "authentication",
+  "pin",
+] as const satisfies readonly (keyof RootStackParamList)[]
+
+export type UnlockRouteName = (typeof UNLOCK_ROUTE_NAMES)[number]
+
+/**
+ * Which `screenPurpose` means the route is unlocking, rather than one of the Settings jobs
+ * that reuse the same screens to SET a PIN or turn biometrics on while the app is already
+ * unlocked. Null is for the route that has no purpose to tell apart because unlocking is
+ * all it ever does. Exhaustive on purpose: a route added above has no entry here and fails
+ * to compile, so a new unlock step can never be classified by omission.
+ */
+const UNLOCK_PURPOSE_BY_ROUTE: Record<
+  UnlockRouteName,
+  AuthenticationScreenPurpose | PinScreenPurpose | null
+> = {
+  authenticationCheck: null,
+  authentication: AuthenticationScreenPurpose.Authenticate,
+  pin: PinScreenPurpose.AuthenticatePin,
+}
+
+const isUnlockRouteName = (name: string): name is UnlockRouteName =>
+  UNLOCK_ROUTE_NAMES.some((unlockRoute) => unlockRoute === name)
+
+/** Whether this route is an unlock the user is working through right now. Judged on the
+ *  purpose and not the name alone, which would read someone setting a PIN in Settings as
+ *  an unlock in progress. */
+export const isUnlockInProgress = (route: { name: string; params?: object }): boolean => {
+  if (!isUnlockRouteName(route.name)) return false
+
+  const unlockPurpose = UNLOCK_PURPOSE_BY_ROUTE[route.name]
+  if (unlockPurpose === null) return true
+
+  const { screenPurpose } = (route.params ?? {}) as { screenPurpose?: string }
+  return screenPurpose === unlockPurpose
+}

--- a/app/screens/authentication-screen/unlock-screen.ts
+++ b/app/screens/authentication-screen/unlock-screen.ts
@@ -9,6 +9,7 @@ import {
 
 import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { UnlockRouteName } from "@app/navigation/unlock-routes"
 
 type UseUnlockScreenParams = {
   isResume: boolean
@@ -23,7 +24,7 @@ type UseUnlockScreenParams = {
 export const unlockScreenOptions = ({
   route,
 }: {
-  route: RouteProp<RootStackParamList, "authenticationCheck" | "authentication" | "pin">
+  route: RouteProp<RootStackParamList, UnlockRouteName>
 }): NativeStackNavigationOptions => ({
   headerShown: false,
   gestureEnabled: !route.params?.isResume,


### PR DESCRIPTION
Closes #4150.

## The bug

A Brazilian Android user reported that the PIN screen reappears empty while he is typing, every time he opens the app, and that it started when he tried to switch to non-custodial.

## Cause

`useMigrationBlocker` turns visible on a server answer (`migrationStatus`, read `no-cache` on every launch, with its loading state deliberately ignored). That answer lands a beat into the launch, by which time the user is already on the PIN screen. The armed-gate effect then reset the root stack, which tore that screen down and mounted a fresh, empty one.

Only an account with a server-side migration lock (or an armed wind-down gate) reaches that code path, which is why it started when he began the migration and why nobody else saw it.

## Video

Both recorded on an emulator against staging, with the network throttled to mobile latency. Two digits are typed as soon as the pad appears, and nothing is touched after that.

**Before** — the digits vanish on their own and the pad starts over

https://github.com/user-attachments/assets/742478e2-e101-42fe-b4d6-4e03c769dbc7


**After** — the digits survive, one entry gets through, and the flow lands on Contact support

https://github.com/user-attachments/assets/800b9aac-128a-45d0-8094-7eedee8c86f6


## The fix

The reset now looks at what is actually in front of it instead of guessing from the lock flag.

**It never tears down an unlock in progress.** The focused route is read off the state's own index, and judged by its `screenPurpose` rather than its name: Settings reuses the very same `pin` and `authentication` routes to SET a PIN or turn biometrics on while the app is already unlocked, and reading the name alone would mistake that for an unlock. The new `app/navigation/unlock-routes.ts` owns that answer, and the unlock screens now type their own options against the same list, so a fourth unlock step cannot be added to one and forgotten in the other.

**A reset an unlock held back retries on every navigation until the way is clear.** Releasing the lock is not the same event as leaving the unlock — the biometric prompt falls back to the PIN pad and steps back onto itself with the lock already down — so keying the retry on the lock would spend it too early. The two triggers do not carry the same authority: arming owns both of the reset's jobs, while a retry exists only to finish the pop, and must not bounce a session elsewhere on the strength of a lock its own flow never lowered (the three-strikes logout resets the stack without unlocking).

**A reset only happens when it would achieve something.** Two jobs qualify: popping whatever is stacked on top of the blocker, and routing a still-locked session through the unlock entry, which is the only thing that lowers the lock and so the only thing that drains the queued deeplink. A stack the blocker is not part of at all — signing in, unlocking, the landing screen a logout returns to — is left alone.

**A retry never pops the migration entry the armed gate lets through**, since that is the one screen that can legitimately appear above the blocker after the gate armed.

`blockerEntryRoute` is kept as it is on `main`: an earlier revision of this branch removed it, which stranded the lock raised and froze the queued migration deeplink for a session that signs in without ever unlocking. `isAppLockedRef` is now written by the two setters instead of by an effect, because the retry runs during a navigation dispatch, before that commit lands.

## Verification

Reproduced and re-verified on an Android emulator against staging, with the network throttled to mobile latency. The status query keeps its real timing; only its value is forced, so no server-side lock is armed on the test account.

Before:

```
PinScreen MOUNTED
migrationStatus resolved                  (+2.9s)
resetToBlocker -> authenticationCheck, isAppLocked: true
PinScreen UNMOUNTED
PinScreen MOUNTED                         (a second, empty screen)
```

After:

```
PinScreen MOUNTED
migrationStatus resolved                  (+4.2s)
                                          (no reset is even warranted: the cold-start
                                           stack has no blocker route to pop)
PinScreen UNMOUNTED                       (the user's own unlock)
```

Digits typed during the window survive, one PIN entry gets through, and the flow lands on the Contact support screen with `locked-without-checkpoint`.

93 tests pass across `__tests__/navigation` and `__tests__/screens/authentication-screen`; `unlock-routes.ts` is at 100% coverage and every branch added to the wrapper is covered. Each guard was mutation-tested by breaking it one at a time: 17 of the 18 mutations fail at least one spec. The one that does not is clearing the deferral when the kill-switch hides the blocker, which is defence in depth rather than behaviour — the re-arming path already recomputes it.

## Scope

This removes the PIN loop for everyone affected. It does not release a server-side lock, so an account that also lost its local checkpoint still lands on the support screen and needs backend to clear it.

Rebased over #4151, so the generated GraphQL types are no longer part of this diff.

### Known limitations

- Arming still pops routes the gate itself is allowed to open (the dollar transfer, the support screen) if the blocker's visibility flips while one of them is open. Only the retry path makes the allowance, since those screens cannot predate an arming. Behaviour that predates this change; a full allowlist of gate-sanctioned routes would be its own ticket.
- A resume unlock that falls back to the PIN pad steps back onto the biometric prompt with the app already unlocked and back blocked, so the user has to tap Unlock once more. That dead end predates this branch; the reset correctly keeps waiting while it is on screen.
- The arming decision is one-shot per visibility flip. A session that arms while the blocker is not in the stack, and only later reaches it while still locked, is not routed through the unlock. The flip is a once-per-launch event, so this is latent rather than reachable today.
