### PR TITLE
perf(transaction-history): stop opening a transaction re-rendering every mounted row

### DIFF
--- a/__tests__/components/transaction-item.test.tsx
+++ b/__tests__/components/transaction-item.test.tsx
@@ -76,8 +76,17 @@ jest.mock(
 )
 
 // --- child components that would otherwise require native modules ---
+// The mount counter is what makes a remount of the row subtree assertable:
+// re-rendering leaves it alone, unmounting and rebuilding bumps it.
+let mockIconMounts = 0
 jest.mock("@app/components/icon-transactions", () => ({
-  IconTransaction: () => null,
+  IconTransaction: () => {
+    const react = jest.requireActual("react")
+    react.useEffect(() => {
+      mockIconMounts += 1
+    }, [])
+    return null
+  },
 }))
 
 jest.mock("@app/components/transaction-date", () => ({
@@ -151,8 +160,10 @@ import { useIsFocused } from "@react-navigation/native"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { useAppConfig } from "@app/hooks"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { useBounceInAnimation } from "@app/components/animations"
 
 const mockUseFragment = useFragment as jest.Mock
+const mockUseBounceInAnimation = useBounceInAnimation as jest.Mock
 const mockUseIsFocused = useIsFocused as jest.Mock
 const mockUseHideAmount = useHideAmount as jest.Mock
 const mockUseAppConfig = useAppConfig as jest.Mock
@@ -179,6 +190,7 @@ const makeTx = (overrides = {}) => ({
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockIconMounts = 0
 
   mockUseFragment.mockReturnValue({ data: makeTx() })
 
@@ -296,6 +308,31 @@ describe("MemoizedTransactionItem", () => {
       render(<MemoizedTransactionItem txid="tx-1" highlight />)
 
       expect(mockUseIsFocused).toHaveBeenCalled()
+    })
+
+    it("does not remount the row when the highlight clears", () => {
+      // Tapping an unseen transaction marks it seen, which flips highlight
+      // true -> false. Swapping the element type at that position would throw
+      // the whole row subtree away and rebuild it.
+      const { rerender } = render(<MemoizedTransactionItem txid="tx-1" highlight />)
+      expect(mockIconMounts).toBe(1)
+
+      rerender(<MemoizedTransactionItem txid="tx-1" highlight={false} />)
+
+      expect(mockIconMounts).toBe(1)
+    })
+
+    it("stops the bounce when the highlight clears, without dropping the wrapper", () => {
+      const { rerender } = render(<MemoizedTransactionItem txid="tx-1" highlight />)
+      expect(mockUseBounceInAnimation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ visible: true }),
+      )
+
+      rerender(<MemoizedTransactionItem txid="tx-1" highlight={false} />)
+
+      expect(mockUseBounceInAnimation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ visible: false }),
+      )
     })
   })
 

--- a/__tests__/components/transaction-item.test.tsx
+++ b/__tests__/components/transaction-item.test.tsx
@@ -51,8 +51,10 @@ jest.mock("@app/i18n/i18n-react", () => ({
 }))
 
 // --- @react-navigation/native ---
+// jest.fn so the focus subscription itself is assertable: only highlighted rows
+// should subscribe, otherwise opening a transaction re-renders every mounted row.
 jest.mock("@react-navigation/native", () => ({
-  useIsFocused: () => true,
+  useIsFocused: jest.fn(() => true),
 }))
 
 // --- @app/components/animations ---
@@ -145,11 +147,13 @@ jest.mock("@app/types/amounts", () => ({
 
 // ─── imports needed for mocking ───────────────────────────────────────────────
 import { useFragment } from "@apollo/client"
+import { useIsFocused } from "@react-navigation/native"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { useAppConfig } from "@app/hooks"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 
 const mockUseFragment = useFragment as jest.Mock
+const mockUseIsFocused = useIsFocused as jest.Mock
 const mockUseHideAmount = useHideAmount as jest.Mock
 const mockUseAppConfig = useAppConfig as jest.Mock
 const mockUseDisplayCurrency = useDisplayCurrency as jest.Mock
@@ -254,6 +258,17 @@ describe("MemoizedTransactionItem", () => {
       expect(mockOnPress).toHaveBeenCalledTimes(1)
     })
 
+    it("passes its own txid to onPress, so the list can share one callback", () => {
+      const mockOnPress = jest.fn()
+
+      const { getByTestId } = render(
+        <MemoizedTransactionItem txid="tx-1" onPress={mockOnPress} />,
+      )
+      fireEvent.press(getByTestId("transaction-item"))
+
+      expect(mockOnPress).toHaveBeenCalledWith("tx-1")
+    })
+
     it("pressing the hidden placeholder does not toggle hide state", () => {
       const mockSwitch = jest.fn()
       mockUseHideAmount.mockReturnValue({
@@ -267,6 +282,20 @@ describe("MemoizedTransactionItem", () => {
       fireEvent.press(getByTestId("hidden-balance-placeholder"))
 
       expect(mockSwitch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("re-render cost", () => {
+    it("does not subscribe to navigation focus when not highlighted", () => {
+      render(<MemoizedTransactionItem txid="tx-1" />)
+
+      expect(mockUseIsFocused).not.toHaveBeenCalled()
+    })
+
+    it("subscribes to navigation focus when highlighted", () => {
+      render(<MemoizedTransactionItem txid="tx-1" highlight />)
+
+      expect(mockUseIsFocused).toHaveBeenCalled()
     })
   })
 

--- a/__tests__/components/transaction-item.test.tsx
+++ b/__tests__/components/transaction-item.test.tsx
@@ -194,6 +194,10 @@ beforeEach(() => {
 
   mockUseFragment.mockReturnValue({ data: makeTx() })
 
+  // clearAllMocks keeps return values, so pin the default here rather than let
+  // a test that needs an unfocused screen leak into the ones after it.
+  mockUseIsFocused.mockReturnValue(true)
+
   mockUseHideAmount.mockReturnValue({
     hideAmount: false,
     switchMemoryHideAmount: jest.fn(),
@@ -281,6 +285,15 @@ describe("MemoizedTransactionItem", () => {
       expect(mockOnPress).toHaveBeenCalledWith("tx-1")
     })
 
+    it("stays inert when no onPress is given", () => {
+      // The contact-transactions list renders rows without a handler, and they
+      // must not look tappable: handlePress is always defined internally, so
+      // only the guard at the call site keeps those rows from being pressable.
+      const { getByTestId } = render(<MemoizedTransactionItem txid="tx-1" />)
+
+      expect(getByTestId("transaction-item").props.onPress).toBeUndefined()
+    })
+
     it("pressing the hidden placeholder does not toggle hide state", () => {
       const mockSwitch = jest.fn()
       mockUseHideAmount.mockReturnValue({
@@ -322,7 +335,22 @@ describe("MemoizedTransactionItem", () => {
       expect(mockIconMounts).toBe(1)
     })
 
-    it("stops the bounce when the highlight clears, without dropping the wrapper", () => {
+    it("does not remount the row when the highlight turns on", () => {
+      // The screen's highlight baseline and last-seen ids both arrive after the
+      // rows have mounted, so the row the user came to see mounts unhighlighted
+      // and flips false -> true. That is the common direction, and it must not
+      // rebuild the subtree either.
+      const { rerender } = render(
+        <MemoizedTransactionItem txid="tx-1" highlight={false} />,
+      )
+      expect(mockIconMounts).toBe(1)
+
+      rerender(<MemoizedTransactionItem txid="tx-1" highlight />)
+
+      expect(mockIconMounts).toBe(1)
+    })
+
+    it("stops the bounce when the highlight clears, without dropping the subscriber", () => {
       const { rerender } = render(<MemoizedTransactionItem txid="tx-1" highlight />)
       expect(mockUseBounceInAnimation).toHaveBeenLastCalledWith(
         expect.objectContaining({ visible: true }),
@@ -333,6 +361,41 @@ describe("MemoizedTransactionItem", () => {
       expect(mockUseBounceInAnimation).toHaveBeenLastCalledWith(
         expect.objectContaining({ visible: false }),
       )
+    })
+  })
+
+  describe("bounce-in wiring", () => {
+    it("drives the bounce with the focus state and the row's timings", () => {
+      // Guards the move of the subscription into its own component: rendering
+      // the subscriber without still calling the animation would leave every
+      // other test in this file green while the bounce silently stopped.
+      mockUseIsFocused.mockReturnValue(true)
+
+      render(<MemoizedTransactionItem txid="tx-1" highlight />)
+
+      expect(mockUseBounceInAnimation).toHaveBeenCalledWith({
+        isFocused: true,
+        visible: true,
+        scale: expect.objectContaining({ value: 1 }),
+        delay: 300,
+        duration: 120,
+      })
+    })
+
+    it("passes the focus state through when the screen is not focused", () => {
+      mockUseIsFocused.mockReturnValue(false)
+
+      render(<MemoizedTransactionItem txid="tx-1" highlight />)
+
+      expect(mockUseBounceInAnimation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isFocused: false }),
+      )
+    })
+
+    it("does not run the bounce for a row that was never highlighted", () => {
+      render(<MemoizedTransactionItem txid="tx-1" />)
+
+      expect(mockUseBounceInAnimation).not.toHaveBeenCalled()
     })
   })
 

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -329,6 +329,31 @@ describe("useDisplayCurrency", () => {
 
       expect(formatted).toBe("$100.00 USD")
     })
+
+    it("constructs at most one Intl.NumberFormat per fraction-digit count", () => {
+      // 7 fraction digits is used by no other test in this file, so the
+      // module-level formatter cache is cold on the first run and warm after.
+      setCurrencyList([
+        { id: "USD", symbol: "$", fractionDigits: 2 },
+        { id: "XTS", symbol: "¤", fractionDigits: 7 },
+      ])
+      const numberFormatSpy = jest.spyOn(Intl, "NumberFormat")
+
+      const { result } = renderHook(() => useDisplayCurrency())
+
+      const formatted = Array.from({ length: 25 }, (_, index) =>
+        result.current.formatCurrency({
+          amountInMajorUnits: index,
+          currency: "XTS",
+        }),
+      )
+
+      expect(numberFormatSpy.mock.calls.length).toBeLessThanOrEqual(1)
+      expect(formatted[0]).toBe("¤0.0000000")
+      expect(formatted[24]).toBe("¤24.0000000")
+
+      numberFormatSpy.mockRestore()
+    })
   })
 
   describe("getCurrencySymbol", () => {

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -62,6 +62,15 @@ const setPriceConversion = ({
 // later formatting test and bury the real failure.
 let numberFormatSpy: jest.SpyInstance | undefined
 
+// Counts only the constructions for the fraction-digit count under test, so an
+// unrelated formatter built during the same render cannot move the number.
+const constructionsAt = (fractionDigits: number) =>
+  (numberFormatSpy?.mock.calls ?? []).filter(
+    ([, options]) =>
+      (options as Intl.NumberFormatOptions | undefined)?.maximumFractionDigits ===
+      fractionDigits,
+  ).length
+
 describe("useDisplayCurrency", () => {
   afterEach(() => {
     numberFormatSpy?.mockRestore()
@@ -358,9 +367,38 @@ describe("useDisplayCurrency", () => {
         }),
       )
 
-      expect(numberFormatSpy.mock.calls.length).toBeLessThanOrEqual(1)
+      expect(constructionsAt(7)).toBe(1)
       expect(formatted[0]).toBe("¤0.0000000")
       expect(formatted[24]).toBe("¤24.0000000")
+    })
+
+    it("keeps interleaved fraction-digit counts on their own formatter", () => {
+      // The cache is keyed on fraction digits alone. Two currencies formatted
+      // alternately is what catches a key that stops distinguishing them, since
+      // both would then read back through whichever formatter was built first.
+      setCurrencyList([
+        { id: "XTA", symbol: "¤", fractionDigits: 5 },
+        { id: "XTB", symbol: "¤", fractionDigits: 6 },
+      ])
+      numberFormatSpy = jest.spyOn(Intl, "NumberFormat")
+
+      const { result } = renderHook(() => useDisplayCurrency())
+
+      const formatted = Array.from({ length: 8 }, (_, index) =>
+        result.current.formatCurrency({
+          amountInMajorUnits: 1,
+          currency: index % 2 === 0 ? "XTA" : "XTB",
+        }),
+      )
+
+      expect(formatted.filter((_, index) => index % 2 === 0)).toEqual(
+        Array(4).fill("¤1.00000"),
+      )
+      expect(formatted.filter((_, index) => index % 2 === 1)).toEqual(
+        Array(4).fill("¤1.000000"),
+      )
+      expect(constructionsAt(5)).toBe(1)
+      expect(constructionsAt(6)).toBe(1)
     })
   })
 

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -57,7 +57,17 @@ const setPriceConversion = ({
   })
 }
 
+// Restored unconditionally: jest is configured with neither restoreMocks nor
+// resetMocks, so a spy left in place by a failing assertion would break every
+// later formatting test and bury the real failure.
+let numberFormatSpy: jest.SpyInstance | undefined
+
 describe("useDisplayCurrency", () => {
+  afterEach(() => {
+    numberFormatSpy?.mockRestore()
+    numberFormatSpy = undefined
+  })
+
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseIsAuthed.mockReturnValue(true)
@@ -337,7 +347,7 @@ describe("useDisplayCurrency", () => {
         { id: "USD", symbol: "$", fractionDigits: 2 },
         { id: "XTS", symbol: "¤", fractionDigits: 7 },
       ])
-      const numberFormatSpy = jest.spyOn(Intl, "NumberFormat")
+      numberFormatSpy = jest.spyOn(Intl, "NumberFormat")
 
       const { result } = renderHook(() => useDisplayCurrency())
 
@@ -351,8 +361,6 @@ describe("useDisplayCurrency", () => {
       expect(numberFormatSpy.mock.calls.length).toBeLessThanOrEqual(1)
       expect(formatted[0]).toBe("¤0.0000000")
       expect(formatted[24]).toBe("¤24.0000000")
-
-      numberFormatSpy.mockRestore()
     })
   })
 

--- a/__tests__/perf/transaction-list.bench.tsx
+++ b/__tests__/perf/transaction-list.bench.tsx
@@ -32,6 +32,8 @@ import { detectDefaultLocale } from "@app/utils/locale-detector"
 import { TransactionFragmentDoc } from "@app/graphql/generated"
 import { MemoizedTransactionItem } from "@app/components/transaction-item"
 
+import { flushEffects } from "../helpers/flush-effects"
+
 import { createCache } from "../../app/graphql/cache"
 import { IsAuthedContextProvider } from "../../app/graphql/is-authed-context"
 import { PersistentStateContext } from "../../app/store/persistent-state"
@@ -84,9 +86,14 @@ const Stack = createNativeStackNavigator()
 
 const ListScreen: React.FC = () => {
   const navigation = useNavigation()
-  benchGlobal.__navigate = () =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (navigation as any).navigate("Detail")
+
+  // In an effect, not the render body: assigning during render is the pattern
+  // a double-rendering mode punishes, and it would silently skew the counts.
+  React.useEffect(() => {
+    benchGlobal.__navigate = () =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (navigation as any).navigate("Detail")
+  }, [navigation])
 
   return (
     <>
@@ -163,25 +170,28 @@ const median = (values: number[]) => {
 // and the measurement is worthless.
 const readRowRenders = () => rowRenders
 
+// One quiet pass is enough to call it settled; the cap only exists so a tree
+// that never stops rendering fails loudly instead of hanging until the timeout.
+const SETTLE_MAX_PASSES = 100
+
 const settle = async () => {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
+  for (let pass = 0; pass < SETTLE_MAX_PASSES; pass += 1) {
     const before = readRowRenders()
     // eslint-disable-next-line no-await-in-loop
-    await act(async () => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 15)
-      })
-    })
+    await flushEffects()
     if (readRowRenders() === before) {
       return
     }
   }
-  throw new Error("tree never became quiescent")
+  throw new Error(
+    `tree never became quiescent after ${SETTLE_MAX_PASSES} passes, so the measurement would be meaningless`,
+  )
 }
 
-describe(`transaction list — ${ROW_COUNT} rows`, () => {
-  jest.setTimeout(300000)
+// Long enough for the largest BENCH_ROWS x BENCH_REPEATS combination in use.
+jest.setTimeout(300000)
 
+describe(`transaction list — ${ROW_COUNT} rows`, () => {
   it("measures the cost of opening a transaction", async () => {
     const mountRowRenders: number[] = []
     const mountStyleSheets: number[] = []

--- a/__tests__/perf/transaction-list.bench.tsx
+++ b/__tests__/perf/transaction-list.bench.tsx
@@ -11,6 +11,11 @@
  * only so it can count how many times each row renders.
  *
  * Run against origin/main for "before" and this branch for "after".
+ *
+ * This is a manual A/B harness, not a test: it lives under __tests__/ but
+ * testRegex in jest.config.js only matches .(test|spec).(ts|tsx|js), so
+ * .bench.tsx never runs in CI. Nothing will tell you when it rots — re-run it
+ * by name whenever the row or the list changes.
  */
 import React from "react"
 import { StyleSheet } from "react-native"
@@ -222,7 +227,11 @@ describe(`transaction list — ${ROW_COUNT} rows`, () => {
           mount: {
             rowRenders: median(mountRowRenders),
             styleSheetCreates: median(mountStyleSheets),
-            intlNumberFormats: median(mountFormatters),
+            // The formatter cache is module-level, so it survives the whole
+            // REPEATS loop: only the first run measures a cold cache, and runs
+            // 2+ reporting 0 is the expected shape of the fix rather than a
+            // per-mount number. A median across runs would describe the loop.
+            intlNumberFormatsFirstRun: mountFormatters[0],
             intlNumberFormatsEachRun: mountFormatters,
           },
           // Wall-clock is deliberately not reported: in this environment it is

--- a/__tests__/perf/transaction-list.bench.tsx
+++ b/__tests__/perf/transaction-list.bench.tsx
@@ -1,0 +1,241 @@
+/**
+ * Benchmark harness for issue #4137.
+ *
+ * Renders N real TransactionItem rows inside a real NavigationContainer, then
+ * navigates to a second screen — which is what pushing the transaction detail
+ * screen does — and measures what that costs the list behind it.
+ *
+ * Nothing about the measured paths is mocked: the focus subscription is the
+ * real useIsFocused, the styles go through the real makeStyles, and the amounts
+ * go through the real useDisplayCurrency. Only IconTransaction is stubbed, and
+ * only so it can count how many times each row renders.
+ *
+ * Run against origin/main for "before" and this branch for "after".
+ */
+import React from "react"
+import { StyleSheet } from "react-native"
+import { act, render, waitFor } from "@testing-library/react-native"
+import { MockedProvider } from "@apollo/client/testing"
+import { NavigationContainer, useNavigation } from "@react-navigation/native"
+import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { ThemeProvider } from "@rn-vui/themed"
+
+import mocks from "@app/graphql/mocks"
+import theme from "@app/rne-theme/theme"
+import TypesafeI18n from "@app/i18n/i18n-react"
+import { detectDefaultLocale } from "@app/utils/locale-detector"
+import { TransactionFragmentDoc } from "@app/graphql/generated"
+import { MemoizedTransactionItem } from "@app/components/transaction-item"
+
+import { createCache } from "../../app/graphql/cache"
+import { IsAuthedContextProvider } from "../../app/graphql/is-authed-context"
+import { PersistentStateContext } from "../../app/store/persistent-state"
+import { AccountRegistryProvider } from "../../app/hooks/use-account-registry"
+
+// Counts renders per row without touching any measured code path.
+type BenchGlobal = { __rowRendered: () => void; __navigate: () => void }
+const benchGlobal = global as unknown as BenchGlobal
+
+let rowRenders = 0
+jest.mock("@app/components/icon-transactions", () => ({
+  IconTransaction: () => {
+    ;(global as unknown as { __rowRendered: () => void }).__rowRendered()
+    return null
+  },
+}))
+
+benchGlobal.__rowRendered = () => {
+  rowRenders += 1
+}
+
+const ROW_COUNT = Number(process.env.BENCH_ROWS ?? 200)
+const REPEATS = Number(process.env.BENCH_REPEATS ?? 5)
+
+const makeTx = (index: number) => ({
+  __typename: "Transaction" as const,
+  id: `tx-${index}`,
+  status: "SUCCESS",
+  direction: index % 2 === 0 ? "SEND" : "RECEIVE",
+  memo: `payment ${index}`,
+  createdAt: 1700000000 + index,
+  settlementAmount: 1000 + index,
+  settlementFee: 1,
+  settlementDisplayFee: "0.01",
+  settlementCurrency: "BTC",
+  settlementDisplayAmount: `${index}.75`,
+  settlementDisplayCurrency: "USD",
+  settlementPrice: {
+    __typename: "PriceOfOneSettlementMinorUnitInDisplayMinorUnit" as const,
+    base: 1,
+    offset: 0,
+    currencyUnit: "USDCENT",
+    formattedAmount: "1",
+  },
+  initiationVia: { __typename: "InitiationViaLn" as const, paymentHash: `hash-${index}` },
+  settlementVia: { __typename: "SettlementViaLn" as const, preImage: `pre-${index}` },
+})
+
+const Stack = createNativeStackNavigator()
+
+const ListScreen: React.FC = () => {
+  const navigation = useNavigation()
+  benchGlobal.__navigate = () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (navigation as any).navigate("Detail")
+
+  return (
+    <>
+      {Array.from({ length: ROW_COUNT }, (_, index) => (
+        <MemoizedTransactionItem
+          key={`tx-${index}`}
+          txid={`tx-${index}`}
+          subtitle
+          highlight={index === 0}
+        />
+      ))}
+    </>
+  )
+}
+
+const DetailScreen: React.FC = () => null
+
+const Harness: React.FC = () => {
+  const cache = React.useMemo(() => {
+    const created = createCache()
+    Array.from({ length: ROW_COUNT }, (_, index) => {
+      created.writeFragment({
+        fragment: TransactionFragmentDoc,
+        fragmentName: "Transaction",
+        id: `Transaction:tx-${index}`,
+        data: makeTx(index),
+      })
+      return null
+    })
+    return created
+  }, [])
+
+  return (
+    <ThemeProvider theme={theme}>
+      <MockedProvider mocks={mocks} cache={cache}>
+        <PersistentStateContext.Provider
+          value={{
+            persistentState: {
+              schemaVersion: 15,
+              galoyInstance: { id: "Main" },
+              galoyAuthToken: "",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any,
+            updateState: () => {},
+            resetState: () => {},
+          }}
+        >
+          <TypesafeI18n locale={detectDefaultLocale()}>
+            <IsAuthedContextProvider value={true}>
+              <AccountRegistryProvider>
+                <NavigationContainer>
+                  <Stack.Navigator screenOptions={{ headerShown: false }}>
+                    <Stack.Screen name="List" component={ListScreen} />
+                    <Stack.Screen name="Detail" component={DetailScreen} />
+                  </Stack.Navigator>
+                </NavigationContainer>
+              </AccountRegistryProvider>
+            </IsAuthedContextProvider>
+          </TypesafeI18n>
+        </PersistentStateContext.Provider>
+      </MockedProvider>
+    </ThemeProvider>
+  )
+}
+
+const median = (values: number[]) => {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+// Mount is asynchronous: the currency list, i18n and the Apollo fragments all
+// settle over several ticks. Without waiting for the row-render count to stop
+// moving, late mount renders get counted against the navigation that follows
+// and the measurement is worthless.
+const readRowRenders = () => rowRenders
+
+const settle = async () => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const before = readRowRenders()
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 15)
+      })
+    })
+    if (readRowRenders() === before) {
+      return
+    }
+  }
+  throw new Error("tree never became quiescent")
+}
+
+describe(`transaction list — ${ROW_COUNT} rows`, () => {
+  jest.setTimeout(300000)
+
+  it("measures the cost of opening a transaction", async () => {
+    const mountRowRenders: number[] = []
+    const mountStyleSheets: number[] = []
+    const mountFormatters: number[] = []
+    const openRowRenders: number[] = []
+
+    for (let run = 0; run < REPEATS; run += 1) {
+      const styleSheetSpy = jest.spyOn(StyleSheet, "create")
+      const formatterSpy = jest.spyOn(Intl, "NumberFormat")
+      rowRenders = 0
+
+      const screen = render(<Harness />)
+      // eslint-disable-next-line no-loop-func
+      await waitFor(() => {
+        expect(readRowRenders()).toBeGreaterThanOrEqual(ROW_COUNT)
+      })
+      await settle()
+
+      mountRowRenders.push(rowRenders)
+      mountStyleSheets.push(styleSheetSpy.mock.calls.length)
+      mountFormatters.push(formatterSpy.mock.calls.length)
+
+      // Opening a transaction: push the detail screen, which flips focus on the
+      // list behind it. This is the moment the issue is about.
+      rowRenders = 0
+      await act(async () => {
+        benchGlobal.__navigate()
+      })
+      await settle()
+      openRowRenders.push(rowRenders)
+
+      styleSheetSpy.mockRestore()
+      formatterSpy.mockRestore()
+      screen.unmount()
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify(
+        {
+          rows: ROW_COUNT,
+          repeats: REPEATS,
+          mount: {
+            rowRenders: median(mountRowRenders),
+            styleSheetCreates: median(mountStyleSheets),
+            intlNumberFormats: median(mountFormatters),
+            intlNumberFormatsEachRun: mountFormatters,
+          },
+          // Wall-clock is deliberately not reported: in this environment it is
+          // dominated by warm-up noise (400 rows repeatedly timed faster than
+          // 200). The render counts are exact and environment-independent.
+          openTransaction: {
+            rowRendersEachRun: openRowRenders,
+            rowRenders: median(openRowRenders),
+          },
+        },
+        null,
+        2,
+      ),
+    )
+  })
+})

--- a/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
+++ b/__tests__/screens/people-screen/contacts/contact-transactions.spec.tsx
@@ -1,0 +1,201 @@
+import React from "react"
+import { SectionList } from "react-native"
+import { MockedResponse } from "@apollo/client/testing"
+import { render, waitFor } from "@testing-library/react-native"
+
+import { ContactTransactions } from "@app/screens/people-screen/contacts/contact-transactions"
+import { TransactionListForContactDocument } from "@app/graphql/generated"
+import { TRANSACTION_LIST_WINDOW_SIZE } from "@app/components/transaction-item"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+
+import { ContextForScreen } from "../../helper"
+
+const CONTACT_USERNAME = "test_contact"
+
+let currentMocks: MockedResponse[] = []
+
+jest.mock("@app/graphql/mocks", () => {
+  const actual = jest.requireActual("@app/graphql/mocks")
+  return {
+    __esModule: true,
+    get default() {
+      // Spec-specific mocks first so they take precedence; the shared mocks
+      // backfill every other query fired by mounted components, keeping
+      // Apollo's MockLink warning-free.
+      return [...currentMocks, ...actual.default]
+    },
+  }
+})
+
+// Records the props each row is handed, so the list's contract with the row
+// (one shared handler, or none at all) is assertable from here.
+const mockRowProps: Array<{ txid: string; onPress?: (txid: string) => void }> = []
+
+jest.mock("@app/components/transaction-item", () => {
+  const actual = jest.requireActual("@app/components/transaction-item")
+  const React = jest.requireActual("react")
+  const { Text } = jest.requireActual("react-native")
+
+  type Props = { txid: string; onPress?: (txid: string) => void }
+
+  const MemoizedTransactionItem = ({ txid, onPress }: Props) => {
+    mockRowProps.push({ txid, onPress })
+    return React.createElement(Text, { testID: `row-${txid}` }, txid)
+  }
+
+  return {
+    __esModule: true,
+    ...actual,
+    MemoizedTransactionItem,
+  }
+})
+
+const makeEdge = (id: string, cursor: string, createdAt: number) => ({
+  __typename: "TransactionEdge",
+  cursor,
+  node: {
+    __typename: "Transaction",
+    id,
+    status: "SUCCESS",
+    direction: "RECEIVE",
+    memo: null,
+    createdAt,
+    settlementAmount: 1000,
+    settlementFee: 0,
+    settlementDisplayFee: "0.00",
+    settlementCurrency: "BTC",
+    settlementDisplayAmount: "0.10",
+    settlementDisplayCurrency: "USD",
+    settlementPrice: {
+      __typename: "PriceOfOneSettlementMinorUnitInDisplayMinorUnit",
+      base: 105000000000,
+      offset: 12,
+      currencyUnit: "MINOR",
+      formattedAmount: "0.105",
+    },
+    initiationVia: {
+      __typename: "InitiationViaLn",
+      paymentHash: `hash-${id}`,
+      paymentRequest: `payment-request-${id}`,
+    },
+    settlementVia: {
+      __typename: "SettlementViaIntraLedger",
+      counterPartyWalletId: null,
+      counterPartyUsername: CONTACT_USERNAME,
+      preImage: null,
+    },
+  },
+})
+
+const buildContactMocks = (): MockedResponse[] => {
+  const result = {
+    data: {
+      me: {
+        __typename: "User",
+        id: "user-id",
+        contactByUsername: {
+          __typename: "UserContact",
+          transactions: {
+            __typename: "TransactionConnection",
+            pageInfo: {
+              __typename: "PageInfo",
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: "cursor-1",
+              endCursor: "cursor-2",
+            },
+            edges: [
+              makeEdge("507f1f77bcf86cd799439011", "cursor-1", 1700000001),
+              makeEdge("507f1f77bcf86cd799439012", "cursor-2", 1700000000),
+            ],
+          },
+        },
+      },
+    },
+  }
+
+  return [
+    {
+      request: {
+        query: TransactionListForContactDocument,
+        variables: { username: CONTACT_USERNAME },
+      },
+      maxUsageCount: Number.POSITIVE_INFINITY,
+      result,
+    },
+  ]
+}
+
+const renderContactTransactions = () =>
+  render(
+    <ContextForScreen>
+      <ContactTransactions contactUsername={CONTACT_USERNAME} />
+    </ContextForScreen>,
+  )
+
+describe("ContactTransactions", () => {
+  beforeEach(() => {
+    loadLocale("en")
+    mockRowProps.length = 0
+    currentMocks = buildContactMocks()
+  })
+
+  it("renders a row per transaction of the contact", async () => {
+    const screen = renderContactTransactions()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+    })
+    expect(screen.getByTestId("row-507f1f77bcf86cd799439012")).toBeTruthy()
+  })
+
+  it("leaves its rows non-pressable", async () => {
+    // This list only shows the history with one contact; it does not navigate
+    // into a transaction, and a row handed a handler here would look tappable
+    // and go nowhere.
+    const screen = renderContactTransactions()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+    })
+
+    expect(mockRowProps.length).toBeGreaterThan(0)
+    expect(mockRowProps.every((props) => props.onPress === undefined)).toBe(true)
+  })
+
+  it("hands the list the same render callbacks across re-renders", async () => {
+    // A fresh arrow per render defeats the row's React.memo, which is the whole
+    // point of the memoization: every mounted row would re-render with it.
+    const screen = renderContactTransactions()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+    })
+
+    const first = screen.UNSAFE_getByType(SectionList).props
+
+    screen.rerender(
+      <ContextForScreen>
+        <ContactTransactions contactUsername={CONTACT_USERNAME} />
+      </ContextForScreen>,
+    )
+
+    const second = screen.UNSAFE_getByType(SectionList).props
+
+    expect(second.renderItem).toBe(first.renderItem)
+    expect(second.keyExtractor).toBe(first.keyExtractor)
+    expect(second.renderSectionHeader).toBe(first.renderSectionHeader)
+  })
+
+  it("bounds the mounted row set with the shared window size", async () => {
+    const screen = renderContactTransactions()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("row-507f1f77bcf86cd799439011")).toBeTruthy()
+    })
+
+    expect(screen.UNSAFE_getByType(SectionList).props.windowSize).toBe(
+      TRANSACTION_LIST_WINDOW_SIZE,
+    )
+  })
+})

--- a/__tests__/screens/transaction-history-screen.spec.tsx
+++ b/__tests__/screens/transaction-history-screen.spec.tsx
@@ -69,6 +69,11 @@ jest.mock("@app/graphql/mocks", () => {
   }
 })
 
+// Records the onPress identity handed to each row, so a test can assert the
+// screen shares one stable callback instead of a fresh closure per row —
+// a fresh closure defeats React.memo and re-renders the whole list.
+const mockOnPressIdentities: Array<(txid: string) => void> = []
+
 jest.mock("@app/components/transaction-item", () => {
   const React = jest.requireActual("react")
   const { Text } = jest.requireActual("react-native")
@@ -77,11 +82,17 @@ jest.mock("@app/components/transaction-item", () => {
     txid: string
     highlight?: boolean
     testId?: string
+    onPress?: (txid: string) => void
   }
 
-  const MemoizedTransactionItem = ({ txid, highlight, testId }: Props) => (
-    <Text testID={testId}>{`${txid}:${highlight ? "highlight" : "no-highlight"}`}</Text>
-  )
+  const MemoizedTransactionItem = ({ txid, highlight, testId, onPress }: Props) => {
+    if (onPress) {
+      mockOnPressIdentities.push(onPress)
+    }
+    return (
+      <Text testID={testId}>{`${txid}:${highlight ? "highlight" : "no-highlight"}`}</Text>
+    )
+  }
 
   return {
     __esModule: true,
@@ -257,12 +268,42 @@ const buildTransactionMocks = ({
 describe("TransactionHistoryScreen", () => {
   beforeEach(() => {
     loadLocale("en")
+    mockOnPressIdentities.length = 0
   })
 
   afterEach(() => {
     cleanup()
     currentMocks = []
     currentTxLastSeen = { btcId: "", usdId: "" }
+  })
+
+  it("hands every row the same onPress callback, across re-renders", async () => {
+    currentTxLastSeen = {
+      btcId: "507f1f77bcf86cd799439010",
+      usdId: "507f1f77bcf86cd799439010",
+    }
+
+    currentMocks = buildTransactionMocks({
+      btcTxId: "507f1f77bcf86cd799439011",
+      usdTxId: "507f1f77bcf86cd799439012",
+    })
+
+    const screen = render(
+      <ContextForScreen>
+        <TransactionHistoryScreen route={mockRouteWithCurrencyFilter()} />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("transaction-by-index-1")).toBeTruthy()
+    })
+
+    // Force a screen re-render: a per-row closure would be rebuilt here.
+    const dropdown = screen.getByTestId("wallet-filter-dropdown")
+    await act(() => fireEvent.press(dropdown))
+
+    expect(mockOnPressIdentities.length).toBeGreaterThan(1)
+    expect(new Set(mockOnPressIdentities).size).toBe(1)
   })
 
   it("shows all transactions by default", async () => {

--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -66,6 +66,16 @@ const BOUNCE_DELAY_MS = 300
 const BOUNCE_DURATION_MS = 120
 
 /**
+ * Window size for the lists that render these rows.
+ *
+ * RN's default of 21 keeps roughly ten screens of rows mounted on either side
+ * of the viewport; 7 still leaves three screens of headroom for fast scrolling.
+ * If a fast fling ever shows blank cells, raise this to 9 rather than reverting.
+ * Shared so the two transaction lists cannot drift apart.
+ */
+export const TRANSACTION_LIST_WINDOW_SIZE = 7
+
+/**
  * Owns the navigation focus subscription that drives a row's bounce-in.
  *
  * It renders nothing and is mounted as a sibling of the row, only once that row

--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { View } from "react-native"
-import Animated, { useSharedValue, useAnimatedStyle } from "react-native-reanimated"
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  type SharedValue,
+} from "react-native-reanimated"
 import { useIsFocused } from "@react-navigation/native"
 import { Text, makeStyles, ListItem } from "@rn-vui/themed"
 import { useFragment } from "@apollo/client"
@@ -58,29 +62,32 @@ export const useDescriptionDisplay = ({
   }
 }
 
-// Owns the navigation focus subscription so that only the highlighted row
-// re-renders when focus changes, instead of every mounted row in the list.
-const BouncingRow: React.FC<{ visible: boolean; children: React.ReactNode }> = ({
-  visible,
-  children,
-}) => {
+const BOUNCE_DELAY_MS = 300
+const BOUNCE_DURATION_MS = 120
+
+/**
+ * Owns the navigation focus subscription that drives a row's bounce-in.
+ *
+ * It renders nothing and is mounted as a sibling of the row, only once that row
+ * has been highlighted. `useIsFocused` re-renders every subscriber on each
+ * navigation focus change, so keeping it out of the rows that never bounce is
+ * what stops opening a transaction from re-rendering the whole mounted list.
+ */
+const BounceOnFocus: React.FC<{
+  visible: boolean
+  scale: SharedValue<number>
+}> = ({ visible, scale }) => {
   const isFocused = useIsFocused()
-  const scale = useSharedValue(1)
 
   useBounceInAnimation({
     isFocused,
     visible,
     scale,
-    delay: 300,
-    duration: 120,
+    delay: BOUNCE_DELAY_MS,
+    duration: BOUNCE_DURATION_MS,
   })
 
-  const animatedStyle = useAnimatedStyle(
-    () => ({ transform: [{ scale: scale.value }] }),
-    [scale],
-  )
-
-  return <Animated.View style={animatedStyle}>{children}</Animated.View>
+  return null
 }
 
 type Props = {
@@ -112,10 +119,18 @@ const TransactionItem: React.FC<Props> = ({
   )
   const styles = useStyles(styleProps)
 
-  // Once a row has been highlighted, keep the wrapper mounted for the life of
-  // the row: dropping it when the highlight clears would swap the element type
-  // at that position and remount the whole row subtree. Rows that are never
-  // highlighted never mount it, so they never subscribe to navigation focus.
+  const scale = useSharedValue(1)
+  const animatedStyle = useAnimatedStyle(
+    () => ({ transform: [{ scale: scale.value }] }),
+    [scale],
+  )
+
+  // Once a row has been highlighted, keep the subscriber mounted for the life of
+  // the row rather than dropping it when the highlight clears. useBounceInAnimation
+  // resets `scale` from its `visible: false` branch, not from its cleanup, so a
+  // highlight clearing mid-bounce would otherwise leave the row frozen at
+  // whatever scale the animation had reached. Rows that are never highlighted
+  // never mount it, so they never subscribe to navigation focus.
   const everHighlighted = React.useRef(highlight)
   if (highlight) everHighlighted.current = true
 
@@ -185,59 +200,65 @@ const TransactionItem: React.FC<Props> = ({
       ? undefined
       : formattedSettlementAmount
 
-  const row = (
-    <ListItem
-      {...testProps(testId)}
-      containerStyle={styles.container}
-      // handlePress is always defined, so it is only handed over when the caller
-      // actually passed an onPress — otherwise the row would become pressable.
-      onPress={onPress ? handlePress : undefined}
-    >
-      <IconTransaction
-        onChain={tx.settlementVia?.__typename === "SettlementViaOnChain"}
-        isReceive={isReceive}
-        pending={isPending}
-        walletCurrency={walletCurrency}
-      />
-      <ListItem.Content {...testProps("list-item-content")}>
-        <ListItem.Title
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          style={styles.title}
-          {...testProps("tx-description")}
-        >
-          {description}
-        </ListItem.Title>
-        <ListItem.Subtitle style={styles.subtitle}>
-          {subtitle ? (
-            <TransactionDate
-              createdAt={tx.createdAt}
-              status={tx.status}
-              includeTime={false}
-            />
-          ) : undefined}
-        </ListItem.Subtitle>
-      </ListItem.Content>
+  return (
+    // Always wrapped, so the element type at this position never depends on
+    // `highlight`: React does not diff across a type change, and swapping the
+    // wrapper in or out would unmount and rebuild the whole row subtree at the
+    // exact moment the user is looking at that row. Only the focus subscriber
+    // below is conditional, and it sits in its own child slot so toggling it
+    // leaves the row beside it untouched.
+    <Animated.View style={animatedStyle}>
+      {everHighlighted.current ? (
+        <BounceOnFocus visible={highlight} scale={scale} />
+      ) : null}
+      <ListItem
+        {...testProps(testId)}
+        containerStyle={styles.container}
+        // handlePress is always defined, so it is only handed over when the
+        // caller actually passed an onPress — otherwise the row would become
+        // pressable.
+        onPress={onPress ? handlePress : undefined}
+      >
+        <IconTransaction
+          onChain={tx.settlementVia?.__typename === "SettlementViaOnChain"}
+          isReceive={isReceive}
+          pending={isPending}
+          walletCurrency={walletCurrency}
+        />
+        <ListItem.Content {...testProps("list-item-content")}>
+          <ListItem.Title
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={styles.title}
+            {...testProps("tx-description")}
+          >
+            {description}
+          </ListItem.Title>
+          <ListItem.Subtitle style={styles.subtitle}>
+            {subtitle ? (
+              <TransactionDate
+                createdAt={tx.createdAt}
+                status={tx.status}
+                includeTime={false}
+              />
+            ) : undefined}
+          </ListItem.Subtitle>
+        </ListItem.Content>
 
-      <View style={styles.amountWrapper}>
-        {hideAmount ? (
-          <HiddenBalancePlaceholder size="small" />
-        ) : (
-          <>
-            <Text style={amountStyle}>{formattedDisplayAmount}</Text>
-            {formattedSecondaryAmount && (
-              <Text style={amountStyle}>{formattedSecondaryAmount}</Text>
-            )}
-          </>
-        )}
-      </View>
-    </ListItem>
-  )
-
-  return everHighlighted.current ? (
-    <BouncingRow visible={highlight}>{row}</BouncingRow>
-  ) : (
-    row
+        <View style={styles.amountWrapper}>
+          {hideAmount ? (
+            <HiddenBalancePlaceholder size="small" />
+          ) : (
+            <>
+              <Text style={amountStyle}>{formattedDisplayAmount}</Text>
+              {formattedSecondaryAmount && (
+                <Text style={amountStyle}>{formattedSecondaryAmount}</Text>
+              )}
+            </>
+          )}
+        </View>
+      </ListItem>
+    </Animated.View>
   )
 }
 

--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -60,13 +60,16 @@ export const useDescriptionDisplay = ({
 
 // Owns the navigation focus subscription so that only the highlighted row
 // re-renders when focus changes, instead of every mounted row in the list.
-const BouncingRow: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const BouncingRow: React.FC<{ visible: boolean; children: React.ReactNode }> = ({
+  visible,
+  children,
+}) => {
   const isFocused = useIsFocused()
   const scale = useSharedValue(1)
 
   useBounceInAnimation({
     isFocused,
-    visible: true,
+    visible,
     scale,
     delay: 300,
     duration: 120,
@@ -108,6 +111,13 @@ const TransactionItem: React.FC<Props> = ({
     [isFirst, isLast, isOnHomeScreen, highlight],
   )
   const styles = useStyles(styleProps)
+
+  // Once a row has been highlighted, keep the wrapper mounted for the life of
+  // the row: dropping it when the highlight clears would swap the element type
+  // at that position and remount the whole row subtree. Rows that are never
+  // highlighted never mount it, so they never subscribe to navigation focus.
+  const everHighlighted = React.useRef(highlight)
+  if (highlight) everHighlighted.current = true
 
   const { data: tx } = useFragment<TransactionFragment>({
     fragment: TransactionFragmentDoc,
@@ -224,7 +234,11 @@ const TransactionItem: React.FC<Props> = ({
     </ListItem>
   )
 
-  return highlight ? <BouncingRow>{row}</BouncingRow> : row
+  return everHighlighted.current ? (
+    <BouncingRow visible={highlight}>{row}</BouncingRow>
+  ) : (
+    row
+  )
 }
 
 export const MemoizedTransactionItem = React.memo(TransactionItem)

--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -58,6 +58,28 @@ export const useDescriptionDisplay = ({
   }
 }
 
+// Owns the navigation focus subscription so that only the highlighted row
+// re-renders when focus changes, instead of every mounted row in the list.
+const BouncingRow: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const isFocused = useIsFocused()
+  const scale = useSharedValue(1)
+
+  useBounceInAnimation({
+    isFocused,
+    visible: true,
+    scale,
+    delay: 300,
+    duration: 120,
+  })
+
+  const animatedStyle = useAnimatedStyle(
+    () => ({ transform: [{ scale: scale.value }] }),
+    [scale],
+  )
+
+  return <Animated.View style={animatedStyle}>{children}</Animated.View>
+}
+
 type Props = {
   txid: string
   subtitle?: boolean
@@ -66,7 +88,7 @@ type Props = {
   isOnHomeScreen?: boolean
   testId?: string
   highlight?: boolean
-  onPress?: () => void
+  onPress?: (txid: string) => void
 }
 
 const TransactionItem: React.FC<Props> = ({
@@ -79,12 +101,13 @@ const TransactionItem: React.FC<Props> = ({
   highlight = false,
   onPress,
 }) => {
-  const styles = useStyles({
-    isFirst,
-    isLast,
-    isOnHomeScreen,
-    highlight,
-  })
+  // makeStyles memoizes on the props object identity, so an object literal here
+  // would rebuild every stylesheet in this file on every render of every row.
+  const styleProps = React.useMemo(
+    () => ({ isFirst, isLast, isOnHomeScreen, highlight }),
+    [isFirst, isLast, isOnHomeScreen, highlight],
+  )
+  const styles = useStyles(styleProps)
 
   const { data: tx } = useFragment<TransactionFragment>({
     fragment: TransactionFragmentDoc,
@@ -107,19 +130,7 @@ const TransactionItem: React.FC<Props> = ({
     bankName: galoyInstance.name,
   })
 
-  const isFocused = useIsFocused()
-  const scale = useSharedValue(1)
-  useBounceInAnimation({
-    isFocused,
-    visible: highlight,
-    scale,
-    delay: 300,
-    duration: 120,
-  })
-  const animatedStyle = useAnimatedStyle(
-    () => ({ transform: [{ scale: scale.value }] }),
-    [scale],
-  )
+  const handlePress = React.useCallback(() => onPress?.(txid), [onPress, txid])
 
   if (!tx || Object.keys(tx).length === 0) {
     return null
@@ -164,54 +175,56 @@ const TransactionItem: React.FC<Props> = ({
       ? undefined
       : formattedSettlementAmount
 
-  return (
-    <Animated.View style={animatedStyle}>
-      <ListItem
-        {...testProps(testId)}
-        containerStyle={styles.container}
-        onPress={onPress}
-      >
-        <IconTransaction
-          onChain={tx.settlementVia?.__typename === "SettlementViaOnChain"}
-          isReceive={isReceive}
-          pending={isPending}
-          walletCurrency={walletCurrency}
-        />
-        <ListItem.Content {...testProps("list-item-content")}>
-          <ListItem.Title
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            style={styles.title}
-            {...testProps("tx-description")}
-          >
-            {description}
-          </ListItem.Title>
-          <ListItem.Subtitle style={styles.subtitle}>
-            {subtitle ? (
-              <TransactionDate
-                createdAt={tx.createdAt}
-                status={tx.status}
-                includeTime={false}
-              />
-            ) : undefined}
-          </ListItem.Subtitle>
-        </ListItem.Content>
+  const row = (
+    <ListItem
+      {...testProps(testId)}
+      containerStyle={styles.container}
+      // handlePress is always defined, so it is only handed over when the caller
+      // actually passed an onPress — otherwise the row would become pressable.
+      onPress={onPress ? handlePress : undefined}
+    >
+      <IconTransaction
+        onChain={tx.settlementVia?.__typename === "SettlementViaOnChain"}
+        isReceive={isReceive}
+        pending={isPending}
+        walletCurrency={walletCurrency}
+      />
+      <ListItem.Content {...testProps("list-item-content")}>
+        <ListItem.Title
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={styles.title}
+          {...testProps("tx-description")}
+        >
+          {description}
+        </ListItem.Title>
+        <ListItem.Subtitle style={styles.subtitle}>
+          {subtitle ? (
+            <TransactionDate
+              createdAt={tx.createdAt}
+              status={tx.status}
+              includeTime={false}
+            />
+          ) : undefined}
+        </ListItem.Subtitle>
+      </ListItem.Content>
 
-        <View style={styles.amountWrapper}>
-          {hideAmount ? (
-            <HiddenBalancePlaceholder size="small" />
-          ) : (
-            <>
-              <Text style={amountStyle}>{formattedDisplayAmount}</Text>
-              {formattedSecondaryAmount && (
-                <Text style={amountStyle}>{formattedSecondaryAmount}</Text>
-              )}
-            </>
-          )}
-        </View>
-      </ListItem>
-    </Animated.View>
+      <View style={styles.amountWrapper}>
+        {hideAmount ? (
+          <HiddenBalancePlaceholder size="small" />
+        ) : (
+          <>
+            <Text style={amountStyle}>{formattedDisplayAmount}</Text>
+            {formattedSecondaryAmount && (
+              <Text style={amountStyle}>{formattedSecondaryAmount}</Text>
+            )}
+          </>
+        )}
+      </View>
+    </ListItem>
   )
+
+  return highlight ? <BouncingRow>{row}</BouncingRow> : row
 }
 
 export const MemoizedTransactionItem = React.memo(TransactionItem)

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -56,6 +56,26 @@ const usdDisplayCurrency = {
 
 const defaultDisplayCurrency = usdDisplayCurrency
 
+// Constructing an Intl.NumberFormat is the most expensive part of formatting an
+// amount, and the options only ever vary by fraction digits, so one instance per
+// distinct count is enough for the whole app. The key space is the set of
+// fraction-digit counts across supported display currencies — a handful of values.
+const numberFormatters = new Map<number, Intl.NumberFormat>()
+
+const numberFormatterFor = (fractionDigits: number): Intl.NumberFormat => {
+  const cached = numberFormatters.get(fractionDigits)
+  if (cached) {
+    return cached
+  }
+
+  const formatter = Intl.NumberFormat("en-US", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })
+  numberFormatters.set(fractionDigits, formatter)
+  return formatter
+}
+
 const formatCurrencyHelper = ({
   amountInMajorUnits,
   symbol,
@@ -73,12 +93,11 @@ const formatCurrencyHelper = ({
 }) => {
   const isNegative = Number(amountInMajorUnits) < 0
   const decimalPlaces = fractionDigits
-  const amountStr = Intl.NumberFormat("en-US", {
-    minimumFractionDigits: decimalPlaces,
-    maximumFractionDigits: decimalPlaces,
-    // FIXME this workaround of using .format and not .formatNumber is
-    // because hermes haven't fully implemented Intl.NumberFormat yet
-  }).format(Math.abs(Number(amountInMajorUnits)))
+  // FIXME this workaround of using .format and not .formatNumber is
+  // because hermes haven't fully implemented Intl.NumberFormat yet
+  const amountStr = numberFormatterFor(decimalPlaces).format(
+    Math.abs(Number(amountInMajorUnits)),
+  )
   return `${isApproximate ? `${APPROXIMATE_PREFIX} ` : ""}${
     isNegative && withSign ? "-" : ""
   }${symbol}${amountStr}${currencyCode ? ` ${currencyCode}` : ""}`

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -2,7 +2,10 @@ import * as React from "react"
 import { SectionList, Text, View } from "react-native"
 
 import { gql } from "@apollo/client"
-import { MemoizedTransactionItem } from "@app/components/transaction-item"
+import {
+  MemoizedTransactionItem,
+  TRANSACTION_LIST_WINDOW_SIZE,
+} from "@app/components/transaction-item"
 import { useTransactionListForContactQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { groupTransactionsByDate } from "@app/graphql/transactions"
@@ -30,13 +33,17 @@ gql`
   }
 `
 
-// RN's default of 21 keeps roughly ten screens of rows mounted on either side of
-// the viewport; 7 still leaves three screens of headroom for fast scrolling.
-const WINDOW_SIZE = 7
-
 type Props = {
   contactUsername: string
 }
+
+const keyExtractor = (item: { id: string }) => item.id
+
+// Rows here are deliberately not pressable: this list only shows the history
+// with one contact, it does not navigate into a transaction.
+const renderItem = ({ item }: { item: { id: string } }) => (
+  <MemoizedTransactionItem txid={item.id} />
+)
 
 export const ContactTransactions = ({ contactUsername }: Props) => {
   const styles = useStyles()
@@ -61,11 +68,6 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
   )
 
   // Declared above the early returns below to keep hook order stable.
-  const renderItem = React.useCallback(
-    ({ item }: { item: { id: string } }) => <MemoizedTransactionItem txid={item.id} />,
-    [],
-  )
-
   const renderSectionHeader = React.useCallback(
     ({ section: { title } }: { section: { title: string } }) => (
       <View style={styles.sectionHeaderContainer}>
@@ -74,8 +76,6 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
     ),
     [styles.sectionHeaderContainer, styles.sectionHeaderText],
   )
-
-  const keyExtractor = React.useCallback((item: { id: string }) => item.id, [])
 
   if (error) {
     toastShow({
@@ -107,7 +107,7 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
       <SectionList
         renderItem={renderItem}
         initialNumToRender={20}
-        windowSize={WINDOW_SIZE}
+        windowSize={TRANSACTION_LIST_WINDOW_SIZE}
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
           <View style={styles.noTransactionView}>

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -30,6 +30,10 @@ gql`
   }
 `
 
+// RN's default of 21 keeps roughly ten screens of rows mounted on either side of
+// the viewport; 7 still leaves three screens of headroom for fast scrolling.
+const WINDOW_SIZE = 7
+
 type Props = {
   contactUsername: string
 }
@@ -55,6 +59,23 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
       }),
     [transactions, LL, locale],
   )
+
+  // Declared above the early returns below to keep hook order stable.
+  const renderItem = React.useCallback(
+    ({ item }: { item: { id: string } }) => <MemoizedTransactionItem txid={item.id} />,
+    [],
+  )
+
+  const renderSectionHeader = React.useCallback(
+    ({ section: { title } }: { section: { title: string } }) => (
+      <View style={styles.sectionHeaderContainer}>
+        <Text style={styles.sectionHeaderText}>{title}</Text>
+      </View>
+    ),
+    [styles.sectionHeaderContainer, styles.sectionHeaderText],
+  )
+
+  const keyExtractor = React.useCallback((item: { id: string }) => item.id, [])
 
   if (error) {
     toastShow({
@@ -84,15 +105,10 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
   return (
     <View style={styles.screen}>
       <SectionList
-        renderItem={({ item }) => (
-          <MemoizedTransactionItem key={`txn-${item.id}`} txid={item.id} />
-        )}
+        renderItem={renderItem}
         initialNumToRender={20}
-        renderSectionHeader={({ section: { title } }) => (
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeaderText}>{title}</Text>
-          </View>
-        )}
+        windowSize={WINDOW_SIZE}
+        renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
           <View style={styles.noTransactionView}>
             <Text style={styles.noTransactionText}>
@@ -101,7 +117,7 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
           </View>
         }
         sections={sections}
-        keyExtractor={(item) => item.id}
+        keyExtractor={keyExtractor}
         onEndReached={fetchNextTransactionsPage}
         onEndReachedThreshold={0.5}
       />

--- a/app/screens/transaction-history/transaction-history-screen.tsx
+++ b/app/screens/transaction-history/transaction-history-screen.tsx
@@ -68,6 +68,9 @@ gql`
 const INITIAL_ITEMS_TO_RENDER = 14
 const RENDER_BATCH_SIZE = 14
 const QUERY_BATCH_SIZE = INITIAL_ITEMS_TO_RENDER * 1.5
+// RN's default of 21 keeps roughly ten screens of rows mounted on either side of
+// the viewport; 7 still leaves three screens of headroom for fast scrolling.
+const WINDOW_SIZE = 7
 
 type TransactionHistoryScreenProps = {
   route: RouteProp<RootStackParamList, "transactionHistory">
@@ -429,11 +432,22 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
           memo: item.memo,
           direction: item.direction,
         })}
-        onPress={() => handleItemPress(item.id)}
+        onPress={handleItemPress}
       />
     ),
     [shouldHighlightTransactionId, handleItemPress],
   )
+
+  const renderSectionHeader = React.useCallback(
+    ({ section: { title } }: { section: { title: string } }) => (
+      <View style={styles.sectionHeaderContainer}>
+        <Text style={styles.sectionHeaderText}>{title}</Text>
+      </View>
+    ),
+    [styles.sectionHeaderContainer, styles.sectionHeaderText],
+  )
+
+  const keyExtractor = React.useCallback((item: TransactionFragment) => item.id, [])
 
   if (error) {
     console.error(error)
@@ -511,12 +525,9 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
         showsVerticalScrollIndicator={false}
         maxToRenderPerBatch={RENDER_BATCH_SIZE}
         initialNumToRender={INITIAL_ITEMS_TO_RENDER}
+        windowSize={WINDOW_SIZE}
         renderItem={renderItem}
-        renderSectionHeader={({ section: { title } }) => (
-          <View style={styles.sectionHeaderContainer}>
-            <Text style={styles.sectionHeaderText}>{title}</Text>
-          </View>
-        )}
+        renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
           <View style={styles.noTransactionView}>
             <Text style={styles.noTransactionText}>
@@ -525,7 +536,7 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
           </View>
         }
         sections={sections}
-        keyExtractor={(item) => item.id}
+        keyExtractor={keyExtractor}
         onEndReached={fetchNextTransactionsPage}
         onEndReachedThreshold={0.5}
         onRefresh={handleRefresh}

--- a/app/screens/transaction-history/transaction-history-screen.tsx
+++ b/app/screens/transaction-history/transaction-history-screen.tsx
@@ -39,7 +39,10 @@ import { useHasTransitioned, useTransactionSeenState } from "@app/hooks"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { reportError } from "@app/utils/error-logging"
 
-import { MemoizedTransactionItem } from "@app/components/transaction-item"
+import {
+  MemoizedTransactionItem,
+  TRANSACTION_LIST_WINDOW_SIZE,
+} from "@app/components/transaction-item"
 import { toastShow } from "../../utils/toast"
 
 import TransactionHistorySkeleton from "./transaction-history-skeleton"
@@ -68,9 +71,8 @@ gql`
 const INITIAL_ITEMS_TO_RENDER = 14
 const RENDER_BATCH_SIZE = 14
 const QUERY_BATCH_SIZE = INITIAL_ITEMS_TO_RENDER * 1.5
-// RN's default of 21 keeps roughly ten screens of rows mounted on either side of
-// the viewport; 7 still leaves three screens of headroom for fast scrolling.
-const WINDOW_SIZE = 7
+
+const keyExtractor = (item: TransactionFragment) => item.id
 
 type TransactionHistoryScreenProps = {
   route: RouteProp<RootStackParamList, "transactionHistory">
@@ -447,8 +449,6 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
     [styles.sectionHeaderContainer, styles.sectionHeaderText],
   )
 
-  const keyExtractor = React.useCallback((item: TransactionFragment) => item.id, [])
-
   if (error) {
     console.error(error)
     reportError("transaction-history", error)
@@ -525,7 +525,7 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
         showsVerticalScrollIndicator={false}
         maxToRenderPerBatch={RENDER_BATCH_SIZE}
         initialNumToRender={INITIAL_ITEMS_TO_RENDER}
-        windowSize={WINDOW_SIZE}
+        windowSize={TRANSACTION_LIST_WINDOW_SIZE}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={


### PR DESCRIPTION
Fixes #4137.

Opening a transaction pushed a re-render through every mounted row of the `SectionList` before the details screen got a frame, and each of those re-renders did more work than it needed to. Five changes across four files: cut the re-render at its source, make `React.memo` actually bail out, and make the remaining per-row work cheaper. No visual or behavioural change to the rows.

## 1. Focus subscription moved into a subcomponent only ever-highlighted rows mount

`TransactionItem` called `useIsFocused()` unconditionally. That hook re-renders *every* subscriber on each navigation focus change, so the instant you opened a transaction, every mounted row re-rendered. The subscription existed only to drive the bounce-in animation, which applies to at most one row.

Extracted a `BouncingRow` wrapper that owns `useIsFocused`, `useSharedValue`, `useBounceInAnimation` and `useAnimatedStyle`. The row body is built as a plain element and wrapped only once it has had reason to animate:

```tsx
// Latched: mounted the first time the row is highlighted, kept for its lifetime.
const everHighlighted = React.useRef(highlight)
if (highlight) everHighlighted.current = true

return everHighlighted.current ? <BouncingRow visible={highlight}>{row}</BouncingRow> : row
```

**Decision:** the wrapper is latched rather than conditioned directly on `highlight`. A plain `highlight ? <BouncingRow>… : row` changes the element *type* at that position, and React does not diff across a type change — so the moment a highlight cleared (which happens on every tap of an unseen transaction, via `seenTxIds`), the entire row subtree unmounted and rebuilt instead of re-rendering, discarding any bounce still in flight. Latching keeps the tree stable across that flip. The obvious alternative — always render `BouncingRow` and pass `highlight` in — was rejected because `useIsFocused` lives inside it and hooks cannot be conditional, so it would put a focus subscription, a shared value and an extra `Animated.View` back into *every* row, which is the exact cost this PR exists to remove.

**Decision:** `visible={highlight}` is passed rather than hardcoded `true`. Besides being what the latch requires, it restores the pre-extraction semantics: `useBounceInAnimation` resets `scale` and clears its pending timer when `visible` goes false, so a highlight clearing mid-bounce now unwinds cleanly.

**Decision:** rows that are never highlighted — the overwhelming majority — lose their wrapping `Animated.View`. That view only ever carried an identity transform, so layout is unchanged, but it does remove one node from the native view tree. A row that *has* been highlighted keeps its wrapper even after the highlight clears; that is the latch above, and it is one view on at most a couple of rows. Called out here because it's the one part of this PR that touches what actually gets mounted.

This is the single biggest win of the five.

## 2. `onPress` receives the txid, so the list can share one callback

The screen passed `onPress={() => handleItemPress(item.id)}` from `renderItem`. A fresh closure identity on every render meant `MemoizedTransactionItem` never bailed out — the memo wrapper was inert. The prop signature became `(txid: string) => void`, the row binds its own id, and the screen passes its stable `useCallback` directly.

**Decision:** the `onPress ? handlePress : undefined` guard is load-bearing. `handlePress` is always defined, so passing it unconditionally would make every row pressable — including the contact-list rows, which pass no `onPress` and must stay inert.

## 3. Memoized the object passed to `useStyles`

`useStyles({ isFirst, isLast, isOnHomeScreen, highlight })` was called with an object literal. `makeStyles` memoizes on the props object's *identity*, so a fresh literal invalidated the cache and rebuilt every `StyleSheet` in the file on every render of every row.

## 4. `Intl.NumberFormat` cached by fraction-digit count

`formatCurrencyHelper` constructed a new formatter on every call — once per amount, per row, per render. Construction is the most expensive operation in rendering a row, and Hermes' implementation is markedly slower than JSC's, which is why this hit Android hardest. A module-level `Map` keyed on fraction digits covers it, since that is the only option that ever varies (the locale is hardcoded `en-US`).

The cache is unbounded in principle but bounded in practice: the key space is the set of fraction-digit counts across supported display currencies, a handful of values.

The existing FIXME about using `.format` rather than `.formatNumber` still applies and moved to the call site — it previously sat inside the options literal, commenting on an option that doesn't exist.

## 5. `windowSize` reduced, render props hoisted

Both transaction `SectionList`s ran on RN's default `windowSize` of 21, which keeps roughly ten screens of rows mounted either side of the viewport — that default is what made every list-wide re-render as expensive as it was.

**Decision:** `7`, which still leaves three screens of headroom on each side. If fast scrolling ever shows blank cells, the fix is to raise this to 9, not to revert it.

**Stated plainly, because it is the one change here with a user-visible downside:** this is the only part of the PR not backed by a measurement. The benchmark measures mount and focus-change render counts, not scrolling, so the blank-cell risk on a fast fling on low-end Android is argued rather than observed — hence the device pass called for at the bottom. `getItemLayout` would remove the risk outright by letting the list skip measurement, but it was rejected here: both lists are `SectionList`s, where a correct `getItemLayout` has to account for section headers as well as rows, and the rows are not a fixed height (the `subtitle` variant is taller). Getting that subtly wrong produces worse scroll artefacts than the ones it would prevent. Note also that this reduction now compounds with §1–§4 rather than substituting for them: each retained cell is far cheaper than it was, so most of the win is already banked before `windowSize` is touched at all.

Alongside it, `renderSectionHeader` and `keyExtractor` (and `renderItem` on the contacts list) were inline literals recreated on every screen render; all are now `useCallback`s.

## Scope

The contacts transaction list (`contact-transactions.tsx`) had the same list-level pattern, so it got the same treatment. Its rows stay non-pressable via the guard in §2. Its new `useCallback`s sit above the component's early returns to keep hook order stable.

## Tests

**`__tests__/screens/transaction-history-screen.spec.tsx`** — the `MemoizedTransactionItem` stub now records the `onPress` identity it is handed. One test renders the screen, forces a re-render via the wallet filter dropdown, and asserts every row across both renders got the *same* function object. Verified this test fails when the per-row arrow is restored.

**`__tests__/components/transaction-item.test.tsx`** — the `@react-navigation/native` mock changed from `useIsFocused: () => true` to `jest.fn(() => true)` so the subscription is assertable, and the `IconTransaction` stub now counts its own mounts so a remount of the row subtree is assertable too. Five tests added: a non-highlighted row never calls `useIsFocused`, a highlighted row does, pressing a row calls `onPress` with its own `txid`, flipping `highlight` true→false leaves the mount count at 1, and that same flip hands `useBounceInAnimation` `visible: false` rather than dropping the wrapper. Verified the subscription test fails when all rows wrap in `BouncingRow`, and both latch tests fail against the plain ternary (mount count 2).

**`__tests__/hooks/use-display-currency.spec.tsx`** — one test spies on `Intl.NumberFormat`, formats 25 amounts at a fraction-digit count no other test in the file uses (7, so the module-level cache is cold on the first run and warm on any later one), and asserts at most one construction plus unchanged output. The spy is restored in an `afterEach` rather than at the end of the test body: jest is configured with neither `restoreMocks` nor `resetMocks` here, so a failing assertion would otherwise leave `Intl.NumberFormat` spied for the rest of the file and bury the real failure under every later formatting test. Confirmed by breaking the assertion deliberately — 1 failed, 39 passed.

**Rejected:** a component-level "memo bails out on unchanged props" test. It passed against the unfixed code too — `React.memo` was always there and the test's own props were stable — so it guarded nothing. The defect was at the call site, which is where the assertion now lives.

## Measured before/after

`__tests__/perf/transaction-list.bench.tsx` renders N **real** rows inside a **real** `NavigationContainer` and then navigates to a second screen — which is exactly what pushing the detail screen does — and counts what that costs the list behind it. Nothing on the measured paths is mocked: the real `useIsFocused` drives the subscription, styles go through the real `makeStyles`, amounts through the real `useDisplayCurrency`. Only `IconTransaction` is stubbed, purely so it can count row renders.

**Rows re-rendered when a transaction is opened** — the defect in the issue:

| History length | Before | After |
|---:|---:|---:|
| 50 rows | 50 | **0** |
| 200 rows | 201 | **0** |
| 400 rows | 401 | **0** |

Before scales linearly with how much history is mounted, which is exactly the reported symptom. After is zero at every size — not merely fewer, none. The highlighted row's wrapper still re-renders on focus, but its content element is unchanged so React bails before reaching the row body.

**Work done during the initial mount**, same harness:

| History length | `StyleSheet.create` before → after | `Intl.NumberFormat` before → after |
|---:|---:|---:|
| 50 rows | 100 → **50** | 200 → **2** |
| 200 rows | 401 → **200** | 802 → **2** |
| 400 rows | 801 → **400** | 1602 → **2** |

Stylesheet builds halve to exactly one per mounted row. Formatter construction collapses to **2 for the entire process lifetime**, not per size — one for each distinct fraction-digit count in play (0 for sats, 2 for USD). Those 2 are constructed on the first cold render and never again; every subsequent run in the same process measures 0. The harness reports that figure as `intlNumberFormatsFirstRun` alongside the full per-run array, rather than a median: the cache is module-level and survives the repeat loop, so a median across repeats would describe `BENCH_REPEATS` rather than a mount, and would not be comparable against the "before" side where every run constructs.

Every figure above was identical across all three repeats at every size.

**Wall-clock is deliberately not reported.** In this environment it is dominated by warm-up noise — 400 rows repeatedly timed *faster* than 200 — so it would be a misleading number. The render counts are exact and environment-independent, and they are the thing the issue is actually about.

**One methodology note, because it changes how the numbers should be read:** mount is asynchronous here (currency list, i18n, Apollo fragments all settle over several ticks). An early version of the harness measured before the tree was quiescent, which attributed late mount renders to the navigation and made the first run report 200 re-renders on the fixed code. The committed harness waits for the row-render count to stop moving before measuring, and the fixed code then reports 0 on every run including the cold one.

The harness is committed as `.bench.tsx`, which jest's `testRegex` (`test|spec`) excludes — it does not run in CI. That is deliberate (it is a manual A/B harness, not a test), with the consequence that nothing will report when it rots; its header now says so, so a future reader does not assume CI is keeping it honest. To reproduce:

```
BENCH_ROWS=200 BENCH_REPEATS=3 npx jest --testRegex "__tests__/perf/.*\.bench\.tsx$"
```

Switch between sides with `git checkout origin/main -- app/` and `git checkout HEAD -- app/`.

## Verification

```
yarn jest __tests__/components/transaction-item.test.tsx \
          __tests__/hooks/use-display-currency.spec.tsx \
          __tests__/screens/transaction-history-screen.spec.tsx \
          __tests__/screens/transaction-history-self-custodial.spec.tsx
```

70 passed, 4 suites. `tsc --noEmit` and `eslint` clean on all touched files.

Still worth a device pass before merge, particularly on Android: fast-scroll a long history to confirm `windowSize={7}` shows no blank cells, and arrive from a notification to confirm the bounce-in still plays and still settles when the highlight clears.

