### PR TITLE
fix(backup): let users dismiss the secure-wallet modal

### DIFF
--- a/__tests__/components/backup-nudge-modal.spec.tsx
+++ b/__tests__/components/backup-nudge-modal.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { TouchableOpacity } from "react-native"
 import { render, fireEvent } from "@testing-library/react-native"
 
 import { BackupNudgeModal } from "@app/components/backup-nudge-modal"
@@ -127,7 +128,7 @@ describe("BackupNudgeModal", () => {
     expect(getByText("Secure wallet")).toBeTruthy()
   })
 
-  it("navigates to backup method screen and closes on button press", () => {
+  it("navigates to the backup method screen without dismissing on button press", () => {
     const onClose = jest.fn()
     const { getByTestId } = render(
       <BackupNudgeModal isVisible={true} onClose={onClose} />,
@@ -135,8 +136,23 @@ describe("BackupNudgeModal", () => {
 
     fireEvent.press(getByTestId("secure-button"))
 
-    expect(onClose).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
+    // Starting the backup flow is not finishing it: a user who backs out of the
+    // backup screen must be nudged again rather than get the cooldown.
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  // The close affordance is CustomModal's own TouchableOpacity around a "close"
+  // GaloyIcon, which this suite mocks away - hence matching by type. This is the
+  // path the original bug report could not escape, so it stays covered here.
+  it("dismisses on close button press", () => {
+    const onClose = jest.fn()
+    const view = render(<BackupNudgeModal isVisible={true} onClose={onClose} />)
+
+    fireEvent.press(view.UNSAFE_getAllByType(TouchableOpacity)[0])
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it("uses primary color for warning icon", () => {

--- a/__tests__/components/backup-nudge-modal.spec.tsx
+++ b/__tests__/components/backup-nudge-modal.spec.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { TouchableOpacity } from "react-native"
 import { render, fireEvent } from "@testing-library/react-native"
 
 import { BackupNudgeModal } from "@app/components/backup-nudge-modal"
@@ -128,7 +127,7 @@ describe("BackupNudgeModal", () => {
     expect(getByText("Secure wallet")).toBeTruthy()
   })
 
-  it("navigates to the backup method screen without dismissing on button press", () => {
+  it("navigates to backup method screen and closes on button press", () => {
     const onClose = jest.fn()
     const { getByTestId } = render(
       <BackupNudgeModal isVisible={true} onClose={onClose} />,
@@ -136,23 +135,8 @@ describe("BackupNudgeModal", () => {
 
     fireEvent.press(getByTestId("secure-button"))
 
-    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
-    // Starting the backup flow is not finishing it: a user who backs out of the
-    // backup screen must be nudged again rather than get the cooldown.
-    expect(onClose).not.toHaveBeenCalled()
-  })
-
-  // The close affordance is CustomModal's own TouchableOpacity around a "close"
-  // GaloyIcon, which this suite mocks away - hence matching by type. This is the
-  // path the original bug report could not escape, so it stays covered here.
-  it("dismisses on close button press", () => {
-    const onClose = jest.fn()
-    const view = render(<BackupNudgeModal isVisible={true} onClose={onClose} />)
-
-    fireEvent.press(view.UNSAFE_getAllByType(TouchableOpacity)[0])
-
     expect(onClose).toHaveBeenCalledTimes(1)
-    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
   })
 
   it("uses primary color for warning icon", () => {

--- a/__tests__/components/balance-header/use-total-balance.spec.ts
+++ b/__tests__/components/balance-header/use-total-balance.spec.ts
@@ -92,5 +92,22 @@ describe("useTotalBalance", () => {
         expect.objectContaining({ amount: 50_000, currencyCode: "USD" }),
       )
     })
+
+    // Hiding a restricted dollar balance is a display rule. Callers that measure
+    // how much is at risk on the device must see the funds that are really there.
+    it("keeps the USD balance when the caller opts out of the display restriction", () => {
+      mockUseDollarBalanceRestricted.mockReturnValue(true)
+      const convert = buildConvertSpy()
+      mockConvertMoneyAmount.mockReturnValue(convert)
+
+      renderHook(() => useTotalBalance(wallets, { applyDollarRestriction: false }))
+
+      const usdCalls = convert.mock.calls.filter(
+        (args) => (args[0] as unknown as { currencyCode: string }).currencyCode === "USD",
+      )
+      expect(usdCalls[0][0]).toEqual(
+        expect.objectContaining({ amount: 50_000, currencyCode: "USD" }),
+      )
+    })
   })
 })

--- a/__tests__/config/backup-nudge-modal-cooldown.spec.tsx
+++ b/__tests__/config/backup-nudge-modal-cooldown.spec.tsx
@@ -1,0 +1,131 @@
+/**
+ * `backupNudgeModalCooldownMs` decides how long the blocking "Secure your funds"
+ * modal stays dismissed. `asNumber()` yields 0 for a missing or malformed remote
+ * value, and a zero cooldown makes the modal undismissable again - the exact bug
+ * #4156 reports. The guard that falls back to the shipped default is therefore
+ * load-bearing and tested here against the real provider, not a copy of it.
+ */
+import React from "react"
+import { render, waitFor } from "@testing-library/react-native"
+import { Text } from "react-native"
+
+import {
+  FeatureFlagContextProvider,
+  defaultRemoteConfig,
+  useRemoteConfig,
+} from "@app/config/feature-flags-context"
+
+const mockAsNumber = jest.fn()
+
+jest.mock("@react-native-firebase/remote-config", () => ({
+  __esModule: true,
+  default: () => ({
+    setDefaults: jest.fn(),
+    setConfigSettings: jest.fn(),
+    getValue: (key: string) => ({
+      asString: () => "",
+      asBoolean: () => false,
+      asNumber: () => mockAsNumber(key),
+    }),
+    fetchAndActivate: jest.fn().mockResolvedValue(true),
+  }),
+}))
+
+jest.mock("@app/graphql/level-context", () => ({
+  useLevel: () => ({ currentLevel: "ZERO" }),
+}))
+
+jest.mock("@app/hooks/use-app-config", () => ({
+  useAppConfig: () => ({ appConfig: { galoyInstance: { id: "Main" } } }),
+}))
+
+jest.mock("@app/hooks/use-has-custodial-account", () => ({
+  useHasCustodialAccount: () => false,
+}))
+
+jest.mock("@app/self-custodial/analytics", () => ({
+  logSelfCustodialRolloutExposed: jest.fn(),
+}))
+
+jest.mock("@app/utils/log-error", () => ({
+  logError: jest.fn(),
+}))
+
+const COOLDOWN_KEY = "backupNudgeModalCooldownMs"
+const SENTINEL_KEY = "backupNudgeModalThreshold"
+// Any value that is not the shipped default for the sentinel key.
+const SENTINEL_VALUE = 999
+
+const CooldownProbe: React.FC = () => {
+  const { backupNudgeModalCooldownMs, backupNudgeModalThreshold } = useRemoteConfig()
+  return (
+    <>
+      <Text testID="cooldown">{String(backupNudgeModalCooldownMs)}</Text>
+      <Text testID="sentinel">{String(backupNudgeModalThreshold)}</Text>
+    </>
+  )
+}
+
+// Returns this render's own queries. Querying the global `screen` instead lets a
+// previous test's still-mounted provider answer, which hid a real failure here.
+const renderWithRemoteCooldown = (value: number) => {
+  mockAsNumber.mockImplementation((key: string) => {
+    if (key === COOLDOWN_KEY) return value
+    if (key === SENTINEL_KEY) return SENTINEL_VALUE
+    return 0
+  })
+
+  return render(
+    <FeatureFlagContextProvider>
+      <CooldownProbe />
+    </FeatureFlagContextProvider>,
+  )
+}
+
+/**
+ * The provider's initial state IS `defaultRemoteConfig`, so asserting "equals the
+ * default" straight after render passes before the async fetch has committed
+ * anything - it would hold even with the fallback deleted. Waiting for the
+ * sentinel to arrive proves the remote values landed first; only then does the
+ * cooldown assertion mean the fallback actually chose the default.
+ */
+const expectCooldownAfterCommit = async (
+  view: ReturnType<typeof render>,
+  expected: number,
+): Promise<void> => {
+  await waitFor(() => {
+    expect(view.getByTestId("sentinel").props.children).toBe(String(SENTINEL_VALUE))
+  })
+  expect(view.getByTestId("cooldown").props.children).toBe(String(expected))
+}
+
+describe("backupNudgeModalCooldownMs remote config", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // Proves the remote value reaches the context at all. Without this the
+  // fallback assertions below would also pass if the provider silently kept its
+  // defaults, so this case is what makes the rest of the suite meaningful.
+  it("uses a positive remote value", async () => {
+    await expectCooldownAfterCommit(renderWithRemoteCooldown(60_000), 60_000)
+  })
+
+  it("falls back to the shipped default when the remote value is 0", async () => {
+    await expectCooldownAfterCommit(
+      renderWithRemoteCooldown(0),
+      defaultRemoteConfig.backupNudgeModalCooldownMs,
+    )
+  })
+
+  it("falls back to the shipped default when the remote value is negative", async () => {
+    await expectCooldownAfterCommit(
+      renderWithRemoteCooldown(-1),
+      defaultRemoteConfig.backupNudgeModalCooldownMs,
+    )
+  })
+
+  it("ships a 24h default", () => {
+    expect(defaultRemoteConfig.backupNudgeModalCooldownMs).toBe(24 * 60 * 60 * 1000)
+  })
+})

--- a/__tests__/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/hooks/use-backup-nudge-state.spec.ts
@@ -8,6 +8,7 @@ const mockRemoteConfig = jest.fn()
 const mockAccountRegistry = jest.fn()
 const mockMultiGet = jest.fn()
 const mockSetItem = jest.fn()
+const mockReportError = jest.fn()
 
 jest.mock("@app/self-custodial/providers/backup-state", () => ({
   BackupStatus: { None: "none", Completed: "completed" },
@@ -43,11 +44,28 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: (...args: string[]) => mockSetItem(...args),
 }))
 
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
 const ACCOUNT_ID = "test-self-custodial-uuid"
 const BANNER_KEY = `backupNudgeDismissedAt:${ACCOUNT_ID}`
 const MODAL_KEY = `backupNudgeModalDismissedAt:${ACCOUNT_ID}`
 
 let storage: Record<string, string> = {}
+
+// `multiGet` does NOT echo the requested key order on Android. The legacy module
+// runs `SELECT key,value ... WHERE key IN (...)` with no ORDER BY, pushes the
+// cursor rows first, then appends every key it did not find as [key, null].
+// Reproducing that here keeps the suite honest about the platform we ship on.
+const androidMultiGetOrder = (keys: string[]): [string, string | null][] => {
+  const found = keys.filter((key) => storage[key] !== undefined)
+  const missing = keys.filter((key) => storage[key] === undefined)
+  return [
+    ...found.map((key): [string, string | null] => [key, storage[key]]),
+    ...missing.map((key): [string, string | null] => [key, null]),
+  ]
+}
 
 const defaultBackupState = { backupState: { status: "none", method: null } }
 const completedBackupState = { backupState: { status: "completed", method: "manual" } }
@@ -83,7 +101,7 @@ describe("useBackupNudgeState", () => {
     mockAccountRegistry.mockReturnValue({ activeAccount: selfCustodialAccount })
     mockRemoteConfig.mockReturnValue(defaultConfig)
     mockMultiGet.mockImplementation((keys: string[]) =>
-      Promise.resolve(keys.map((key) => [key, storage[key] ?? null])),
+      Promise.resolve(androidMultiGetOrder(keys)),
     )
     mockSetItem.mockResolvedValue(undefined)
   })
@@ -232,6 +250,27 @@ describe("useBackupNudgeState", () => {
     expect(result.current.shouldShowBanner).toBe(true)
   })
 
+  it("keeps the modal dismissed when only the modal key exists (Android key order)", async () => {
+    // The reported scenario: dismissed the modal, never dismissed the banner.
+    // Android returns [[MODAL_KEY, ts], [BANNER_KEY, null]] - the reverse of the
+    // request - so reading the reply positionally swaps the two timestamps and
+    // brings the blocking modal back on every launch.
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    storage[MODAL_KEY] = String(Date.now())
+
+    expect(await mockMultiGet([BANNER_KEY, MODAL_KEY])).toEqual([
+      [MODAL_KEY, expect.any(String)],
+      [BANNER_KEY, null],
+    ])
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(false)
+    expect(result.current.shouldShowBanner).toBe(true)
+  })
+
   it("shows the modal again once its cooldown elapsed", async () => {
     mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
     storage[MODAL_KEY] = String(Date.now() - 25 * 60 * 60 * 1000)
@@ -276,6 +315,53 @@ describe("useBackupNudgeState", () => {
     // ...and dismissing the modal must not resurrect the dismissed banner.
     expect(result.current.shouldShowModal).toBe(false)
     expect(result.current.shouldShowBanner).toBe(false)
+  })
+
+  it("fails open and reports when the dismissal read rejects", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    mockMultiGet.mockRejectedValue(new Error("SQLiteDiskIOException"))
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    // A storage failure must not silently suppress a security nudge.
+    expect(result.current.shouldShowModal).toBe(true)
+    expect(mockReportError).toHaveBeenCalledWith("Nudge dismiss read", expect.any(Error))
+  })
+
+  it("ignores a stale read from the previously active account", async () => {
+    const OTHER_ACCOUNT_ID = "other-self-custodial-uuid"
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+
+    // Account A has a dismissed modal, account B has nothing dismissed.
+    storage[MODAL_KEY] = String(Date.now())
+
+    let resolveAccountA: (entries: [string, string | null][]) => void = () => {}
+    mockMultiGet.mockImplementationOnce(
+      (keys: string[]) =>
+        new Promise((resolve) => {
+          resolveAccountA = () => resolve(androidMultiGetOrder(keys))
+        }),
+    )
+
+    const { result, rerender } = renderHook(() => useBackupNudgeState())
+
+    // Switch to account B, whose read resolves immediately...
+    mockAccountRegistry.mockReturnValue({
+      activeAccount: { type: "self-custodial", id: OTHER_ACCOUNT_ID },
+    })
+    rerender({})
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(true)
+
+    // ...and only then does account A's read land. It must not apply.
+    await act(async () => {
+      resolveAccountA([])
+    })
+
+    expect(result.current.shouldShowModal).toBe(true)
   })
 
   it("triggers banner when USD weight pushes combined balance over the threshold", async () => {

--- a/__tests__/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/hooks/use-backup-nudge-state.spec.ts
@@ -322,6 +322,10 @@ describe("useBackupNudgeState", () => {
     // ...and dismissing the modal must not resurrect the dismissed banner.
     expect(result.current.shouldShowModal).toBe(false)
     expect(result.current.shouldShowBanner).toBe(false)
+    // With both home-screen surfaces quiet, the settings banner is the warning
+    // that has to remain - it is the only thing standing between this user and
+    // no backup reminder at all.
+    expect(result.current.shouldShowSettingsBanner).toBe(true)
   })
 
   it("fails open and reports when the dismissal read rejects", async () => {
@@ -379,6 +383,75 @@ describe("useBackupNudgeState", () => {
     // hidden forever. shouldShowBanner is the one that proves it: it is gated on
     // `loaded`, unlike shouldShowSettingsBanner.
     expect(result.current.shouldShowBanner).toBe(true)
+  })
+
+  it("ignores a stale read from the previously active account", async () => {
+    const OTHER_ACCOUNT_ID = "other-self-custodial-uuid"
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+
+    // Account A dismissed its modal; account B has dismissed nothing.
+    storage[MODAL_KEY] = String(Date.now())
+
+    let landAccountARead: () => void = () => {}
+    mockMultiGet.mockImplementationOnce(
+      (keys: string[]) =>
+        new Promise((resolve) => {
+          landAccountARead = () => resolve(androidMultiGetOrder(keys))
+        }),
+    )
+
+    const { result, rerender } = renderHook(() => useBackupNudgeState())
+
+    // Switch to account B, whose read resolves straight away...
+    mockAccountRegistry.mockReturnValue({
+      activeAccount: { type: "self-custodial", id: OTHER_ACCOUNT_ID },
+    })
+    rerender({})
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(true)
+
+    // ...and only now does account A's read land. Applying it would hide B's
+    // modal using A's dismissal.
+    await act(async () => {
+      landAccountARead()
+    })
+
+    expect(result.current.shouldShowModal).toBe(true)
+  })
+
+  // Same race on the failure path: fail-open clears the dismissal state, so a
+  // late rejection from the previous account would wipe the current account's
+  // freshly loaded timestamps and re-show a modal it had already dismissed.
+  it("ignores a stale failed read from the previously active account", async () => {
+    const OTHER_ACCOUNT_ID = "other-self-custodial-uuid"
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+
+    let failAccountARead: () => void = () => {}
+    mockMultiGet.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failAccountARead = () => reject(new Error("SQLiteDiskIOException"))
+        }),
+    )
+
+    const { result, rerender } = renderHook(() => useBackupNudgeState())
+
+    // Account B loads cleanly and has a dismissed modal.
+    storage[`backupNudgeModalDismissedAt:${OTHER_ACCOUNT_ID}`] = String(Date.now())
+    mockAccountRegistry.mockReturnValue({
+      activeAccount: { type: "self-custodial", id: OTHER_ACCOUNT_ID },
+    })
+    rerender({})
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(false)
+
+    await act(async () => {
+      failAccountARead()
+    })
+
+    expect(result.current.shouldShowModal).toBe(false)
   })
 
   // The keys are account-scoped, so with no self-custodial account there is no

--- a/__tests__/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/hooks/use-backup-nudge-state.spec.ts
@@ -9,6 +9,7 @@ const mockAccountRegistry = jest.fn()
 const mockMultiGet = jest.fn()
 const mockSetItem = jest.fn()
 const mockReportError = jest.fn()
+const mockUseTotalBalance = jest.fn()
 
 jest.mock("@app/self-custodial/providers/backup-state", () => ({
   BackupStatus: { None: "none", Completed: "completed" },
@@ -30,13 +31,19 @@ jest.mock("@app/config/feature-flags-context", () => ({
 const SATS_PER_USD_CENT = 10
 
 jest.mock("@app/components/balance-header/use-total-balance", () => ({
-  useTotalBalance: (wallets: Array<{ walletCurrency: string; balance: number }>) => ({
-    satsBalance: wallets.reduce((sum, w) => {
-      if (w.walletCurrency === "BTC") return sum + w.balance
-      if (w.walletCurrency === "USD") return sum + w.balance * 10
-      return sum
-    }, 0),
-  }),
+  useTotalBalance: (
+    wallets: Array<{ walletCurrency: string; balance: number }>,
+    options?: { applyDollarRestriction?: boolean },
+  ) => {
+    mockUseTotalBalance(wallets, options)
+    return {
+      satsBalance: wallets.reduce((sum, w) => {
+        if (w.walletCurrency === "BTC") return sum + w.balance
+        if (w.walletCurrency === "USD") return sum + w.balance * 10
+        return sum
+      }, 0),
+    }
+  },
 }))
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
@@ -328,6 +335,69 @@ describe("useBackupNudgeState", () => {
     // A storage failure must not silently suppress a security nudge.
     expect(result.current.shouldShowModal).toBe(true)
     expect(mockReportError).toHaveBeenCalledWith("Nudge dismiss read", expect.any(Error))
+  })
+
+  // A dollar-restricted region hides the stable-token balance from the display,
+  // but the funds are still on the device and still unbacked.
+  it("measures the balance without the dollar-display restriction", async () => {
+    renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    expect(mockUseTotalBalance).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ applyDollarRestriction: false }),
+    )
+  })
+
+  it("reports a failed dismissal write", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    mockSetItem.mockRejectedValue(new Error("SQLiteFullException"))
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+    await act(async () => {
+      result.current.dismissModal()
+    })
+
+    expect(mockReportError).toHaveBeenCalledWith("Nudge dismiss write", expect.any(Error))
+  })
+
+  it("clears dismissal state and finishes loading for a custodial account", async () => {
+    mockAccountRegistry.mockReturnValue({
+      activeAccount: { type: "custodial", id: "custodial-uuid" },
+    })
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    // No account-scoped key to read, so storage is never touched...
+    expect(mockMultiGet).not.toHaveBeenCalled()
+    // ...but `loaded` must still flip, or every threshold-gated surface stays
+    // hidden forever. shouldShowBanner is the one that proves it: it is gated on
+    // `loaded`, unlike shouldShowSettingsBanner.
+    expect(result.current.shouldShowBanner).toBe(true)
+  })
+
+  // The keys are account-scoped, so with no self-custodial account there is no
+  // key to write. Persisting anything here would land under a wrong or partial
+  // key and silence a later account's nudge.
+  it("never persists a dismissal without a self-custodial account", async () => {
+    mockAccountRegistry.mockReturnValue({
+      activeAccount: { type: "custodial", id: "custodial-uuid" },
+    })
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+    act(() => {
+      result.current.dismissBanner()
+      result.current.dismissModal()
+    })
+
+    expect(mockSetItem).not.toHaveBeenCalled()
   })
 
   it("triggers banner when USD weight pushes combined balance over the threshold", async () => {

--- a/__tests__/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/hooks/use-backup-nudge-state.spec.ts
@@ -6,7 +6,7 @@ const mockBackupState = jest.fn()
 const mockActiveWallet = jest.fn()
 const mockRemoteConfig = jest.fn()
 const mockAccountRegistry = jest.fn()
-const mockGetItem = jest.fn()
+const mockMultiGet = jest.fn()
 const mockSetItem = jest.fn()
 
 jest.mock("@app/self-custodial/providers/backup-state", () => ({
@@ -39,9 +39,15 @@ jest.mock("@app/components/balance-header/use-total-balance", () => ({
 }))
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
-  getItem: (...args: string[]) => mockGetItem(...args),
+  multiGet: (keys: string[]) => mockMultiGet(keys),
   setItem: (...args: string[]) => mockSetItem(...args),
 }))
+
+const ACCOUNT_ID = "test-self-custodial-uuid"
+const BANNER_KEY = `backupNudgeDismissedAt:${ACCOUNT_ID}`
+const MODAL_KEY = `backupNudgeModalDismissedAt:${ACCOUNT_ID}`
+
+let storage: Record<string, string> = {}
 
 const defaultBackupState = { backupState: { status: "none", method: null } }
 const completedBackupState = { backupState: { status: "completed", method: "manual" } }
@@ -55,26 +61,35 @@ const custodialWallet = {
   isReady: true,
   wallets: [{ id: "btc-1", walletCurrency: "BTC", balance: { amount: 50000 } }],
 }
+const aboveModalThresholdWallet = {
+  accountType: "self-custodial",
+  isReady: true,
+  wallets: [{ id: "btc-1", walletCurrency: "BTC", balance: { amount: 22000 } }],
+}
 const defaultConfig = {
   backupNudgeBannerThreshold: 2100,
   backupNudgeModalThreshold: 21000,
+  backupNudgeModalCooldownMs: 24 * 60 * 60 * 1000,
 }
 
-const selfCustodialAccount = { type: "self-custodial", id: "test-self-custodial-uuid" }
+const selfCustodialAccount = { type: "self-custodial", id: ACCOUNT_ID }
 
 describe("useBackupNudgeState", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    storage = {}
     mockBackupState.mockReturnValue(defaultBackupState)
     mockActiveWallet.mockReturnValue(selfCustodialWallet)
     mockAccountRegistry.mockReturnValue({ activeAccount: selfCustodialAccount })
     mockRemoteConfig.mockReturnValue(defaultConfig)
-    mockGetItem.mockResolvedValue(null)
+    mockMultiGet.mockImplementation((keys: string[]) =>
+      Promise.resolve(keys.map((key) => [key, storage[key] ?? null])),
+    )
     mockSetItem.mockResolvedValue(undefined)
   })
 
   it("hides banner and modal while dismissal-load is pending", () => {
-    mockGetItem.mockReturnValue(new Promise(() => {}))
+    mockMultiGet.mockReturnValue(new Promise(() => {}))
 
     const { result } = renderHook(() => useBackupNudgeState())
 
@@ -83,7 +98,7 @@ describe("useBackupNudgeState", () => {
   })
 
   it("shows settings banner without waiting for dismissal-load", () => {
-    mockGetItem.mockReturnValue(new Promise(() => {}))
+    mockMultiGet.mockReturnValue(new Promise(() => {}))
 
     const { result } = renderHook(() => useBackupNudgeState())
 
@@ -100,11 +115,7 @@ describe("useBackupNudgeState", () => {
   })
 
   it("shows modal when balance >= modal threshold", async () => {
-    mockActiveWallet.mockReturnValue({
-      accountType: "self-custodial",
-      isReady: true,
-      wallets: [{ id: "btc-1", walletCurrency: "BTC", balance: { amount: 22000 } }],
-    })
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
 
     const { result } = renderHook(() => useBackupNudgeState())
 
@@ -155,14 +166,11 @@ describe("useBackupNudgeState", () => {
     })
 
     expect(result.current.shouldShowBanner).toBe(false)
-    expect(mockSetItem).toHaveBeenCalledWith(
-      "backupNudgeDismissedAt:test-self-custodial-uuid",
-      expect.any(String),
-    )
+    expect(mockSetItem).toHaveBeenCalledWith(BANNER_KEY, expect.any(String))
   })
 
   it("loads dismissed state from AsyncStorage", async () => {
-    mockGetItem.mockResolvedValue(String(Date.now()))
+    storage[BANNER_KEY] = String(Date.now())
 
     const { result } = renderHook(() => useBackupNudgeState())
 
@@ -172,13 +180,102 @@ describe("useBackupNudgeState", () => {
   })
 
   it("shows banner again after 24h cooldown", async () => {
-    mockGetItem.mockResolvedValue(String(Date.now() - 25 * 60 * 60 * 1000))
+    storage[BANNER_KEY] = String(Date.now() - 25 * 60 * 60 * 1000)
 
     const { result } = renderHook(() => useBackupNudgeState())
 
     await act(async () => {})
 
     expect(result.current.shouldShowBanner).toBe(true)
+  })
+
+  it("dismisses the modal and persists it under its own key", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+    expect(result.current.shouldShowModal).toBe(true)
+
+    act(() => {
+      result.current.dismissModal()
+    })
+
+    expect(result.current.shouldShowModal).toBe(false)
+    expect(mockSetItem).toHaveBeenCalledWith(MODAL_KEY, expect.any(String))
+  })
+
+  it("falls back to the banner once the modal is dismissed", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+    expect(result.current.shouldShowBanner).toBe(false)
+
+    act(() => {
+      result.current.dismissModal()
+    })
+
+    expect(result.current.shouldShowBanner).toBe(true)
+  })
+
+  it("keeps the modal dismissed across a remount within the cooldown", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    storage[MODAL_KEY] = String(Date.now())
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(false)
+    expect(result.current.shouldShowBanner).toBe(true)
+  })
+
+  it("shows the modal again once its cooldown elapsed", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    storage[MODAL_KEY] = String(Date.now() - 25 * 60 * 60 * 1000)
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(true)
+  })
+
+  it("honours the remote-config modal cooldown", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    mockRemoteConfig.mockReturnValue({
+      ...defaultConfig,
+      backupNudgeModalCooldownMs: 7 * 24 * 60 * 60 * 1000,
+    })
+    storage[MODAL_KEY] = String(Date.now() - 25 * 60 * 60 * 1000)
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    expect(result.current.shouldShowModal).toBe(false)
+  })
+
+  it("keeps the two dismissals independent", async () => {
+    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
+    storage[BANNER_KEY] = String(Date.now())
+
+    const { result } = renderHook(() => useBackupNudgeState())
+
+    await act(async () => {})
+
+    // A dismissed banner must not silence the blocking modal...
+    expect(result.current.shouldShowModal).toBe(true)
+
+    act(() => {
+      result.current.dismissModal()
+    })
+
+    // ...and dismissing the modal must not resurrect the dismissed banner.
+    expect(result.current.shouldShowModal).toBe(false)
+    expect(result.current.shouldShowBanner).toBe(false)
   })
 
   it("triggers banner when USD weight pushes combined balance over the threshold", async () => {

--- a/__tests__/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/hooks/use-backup-nudge-state.spec.ts
@@ -330,40 +330,6 @@ describe("useBackupNudgeState", () => {
     expect(mockReportError).toHaveBeenCalledWith("Nudge dismiss read", expect.any(Error))
   })
 
-  it("ignores a stale read from the previously active account", async () => {
-    const OTHER_ACCOUNT_ID = "other-self-custodial-uuid"
-    mockActiveWallet.mockReturnValue(aboveModalThresholdWallet)
-
-    // Account A has a dismissed modal, account B has nothing dismissed.
-    storage[MODAL_KEY] = String(Date.now())
-
-    let resolveAccountA: (entries: [string, string | null][]) => void = () => {}
-    mockMultiGet.mockImplementationOnce(
-      (keys: string[]) =>
-        new Promise((resolve) => {
-          resolveAccountA = () => resolve(androidMultiGetOrder(keys))
-        }),
-    )
-
-    const { result, rerender } = renderHook(() => useBackupNudgeState())
-
-    // Switch to account B, whose read resolves immediately...
-    mockAccountRegistry.mockReturnValue({
-      activeAccount: { type: "self-custodial", id: OTHER_ACCOUNT_ID },
-    })
-    rerender({})
-    await act(async () => {})
-
-    expect(result.current.shouldShowModal).toBe(true)
-
-    // ...and only then does account A's read land. It must not apply.
-    await act(async () => {
-      resolveAccountA([])
-    })
-
-    expect(result.current.shouldShowModal).toBe(true)
-  })
-
   it("triggers banner when USD weight pushes combined balance over the threshold", async () => {
     const btcAmount = 1_000
     const usdCentsAmount = 200

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -44,7 +44,7 @@ const mockBackupNudgeState = {
   dismissBanner: jest.fn(),
   dismissModal: jest.fn(),
 }
-jest.mock("@app/hooks/use-backup-nudge-state", () => ({
+jest.mock("@app/self-custodial/hooks/use-backup-nudge-state", () => ({
   useBackupNudgeState: () => mockBackupNudgeState,
 }))
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -42,6 +42,7 @@ const mockBackupNudgeState = {
   shouldShowModal: false,
   shouldShowSettingsBanner: false,
   dismissBanner: jest.fn(),
+  dismissModal: jest.fn(),
 }
 jest.mock("@app/hooks/use-backup-nudge-state", () => ({
   useBackupNudgeState: () => mockBackupNudgeState,
@@ -1418,6 +1419,8 @@ describe("HomeScreen", () => {
 
     beforeEach(() => {
       mockBackupNudgeModal.mockClear()
+      mockBackupNudgeState.dismissModal.mockClear()
+      mockBackupNudgeState.dismissBanner.mockClear()
       mockBackupNudgeState.shouldShowModal = false
       mockIsFocused = true
     })
@@ -1481,6 +1484,26 @@ describe("HomeScreen", () => {
       await flushEffects()
 
       expect(lastIsVisible()).toBe(false)
+    })
+
+    // #4156: closing the modal used to write the banner's dismissal key, which the
+    // modal never reads — so the prompt reopened on the same render and trapped users.
+    it("closes through the modal's own dismissal, not the banner's", async () => {
+      mockBackupNudgeState.shouldShowModal = true
+      mockIsFocused = true
+
+      render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      const calls = mockBackupNudgeModal.mock.calls
+      calls[calls.length - 1][0].onClose()
+
+      expect(mockBackupNudgeState.dismissModal).toHaveBeenCalled()
+      expect(mockBackupNudgeState.dismissBanner).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/screens/settings-screen/settings-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/settings-screen.spec.tsx
@@ -1,4 +1,4 @@
-jest.mock("@app/hooks/use-backup-nudge-state", () => ({
+jest.mock("@app/self-custodial/hooks/use-backup-nudge-state", () => ({
   useBackupNudgeState: () => ({
     shouldShowBanner: false,
     shouldShowModal: false,

--- a/__tests__/screens/settings-screen/settings-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/settings-screen.spec.tsx
@@ -4,6 +4,7 @@ jest.mock("@app/hooks/use-backup-nudge-state", () => ({
     shouldShowModal: false,
     shouldShowSettingsBanner: false,
     dismissBanner: jest.fn(),
+    dismissModal: jest.fn(),
   }),
 }))
 

--- a/__tests__/self-custodial/hooks/use-backup-nudge-state.spec.ts
+++ b/__tests__/self-custodial/hooks/use-backup-nudge-state.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react-native"
 
-import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
+import { useBackupNudgeState } from "@app/self-custodial/hooks/use-backup-nudge-state"
 
 const mockBackupState = jest.fn()
 const mockActiveWallet = jest.fn()

--- a/app/components/backup-nudge-modal/backup-nudge-modal.tsx
+++ b/app/components/backup-nudge-modal/backup-nudge-modal.tsx
@@ -13,6 +13,7 @@ import CustomModal from "../custom-modal/custom-modal"
 
 type BackupNudgeModalProps = {
   isVisible: boolean
+  // Dismissal: X, backdrop tap and Android back. Starts the modal cooldown.
   onClose: () => void
 }
 
@@ -27,8 +28,10 @@ export const BackupNudgeModal: React.FC<BackupNudgeModalProps> = ({
   const { LL } = useI18nContext()
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
+  // Deliberately no `onClose()` here: reaching the backup screen is not a
+  // backup. The caller hides the modal while this screen is unfocused, so a
+  // user who abandons the flow is nudged again instead of buying a quiet day.
   const handleSecure = () => {
-    onClose()
     navigation.navigate("selfCustodialBackupMethod")
   }
 

--- a/app/components/backup-nudge-modal/backup-nudge-modal.tsx
+++ b/app/components/backup-nudge-modal/backup-nudge-modal.tsx
@@ -13,7 +13,6 @@ import CustomModal from "../custom-modal/custom-modal"
 
 type BackupNudgeModalProps = {
   isVisible: boolean
-  // Dismissal: X, backdrop tap and Android back. Starts the modal cooldown.
   onClose: () => void
 }
 
@@ -28,10 +27,8 @@ export const BackupNudgeModal: React.FC<BackupNudgeModalProps> = ({
   const { LL } = useI18nContext()
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
-  // Deliberately no `onClose()` here: reaching the backup screen is not a
-  // backup. The caller hides the modal while this screen is unfocused, so a
-  // user who abandons the flow is nudged again instead of buying a quiet day.
   const handleSecure = () => {
+    onClose()
     navigation.navigate("selfCustodialBackupMethod")
   }
 

--- a/app/components/balance-header/use-total-balance.ts
+++ b/app/components/balance-header/use-total-balance.ts
@@ -10,8 +10,19 @@ import {
   DisplayCurrency,
 } from "@app/types/amounts"
 
+type TotalBalanceOptions = {
+  /**
+   * Zeroing a restricted dollar balance is a display rule: the funds are still
+   * on the account, we just may not show them. Callers that measure what is at
+   * stake rather than what to render — the backup nudge, for one — pass false so
+   * a restricted user's stable-token holdings still count.
+   */
+  applyDollarRestriction?: boolean
+}
+
 export const useTotalBalance = (
   wallets?: readonly WalletBalance[],
+  { applyDollarRestriction = true }: TotalBalanceOptions = {},
 ): {
   formattedBalance: string
   numericBalance: number
@@ -20,7 +31,7 @@ export const useTotalBalance = (
 } => {
   const { formatMoneyAmount } = useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
-  const isDollarBalanceRestricted = useDollarBalanceRestricted()
+  const isDollarBalanceRestricted = useDollarBalanceRestricted() && applyDollarRestriction
 
   // TODO: check that there are 2 wallets.
   // otherwise fail (account with more/less 2 wallets will not be working with the current mobile app)

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -38,6 +38,7 @@ const ReplaceCardDeliveryConfigKey = "replaceCardDeliveryConfig"
 const SparkCompatibleWalletsUrlKey = "sparkCompatibleWalletsUrl"
 const BackupNudgeBannerThresholdKey = "backupNudgeBannerThreshold"
 const BackupNudgeModalThresholdKey = "backupNudgeModalThreshold"
+const BackupNudgeModalCooldownMsKey = "backupNudgeModalCooldownMs"
 const NonCustodialEnabledKey = "nonCustodialEnabled"
 const StableBalanceEnabledKey = "stableBalanceEnabled"
 const DollarRestrictionCacheEnabledKey = "dollarRestrictionCacheEnabled"
@@ -108,6 +109,7 @@ type RemoteConfig = {
   [SparkCompatibleWalletsUrlKey]: string
   [BackupNudgeBannerThresholdKey]: number
   [BackupNudgeModalThresholdKey]: number
+  [BackupNudgeModalCooldownMsKey]: number
   [NonCustodialEnabledKey]: boolean
   [StableBalanceEnabledKey]: boolean
   [DollarRestrictionCacheEnabledKey]: boolean
@@ -212,6 +214,10 @@ export const defaultRemoteConfig: RemoteConfig = {
   sparkCompatibleWalletsUrl: "https://docs.spark.money/wallets/overview",
   backupNudgeBannerThreshold: 2100,
   backupNudgeModalThreshold: 21000,
+  /** How long the self-custodial backup modal stays dismissed after the user closes it.
+   *  The less intrusive home-screen nudge banner takes over in the meantime, so the
+   *  warning never disappears entirely (#4156). */
+  backupNudgeModalCooldownMs: 24 * 60 * 60 * 1000,
   nonCustodialEnabled: false,
   stableBalanceEnabled: false,
   dollarRestrictionCacheEnabled: true,
@@ -395,6 +401,16 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .getValue(BackupNudgeModalThresholdKey)
           .asNumber()
 
+        // asNumber() yields 0 for a malformed remote value, and a zero cooldown would
+        // make the modal undismissable again — fall back to the shipped default.
+        const remoteBackupNudgeModalCooldownMs = remoteConfigInstance()
+          .getValue(BackupNudgeModalCooldownMsKey)
+          .asNumber()
+        const backupNudgeModalCooldownMs =
+          remoteBackupNudgeModalCooldownMs > 0
+            ? remoteBackupNudgeModalCooldownMs
+            : defaultRemoteConfig.backupNudgeModalCooldownMs
+
         const nonCustodialEnabled = remoteConfigInstance()
           .getValue(NonCustodialEnabledKey)
           .asBoolean()
@@ -516,6 +532,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           sparkCompatibleWalletsUrl,
           backupNudgeBannerThreshold,
           backupNudgeModalThreshold,
+          backupNudgeModalCooldownMs,
           nonCustodialEnabled,
           stableBalanceEnabled,
           dollarRestrictionCacheEnabled,

--- a/app/hooks/use-backup-nudge-state.ts
+++ b/app/hooks/use-backup-nudge-state.ts
@@ -10,6 +10,7 @@ import { reportError } from "@app/utils/error-logging"
 
 import { useAccountRegistry } from "./use-account-registry"
 import { useActiveWallet } from "./use-active-wallet"
+import { useIsSelfCustodialAccount } from "./use-is-self-custodial-account"
 
 const BANNER_DISMISSAL_COOLDOWN_MS = 24 * 60 * 60 * 1000
 const BANNER_DISMISSAL_KEY_PREFIX = "backupNudgeDismissedAt"
@@ -41,6 +42,7 @@ type BackupNudgeState = {
 export const useBackupNudgeState = (): BackupNudgeState => {
   const { backupState } = useBackupState()
   const activeWallet = useActiveWallet()
+  const isSelfCustodial = useIsSelfCustodialAccount()
   const { activeAccount } = useAccountRegistry()
   const {
     backupNudgeBannerThreshold,
@@ -99,7 +101,6 @@ export const useBackupNudgeState = (): BackupNudgeState => {
   }, [activeSelfCustodialAccountId])
 
   const isBackedUp = backupState.status === BackupStatus.Completed
-  const isSelfCustodial = activeWallet.accountType === AccountType.SelfCustodial
   const isWalletReady = activeWallet.isReady
 
   const walletsForTotal = useMemo(
@@ -112,7 +113,12 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     [activeWallet.wallets],
   )
 
-  const { satsBalance } = useTotalBalance(walletsForTotal)
+  // Opt out of the dollar-balance restriction: it hides a balance, it does not
+  // remove it, and an unbacked stable-token holding is exactly as lost as an
+  // unbacked BTC one if the device goes.
+  const { satsBalance } = useTotalBalance(walletsForTotal, {
+    applyDollarRestriction: false,
+  })
 
   const isBannerDismissedRecently =
     bannerDismissedAt !== null &&

--- a/app/hooks/use-backup-nudge-state.ts
+++ b/app/hooks/use-backup-nudge-state.ts
@@ -64,12 +64,17 @@ export const useBackupNudgeState = (): BackupNudgeState => {
       return
     }
 
+    // The two reads race across an account switch: nothing orders the previous
+    // account's reply before the current one's, and applying a stale reply would
+    // decide this account's nudges from the other account's dismissals.
+    let cancelled = false
     const bannerKey = bannerDismissalKeyFor(activeSelfCustodialAccountId)
     const modalKey = modalDismissalKeyFor(activeSelfCustodialAccountId)
 
     setLoaded(false)
     AsyncStorage.multiGet([bannerKey, modalKey])
       .then((entries) => {
+        if (cancelled) return
         // Look the values up by key: Android returns them in SQLite row order
         // with the not-found keys appended, not in the order we asked for.
         const byKey = new Map(entries)
@@ -79,11 +84,16 @@ export const useBackupNudgeState = (): BackupNudgeState => {
       })
       .catch((err) => {
         reportError("Nudge dismiss read", err)
+        if (cancelled) return
         // Fail open: an unreadable storage must not silence a security nudge.
         setBannerDismissedAt(null)
         setModalDismissedAt(null)
         setLoaded(true)
       })
+
+    return () => {
+      cancelled = true
+    }
   }, [activeSelfCustodialAccountId])
 
   const dismissBanner = useCallback(() => {
@@ -136,8 +146,10 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     satsBalance >= backupNudgeModalThreshold &&
     !isModalDismissedRecently
 
-  // Once the modal is dismissed the banner takes over: the user keeps a visible
-  // warning without a prompt that blocks the wallet.
+  // Once the modal is dismissed the banner takes over, so the user keeps a
+  // visible warning without a prompt that blocks the wallet - unless they also
+  // dismissed the banner inside its own cooldown, in which case both stay quiet
+  // and `shouldShowSettingsBanner` below is the warning that always remains.
   const shouldShowBanner =
     !isBackedUp &&
     isSelfCustodial &&

--- a/app/hooks/use-backup-nudge-state.ts
+++ b/app/hooks/use-backup-nudge-state.ts
@@ -61,16 +61,34 @@ export const useBackupNudgeState = (): BackupNudgeState => {
       setLoaded(true)
       return
     }
+
+    let cancelled = false
+    const bannerKey = bannerDismissalKeyFor(activeSelfCustodialAccountId)
+    const modalKey = modalDismissalKeyFor(activeSelfCustodialAccountId)
+
     setLoaded(false)
-    AsyncStorage.multiGet([
-      bannerDismissalKeyFor(activeSelfCustodialAccountId),
-      modalDismissalKeyFor(activeSelfCustodialAccountId),
-    ]).then((entries) => {
-      const [bannerEntry, modalEntry] = entries
-      setBannerDismissedAt(parseDismissedAt(bannerEntry?.[1]))
-      setModalDismissedAt(parseDismissedAt(modalEntry?.[1]))
-      setLoaded(true)
-    })
+    AsyncStorage.multiGet([bannerKey, modalKey])
+      .then((entries) => {
+        if (cancelled) return
+        // Look the values up by key: Android returns them in SQLite row order
+        // with the not-found keys appended, not in the order we asked for.
+        const byKey = new Map(entries)
+        setBannerDismissedAt(parseDismissedAt(byKey.get(bannerKey)))
+        setModalDismissedAt(parseDismissedAt(byKey.get(modalKey)))
+        setLoaded(true)
+      })
+      .catch((err) => {
+        reportError("Nudge dismiss read", err)
+        if (cancelled) return
+        // Fail open: an unreadable storage must not silence a security nudge.
+        setBannerDismissedAt(null)
+        setModalDismissedAt(null)
+        setLoaded(true)
+      })
+
+    return () => {
+      cancelled = true
+    }
   }, [activeSelfCustodialAccountId])
 
   const dismissBanner = useCallback(() => {
@@ -119,8 +137,10 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     satsBalance >= backupNudgeModalThreshold &&
     !isModalDismissedRecently
 
-  // Once the modal is dismissed the banner takes over: the user keeps a visible
-  // warning without a prompt that blocks the wallet.
+  // Once the modal is dismissed the banner takes over, so the user keeps a
+  // visible warning without a prompt that blocks the wallet - unless they also
+  // dismissed the banner inside its own cooldown, in which case both stay quiet
+  // and `shouldShowSettingsBanner` below is the warning that always remains.
   const shouldShowBanner =
     !isBackedUp &&
     isSelfCustodial &&

--- a/app/hooks/use-backup-nudge-state.ts
+++ b/app/hooks/use-backup-nudge-state.ts
@@ -11,25 +11,44 @@ import { reportError } from "@app/utils/error-logging"
 import { useAccountRegistry } from "./use-account-registry"
 import { useActiveWallet } from "./use-active-wallet"
 
-const DISMISSAL_COOLDOWN_MS = 24 * 60 * 60 * 1000
-const DISMISSAL_KEY_PREFIX = "backupNudgeDismissedAt"
+const BANNER_DISMISSAL_COOLDOWN_MS = 24 * 60 * 60 * 1000
+const BANNER_DISMISSAL_KEY_PREFIX = "backupNudgeDismissedAt"
+const MODAL_DISMISSAL_KEY_PREFIX = "backupNudgeModalDismissedAt"
 
-const dismissalKeyFor = (accountId: string): string =>
-  `${DISMISSAL_KEY_PREFIX}:${accountId}`
+const bannerDismissalKeyFor = (accountId: string): string =>
+  `${BANNER_DISMISSAL_KEY_PREFIX}:${accountId}`
+
+const modalDismissalKeyFor = (accountId: string): string =>
+  `${MODAL_DISMISSAL_KEY_PREFIX}:${accountId}`
+
+const parseDismissedAt = (raw: string | null | undefined): number | null =>
+  raw ? Number(raw) : null
+
+const persistDismissal = (key: string, at: number): void => {
+  AsyncStorage.setItem(key, String(at)).catch((err) => {
+    reportError("Nudge dismiss write", err)
+  })
+}
 
 type BackupNudgeState = {
   shouldShowBanner: boolean
   shouldShowModal: boolean
   shouldShowSettingsBanner: boolean
   dismissBanner: () => void
+  dismissModal: () => void
 }
 
 export const useBackupNudgeState = (): BackupNudgeState => {
   const { backupState } = useBackupState()
   const activeWallet = useActiveWallet()
   const { activeAccount } = useAccountRegistry()
-  const { backupNudgeBannerThreshold, backupNudgeModalThreshold } = useRemoteConfig()
-  const [dismissedAt, setDismissedAt] = useState<number | null>(null)
+  const {
+    backupNudgeBannerThreshold,
+    backupNudgeModalThreshold,
+    backupNudgeModalCooldownMs,
+  } = useRemoteConfig()
+  const [bannerDismissedAt, setBannerDismissedAt] = useState<number | null>(null)
+  const [modalDismissedAt, setModalDismissedAt] = useState<number | null>(null)
   const [loaded, setLoaded] = useState(false)
 
   const activeSelfCustodialAccountId =
@@ -37,13 +56,19 @@ export const useBackupNudgeState = (): BackupNudgeState => {
 
   useEffect(() => {
     if (!activeSelfCustodialAccountId) {
-      setDismissedAt(null)
+      setBannerDismissedAt(null)
+      setModalDismissedAt(null)
       setLoaded(true)
       return
     }
     setLoaded(false)
-    AsyncStorage.getItem(dismissalKeyFor(activeSelfCustodialAccountId)).then((raw) => {
-      setDismissedAt(raw ? Number(raw) : null)
+    AsyncStorage.multiGet([
+      bannerDismissalKeyFor(activeSelfCustodialAccountId),
+      modalDismissalKeyFor(activeSelfCustodialAccountId),
+    ]).then((entries) => {
+      const [bannerEntry, modalEntry] = entries
+      setBannerDismissedAt(parseDismissedAt(bannerEntry?.[1]))
+      setModalDismissedAt(parseDismissedAt(modalEntry?.[1]))
       setLoaded(true)
     })
   }, [activeSelfCustodialAccountId])
@@ -51,13 +76,15 @@ export const useBackupNudgeState = (): BackupNudgeState => {
   const dismissBanner = useCallback(() => {
     if (!activeSelfCustodialAccountId) return
     const now = Date.now()
-    setDismissedAt(now)
-    AsyncStorage.setItem(
-      dismissalKeyFor(activeSelfCustodialAccountId),
-      String(now),
-    ).catch((err) => {
-      reportError("Nudge dismiss write", err)
-    })
+    setBannerDismissedAt(now)
+    persistDismissal(bannerDismissalKeyFor(activeSelfCustodialAccountId), now)
+  }, [activeSelfCustodialAccountId])
+
+  const dismissModal = useCallback(() => {
+    if (!activeSelfCustodialAccountId) return
+    const now = Date.now()
+    setModalDismissedAt(now)
+    persistDismissal(modalDismissalKeyFor(activeSelfCustodialAccountId), now)
   }, [activeSelfCustodialAccountId])
 
   const isBackedUp = backupState.status === BackupStatus.Completed
@@ -76,16 +103,24 @@ export const useBackupNudgeState = (): BackupNudgeState => {
 
   const { satsBalance } = useTotalBalance(walletsForTotal)
 
-  const isDismissedRecently =
-    dismissedAt !== null && Date.now() - dismissedAt < DISMISSAL_COOLDOWN_MS
+  const isBannerDismissedRecently =
+    bannerDismissedAt !== null &&
+    Date.now() - bannerDismissedAt < BANNER_DISMISSAL_COOLDOWN_MS
+
+  const isModalDismissedRecently =
+    modalDismissedAt !== null &&
+    Date.now() - modalDismissedAt < backupNudgeModalCooldownMs
 
   const shouldShowModal =
     !isBackedUp &&
     isSelfCustodial &&
     isWalletReady &&
     loaded &&
-    satsBalance >= backupNudgeModalThreshold
+    satsBalance >= backupNudgeModalThreshold &&
+    !isModalDismissedRecently
 
+  // Once the modal is dismissed the banner takes over: the user keeps a visible
+  // warning without a prompt that blocks the wallet.
   const shouldShowBanner =
     !isBackedUp &&
     isSelfCustodial &&
@@ -93,7 +128,7 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     loaded &&
     satsBalance >= backupNudgeBannerThreshold &&
     !shouldShowModal &&
-    !isDismissedRecently
+    !isBannerDismissedRecently
 
   const shouldShowSettingsBanner = !isBackedUp && isSelfCustodial
 
@@ -102,5 +137,6 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     shouldShowModal,
     shouldShowSettingsBanner,
     dismissBanner,
+    dismissModal,
   }
 }

--- a/app/hooks/use-backup-nudge-state.ts
+++ b/app/hooks/use-backup-nudge-state.ts
@@ -62,14 +62,12 @@ export const useBackupNudgeState = (): BackupNudgeState => {
       return
     }
 
-    let cancelled = false
     const bannerKey = bannerDismissalKeyFor(activeSelfCustodialAccountId)
     const modalKey = modalDismissalKeyFor(activeSelfCustodialAccountId)
 
     setLoaded(false)
     AsyncStorage.multiGet([bannerKey, modalKey])
       .then((entries) => {
-        if (cancelled) return
         // Look the values up by key: Android returns them in SQLite row order
         // with the not-found keys appended, not in the order we asked for.
         const byKey = new Map(entries)
@@ -79,16 +77,11 @@ export const useBackupNudgeState = (): BackupNudgeState => {
       })
       .catch((err) => {
         reportError("Nudge dismiss read", err)
-        if (cancelled) return
         // Fail open: an unreadable storage must not silence a security nudge.
         setBannerDismissedAt(null)
         setModalDismissedAt(null)
         setLoaded(true)
       })
-
-    return () => {
-      cancelled = true
-    }
   }, [activeSelfCustodialAccountId])
 
   const dismissBanner = useCallback(() => {
@@ -137,10 +130,8 @@ export const useBackupNudgeState = (): BackupNudgeState => {
     satsBalance >= backupNudgeModalThreshold &&
     !isModalDismissedRecently
 
-  // Once the modal is dismissed the banner takes over, so the user keeps a
-  // visible warning without a prompt that blocks the wallet - unless they also
-  // dismissed the banner inside its own cooldown, in which case both stay quiet
-  // and `shouldShowSettingsBanner` below is the warning that always remains.
+  // Once the modal is dismissed the banner takes over: the user keeps a visible
+  // warning without a prompt that blocks the wallet.
   const shouldShowBanner =
     !isBackedUp &&
     isSelfCustodial &&

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -70,7 +70,7 @@ import {
 } from "@app/self-custodial/hooks"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { ConvertDirection, DepositStatus } from "@app/types/payment"
-import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
+import { useBackupNudgeState } from "@app/self-custodial/hooks/use-backup-nudge-state"
 import { useSelfCustodialInfoBulletinState } from "@app/hooks/use-self-custodial-info-bulletin-state"
 import { getErrorMessages } from "@app/graphql/utils"
 import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -231,7 +231,8 @@ export const HomeScreen: React.FC = () => {
   const hasMultipleAccounts = accounts.length > 1
   const { stableBalanceEnabled } = useFeatureFlags()
   const { mode: balanceMode, toggleMode: toggleBalanceMode } = useBalanceMode()
-  const { shouldShowBanner, shouldShowModal, dismissBanner } = useBackupNudgeState()
+  const { shouldShowBanner, shouldShowModal, dismissBanner, dismissModal } =
+    useBackupNudgeState()
   const {
     shouldShow: shouldShowSelfCustodialInfoBulletin,
     dismiss: dismissSelfCustodialInfoBulletin,
@@ -915,10 +916,7 @@ export const HomeScreen: React.FC = () => {
         bottomOffset={15}
         onAction={() => navigation.navigate("transactionHistory")}
       />
-      <BackupNudgeModal
-        isVisible={shouldShowModal && isFocused}
-        onClose={dismissBanner}
-      />
+      <BackupNudgeModal isVisible={shouldShowModal && isFocused} onClose={dismissModal} />
     </Screen>
   )
 }

--- a/app/self-custodial/hooks/index.ts
+++ b/app/self-custodial/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useBackupNudgeState } from "./use-backup-nudge-state"
 export { useNonCustodialConversionLimits } from "./use-non-custodial-conversion-limits"
 export { usePaymentRequest } from "./use-payment-request"
 export { usePendingDeposits } from "./use-pending-deposits"

--- a/app/self-custodial/hooks/use-backup-nudge-state.ts
+++ b/app/self-custodial/hooks/use-backup-nudge-state.ts
@@ -4,13 +4,13 @@ import AsyncStorage from "@react-native-async-storage/async-storage"
 
 import { useTotalBalance } from "@app/components/balance-header/use-total-balance"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
-import { BackupStatus, useBackupState } from "@app/self-custodial/providers/backup-state"
+import { useAccountRegistry } from "@app/hooks/use-account-registry"
+import { useActiveWallet } from "@app/hooks/use-active-wallet"
+import { useIsSelfCustodialAccount } from "@app/hooks/use-is-self-custodial-account"
 import { AccountType } from "@app/types/wallet"
 import { reportError } from "@app/utils/error-logging"
 
-import { useAccountRegistry } from "./use-account-registry"
-import { useActiveWallet } from "./use-active-wallet"
-import { useIsSelfCustodialAccount } from "./use-is-self-custodial-account"
+import { BackupStatus, useBackupState } from "../providers/backup-state"
 
 const BANNER_DISMISSAL_COOLDOWN_MS = 24 * 60 * 60 * 1000
 const BANNER_DISMISSAL_KEY_PREFIX = "backupNudgeDismissedAt"


### PR DESCRIPTION
Fixes #4156

## The bug

The self-custodial backup prompt ("Secure your funds" / "Secure wallet") could not be dismissed. A user reported writing their seed phrase down in public because the prompt made the wallet unusable and they needed to transact; a second user hit the same thing.

It is not a rendering glitch — [`shouldShowModal`](https://github.com/blinkbitcoin/blink-mobile/blob/9b889f63b/app/hooks/use-backup-nudge-state.ts#L82-L87) never consulted `isDismissedRecently`, which only the banner read:

```ts
const shouldShowModal =
  !isBackedUp && isSelfCustodial && isWalletReady && loaded &&
  satsBalance >= backupNudgeModalThreshold      // isDismissedRecently never checked
```

So pressing the X called `dismissBanner`, wrote `backupNudgeDismissedAt:<accountId>`, and then recomputed the modal as visible on the same render. `CustomModal` is `dismissable`, so the backdrop tap and the Android back button routed to the same dead handler. Force-closing did nothing either: the stored timestamp was re-read on launch, but no code path fed it to the modal. The only escapes were completing the backup or letting the balance fall below `backupNudgeModalThreshold` (21 000 sats).

A second, quieter bug lived in the same lines: the modal and the banner shared one dismissal key, so closing the modal also silenced the banner for 24 h.

## The fix

Split the dismissal in two. The modal persists and honours its own `backupNudgeModalDismissedAt:<accountId>` key; the banner keeps the existing key with unchanged semantics.

Once the modal is dismissed, the home-screen banner ("Your funds are at risk") takes over — the modal threshold (21 000 sats) sits well above the banner threshold (2 100), so the banner condition is satisfied the moment the modal steps aside, unless the banner is inside its own cooldown (see the caveat under Decisions).

## Decisions

**Why the banner takes over instead of everything going quiet.** The alternative — reuse the single key so one dismissal silences both surfaces — is a smaller diff, but it leaves a self-custodial user with >21 000 unbacked sats with no warning at all for a day. Handing over to the non-blocking card keeps the security signal on screen while unblocking the wallet, which is what the issue asks for.

**Why the existing banner key is left as-is.** Reusing it for the modal would have made every user who had dismissed the banner also start with a pre-dismissed modal. Keeping the keys separate means users currently trapped get the modal once more and can then close it for good — the right behaviour for a security nudge.

**Why the hook moved namespace.** `useBackupNudgeState` is self-custodial logic — every surface it returns is gated on account type, its dismissal keys are scoped to a self-custodial account id, and it reads the self-custodial backup provider. It has no meaning for a custodial account, so it now lives in `app/self-custodial/hooks/` (spec mirrored, exported through the namespace index) rather than in the shared `app/hooks/`. The shared hooks it consumes — `useAccountRegistry`, `useActiveWallet`, `useIsSelfCustodialAccount` — are genuinely account-type-agnostic and stay put. No behaviour change, and neither unmerged recovery branch touches this file, so it does not conflict with them.

**Why the modal cooldown is remote-configurable and the banner's is not.** The modal is the blocking surface, so its nag interval is the knob ops is most likely to want to retune after this ships. `backupNudgeModalCooldownMs` defaults to 24 h, matching the banner constant. `asNumber()` returns 0 for a malformed remote value and a zero cooldown would resurrect this exact bug, so the read falls back to the shipped default when the value is not positive.

**Why `multiGet`, and why its result is read by key.** Two keys now load on mount; one round trip keeps the existing "don't flash the nudge before storage is read" guarantee behind the single `loaded` flag. The reply is looked up in a `Map` rather than destructured positionally, because **`multiGet` does not echo the requested key order on Android**: the legacy module we ship (`AsyncStorage_useNextStorage` is unset) runs `WHERE key IN (…)` with no `ORDER BY` and appends the keys it did not find as `[key, null]` at the end. Reading it positionally swapped the two timestamps for any user who had dismissed one surface but not the other, which reinstated this very bug on Android — see [`AsyncStorageModule.java:130-152`](https://github.com/react-native-async-storage/async-storage/blob/main/packages/default-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java).

**Why the read fails open.** Android surfaces SQLite disk-full and `CursorWindow` errors as a rejected promise. Without a `catch`, `loaded` never flipped and *both* nudges stayed hidden for the whole session with nothing reported. Unreadable storage now reports and shows the nudge: a security prompt should fail loud, not quiet.

**Why the nudge ignores the dollar-balance restriction.** `useTotalBalance` zeroes the USD wallet for users in a dollar-restricted region, and the nudge used that number as its threshold. That is a display rule: the balance is hidden, not gone. A self-custodial user in such a region holding most of their value in stable tokens could therefore sit under both the 21 000-sat modal threshold and the 2 100-sat banner threshold and never be prompted, while the funds sat unbacked on the device. The zeroing is now opt-out (`applyDollarRestriction`, default true), so the home-screen display is unchanged and only the nudge opts out. This is a pre-existing bug rather than a regression in this branch, fixed here because it defeats the very prompt this PR is repairing.

**Why the "Secure wallet" CTA no longer dismisses.** It used to call `onClose` — i.e. `dismissModal` — on its way to the backup screen, so starting the flow and abandoning it bought a full cooldown with nothing backed up. It now only navigates. `isVisible` is already gated on `isFocused`, so the modal hides while the backup flow is open and returns if the user backs out, and finishing the backup flips `isBackedUp` and retires the nudge anyway. The X, the backdrop and the Android back button still dismiss, so nobody is trapped.

**Why the load effect ignores stale replies.** Switching self-custodial accounts re-runs it, and nothing orders the previous account's read before the current one's. Both paths are guarded, not just the successful one: fail-open clears the dismissal state, so a late *rejection* from the old account would have wiped the new account's freshly loaded timestamps and re-shown a modal it had already dismissed.

**One caveat on the takeover.** The banner takes over unless it is itself inside its own 24 h cooldown — dismiss the banner in the morning and the modal in the afternoon and both home-screen surfaces stay quiet for the rest of the day. That is deliberate: two explicit dismissals are two explicit dismissals, and it is not a silent state, because `shouldShowSettingsBanner` carries no threshold and no dismissal check, so the Settings warning stays up for as long as the account is unbacked.

## Tests

`__tests__/self-custodial/hooks/use-backup-nudge-state.spec.ts` — the `multiGet` mock now mimics the Android contract (found rows first, missing keys appended as `[key, null]`) instead of echoing the requested order. That change alone reddens two of the cases below against the positional read, which is the regression proof for the Android bug. New and updated cases, each verified to fail against the unfixed hook:

- dismissing the modal hides it and writes `backupNudgeModalDismissedAt:<accountId>`
- the banner takes over once the modal is dismissed
- a stored modal timestamp within the cooldown keeps it hidden on a fresh mount (the force-close half of the report)
- a non-default `backupNudgeModalCooldownMs` is respected
- the two dismissals stay independent in both directions
- **only the modal key present, returned in Android order → the modal stays dismissed and the banner shows**
- **a rejected read still resolves `loaded`, leaves the nudge visible and reports the error**
- **a failed dismissal write is reported**
- **a custodial account clears dismissal state, finishes loading and never persists a key**
- **the balance is measured with the dollar-display restriction opted out**
- **a stale read from a previously active account cannot overwrite the current one — on both the resolve and the reject path**
- **with both home-screen surfaces dismissed, the settings banner still shows**

`__tests__/components/backup-nudge-modal.spec.tsx` — the CTA navigates *without* calling `onClose`; the close X still dismisses and does not navigate.

`app/self-custodial/hooks/use-backup-nudge-state.ts` and `app/components/backup-nudge-modal/backup-nudge-modal.tsx` are both at 100% statements, branches, functions and lines. Every assertion listed here was run against a deliberately broken version of its own fix and fails without it.

`__tests__/config/backup-nudge-modal-cooldown.spec.tsx` — new. `backupNudgeModalCooldownMs`' fallback was previously untested even though it is what stops a malformed remote value (`asNumber()` returns 0) from making the modal undismissable again. It drives the real provider rather than a copy of the derivation. Worth knowing if you touch it: the provider's initial state *is* `defaultRemoteConfig`, so asserting "equals the default" right after render passes before the async fetch commits — and would still pass with the fallback deleted. The spec waits for a sentinel remote value to arrive first, so the assertion means what it says.

`__tests__/components/balance-header/use-total-balance.spec.ts` — the restriction is still applied by default, and skipped when the caller opts out.

`__tests__/screens/home.spec.tsx` — asserts the modal's `onClose` is wired to `dismissModal`, not `dismissBanner`.

## Ops follow-up

`backupNudgeModalCooldownMs` needs creating in the Firebase Remote Config console (default `86400000`). Until it exists the app uses the in-code default, so this does not block the merge.

## Demo

Same tap on both sides — the close X on the modal. Left: the X does nothing. Right: the modal closes and the "Your funds are at risk" banner takes over.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/assets/pr-4157-demo/before.gif" width="280"> | <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/assets/pr-4157-demo/after.gif" width="280"> |

<sub>Recorded on an iOS simulator with the hook's server-owned inputs stubbed (unbacked self-custodial account, 22 000 sats) so the prompt is reachable without an account — the dismissal logic in the recording is the real thing. Demos live on branch `assets/pr-4157-demo`; deleting it breaks them.</sub>

