### PR TITLE
feat(security): gate the WebView WebLN bridge to allowlisted origins

### DIFF
--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -74,6 +74,36 @@ it("backfills fields missing from a persisted Custom instance with Main defaults
   expect(res.blockExplorer).toBe("https://mempool.space/tx/")
 })
 
+it("backfills fields persisted as blank strings on a Custom instance", () => {
+  // The developer screen seeds every URL input with "" when the current instance
+  // is not Custom and saves them verbatim. Keeping those blanks would override
+  // the Main defaults: an empty kycUrl/fiatUrl empties the WebView entry
+  // allowlist and locks KYC and buy/sell out behind a generic error.
+  const customInstanceWithBlanks = {
+    id: "Custom",
+    name: "Custom",
+    graphqlUri: "https://api.custom.com/graphql",
+    graphqlWsUri: "ws://ws.custom.com/graphql",
+    authUrl: "https://api.custom.com",
+    posUrl: "",
+    kycUrl: "",
+    fiatUrl: "   ",
+    lnAddressHostname: "custom.com",
+    blockExplorer: "https://mempool.space/tx/",
+    sparkExplorer: "https://sparkscan.io/tx/",
+  } as never
+
+  const res = resolveGaloyInstanceOrDefault(customInstanceWithBlanks)
+
+  expect(res.kycUrl).toBe(GALOY_INSTANCES[0].kycUrl)
+  expect(res.fiatUrl).toBe(GALOY_INSTANCES[0].fiatUrl)
+  expect(res.posUrl).toBe(GALOY_INSTANCES[0].posUrl)
+  // non-blank persisted values are still kept
+  expect(res.id).toBe("Custom")
+  expect(res.graphqlUri).toBe("https://api.custom.com/graphql")
+  expect(res.lnAddressHostname).toBe("custom.com")
+})
+
 it("backfills fields persisted as undefined on a Custom instance", () => {
   const customInstanceWithUndefined = {
     id: "Custom",

--- a/__tests__/navigation/deep-link-screens.spec.ts
+++ b/__tests__/navigation/deep-link-screens.spec.ts
@@ -1,0 +1,41 @@
+import { DEEP_LINK_SCREENS } from "@app/navigation/deep-link-screens"
+
+/**
+ * The webView route's `allowArbitraryUrl` param bypasses the WebView entry-origin
+ * allowlist (see stack-param-lists.ts). That is only safe while no deep link can
+ * reach the route: a crafted `blink://…` URL carrying the param would otherwise
+ * load an attacker origin in the trusted WebView, WebLN bridge included.
+ *
+ * These tests fail the moment someone makes the route deep-linkable, which is the
+ * signal to re-derive the bypass rather than to delete the assertion.
+ */
+
+type ScreenConfig = Record<string, unknown>
+
+const collectRouteNames = (screens: ScreenConfig): string[] =>
+  Object.entries(screens).flatMap(([name, value]) => {
+    const nested =
+      value && typeof value === "object" && "screens" in value
+        ? collectRouteNames((value as { screens: ScreenConfig }).screens)
+        : []
+    return [name, ...nested]
+  })
+
+describe("deep-linkable routes", () => {
+  it("does not expose the webView route at the top level", () => {
+    expect(Object.keys(DEEP_LINK_SCREENS)).not.toContain("webView")
+  })
+
+  it("does not expose the webView route nested under any navigator", () => {
+    expect(collectRouteNames(DEEP_LINK_SCREENS as ScreenConfig)).not.toContain("webView")
+  })
+
+  it("still exposes the routes deep links depend on", () => {
+    // Guards the traversal itself: a helper that silently returned nothing would
+    // make the assertions above vacuous.
+    const routeNames = collectRouteNames(DEEP_LINK_SCREENS as ScreenConfig)
+    expect(routeNames).toContain("Home")
+    expect(routeNames).toContain("circlesDashboard")
+    expect(routeNames).toContain("sendBitcoinDestination")
+  })
+})

--- a/__tests__/screens/webview-screen.spec.tsx
+++ b/__tests__/screens/webview-screen.spec.tsx
@@ -1,19 +1,36 @@
 import React from "react"
 import { it } from "@jest/globals"
+import { Alert } from "react-native"
+import type { ReactTestInstance } from "react-test-renderer"
 import { render, waitFor } from "@testing-library/react-native"
 
+import { injectJs } from "react-native-webln"
+
 import { WebViewScreen } from "@app/screens/webview/webview"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { ContextForScreen } from "./helper"
 
+type TestRoute = {
+  key: string
+  name: "webView"
+  params: RootStackParamList["webView"]
+}
+
+const mockInjectJavaScript = jest.fn()
+
 jest.mock("react-native-webview", () => {
+  const ReactActual = jest.requireActual<typeof React>("react")
   const { View } = jest.requireActual("react-native")
 
-  const MockWebView = React.forwardRef<
-    React.ComponentRef<typeof View>,
-    React.ComponentProps<typeof View>
-  >((props, ref) => {
-    return <View ref={ref} {...props} testID="webview" />
-  })
+  const MockWebView = ReactActual.forwardRef<unknown, React.ComponentProps<typeof View>>(
+    (props, ref) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        injectJavaScript: mockInjectJavaScript,
+        goBack: jest.fn(),
+      }))
+      return <View {...props} testID="webview" />
+    },
+  )
   MockWebView.displayName = "WebView"
 
   return {
@@ -21,39 +38,72 @@ jest.mock("react-native-webview", () => {
   }
 })
 
+const mockWeblnHandler = jest.fn()
+
 jest.mock("react-native-webln", () => ({
-  injectJs: jest.fn(() => ""),
-  onMessageHandler: jest.fn(() => jest.fn()),
+  injectJs: jest.fn(() => "webln-bridge-js"),
+  onMessageHandler: jest.fn(() => mockWeblnHandler),
 }))
 
-const mockRoute = {
+jest.mock("@app/utils/external", () => ({
+  openExternalUrl: jest.fn(),
+}))
+
+// The test context pins the Main galoy instance:
+// kycUrl = https://kyc.blink.sv, fiatUrl = https://fiat.blink.sv
+const FIAT_URL = "https://fiat.blink.sv?accountId=test"
+const KYC_URL = "https://kyc.blink.sv/webflow?token=test&lang=en"
+
+const mockRoute: TestRoute = {
   key: "webView",
   name: "webView" as const,
   params: {
-    url: "https://example.com",
+    url: FIAT_URL,
     initialTitle: "Test Page",
   },
 }
 
-const mockRouteWithHeaderTitle = {
+const mockRouteWithHeaderTitle: TestRoute = {
   key: "webView",
   name: "webView" as const,
   params: {
-    url: "https://verification.example.com/flow?token=test",
+    url: KYC_URL,
     headerTitle: "Identity Verification",
   },
 }
 
-const mockRouteForMediaCapture = {
+const mockRouteForMediaCapture: TestRoute = {
   key: "webView",
   name: "webView" as const,
   params: {
-    url: "https://kyc.example.com/webflow?token=test&idDocType=ID_CARD",
+    url: "https://kyc.blink.sv/webflow?token=test&idDocType=ID_CARD",
     headerTitle: "Card ID Verification",
   },
 }
 
+const renderScreen = (route: TestRoute) =>
+  render(
+    <ContextForScreen>
+      <WebViewScreen route={route} />
+    </ContextForScreen>,
+  )
+
+const getWebView = async (route: TestRoute) => {
+  const { getByTestId } = renderScreen(route)
+  await waitFor(() => expect(getByTestId("webview")).toBeTruthy())
+  return getByTestId("webview")
+}
+
+const simulateLoad = (webViewInstance: ReactTestInstance, url: string) => {
+  webViewInstance.props.onLoadStart()
+  webViewInstance.props.onLoadProgress({ nativeEvent: { progress: 0.8, url } })
+}
+
 describe("WebViewScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe("allowsInlineMediaPlayback property", () => {
     it("should have allowsInlineMediaPlayback enabled on iOS", async () => {
       jest.doMock("@app/utils/helper", () => ({
@@ -61,17 +111,8 @@ describe("WebViewScreen", () => {
         isIos: true,
       }))
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRoute} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
-      })
+      const webViewInstance = await getWebView(mockRoute)
+      expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
     })
 
     it("should have allowsInlineMediaPlayback enabled on Android", async () => {
@@ -80,17 +121,8 @@ describe("WebViewScreen", () => {
         isIos: false,
       }))
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRoute} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
-      })
+      const webViewInstance = await getWebView(mockRoute)
+      expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
     })
   })
 
@@ -101,18 +133,9 @@ describe("WebViewScreen", () => {
         isIos: true,
       }))
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRouteWithHeaderTitle} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
-        expect(webViewInstance.props.source.uri).toContain("verification.example.com")
-      })
+      const webViewInstance = await getWebView(mockRouteWithHeaderTitle)
+      expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
+      expect(webViewInstance.props.source.uri).toContain("kyc.blink.sv")
     })
 
     it("should render WebView with allowsInlineMediaPlayback on Android", async () => {
@@ -121,34 +144,16 @@ describe("WebViewScreen", () => {
         isIos: false,
       }))
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRouteWithHeaderTitle} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
-        expect(webViewInstance.props.source.uri).toContain("verification.example.com")
-      })
+      const webViewInstance = await getWebView(mockRouteWithHeaderTitle)
+      expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
+      expect(webViewInstance.props.source.uri).toContain("kyc.blink.sv")
     })
   })
 
   describe("WebView rendering", () => {
     it("should render WebView with correct URL", async () => {
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRoute} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.source.uri).toBe("https://example.com")
-      })
+      const webViewInstance = await getWebView(mockRoute)
+      expect(webViewInstance.props.source.uri).toBe(FIAT_URL)
     })
 
     it("should render WebView with custom header title", async () => {
@@ -160,16 +165,8 @@ describe("WebViewScreen", () => {
         },
       }
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={customRoute} />
-        </ContextForScreen>,
-      )
-
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-      })
+      const webViewInstance = await getWebView(customRoute)
+      expect(webViewInstance).toBeTruthy()
     })
   })
 
@@ -180,17 +177,135 @@ describe("WebViewScreen", () => {
         isIos: true,
       }))
 
-      const { getByTestId } = render(
-        <ContextForScreen>
-          <WebViewScreen route={mockRouteForMediaCapture} />
-        </ContextForScreen>,
-      )
+      const webViewInstance = await getWebView(mockRouteForMediaCapture)
+      expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
+    })
+  })
 
-      await waitFor(() => {
-        const webViewInstance = getByTestId("webview")
-        expect(webViewInstance).toBeTruthy()
-        expect(webViewInstance.props.allowsInlineMediaPlayback).toBe(true)
+  describe("entry allowlist", () => {
+    it("refuses an off-instance entry URL without mounting the WebView", async () => {
+      const alertSpy = jest.spyOn(Alert, "alert")
+
+      const { queryByTestId } = renderScreen({
+        ...mockRoute,
+        params: { url: "https://evil.example/phishing" },
       })
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      expect(queryByTestId("webview")).toBeNull()
+
+      const buttons = alertSpy.mock.calls[0][2]
+      expect(buttons).toHaveLength(1)
+      expect(typeof buttons?.[0]?.onPress).toBe("function")
+    })
+
+    it("refuses unparseable entry URLs", async () => {
+      const alertSpy = jest.spyOn(Alert, "alert")
+
+      const { queryByTestId } = renderScreen({
+        ...mockRoute,
+        params: { url: "about:blank" },
+      })
+
+      await waitFor(() => expect(alertSpy).toHaveBeenCalled())
+      expect(queryByTestId("webview")).toBeNull()
+    })
+
+    it("allows an arbitrary URL only with the developer-screen escape hatch", async () => {
+      const webViewInstance = await getWebView({
+        ...mockRoute,
+        params: { url: "http://localhost:3000/dev", allowArbitraryUrl: true },
+      })
+      expect(webViewInstance.props.source.uri).toBe("http://localhost:3000/dev")
+      // http entry widens the native scheme filter for that session only
+      expect(webViewInstance.props.originWhitelist).toEqual(["https://*", "http://*"])
+    })
+  })
+
+  describe("WebLN bridge gating", () => {
+    it("injects the bridge on the fiat origin", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      simulateLoad(webViewInstance, "https://fiat.blink.sv/checkout?step=2")
+
+      expect(injectJs).toHaveBeenCalledTimes(1)
+      expect(mockInjectJavaScript).toHaveBeenCalledWith("webln-bridge-js")
+    })
+
+    it("does not inject the bridge after navigating off-origin", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      simulateLoad(webViewInstance, "https://fiat.blink.sv/checkout")
+      expect(injectJs).toHaveBeenCalledTimes(1)
+
+      simulateLoad(webViewInstance, "https://payment-partner.example/redirect")
+      expect(injectJs).toHaveBeenCalledTimes(1) // unchanged: theme only, no bridge
+    })
+
+    it("does not inject the bridge on the KYC origin", async () => {
+      const webViewInstance = await getWebView(mockRouteWithHeaderTitle)
+
+      simulateLoad(webViewInstance, "https://kyc.blink.sv/webflow?token=test")
+
+      expect(injectJs).not.toHaveBeenCalled()
+      expect(mockInjectJavaScript).toHaveBeenCalled() // theme js still injected
+    })
+
+    it("injects the bridge on the entry origin under allowArbitraryUrl", async () => {
+      const webViewInstance = await getWebView({
+        ...mockRoute,
+        params: { url: "http://localhost:3000/dev", allowArbitraryUrl: true },
+      })
+
+      simulateLoad(webViewInstance, "http://localhost:3000/webln-test")
+
+      expect(injectJs).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("message gating", () => {
+    it("drops messages from non-bridge origins", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      webViewInstance.props.onMessage({
+        nativeEvent: { url: "https://evil.example", data: "{}" },
+      })
+      expect(mockWeblnHandler).not.toHaveBeenCalled()
+
+      webViewInstance.props.onMessage({
+        nativeEvent: { url: "https://kyc.blink.sv/webflow", data: "{}" },
+      })
+      expect(mockWeblnHandler).not.toHaveBeenCalled() // kyc is not a bridge origin
+
+      webViewInstance.props.onMessage({
+        nativeEvent: { url: "https://fiat.blink.sv/checkout", data: "{}" },
+      })
+      expect(mockWeblnHandler).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("hardening props", () => {
+    it("restricts navigation to https and disables multiple windows", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      expect(webViewInstance.props.originWhitelist).toEqual(["https://*"])
+      expect(webViewInstance.props.setSupportMultipleWindows).toBe(false)
+      expect(typeof webViewInstance.props.onOpenWindow).toBe("function")
+    })
+
+    it("sends window.open targets to the external browser only when https", async () => {
+      const { openExternalUrl } = jest.requireMock("@app/utils/external")
+      const webViewInstance = await getWebView(mockRoute)
+
+      webViewInstance.props.onOpenWindow({
+        nativeEvent: { targetUrl: "https://help.example/faq" },
+      })
+      expect(openExternalUrl).toHaveBeenCalledWith("https://help.example/faq")
+
+      webViewInstance.props.onOpenWindow({
+        nativeEvent: { targetUrl: "javascript:void(0)" }, // eslint-disable-line no-script-url
+      })
+      expect(openExternalUrl).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__tests__/screens/webview-screen.spec.tsx
+++ b/__tests__/screens/webview-screen.spec.tsx
@@ -49,6 +49,15 @@ jest.mock("@app/utils/external", () => ({
   openExternalUrl: jest.fn(),
 }))
 
+jest.mock("@app/utils/log-error", () => ({
+  logError: jest.fn(),
+}))
+
+const getLogError = () => jest.requireMock("@app/utils/log-error").logError as jest.Mock
+
+const loggedMessages = () =>
+  getLogError().mock.calls.map((call) => String(call[0]?.error ?? ""))
+
 // The test context pins the Main galoy instance:
 // kycUrl = https://kyc.blink.sv, fiatUrl = https://fiat.blink.sv
 const FIAT_URL = "https://fiat.blink.sv?accountId=test"
@@ -199,6 +208,22 @@ describe("WebViewScreen", () => {
       expect(typeof buttons?.[0]?.onPress).toBe("function")
     })
 
+    it("records which origin was refused and what was allowed", async () => {
+      jest.spyOn(Alert, "alert").mockImplementation(() => {})
+
+      renderScreen({
+        ...mockRoute,
+        params: { url: "https://evil.example/phishing" },
+      })
+
+      // The user only ever sees a generic error, so a misconfigured instance and
+      // a genuine block are indistinguishable without this breadcrumb.
+      await waitFor(() => expect(getLogError()).toHaveBeenCalled())
+      const message = loggedMessages()[0]
+      expect(message).toContain("https://evil.example")
+      expect(message).toContain("https://fiat.blink.sv")
+    })
+
     it("refuses unparseable entry URLs", async () => {
       const alertSpy = jest.spyOn(Alert, "alert")
 
@@ -238,8 +263,66 @@ describe("WebViewScreen", () => {
       simulateLoad(webViewInstance, "https://fiat.blink.sv/checkout")
       expect(injectJs).toHaveBeenCalledTimes(1)
 
+      mockInjectJavaScript.mockClear()
       simulateLoad(webViewInstance, "https://payment-partner.example/redirect")
       expect(injectJs).toHaveBeenCalledTimes(1) // unchanged: theme only, no bridge
+      // The bridge count alone cannot tell a working origin gate from a stuck
+      // injection latch — both leave it at 1. Theme JS re-injection proves the
+      // second load was actually processed and only the bridge was withheld.
+      expect(mockInjectJavaScript).toHaveBeenCalledTimes(1)
+      expect(mockInjectJavaScript).toHaveBeenCalledWith(
+        expect.stringContaining("data-theme"),
+      )
+    })
+
+    it("injects each payload once when two progress events land in one load", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      // Native progress callbacks can both arrive before React re-renders. A
+      // state-based guard let both through, double-registering the WebLN
+      // listeners and pollers so one sendPayment navigated twice.
+      webViewInstance.props.onLoadStart()
+      webViewInstance.props.onLoadProgress({
+        nativeEvent: { progress: 0.8, url: "https://fiat.blink.sv/checkout" },
+      })
+      webViewInstance.props.onLoadProgress({
+        nativeEvent: { progress: 0.9, url: "https://fiat.blink.sv/checkout" },
+      })
+
+      expect(injectJs).toHaveBeenCalledTimes(1)
+      expect(mockInjectJavaScript).toHaveBeenCalledTimes(2) // theme + bridge, once each
+    })
+
+    it("ignores progress events below the injection threshold", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      webViewInstance.props.onLoadStart()
+      webViewInstance.props.onLoadProgress({
+        nativeEvent: { progress: 0.5, url: "https://fiat.blink.sv/checkout" },
+      })
+
+      expect(mockInjectJavaScript).not.toHaveBeenCalled()
+      expect(injectJs).not.toHaveBeenCalled()
+    })
+
+    it("records a breadcrumb when a fiat flow loses the bridge off-origin", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      simulateLoad(webViewInstance, "https://payment-partner.example/redirect")
+
+      // Withholding the bridge is invisible to the user: the page just never
+      // gets window.webln and the payment never starts.
+      expect(loggedMessages()).toContainEqual(
+        expect.stringContaining("https://payment-partner.example"),
+      )
+    })
+
+    it("does not record a bridge breadcrumb for KYC, which never has one", async () => {
+      const webViewInstance = await getWebView(mockRouteWithHeaderTitle)
+
+      simulateLoad(webViewInstance, "https://kyc.blink.sv/webflow?token=test")
+
+      expect(getLogError()).not.toHaveBeenCalled()
     })
 
     it("does not inject the bridge on the KYC origin", async () => {
@@ -285,12 +368,23 @@ describe("WebViewScreen", () => {
   })
 
   describe("hardening props", () => {
-    it("restricts navigation to https and disables multiple windows", async () => {
+    it("restricts navigation to https and routes popups through the handler", async () => {
       const webViewInstance = await getWebView(mockRoute)
 
       expect(webViewInstance.props.originWhitelist).toEqual(["https://*"])
-      expect(webViewInstance.props.setSupportMultipleWindows).toBe(false)
       expect(typeof webViewInstance.props.onOpenWindow).toBe("function")
+    })
+
+    it("keeps multiple-window support on so onOpenWindow fires on Android", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      // Android dispatches the open-window event only from
+      // RNCWebChromeClient.onCreateWindow, which the platform calls only while
+      // multiple windows are supported. Setting this false makes onOpenWindow
+      // dead code there and lets window.open navigate this trusted WebView in
+      // place — react-native-webview drops the popup itself once a handler is
+      // registered, so nothing opens in-app regardless.
+      expect(webViewInstance.props.setSupportMultipleWindows).toBe(true)
     })
 
     it("sends window.open targets to the external browser only when https", async () => {
@@ -306,6 +400,27 @@ describe("WebViewScreen", () => {
         nativeEvent: { targetUrl: "javascript:void(0)" }, // eslint-disable-line no-script-url
       })
       expect(openExternalUrl).toHaveBeenCalledTimes(1)
+
+      webViewInstance.props.onOpenWindow({
+        nativeEvent: { targetUrl: "http://insecure.example/page" },
+      })
+      expect(openExternalUrl).toHaveBeenCalledTimes(1)
+    })
+
+    it("records a breadcrumb for every dropped window.open target", async () => {
+      const webViewInstance = await getWebView(mockRoute)
+
+      // A partner flow that opens about:blank and writes into the handle gets a
+      // dead window and stalls with nothing surfaced to the user.
+      webViewInstance.props.onOpenWindow({
+        nativeEvent: { targetUrl: "about:blank" },
+      })
+      webViewInstance.props.onOpenWindow({
+        nativeEvent: { targetUrl: "http://insecure.example/page" },
+      })
+
+      expect(getLogError()).toHaveBeenCalledTimes(2)
+      expect(loggedMessages()[1]).toContain("http://insecure.example")
     })
   })
 })

--- a/__tests__/utils/webview-origin.spec.ts
+++ b/__tests__/utils/webview-origin.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals"
+
+import { isAllowedOrigin, originOf, originsFromUrls } from "@app/utils/webview-origin"
+
+describe("originOf", () => {
+  it("returns the origin of an https URL, ignoring path and query", () => {
+    expect(originOf("https://kyc.blink.sv/webflow?token=abc&lang=en")).toBe(
+      "https://kyc.blink.sv",
+    )
+  })
+
+  it("keeps explicit non-default ports", () => {
+    expect(originOf("http://localhost:3000/page")).toBe("http://localhost:3000")
+    expect(originOf("https://kyc.blink.sv:8443/")).toBe("https://kyc.blink.sv:8443")
+  })
+
+  it("normalizes host case and elides default ports", () => {
+    expect(originOf("https://KYC.Blink.SV/x")).toBe("https://kyc.blink.sv")
+    expect(originOf("https://kyc.blink.sv:443/x")).toBe("https://kyc.blink.sv")
+  })
+
+  it.each([
+    ["empty string", ""],
+    ["garbage", "not a url"],
+    ["about:blank", "about:blank"],
+    // eslint-disable-next-line no-script-url
+    ["javascript scheme", "javascript:alert(1)"],
+    ["data scheme", "data:text/html,<script>alert(1)</script>"],
+    ["file scheme", "file:///etc/passwd"],
+  ])("fails closed on %s", (_label, url) => {
+    expect(originOf(url)).toBeNull()
+  })
+
+  it("fails closed on undefined and null", () => {
+    expect(originOf(undefined)).toBeNull()
+    expect(originOf(null)).toBeNull()
+  })
+})
+
+describe("isAllowedOrigin", () => {
+  const allowlist = ["https://kyc.blink.sv", "https://fiat.blink.sv"]
+
+  it("matches an exact origin regardless of path and query", () => {
+    expect(isAllowedOrigin("https://kyc.blink.sv/webflow?token=x", allowlist)).toBe(true)
+    expect(isAllowedOrigin("https://fiat.blink.sv?accountId=1", allowlist)).toBe(true)
+  })
+
+  it.each([
+    ["allowlisted host in the path", "https://evil.com/kyc.blink.sv"],
+    ["allowlisted host as subdomain prefix", "https://kyc.blink.sv.evil.com"],
+    ["lookalike host", "https://kycxblink.sv"],
+    ["subdomain of allowlisted host", "https://sub.kyc.blink.sv"],
+  ])("rejects substring attacks: %s", (_label, url) => {
+    expect(isAllowedOrigin(url, allowlist)).toBe(false)
+  })
+
+  it("rejects scheme and port confusion", () => {
+    expect(isAllowedOrigin("http://kyc.blink.sv", allowlist)).toBe(false)
+    expect(isAllowedOrigin("https://kyc.blink.sv:8443", allowlist)).toBe(false)
+  })
+
+  it("rejects anything against an empty allowlist", () => {
+    expect(isAllowedOrigin("https://kyc.blink.sv", [])).toBe(false)
+  })
+
+  it("rejects unparseable urls", () => {
+    expect(isAllowedOrigin("about:blank", allowlist)).toBe(false)
+    expect(isAllowedOrigin(undefined, allowlist)).toBe(false)
+  })
+})
+
+describe("originsFromUrls", () => {
+  it("maps urls to their origins", () => {
+    expect(
+      originsFromUrls(["https://kyc.blink.sv/webflow", "https://fiat.blink.sv?a=1"]),
+    ).toEqual(["https://kyc.blink.sv", "https://fiat.blink.sv"])
+  })
+
+  it("dedupes same-origin urls", () => {
+    expect(
+      originsFromUrls(["http://localhost:3000/kyc", "http://localhost:3000/fiat"]),
+    ).toEqual(["http://localhost:3000"])
+  })
+
+  it("drops unparseable and empty entries instead of failing open", () => {
+    expect(
+      originsFromUrls(["", undefined, null, "garbage", "https://ok.example"]),
+    ).toEqual(["https://ok.example"])
+  })
+
+  it("returns an empty list for empty input", () => {
+    expect(originsFromUrls([])).toEqual([])
+  })
+})

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -77,8 +77,18 @@ export const resolveGaloyInstanceOrDefault = (
     // A Custom instance persisted by an older app version lacks fields added
     // since it was saved (e.g. fiatUrl, sparkExplorer) — backfill those from
     // the Main instance defaults while keeping every persisted custom value.
+    //
+    // A blank string counts as absent, not as a custom value: the developer
+    // screen seeds every URL input with "" when the current instance is not
+    // Custom and saves them verbatim, so a user who switches to Custom while
+    // filling in only some fields would otherwise persist "" over the defaults.
+    // For kycUrl/fiatUrl that empties the WebView entry allowlist and locks KYC
+    // and buy/sell out behind a generic error (see webview.tsx entryOrigins).
     const persistedFields = Object.fromEntries(
-      Object.entries(input).filter(([, value]) => value !== undefined),
+      Object.entries(input).filter(
+        ([, value]) =>
+          value !== undefined && !(typeof value === "string" && value.trim() === ""),
+      ),
     )
     return { ...GALOY_INSTANCES[0], ...persistedFields, id: "Custom" }
   }

--- a/app/navigation/deep-link-screens.ts
+++ b/app/navigation/deep-link-screens.ts
@@ -1,0 +1,66 @@
+import { LinkingOptions } from "@react-navigation/native"
+
+import { RootStackParamList } from "./stack-param-lists"
+
+/**
+ * The deep-linkable routes. Kept in its own module so the set can be asserted
+ * in tests: adding a route here makes it reachable from a crafted external URL,
+ * so any route that trusts its own params must stay out. `webView` is the live
+ * example — its `allowArbitraryUrl` param bypasses the origin allowlist and is
+ * safe only because no deep link can reach the route (see stack-param-lists.ts).
+ */
+export const DEEP_LINK_SCREENS: NonNullable<
+  NonNullable<LinkingOptions<RootStackParamList>["config"]>["screens"]
+> = {
+  Primary: {
+    screens: {
+      Home: "home",
+      People: {
+        path: "people",
+        initialRouteName: "peopleHome",
+        screens: {
+          circlesDashboard: "circles",
+        },
+      },
+      Earn: "earn",
+      Map: "map",
+    },
+  },
+  priceHistory: "price",
+  receiveBitcoin: "receive",
+  conversionDetails: "convert",
+  scanningQRCode: "scan-qr",
+  totpRegistrationInitiate: "settings/2fa",
+  currency: "settings/display-currency",
+  defaultWallet: "settings/default-account",
+  language: "settings/language",
+  theme: "settings/theme",
+  security: "settings/security",
+  accountScreen: "settings/account",
+  transactionLimitsScreen: "settings/tx-limits",
+  feeRatesScreen: "settings/fee-rates",
+  notificationSettingsScreen: "settings/notifications",
+  emailRegistrationInitiate: "settings/email",
+  settings: "settings",
+  cardDashboardScreen: "card",
+  cardDetailsScreen: "card/details",
+  cardLimitsScreen: "card/limits",
+  cardSettingsScreen: "card/settings",
+  cardStatementsScreen: "card/statements",
+  cardTransactionDetailsScreen: {
+    path: "card/transaction/:transactionId",
+  },
+  accountMigrationEntry: "account-migration",
+  cardOnboardingWelcomeScreen: "card/onboarding",
+  cardOnboardingSubscribeScreen: "card/onboarding/subscribe",
+  cardOnboardingLoadingScreen: "card/onboarding/loading",
+  cardOnboardingPersonalInfoScreen: "card/onboarding/personal-info",
+  cardOnboardingAcknowledgementScreen: "card/onboarding/acknowledgement",
+  cardOnboardingProcessingScreen: "card/onboarding/processing",
+  cardOnboardingPreapprovedScreen: "card/onboarding/preapproved",
+  cardOnboardingApprovedScreen: "card/onboarding/approved",
+  transactionDetail: {
+    path: "transaction/:txid",
+  },
+  sendBitcoinDestination: ":payment",
+}

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -20,6 +20,7 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useMigrationBlocker } from "@app/screens/account-migration/hooks/use-migration-blocker"
 
+import { DEEP_LINK_SCREENS } from "./deep-link-screens"
 import { isMigrationRoute } from "./migration-routes"
 import { RootStackParamList } from "./stack-param-lists"
 import { isUnlockInProgress } from "./unlock-routes"
@@ -283,59 +284,7 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
       "lnurl://",
     ],
     config: {
-      screens: {
-        Primary: {
-          screens: {
-            Home: "home",
-            People: {
-              path: "people",
-              initialRouteName: "peopleHome",
-              screens: {
-                circlesDashboard: "circles",
-              },
-            },
-            Earn: "earn",
-            Map: "map",
-          },
-        },
-        priceHistory: "price",
-        receiveBitcoin: "receive",
-        conversionDetails: "convert",
-        scanningQRCode: "scan-qr",
-        totpRegistrationInitiate: "settings/2fa",
-        currency: "settings/display-currency",
-        defaultWallet: "settings/default-account",
-        language: "settings/language",
-        theme: "settings/theme",
-        security: "settings/security",
-        accountScreen: "settings/account",
-        transactionLimitsScreen: "settings/tx-limits",
-        feeRatesScreen: "settings/fee-rates",
-        notificationSettingsScreen: "settings/notifications",
-        emailRegistrationInitiate: "settings/email",
-        settings: "settings",
-        cardDashboardScreen: "card",
-        cardDetailsScreen: "card/details",
-        cardLimitsScreen: "card/limits",
-        cardSettingsScreen: "card/settings",
-        cardStatementsScreen: "card/statements",
-        cardTransactionDetailsScreen: {
-          path: "card/transaction/:transactionId",
-        },
-        accountMigrationEntry: "account-migration",
-        cardOnboardingWelcomeScreen: "card/onboarding",
-        cardOnboardingSubscribeScreen: "card/onboarding/subscribe",
-        cardOnboardingLoadingScreen: "card/onboarding/loading",
-        cardOnboardingPersonalInfoScreen: "card/onboarding/personal-info",
-        cardOnboardingAcknowledgementScreen: "card/onboarding/acknowledgement",
-        cardOnboardingProcessingScreen: "card/onboarding/processing",
-        cardOnboardingPreapprovedScreen: "card/onboarding/preapproved",
-        cardOnboardingApprovedScreen: "card/onboarding/approved",
-        transactionDetail: {
-          path: "transaction/:txid",
-        },
-        sendBitcoinDestination: ":payment",
-      },
+      screens: DEEP_LINK_SCREENS,
     },
     getInitialURL: async () => {
       const url = await Linking.getInitialURL()

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -172,7 +172,10 @@ export type RootStackParamList = {
     /**
      * DEV ONLY — bypasses the instance-origin allowlist of the WebView screen.
      * Must only be set from the developer screen; the webView route is not
-     * deep-linkable, so the param cannot arrive from outside the app.
+     * deep-linkable, so the param cannot arrive from outside the app. That
+     * invariant is enforced by a test over DEEP_LINK_SCREENS in
+     * navigation-container-wrapper — adding a deep link for this route would
+     * make the bypass reachable from a crafted URL.
      */
     allowArbitraryUrl?: boolean
   }

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -165,7 +165,17 @@ export type RootStackParamList = {
   totpRegistrationInitiate: undefined
   totpRegistrationValidate: { totpRegistrationId: string }
   totpLoginValidate: { authToken: string }
-  webView: { url: string; initialTitle?: string; headerTitle?: string }
+  webView: {
+    url: string
+    initialTitle?: string
+    headerTitle?: string
+    /**
+     * DEV ONLY — bypasses the instance-origin allowlist of the WebView screen.
+     * Must only be set from the developer screen; the webView route is not
+     * deep-linkable, so the param cannot arrive from outside the app.
+     */
+    allowArbitraryUrl?: boolean
+  }
   fullOnboardingFlow: undefined
   notificationHistory: undefined
   onboarding: NavigatorScreenParams<OnboardingStackParamList>

--- a/app/screens/developer-screen/developer-screen.tsx
+++ b/app/screens/developer-screen/developer-screen.tsx
@@ -293,6 +293,7 @@ export const DeveloperScreen: React.FC = () => {
             onPress={() =>
               navigate("webView", {
                 url: urlWebView,
+                allowArbitraryUrl: true,
               })
             }
           />

--- a/app/screens/webview/webview.tsx
+++ b/app/screens/webview/webview.tsx
@@ -8,6 +8,7 @@ import { headerLeftNoGlass } from "@app/components/header-no-glass"
 import { useAppConfig } from "@app/hooks/use-app-config"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { openExternalUrl } from "@app/utils/external"
+import { logError } from "@app/utils/log-error"
 import { isAllowedOrigin, originOf, originsFromUrls } from "@app/utils/webview-origin"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -41,7 +42,9 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
   } = useAppConfig()
 
   const webview = React.useRef<WebView | null>(null)
-  const [jsInjected, setJsInjected] = React.useState(false)
+  // Not state: this guards a native side effect, is read and written inside the
+  // same event callback, and must be atomic across events within one render.
+  const jsInjected = React.useRef(false)
 
   const navigation = useNavigation()
   const [canGoBack, setCanGoBack] = React.useState<boolean>(false)
@@ -66,6 +69,10 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
     () => originsFromUrls(allowArbitraryUrl ? [url] : [fiatUrl]),
     [allowArbitraryUrl, url, fiatUrl],
   )
+
+  // Only a flow that started on a bridge origin can lose the bridge by hopping
+  // off it; KYC never had one, so its loads must not raise a breadcrumb.
+  const entryIsBridgeOrigin = isAllowedOrigin(url, bridgeOrigins)
 
   // https-only navigation, except when the entry itself is http (Local
   // instance / developer screen) — the scheme filter is enforced natively.
@@ -106,10 +113,20 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
 
   React.useEffect(() => {
     if (entryAllowed) return
+    // The user only ever sees a generic error, so record which origin was
+    // refused — a misconfigured instance and a genuine block look identical.
+    logError({
+      scope: "webview",
+      error: `refused entry URL (${originOf(url) ?? "unparseable"}), allowed: ${
+        entryOrigins.join(", ") || "none"
+      }`,
+      expected: true,
+      dedupKey: "webview-entry-refused",
+    })
     Alert.alert(LL.common.error(), LL.GaloyAddressScreen.somethingWentWrong(), [
       { text: LL.common.ok(), onPress: () => navigation.goBack() },
     ])
-  }, [entryAllowed, LL, navigation])
+  }, [entryAllowed, url, entryOrigins, LL, navigation])
 
   const handleWebViewNavigationStateChange = (newNavState: WebViewNavigation) => {
     setCanGoBack(newNavState.canGoBack)
@@ -173,28 +190,64 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
         ref={webview}
         source={{ uri: url }}
         originWhitelist={originWhitelist}
-        setSupportMultipleWindows={false}
+        // Load-bearing, do not set to false: on Android the open-window event is
+        // dispatched only from RNCWebChromeClient.onCreateWindow, which the
+        // platform calls only while multiple windows are supported. With false
+        // the handler below is dead code there and window.open / target=_blank
+        // navigates this trusted WebView in place instead — the opposite of the
+        // intent. react-native-webview drops the popup itself once the handler
+        // is registered, so nothing opens in-app either way.
+        setSupportMultipleWindows={true}
         onOpenWindow={(e: WebViewOpenWindowEvent) => {
           // window.open / target=_blank never spawns a second in-app view:
           // https targets go to the system browser, everything else is dropped.
           const target = e.nativeEvent.targetUrl
           if (originOf(target)?.startsWith("https:")) {
             openExternalUrl(target)
+            return
           }
+          // Dropping is silent to the page, so leave a breadcrumb: a partner
+          // flow that stalls on a swallowed popup is otherwise undiagnosable.
+          logError({
+            scope: "webview",
+            error: `dropped non-https window.open target (${originOf(target) ?? "unparseable"})`,
+            expected: true,
+            dedupKey: "webview-window-open-dropped",
+          })
         }}
-        onLoadStart={() => setJsInjected(false)}
+        onLoadStart={() => {
+          jsInjected.current = false
+        }}
         onLoadProgress={(e: WebViewProgressEvent) => {
-          if (!jsInjected && e.nativeEvent.progress > 0.75) {
-            if (webview.current) {
-              webview.current.injectJavaScript(injectThemeJs())
-              // The WebLN bridge is decided per load, against the URL of the
-              // document actually loading, so a cross-origin redirect never
-              // carries the bridge with it.
-              if (isAllowedOrigin(e.nativeEvent.url, bridgeOrigins)) {
-                webview.current.injectJavaScript(injectJs())
-              }
-              setJsInjected(true)
-            } else Alert.alert("Error", "Webview not ready")
+          if (jsInjected.current || e.nativeEvent.progress <= 0.75) return
+          if (!webview.current) {
+            Alert.alert("Error", "Webview not ready")
+            return
+          }
+          // Latch before injecting, and in a ref rather than state: two progress
+          // callbacks can arrive before React re-renders, and a state guard lets
+          // both through — double-injecting the WebLN shim registers duplicate
+          // listeners and pollers, so one sendPayment navigates twice.
+          jsInjected.current = true
+          webview.current.injectJavaScript(injectThemeJs())
+          // The WebLN bridge is decided per load, against the URL of the
+          // document actually loading, so a cross-origin redirect never
+          // carries the bridge with it.
+          if (isAllowedOrigin(e.nativeEvent.url, bridgeOrigins)) {
+            webview.current.injectJavaScript(injectJs())
+            return
+          }
+          // Withholding the bridge mid-flow is invisible to the user: the page
+          // just never gets window.webln and the payment silently never starts.
+          if (entryIsBridgeOrigin) {
+            logError({
+              scope: "webview",
+              error: `WebLN bridge withheld: ${
+                originOf(e.nativeEvent.url) ?? "unparseable"
+              } is not a bridge origin`,
+              expected: true,
+              dedupKey: "webview-webln-bridge-withheld",
+            })
           }
         }}
         onNavigationStateChange={handleWebViewNavigationStateChange}
@@ -202,6 +255,10 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
           // Pages can reach window.ReactNativeWebView.postMessage without the
           // injected shim, so the injection gate alone is not a boundary —
           // drop any message that does not come from a bridge origin.
+          // Note this is the TOP-FRAME url: a third-party iframe embedded by a
+          // bridge origin passes the check. Accepted for now (the bridge origin
+          // is ours and controls what it embeds); frame-level identity would
+          // need a nonce handshake through the injected shim.
           if (!isAllowedOrigin(event.nativeEvent.url, bridgeOrigins)) return
           weblnHandler(event)
         }}

--- a/app/screens/webview/webview.tsx
+++ b/app/screens/webview/webview.tsx
@@ -1,18 +1,24 @@
 import * as React from "react"
 import { Alert, TouchableOpacity } from "react-native"
 import { injectJs, onMessageHandler } from "react-native-webln"
-import { WebView, WebViewNavigation } from "react-native-webview"
+import { WebView, WebViewMessageEvent, WebViewNavigation } from "react-native-webview"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { headerLeftNoGlass } from "@app/components/header-no-glass"
+import { useAppConfig } from "@app/hooks/use-app-config"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { openExternalUrl } from "@app/utils/external"
+import { isAllowedOrigin, originOf, originsFromUrls } from "@app/utils/webview-origin"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, useTheme } from "@rn-vui/themed"
 
 import { Screen } from "../../components/screen"
 import { RootStackParamList } from "../../navigation/stack-param-lists"
-import { WebViewProgressEvent } from "react-native-webview/lib/WebViewTypes"
+import {
+  WebViewOpenWindowEvent,
+  WebViewProgressEvent,
+} from "react-native-webview/lib/WebViewTypes"
 
 type WebViewDebugScreenRouteProp = RouteProp<RootStackParamList, "webView">
 
@@ -25,8 +31,14 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
 
   const { navigate } =
     useNavigation<NativeStackNavigationProp<RootStackParamList, "Primary">>()
-  const { url, initialTitle, headerTitle } = route.params
+  const { url, initialTitle, headerTitle, allowArbitraryUrl } = route.params
   const { LL } = useI18nContext()
+
+  const {
+    appConfig: {
+      galoyInstance: { kycUrl, fiatUrl },
+    },
+  } = useAppConfig()
 
   const webview = React.useRef<WebView | null>(null)
   const [jsInjected, setJsInjected] = React.useState(false)
@@ -37,6 +49,31 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
   const {
     theme: { colors, mode },
   } = useTheme()
+
+  // Only origins owned by the active Galoy instance may load in this WebView
+  // (the developer screen's free-text entry bypasses this via allowArbitraryUrl).
+  const entryOrigins = React.useMemo(
+    () => originsFromUrls([kycUrl, fiatUrl]),
+    [kycUrl, fiatUrl],
+  )
+  const entryAllowed = allowArbitraryUrl === true || isAllowedOrigin(url, entryOrigins)
+
+  // The WebLN bridge (window.webln -> sendPayment) is only for the fiat
+  // buy/sell pages; KYC never needs it. Under allowArbitraryUrl the entry
+  // origin doubles as the bridge origin so WebLN stays testable from the
+  // developer screen.
+  const bridgeOrigins = React.useMemo(
+    () => originsFromUrls(allowArbitraryUrl ? [url] : [fiatUrl]),
+    [allowArbitraryUrl, url, fiatUrl],
+  )
+
+  // https-only navigation, except when the entry itself is http (Local
+  // instance / developer screen) — the scheme filter is enforced natively.
+  const originWhitelist = React.useMemo(
+    () =>
+      originOf(url)?.startsWith("http:") ? ["https://*", "http://*"] : ["https://*"],
+    [url],
+  )
 
   const handleBackPress = React.useCallback(() => {
     if (webview.current && canGoBack) {
@@ -67,6 +104,13 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
     })
   }, [navigation, handleBackPress, LL, styles.iconContainer, colors.black])
 
+  React.useEffect(() => {
+    if (entryAllowed) return
+    Alert.alert(LL.common.error(), LL.GaloyAddressScreen.somethingWentWrong(), [
+      { text: LL.common.ok(), onPress: () => navigation.goBack() },
+    ])
+  }, [entryAllowed, LL, navigation])
+
   const handleWebViewNavigationStateChange = (newNavState: WebViewNavigation) => {
     setCanGoBack(newNavState.canGoBack)
     if (!headerTitle && newNavState.title) {
@@ -80,60 +124,87 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
     `
   }
 
+  const weblnHandler = onMessageHandler(webview as React.MutableRefObject<WebView>, {
+    enable: async () => {
+      /* Your implementation goes here */
+    },
+    getInfo: async () => {
+      /* Your implementation goes here */
+      return { node: { alias: "alias", color: "color", pubkey: "pubkey" } }
+    },
+    makeInvoice: async (_args) => {
+      /* Your implementation goes here */
+      return { paymentRequest: "paymentRequest" }
+    },
+    sendPayment: async (paymentRequestStr) => {
+      navigate("sendBitcoinDestination", {
+        payment: paymentRequestStr,
+      })
+
+      return { preimage: "preimage" }
+      /* Your implementation goes here */
+    },
+    signMessage: async (_message) => {
+      /* Your implementation goes here */
+      return { signature: "signature", message: "message" }
+    },
+    verifyMessage: async (_signature, _message) => {
+      /* Your implementation goes here */
+    },
+    keysend: async (_args) => {
+      /* Your implementation goes here */
+      return { preimage: "preimage" }
+    },
+
+    // Non-WebLN
+    // Called when an a-tag containing a `lightning:` uri is found on a page
+    // foundInvoice: async (paymentRequestStr) => {
+    //   /* Your implementation goes here */
+    // },
+  })
+
+  if (!entryAllowed) {
+    return <Screen />
+  }
+
   return (
     <Screen>
       <WebView
         ref={webview}
         source={{ uri: url }}
+        originWhitelist={originWhitelist}
+        setSupportMultipleWindows={false}
+        onOpenWindow={(e: WebViewOpenWindowEvent) => {
+          // window.open / target=_blank never spawns a second in-app view:
+          // https targets go to the system browser, everything else is dropped.
+          const target = e.nativeEvent.targetUrl
+          if (originOf(target)?.startsWith("https:")) {
+            openExternalUrl(target)
+          }
+        }}
         onLoadStart={() => setJsInjected(false)}
         onLoadProgress={(e: WebViewProgressEvent) => {
           if (!jsInjected && e.nativeEvent.progress > 0.75) {
             if (webview.current) {
               webview.current.injectJavaScript(injectThemeJs())
-              webview.current.injectJavaScript(injectJs())
+              // The WebLN bridge is decided per load, against the URL of the
+              // document actually loading, so a cross-origin redirect never
+              // carries the bridge with it.
+              if (isAllowedOrigin(e.nativeEvent.url, bridgeOrigins)) {
+                webview.current.injectJavaScript(injectJs())
+              }
               setJsInjected(true)
             } else Alert.alert("Error", "Webview not ready")
           }
         }}
         onNavigationStateChange={handleWebViewNavigationStateChange}
-        onMessage={onMessageHandler(webview as React.MutableRefObject<WebView>, {
-          enable: async () => {
-            /* Your implementation goes here */
-          },
-          getInfo: async () => {
-            /* Your implementation goes here */
-            return { node: { alias: "alias", color: "color", pubkey: "pubkey" } }
-          },
-          makeInvoice: async (_args) => {
-            /* Your implementation goes here */
-            return { paymentRequest: "paymentRequest" }
-          },
-          sendPayment: async (paymentRequestStr) => {
-            navigate("sendBitcoinDestination", {
-              payment: paymentRequestStr,
-            })
-
-            return { preimage: "preimage" }
-            /* Your implementation goes here */
-          },
-          signMessage: async (_message) => {
-            /* Your implementation goes here */
-            return { signature: "signature", message: "message" }
-          },
-          verifyMessage: async (_signature, _message) => {
-            /* Your implementation goes here */
-          },
-          keysend: async (_args) => {
-            /* Your implementation goes here */
-            return { preimage: "preimage" }
-          },
-
-          // Non-WebLN
-          // Called when an a-tag containing a `lightning:` uri is found on a page
-          // foundInvoice: async (paymentRequestStr) => {
-          //   /* Your implementation goes here */
-          // },
-        })}
+        onMessage={(event: WebViewMessageEvent) => {
+          // Pages can reach window.ReactNativeWebView.postMessage without the
+          // injected shim, so the injection gate alone is not a boundary —
+          // drop any message that does not come from a bridge origin.
+          if (!isAllowedOrigin(event.nativeEvent.url, bridgeOrigins)) return
+          weblnHandler(event)
+        }}
         style={styles.full}
         allowsInlineMediaPlayback
       />

--- a/app/utils/webview-origin.ts
+++ b/app/utils/webview-origin.ts
@@ -1,0 +1,44 @@
+/**
+ * Origin helpers for the in-app WebView (see webview.tsx).
+ *
+ * All helpers fail closed: an unparseable or non-http(s) URL never matches
+ * anything. Same pattern as isMigrationDeeplink in navigation-container-wrapper.
+ */
+
+/**
+ * Returns the exact origin (scheme://host[:port]) of a URL, or null when the
+ * URL is unparseable or not http(s). `URL.origin` normalizes case and elides
+ * default ports, so matching is structural — never a substring comparison.
+ */
+export const originOf = (url: string | undefined | null): string | null => {
+  if (!url) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null
+    return parsed.origin
+  } catch {
+    return null
+  }
+}
+
+/** Exact-origin membership test. Unparseable url or empty allowlist => false. */
+export const isAllowedOrigin = (
+  url: string | undefined | null,
+  allowedOrigins: readonly string[],
+): boolean => {
+  const origin = originOf(url)
+  if (origin === null) return false
+  return allowedOrigins.includes(origin)
+}
+
+/**
+ * Origins of the given URLs, deduplicated. Unparseable entries are dropped —
+ * a misconfigured (e.g. Custom-instance) URL must shrink the allowlist, not
+ * open it.
+ */
+export const originsFromUrls = (
+  urls: readonly (string | undefined | null)[],
+): string[] => {
+  const origins = urls.map(originOf).filter((origin): origin is string => origin !== null)
+  return [...new Set(origins)]
+}


### PR DESCRIPTION
Closes blinkbitcoin/blink-wip#1139 — item 1 (the Medium lead item) of the red-team hardening epic [blink-wip#1092](https://github.com/blinkbitcoin/blink-wip/issues/1092).

> **One deliberate deviation from the issue text.** #1139's remediation summary lists `setSupportMultipleWindows={false}`. This PR ships `true`. That line of the remediation is wrong: `false` makes `onOpenWindow` dead code on Android, so `window.open` navigates the trusted WebView in place — defeating the very requirement it sits next to. The intent of the item is met; the letter is not. Reasoning and sources under "Review follow-ups" below.

## Problem

`webview.tsx` — the app's only WebView, used for KYC/Onfido and the fiat buy/sell pages — had no origin controls at all:

- the `url` route param rendered unvalidated, with the default `originWhitelist` (http+https);
- the WebLN shim was re-injected on **every** navigation, including cross-origin redirects;
- the hole is actually wider than the audit stated: `onMessage` was wired unconditionally, so a page didn't even need the injected shim — anything posting a correctly-shaped message to `window.ReactNativeWebView.postMessage` reached the live `sendPayment` handler, which navigates into the send flow with an attacker-chosen bolt11 (pre-fill/phishing vector; payment still needs user confirmation downstream).

## Fix — three layers

1. **Entry gate**: only origins of the active galoy instance's `kycUrl`/`fiatUrl` may load; a refused URL shows the generic error alert and never mounts the WebView.
2. **Injection gate**: the WebLN shim is injected per load, decided against `e.nativeEvent.url` of the document actually loading — a cross-origin redirect never carries the bridge, and redirecting back re-injects correctly.
3. **Message gate** (the load-bearing one): `onMessage` drops any event whose origin is not a bridge origin.

Plus cheap native-layer hardening: `originWhitelist` https-only (widened to http only when the entry URL itself is http — Local instance / dev screen), `setSupportMultipleWindows={true}` (**deliberately not `false`** — see "Review follow-ups" below; `false` makes the popup handler dead code on Android), and `onOpenWindow` routing https popups to the system browser and dropping everything else.

The new `app/utils/webview-origin.ts` helpers are fail-closed (`URL.origin` exact matching — no substring logic; unparseable/`about:blank`/`javascript:`/`data:`/`file:` URLs match nothing, and a misconfigured Custom-instance URL shrinks the allowlist rather than opening it).

## Decisions & rejected alternatives

- **Bridge origins = fiat only.** KYC/Onfido pages have no use for `window.webln`; the only live handler exists for the buy/sell flow. Under `allowArbitraryUrl` the entry origin doubles as the bridge origin so WebLN stays testable from the developer screen.
- **Allowlist derived from the active instance, not hardcoded** — Main/Staging/Local/Custom keep working with zero config.
- **Off-origin https navigation stays allowed.** Onfido KYC redirects through its own domains mid-flow; hard-blocking navigation would break KYC. The boundary is "no bridge off-origin", not "no navigation off-origin".
- **No `onShouldStartLoadWithRequest` policy** — it misses iOS server-side redirects and is platform-asymmetric for iframes; building the boundary there would be fragile. Scheme filtering is delegated to the natively-enforced `originWhitelist`.
- **Dev escape hatch is a route param** (`allowArbitraryUrl`, set only by the dev-gated developer screen). The `webView` route is not in the deep-link config, so the param cannot be forged from outside the app.

## Accepted residual risks

- A hostile iframe *inside* an allowlisted Blink-owned page is within the page owner's trust domain.
- The page-title-as-header behavior is left as is — entry is now origin-restricted, and changing header behavior would touch KYC UX.
- The audit's KYC-token-in-query-string observation is a server-side URL design issue, out of scope here.

## Tests

- New `__tests__/utils/webview-origin.spec.ts` (22 cases): normalization, fail-closed set, substring attacks (`kyc.blink.sv.evil.com`, `evil.com/kyc.blink.sv`), scheme/port confusion, dedupe/drop.
- `webview-screen.spec.tsx` extended (24 cases): bridge injected on fiat origin / not after off-origin load / never on KYC; off-origin messages dropped; refused entry never mounts; dev escape hatch works; hardening props asserted. Existing fixtures moved from `example.com` hosts to the Main-instance origins the test context pins.



---

## Review follow-ups (a0b49cd)

[a0b49cd](https://github.com/blinkbitcoin/blink-mobile/commit/a0b49cd1c30f3d787cd20210349a7c7c90271389) addresses findings from review of e4c0b50.

**`setSupportMultipleWindows` is now `true`, and that is load-bearing.** Setting it `false` made `onOpenWindow` dead code on Android: the open-window event is dispatched only from [`RNCWebChromeClient.onCreateWindow`](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java#L89), which the platform calls only while multiple windows are supported ([the library's own default is `true`](https://github.com/react-native-webview/react-native-webview/blob/master/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt#L79)). So `window.open` / `target=_blank` navigated *this* trusted WebView in place — the opposite of the intent, and the one case the hardening was meant to cover. With the handler registered, react-native-webview drops the popup itself, so nothing opens in-app either way. The old prop was asserted by a test, which is why the contradiction survived; the test now asserts `true` and says why.

**Blank Custom-instance URLs no longer lock the user out.** The developer screen seeds every URL input with `""` when the current instance is not Custom and [saves them verbatim](https://github.com/blinkbitcoin/blink-mobile/blob/a0b49cd1c30f3d787cd20210349a7c7c90271389/app/screens/developer-screen/developer-screen.tsx#L92-L98), and `resolveGaloyInstanceOrDefault` only backfilled `undefined`. The empty strings therefore overrode the Main defaults, `entryOrigins` came out empty, and every KYC and buy/sell entry failed the check behind the generic error — with nothing in the logs to distinguish it from a genuine block. Fixed [in the resolver rather than at the developer screen](https://github.com/blinkbitcoin/blink-mobile/blob/a0b49cd1c30f3d787cd20210349a7c7c90271389/app/config/galoy-instances.ts#L80-L92): blank now counts as absent for *every* field, so `posUrl`, `lnAddressHostname` and the rest get the same protection instead of one patched call site.

**The injection latch is a ref, and latches before injecting.** Two native progress callbacks can arrive before React re-renders; both passed the old state guard, double-injecting the WebLN shim. `react-native-webln`'s `inject.ts` accumulates rather than replaces, so duplicate listeners and pollers registered and one `sendPayment` could navigate twice. This one predates the PR but sits in a function it rewrites, and the PR made the origin decision depend on the same timing.

**Three silent-failure paths now leave a breadcrumb** (all `expected: true`, so they are Crashlytics breadcrumbs, not non-fatals): a refused entry URL records which origin was refused and what was allowed; a fiat flow that hops off-origin records that the bridge was withheld; a dropped `window.open` target records the scheme. The bridge breadcrumb is gated on the entry itself being a bridge origin, so KYC — which never has a bridge — stays quiet.

**The `allowArbitraryUrl` invariant is now tested.** Its safety rested on "the `webView` route is not deep-linkable", asserted only in a doc comment, with nothing to catch a later PR adding a deep link for it. The screens map moved to `app/navigation/deep-link-screens.ts` and [a test locks it](https://github.com/blinkbitcoin/blink-mobile/blob/a0b49cd1c30f3d787cd20210349a7c7c90271389/__tests__/navigation/deep-link-screens.spec.ts), top level and nested, plus a positive assertion so the traversal cannot go vacuously green.

### Reviewed and deliberately not changed

- **`window.opener` is severed for https popups.** Routing them to the system browser does break the opener/`postMessage` channel that popup-based 3DS and bank SSO use. Kept anyway: pre-PR those popups landed in a `WebView` that `onCreateWindow` creates but never attaches to a view hierarchy, so the user could not see or interact with them either. If a partner flow turns out to need this, the fix is an in-app popup screen, not re-opening in-place navigation.
- **`onOpenWindow` forwards any https target without a host allowlist.** An external browser open exposes no app credentials or session, and scoping it to instance origins would break ordinary help/ToS links. The scheme check stays the boundary.
- **`originWhitelist` widening to `http://*` for an http entry** was raised as a host-level wildcard. It is — but `extractOrigin` in the library matches scheme+host+port, the pre-PR code passed no `originWhitelist` at all, and this only applies to a Local/dev entry. Unchanged prior default, not a regression from this PR.
- **The message gate reads the top-frame URL,** so a third-party iframe embedded by a bridge origin passes it. Already listed as an accepted residual risk above; the code comment now says so explicitly instead of implying frame-level identity.

### Tests

134 tests green across the webview, config, navigation and authentication suites. Each new test was verified non-vacuous by mutation: reverting the popup prop, the ref latch, and the blank-string filter each fails exactly its own test and nothing else.

- `webview-screen.spec.tsx`: multiple-window support asserted on with the Android reasoning; two progress events in one load inject each payload once; sub-threshold progress injects nothing; off-origin load now asserts theme JS *is* re-injected (previously the bridge count alone could not distinguish a working origin gate from a stuck latch); breadcrumbs for refused entry, withheld bridge and dropped popup targets, and the KYC quiet case; `http:` popup target dropped alongside `javascript:`.
- `galoy-instances.spec.ts`: blank and whitespace-only Custom URLs fall back to Main defaults while non-blank persisted values survive.
- `deep-link-screens.spec.ts` (new): `webView` absent top level and nested, with a positive control.

