### PR TITLE
feat(agents): Android session claiming — the port trap that silently breaks Android demos

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(xcrun simctl *)",
+      "Bash(adb *)",
+      "Bash(emulator *)",
       "Bash(maestro *)",
       "Bash(ffmpeg *)",
       "Bash(ffprobe *)",

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -21,6 +21,7 @@ instructions (e.g. `AGENTS.md`).
 | Skill | One line |
 |---|---|
 | [`react-native-ios-simulator`](./react-native-ios-simulator/SKILL.md) | Claim/release an **isolated** simulator + Metro port; reach screens and states (stubs, reinstall via `reset-app.sh`); never touches your simulator or your Metro on 8081 |
+| [`react-native-android-emulator`](./react-native-android-emulator/SKILL.md) | Claim/release an **isolated** emulator + Metro port (shares the iOS skill's registry, so the two can never collide); points the app at your port via `debug_http_host`, because an emulator otherwise dials 10.0.2.2:8081 — another agent's Metro |
 | [`react-native-demo-screenshots`](./react-native-demo-screenshots/SKILL.md) | Settle-aware capture, honest before/after crop pairs, numeric comparison against design mocks |
 | [`react-native-demo-videos`](./react-native-demo-videos/SKILL.md) | Maestro-driven recordings with safe recorder stop paths, GIF/MP4/WebM encoding, and a guard against the `clearState` Metro-redirect trap |
 | [`github-pr-image-attachments`](./github-pr-image-attachments/SKILL.md) | Embed images in PR comments via an orphan `assets/pr-<N>-*` branch (`gh` has no attachment upload); repo derived from the origin remote |

--- a/.claude/skills/blink-staging-session/SKILL.md
+++ b/.claude/skills/blink-staging-session/SKILL.md
@@ -86,7 +86,7 @@ maestro upgrade voided the baked driver.
 ## After Editing the Scripts
 
 ```bash
-"$BLINK/tests/run.sh"     # exits non-zero on failure; fake maestro/xcrun, no simulator, no network
+"$BLINK/tests/run.sh"     # 23 assertions, ~5s, exits non-zero on failure; fake maestro/xcrun, no simulator, no network
 ```
 
 Same house rule as the other skills: a new guarantee lands with the

--- a/.claude/skills/blink-staging-session/tests/run.sh
+++ b/.claude/skills/blink-staging-session/tests/run.sh
@@ -108,6 +108,15 @@ check "SKILL.md carries the demo-worktree native build prerequisites" "yes" \
 check "SKILL.md never contains a 6-digit literal that could be the PIN" "0" \
   "$(grep -cE '(^|[^0-9.])[0-9]{6}([^0-9.]|$)' "$SKILL_MD")"
 
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
+
 echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.claude/skills/github-pr-image-attachments/SKILL.md
+++ b/.claude/skills/github-pr-image-attachments/SKILL.md
@@ -102,3 +102,13 @@ than the one you embedded.
 ```bash
 curl -sSI "$RAW/after.png" | head -1
 ```
+
+## After Editing the Scripts
+
+```bash
+"$ATT/tests/run.sh"     # 27 assertions, ~5s, exits non-zero on failure
+```
+
+Pushes for real, to a local bare repo standing in for origin: no network, but
+the plumbing that fails silently (tree, refspec) is exercised end to end. If you
+add a guarantee, add the assertion that fails without it.

--- a/.claude/skills/github-pr-image-attachments/tests/run.sh
+++ b/.claude/skills/github-pr-image-attachments/tests/run.sh
@@ -138,6 +138,15 @@ check "SKILL.md keeps the per-org consent rule" "yes" \
 check "SKILL.md warns that raw MP4 will not play" "yes" \
   "$(grep -qi 'octet-stream' "$TESTS_DIR/../SKILL.md" && echo yes || echo no)"
 
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
+
 echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.claude/skills/react-native-android-emulator/SKILL.md
+++ b/.claude/skills/react-native-android-emulator/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: react-native-android-emulator
+description: Use when running a React Native app on an Android emulator — claiming an isolated emulator and Metro port, pointing the app at that port, or any task involving adb, avd, emulator serials or an Android demo. Required before capturing Android screenshots or video, and whenever other agents may share the same machine.
+allowed-tools: Bash(adb *) Bash(emulator *) Bash(maestro *) Bash(node node_modules/react-native/cli.js *) Bash(/*/.claude/skills/*/scripts/*.sh) Bash(/*/.claude/skills/*/scripts/*.sh *) Bash(/*/.claude/skills/*/tests/run.sh)
+---
+
+# React Native on an Isolated Android Emulator
+
+## Overview
+
+The Android twin of `react-native-ios-simulator`, and it exists because the
+documented alternative — "pin the serial of an emulator you started" — does not
+merely run slowly, it **silently produces a broken session**: a red *Unable to
+load script* screen with **zero requests in your Metro log**, which reads like a
+broken bundler rather than a request that went somewhere else.
+
+**Core principle:** every `adb` call is scoped to `$DEMO_ANDROID_SERIAL`, and the
+serial is *ours by construction* — the claim reserves an emulator console port and
+boots with `-port <N>`, which fixes the serial at `emulator-<N>`. An `adb` command
+without `-s` is a bug.
+
+The app under test is configuration: set `DEMO_APP_ID_ANDROID` once per session.
+
+## The thing that surprises everyone
+
+**A React Native app on a stock emulator dials `10.0.2.2:8081`** — the host
+loopback, on a port compiled into the framework. On a machine where several agents
+each hold a Metro, 8081 is somebody else's, so your app loads *their* bundle or
+nothing at all.
+
+Two natural fixes both fail, and it is worth knowing why before you lose an hour:
+
+| Attempt | What actually happens |
+|---|---|
+| `adb reverse tcp:8121 tcp:8121` | Succeeds, changes nothing. Reverse forwarding binds **device-localhost**, and the app is dialing **10.0.2.2** — an address the tunnel never sees. (Reverse forwarding is *not* broken on emulators; it is simply aimed at a door nobody knocks on.) |
+| `adb shell setprop metro.host …` | Does override the emulator heuristic — but carries **no port**; the framework appends its own. It cannot express a claimed port. |
+
+What works is the override the dev menu itself writes: the **`debug_http_host`**
+preference, `host:port`, which `point-app-at-metro.sh` sets to
+`10.0.2.2:<claimed port>`. No tunnel, your port.
+
+## Never Do These
+
+| Forbidden | Why |
+|---|---|
+| `adb` without `-s $DEMO_ANDROID_SERIAL` | Targets whichever single device is attached — usually another agent's emulator |
+| `adb emu kill` on a serial you found | Kills a session that isn't yours; release only ever kills the PID it started |
+| `pkill emulator` / `adb kill-server` | Takes out every agent's emulator and the adb daemon they share |
+| Adopting a running emulator | It is someone's session; claim boots its own, and fails loudly when no AVD is free |
+| Deleting an AVD to free a reservation | AVDs are durable hand-made artifacts; the reaper frees *reservations*, never AVDs |
+| Assuming the app reached your Metro | The failure is silent — `verify-session.sh` is how you know |
+
+## Workflow
+
+### 1. Claim a session
+
+```bash
+SKILL="$(git rev-parse --show-toplevel)"/.claude/skills/react-native-android-emulator
+export DEMO_APP_ID_ANDROID=<your app's application id>
+eval "$("$SKILL/scripts/claim-session.sh" 3712)"          # or: … 3712 Pixel_9a
+```
+
+Exports `DEMO_PR`, `DEMO_ANDROID_SERIAL`, `DEMO_PORT`, `DEMO_SIM_NAME`,
+`DEMO_SESSION_DIR`. It reserves a Metro port **from the same registry the iOS skill
+uses** (an iOS session and an Android session must never land on one port),
+reserves an emulator console port and an AVD, boots that AVD with `-port`, waits
+for `sys.boot_completed`, and records serial/PID/AVD plus a pre-flight list of
+attached devices.
+
+Re-running is idempotent. Concurrency is bounded by **AVD count** — unlike iOS,
+where `simctl create` conjures devices; when all AVDs are reserved the claim fails
+with the list rather than adopting somebody's emulator.
+
+### 2. Get the app onto the emulator
+
+```bash
+adb -s "$DEMO_ANDROID_SERIAL" install -r <path>/app-debug.apk
+```
+
+A debuggable build is required for step 3 (`run-as`), which is the demo case
+anyway.
+
+### 3. Point the app at *your* Metro — the step that is easy to skip
+
+```bash
+node node_modules/react-native/cli.js start --port "$DEMO_PORT" \
+  --config "$(git rev-parse --show-toplevel)"/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js &
+echo $! > "$DEMO_SESSION_DIR/metro.pid"
+
+"$SKILL/scripts/point-app-at-metro.sh"        # debug_http_host = 10.0.2.2:$DEMO_PORT
+adb -s "$DEMO_ANDROID_SERIAL" shell monkey -p "$DEMO_APP_ID_ANDROID" 1
+```
+
+`point-app-at-metro.sh` **force-stops the app** after writing, and that is not
+superstition: the framework caches the resolved host in a process-static field, so
+a value written after auto-detection has already run is ignored until the process
+restarts.
+
+If your worktree shares `node_modules` with another checkout, export
+`DEMO_NODE_MODULES=<real clone>/node_modules` before starting Metro.
+
+### 4. Verify — never assume
+
+```bash
+"$(git rev-parse --show-toplevel)"/.claude/skills/react-native-ios-simulator/scripts/verify-session.sh
+```
+
+Asserts Metro actually served a bundle on your port (watching the dev server's own
+`/events` stream), reports a foreign Metro on 8081, and catches **checkout drift** —
+the shared clone moving to another branch mid-session, which once manufactured a
+phantom crash that looked like the change under test. Demos run from a **detached
+worktree** for exactly this reason.
+
+### 5. Capture
+
+`react-native-demo-screenshots` and `react-native-demo-videos` pick Android up from
+`$DEMO_ANDROID_SERIAL` automatically. One Android-specific rule: a Maestro flow
+with `clearState` **deletes the `debug_http_host` preference**, so the next launch
+dials 8081 again — re-run `point-app-at-metro.sh` after it (the videos skill
+refuses such a flow unless the re-point is acknowledged).
+
+### 6. Release
+
+```bash
+"$SKILL/scripts/release-session.sh" 3712            # keep the session 72h
+"$SKILL/scripts/release-session.sh" 3712 --delete   # drop it now
+```
+
+Kills only the emulator PID this session started and only the Metro PID it
+recorded, frees the port/console-port/AVD reservations, then asserts every device
+attached at claim time is still attached. **A non-zero exit means you disturbed
+someone else's session — report it, don't ignore it.**
+
+## Reaching a screen, and what Android cannot demo yet
+
+The JS-side techniques in the iOS skill (TEMP `initialRouteName`, stubbed hooks,
+TEMP-mounted components, on-screen debug text) are platform-neutral and work here
+unchanged. The `simctl`-side ones do not; Android equivalents:
+
+| Goal | How |
+|---|---|
+| Fresh-install state | `adb -s "$SERIAL" shell pm clear <app-id>` — then **re-run `point-app-at-metro.sh`**, it wipes the pref too |
+| A specific locale | `adb -s "$SERIAL" shell am start -e … ` per app, or change the emulator's system locale |
+| Scrolling / taps | `maestro --udid "$SERIAL" test flow.yaml` (`--udid` takes a serial) |
+| Screens under `FLAG_SECURE` | Black frames — TEMP-disable the screen-security hook and caption it |
+
+**Account-gated screens cannot be demoed on Android yet.** There is no Android
+equivalent of the iOS golden simulator (a blessed, logged-in device cloned per
+session), so a screen reachable only from a signed-in account has no honest
+recording path — the fallback is stills plus a captioned explanation. That gap is
+tracked separately.
+
+## After Editing the Scripts
+
+```bash
+"$SKILL/tests/run.sh"     # 56 assertions, ~20s, exits non-zero on failure; fake adb + emulator, no device, no network
+```
+
+Run it after touching anything in `scripts/`. If you add a guarantee, add the
+assertion that fails without it — the suite is mutation-checked.

--- a/.claude/skills/react-native-android-emulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-android-emulator/scripts/claim-session.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# Claim an isolated Android emulator + Metro port for one PR's demo run.
+#
+# The iOS twin proves ownership with a per-session device NAME; an emulator has
+# no renameable identity, so ownership here rests on three facts recorded at
+# claim time and re-checked at release:
+#
+#   console port  reserved in the shared registry and passed as `emulator -port
+#                 <N>`, which FIXES the serial at emulator-<N>. The serial is
+#                 ours by construction, not by convention.
+#   emulator pid  the process we started; release kills that and nothing else
+#                 (never pkill, never `adb emu kill` on a serial we found).
+#   avd name      reserved too, because an AVD cannot run twice concurrently,
+#                 and cross-checked live with `adb -s <serial> emu avd name`.
+#
+# Usage: claim-session.sh <pr-number> [avd-name]
+#   With no AVD name, the first free AVD from `emulator -list-avds` is taken.
+#   Concurrency is bounded by how many AVDs exist - unlike iOS, where simctl
+#   creates devices on demand. When all are reserved the claim FAILS with the
+#   list rather than adopting somebody's running emulator.
+#
+# Emits the same eval-able contract as the iOS claim, plus DEMO_ANDROID_SERIAL:
+#   eval "$(claim-session.sh 3712)"
+
+set -euo pipefail
+
+# Telemetry is best-effort: a broken, unreadable or absent lib must never break
+# a claim - the fallbacks below turn every tel_* call into a no-op.
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_CLAIM=$(tel_now)
+
+# Reservations are NOT best-effort: an unreserved port silently steals another
+# agent's bundler, so a missing lib is fatal.
+PORTS_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/ports.sh"
+[ -f "$PORTS_LIB" ] || { echo "FATAL: missing $PORTS_LIB - the Android skill shares the iOS skill's registry; they ship together" >&2; exit 1; }
+. "$PORTS_LIB"
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+PR="${1:?usage: claim-session.sh <pr-number> [avd-name]}"
+WANT_AVD="${2:-}"
+
+case "$PR" in
+  ''|*[!0-9]*) die "pr-number must be numeric, got '$PR'" ;;
+esac
+
+command -v adb >/dev/null 2>&1 || die "adb is not on PATH (Android SDK platform-tools)"
+command -v emulator >/dev/null 2>&1 || die "emulator is not on PATH (Android SDK emulator)"
+
+REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
+# Same keying rule as iOS: the full session name, because the registry is
+# machine-wide and two repos can hold the same PR number at once.
+SESSION_NAME="${DEMO_EMU_PREFIX:-${DEMO_SIM_PREFIX:-rn-demo}}-android-pr${PR}"
+SESSION_DIR="$REGISTRY/${SESSION_NAME}"
+
+DEMO_SIM_NAME="$SESSION_NAME"   # session label for telemetry spans
+
+# Sweep expired sessions first, then un-mark our own: an active claim is never
+# reaped.
+T_REAP=$(tel_now)
+"$(dirname "${BASH_SOURCE[0]}")/reap-stale.sh" >/dev/null 2>&1 || true
+tel_emit android.claim.reap "$T_REAP"
+mkdir -p "$SESSION_DIR"
+rm -f "$SESSION_DIR/released-at"
+
+# --- Pre-flight snapshot -----------------------------------------------------
+# Every device attached before we touch anything. release-session.sh asserts
+# this exact set is still attached afterwards - the Android twin of the iOS
+# collateral-damage assertion.
+adb devices | tail -n +2 | awk 'NF>=2 {print $1}' > "$SESSION_DIR/preflight-devices.txt" 2>/dev/null || : > "$SESSION_DIR/preflight-devices.txt"
+PREFLIGHT_COUNT=$(grep -c . "$SESSION_DIR/preflight-devices.txt" || true)
+
+# DEMO_REQUIRED_ENV lists the names of credentials this repo's real-account
+# flows need; unset ones are reported, never blocking - most demos need no
+# account at all. (Same contract as the iOS claim.)
+MISSING_CREDS=""
+for CRED_NAME in ${DEMO_REQUIRED_ENV:-}; do
+  [ -n "$CRED_NAME" ] || continue
+  [ -z "${!CRED_NAME:-}" ] && MISSING_CREDS="$MISSING_CREDS $CRED_NAME"
+done
+MISSING_CREDS="${MISSING_CREDS# }"
+
+# --- Where the demo runs from ------------------------------------------------
+# Recorded so verify-session.sh can catch the trap that manufactured a phantom
+# regression once: the checkout moving to another branch mid-session, after
+# which Metro serves code that is not the code under test.
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  git rev-parse --show-toplevel > "$SESSION_DIR/worktree"
+  git rev-parse HEAD > "$SESSION_DIR/head-sha"
+fi
+
+# --- Metro port --------------------------------------------------------------
+if [ -f "$SESSION_DIR/port" ]; then
+  PORT=$(cat "$SESSION_DIR/port")   # idempotent re-claim
+else
+  PORT=$(reserve_metro_port "$REGISTRY" "$SESSION_NAME" "$PR") || exit 1
+  echo "$PORT" > "$SESSION_DIR/port"
+fi
+
+# A foreign Metro on 8081 is the normal state on a shared Mac, and the reason
+# "just run on 8081" is not available. Name it here rather than leaving the
+# next agent to find it with lsof.
+FOREIGN_8081=""
+lsof -nP -iTCP:8081 -sTCP:LISTEN >/dev/null 2>&1 && FOREIGN_8081=1
+
+# --- Emulator ----------------------------------------------------------------
+serial_of() { echo "emulator-$1"; }
+device_attached() { adb devices | grep -q "^$1[[:space:]]"; }
+
+if [ -f "$SESSION_DIR/console-port" ] && [ -f "$SESSION_DIR/avd" ] \
+   && device_attached "$(serial_of "$(cat "$SESSION_DIR/console-port")")"; then
+  # Idempotent re-claim: our emulator is still running.
+  CONSOLE_PORT=$(cat "$SESSION_DIR/console-port")
+  AVD=$(cat "$SESSION_DIR/avd")
+  SERIAL=$(serial_of "$CONSOLE_PORT")
+  CLAIM_ORIGIN="reclaim"
+else
+  # --- pick an AVD ---
+  AVAILABLE_AVDS=$(emulator -list-avds 2>/dev/null | grep -v '^$' || true)
+  [ -n "$AVAILABLE_AVDS" ] || die "no AVDs exist - create one with:
+       \$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n demo -k '<system-image>'"
+
+  AVD=""
+  if [ -n "$WANT_AVD" ]; then
+    echo "$AVAILABLE_AVDS" | grep -qx "$WANT_AVD" || die "no such AVD '$WANT_AVD'. Available:
+$AVAILABLE_AVDS"
+    reserve_slot "$REGISTRY" avds "$WANT_AVD" "$SESSION_NAME" \
+      || die "AVD '$WANT_AVD' is reserved by another session ($(cat "$REGISTRY/avds/$WANT_AVD/owner" 2>/dev/null))"
+    AVD="$WANT_AVD"
+  else
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if reserve_slot "$REGISTRY" avds "$candidate" "$SESSION_NAME"; then
+        AVD="$candidate"; break
+      fi
+    done <<< "$AVAILABLE_AVDS"
+    # Unlike iOS, we cannot conjure another device: an AVD is a real on-disk
+    # config and running one twice corrupts it. Fail with the reason.
+    [ -n "$AVD" ] || die "every AVD is reserved by another session - Android concurrency is bounded by AVD count.
+       Reserved: $(ls "$REGISTRY/avds" 2>/dev/null | tr '\n' ' ')
+       Create another with: \$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n demo2 -k '<system-image>'"
+  fi
+  echo "$AVD" > "$SESSION_DIR/avd"
+
+  # --- reserve a console port; the serial follows from it ---
+  CONSOLE_PORT=""
+  if [ -f "$SESSION_DIR/console-port" ]; then
+    CONSOLE_PORT=$(cat "$SESSION_DIR/console-port")
+    reserve_slot "$REGISTRY" emu-ports "$CONSOLE_PORT" "$SESSION_NAME" || CONSOLE_PORT=""
+  fi
+  if [ -z "$CONSOLE_PORT" ]; then
+    # Console ports are even and live in 5554..5680; the serial is
+    # emulator-<console port>, which is what makes it ours by construction.
+    for candidate in $(seq 5554 2 5680); do
+      device_attached "$(serial_of "$candidate")" && continue
+      if reserve_slot "$REGISTRY" emu-ports "$candidate" "$SESSION_NAME"; then
+        CONSOLE_PORT="$candidate"; break
+      fi
+    done
+    [ -n "$CONSOLE_PORT" ] || die "no free emulator console port in 5554..5680"
+  fi
+  echo "$CONSOLE_PORT" > "$SESSION_DIR/console-port"
+  SERIAL=$(serial_of "$CONSOLE_PORT")
+
+  # --- boot it ---
+  # -no-snapshot-load so the session starts from a known state; the AVD's own
+  # snapshot would otherwise resurrect whatever the last session left behind.
+  T_BOOT=$(tel_now)
+  emulator -avd "$AVD" -port "$CONSOLE_PORT" -no-snapshot-load -no-boot-anim \
+    ${DEMO_EMU_ARGS:-} >"$SESSION_DIR/emulator.log" 2>&1 &
+  EMU_PID=$!
+  echo "$EMU_PID" > "$SESSION_DIR/emulator.pid"
+  echo "created" > "$SESSION_DIR/origin"
+  CLAIM_ORIGIN="created"
+
+  # Boot wait: attached, then the framework is actually up. A screenshot or an
+  # install against a half-booted emulator fails in ways that read like a
+  # broken app.
+  BOOT_TIMEOUT="${DEMO_EMU_BOOT_TIMEOUT:-180}"
+  BOOT_DEADLINE=$(( $(date +%s) + BOOT_TIMEOUT ))
+  until device_attached "$SERIAL"; do
+    kill -0 "$EMU_PID" 2>/dev/null || die "the emulator process died during boot - see $SESSION_DIR/emulator.log"
+    [ "$(date +%s)" -lt "$BOOT_DEADLINE" ] || die "emulator $SERIAL never attached within ${BOOT_TIMEOUT}s"
+    sleep 2
+  done
+  until [ "$(adb -s "$SERIAL" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do
+    kill -0 "$EMU_PID" 2>/dev/null || die "the emulator process died during boot - see $SESSION_DIR/emulator.log"
+    [ "$(date +%s)" -lt "$BOOT_DEADLINE" ] || die "emulator $SERIAL attached but never finished booting within ${BOOT_TIMEOUT}s"
+    sleep 2
+  done
+  tel_emit android.claim.boot "$T_BOOT" avd="$AVD" console_port="$CONSOLE_PORT"
+fi
+
+echo "$SERIAL" > "$SESSION_DIR/serial"
+echo "$SESSION_NAME" > "$SESSION_DIR/name"
+
+# Cross-check the live AVD identity: the serial is ours by construction, and
+# this catches the one case construction cannot - a foreign emulator that was
+# already sitting on the console port we reserved.
+LIVE_AVD=$(adb -s "$SERIAL" emu avd name 2>/dev/null | head -1 | tr -d '\r' || true)
+if [ -n "$LIVE_AVD" ] && [ "$LIVE_AVD" != "$AVD" ]; then
+  die "refusing $SERIAL - it is running AVD '$LIVE_AVD', not the '$AVD' this session reserved"
+fi
+
+tel_emit android.claim.total "$T_CLAIM" origin="${CLAIM_ORIGIN:-reclaim}" \
+  serial="$SERIAL" port="$PORT" avd="$AVD"
+
+cat <<EOF
+# Claimed Android session for PR #$PR
+export DEMO_PR=$PR
+export DEMO_SIM_NAME="$SESSION_NAME"
+export DEMO_ANDROID_SERIAL=$SERIAL
+export DEMO_PORT=$PORT
+export DEMO_SESSION_DIR="$SESSION_DIR"
+# AVD $AVD on console port $CONSOLE_PORT; devices attached before this session: $PREFLIGHT_COUNT
+EOF
+
+if [ -n "$FOREIGN_8081" ]; then
+  echo "# note: port 8081 is held by another process - that is why this session runs on $PORT."
+  echo "#       The app must be pointed at $PORT with point-app-at-metro.sh; an emulator"
+  echo "#       otherwise dials 10.0.2.2:8081 and loads somebody else's bundle."
+fi
+
+if [ -n "${MISSING_CREDS:-}" ]; then
+  echo "# note: missing credentials: $MISSING_CREDS"
+fi

--- a/.claude/skills/react-native-android-emulator/scripts/point-app-at-metro.sh
+++ b/.claude/skills/react-native-android-emulator/scripts/point-app-at-metro.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Point the app on this session's emulator at this session's Metro port.
+#
+# WHY THIS EXISTS, because the obvious alternatives all fail quietly:
+#
+# A React Native app on a stock emulator resolves its dev server to
+# 10.0.2.2:8081 - the host loopback, on a port constant compiled into the
+# framework (AndroidInfoHelpers.getServerHost, which picks 10.0.2.2 purely from
+# a Build.FINGERPRINT heuristic). On a Mac where several agents each hold a
+# Metro, 8081 belongs to somebody else, so the app loads SOMEBODY ELSE'S BUNDLE
+# or fails with "Unable to load script" and no requests in your Metro log -
+# which reads like a broken bundler rather than a request that went elsewhere.
+#
+# `adb reverse tcp:<p> tcp:<p>` does not fix it, and not because reverse
+# forwarding is broken on emulators (it works fine, and RN's own CLI runs it
+# unconditionally). It binds DEVICE-localhost, and the app is dialing 10.0.2.2 -
+# an address the tunnel never sees. The tunnel is aimed at a door nobody knocks
+# on.
+#
+# `setprop metro.host <ip>` does override the emulator heuristic, and carries
+# NO PORT (the framework appends its own), so it cannot express a claimed port.
+#
+# What does work is the persisted override the dev menu writes:
+# `debug_http_host = <host>:<port>` in the app's default SharedPreferences.
+# We set it to 10.0.2.2:<claimed port> - host loopback, our port, no tunnel.
+#
+# Two details that are load-bearing, both learned the expensive way:
+#
+#   * PUSH A FILE. Piping XML through `run-as ... sh -c 'printf ...'` mangles
+#     the header and yields prefs Android silently ignores. adb push + run-as cp
+#     moves bytes verbatim.
+#   * FORCE-STOP AFTER WRITING. PackagerConnectionSettings caches the resolved
+#     host in a companion object - process-static. A value written after
+#     auto-detection has already run is ignored until the process restarts.
+#
+# Requires a debuggable build (run-as); that is the demo case by definition.
+#
+# Usage: point-app-at-metro.sh [--serial S] [--port N] [--app-id ID] [--host H]
+#   defaults: $DEMO_ANDROID_SERIAL, $DEMO_PORT, $DEMO_APP_ID_ANDROID, 10.0.2.2
+
+set -euo pipefail
+
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+SERIAL="${DEMO_ANDROID_SERIAL:-}"
+PORT="${DEMO_PORT:-}"
+APP_ID="${DEMO_APP_ID_ANDROID:-}"
+HOST="10.0.2.2"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --serial) SERIAL="${2:?--serial needs a value}"; shift 2 ;;
+    --port)   PORT="${2:?--port needs a value}"; shift 2 ;;
+    --app-id) APP_ID="${2:?--app-id needs a value}"; shift 2 ;;
+    --host)   HOST="${2:?--host needs a value}"; shift 2 ;;
+    *) die "unknown argument '$1' (usage: point-app-at-metro.sh [--serial S] [--port N] [--app-id ID] [--host H])" ;;
+  esac
+done
+
+# No guessing: an unpinned adb command targets whichever single device is
+# attached, which on a shared Mac is somebody else's emulator.
+[ -n "$SERIAL" ] || die "no serial: eval claim-session.sh first (an unpinned adb call would target whichever emulator is attached)"
+[ -n "$PORT" ] || die "no port: eval claim-session.sh first (without a claimed port the app would dial 10.0.2.2:8081 - another agent's Metro)"
+[ -n "$APP_ID" ] || die "no app id: set DEMO_APP_ID_ANDROID to your app's application id (see AGENTS.md)"
+case "$PORT" in ''|*[!0-9]*) die "port must be numeric, got '$PORT'" ;; esac
+
+adb devices | grep -q "^$SERIAL[[:space:]]" || die "$SERIAL is not attached"
+
+T_POINT=$(tel_now)
+PREFS_FILE="/data/data/$APP_ID/shared_prefs/${APP_ID}_preferences.xml"
+TMP_LOCAL="$(mktemp -t debug-http-host)"
+trap 'rm -f "$TMP_LOCAL"' EXIT
+
+# The dev menu writes exactly this shape; anything else and the framework
+# ignores the file rather than telling you.
+cat > "$TMP_LOCAL" <<EOF
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <string name="debug_http_host">$HOST:$PORT</string>
+</map>
+EOF
+
+adb -s "$SERIAL" push "$TMP_LOCAL" /data/local/tmp/debug_http_host.xml >/dev/null \
+  || die "adb push failed"
+adb -s "$SERIAL" shell run-as "$APP_ID" mkdir -p "/data/data/$APP_ID/shared_prefs" 2>/dev/null || true
+adb -s "$SERIAL" shell run-as "$APP_ID" cp /data/local/tmp/debug_http_host.xml "$PREFS_FILE" \
+  || die "run-as cp failed - is $APP_ID installed, and is this a debuggable build?"
+adb -s "$SERIAL" shell rm -f /data/local/tmp/debug_http_host.xml 2>/dev/null || true
+
+# The value is only consulted at process start (see the companion-object cache
+# above), so this force-stop is what makes the write take effect.
+adb -s "$SERIAL" shell am force-stop "$APP_ID" 2>/dev/null || true
+
+tel_emit android.point_at_metro.total "$T_POINT" port="$PORT" host="$HOST"
+
+echo "$APP_ID on $SERIAL now points at $HOST:$PORT (app force-stopped; next launch picks it up)"
+echo "verify it actually landed with verify-session.sh after launching - a silent"
+echo "miss looks exactly like a broken bundler."

--- a/.claude/skills/react-native-android-emulator/scripts/reap-stale.sh
+++ b/.claude/skills/react-native-android-emulator/scripts/reap-stale.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Free reservations from Android sessions released more than the TTL ago.
+#
+# The iOS reaper deletes simulators; this one has nothing to delete (an AVD is
+# a durable, hand-made artifact - deleting it would destroy work nobody asked
+# us to destroy). What it sweeps is the SESSION and its RESERVATIONS, so a
+# crashed or forgotten session cannot hold an AVD and a port hostage forever.
+#
+# Safety mirrors release-session.sh: a session whose emulator is still attached
+# and alive is never swept, and only this prefix's sessions are touched -
+# another repo's expired sessions belong to its own reaper.
+#
+# Usage: reap-stale.sh
+#   DEMO_SIM_TTL_HOURS  retention window, default 72
+#   DEMO_SIM_REGISTRY   session registry, default ~/.claude/rn-sim-sessions
+
+set -uo pipefail
+
+REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
+TTL_HOURS="${DEMO_SIM_TTL_HOURS:-72}"
+PREFIX="${DEMO_EMU_PREFIX:-${DEMO_SIM_PREFIX:-rn-demo}}"
+NOW=$(date +%s)
+TTL_SECONDS=$((TTL_HOURS * 3600))
+
+[ -d "$REGISTRY" ] || exit 0
+
+PORTS_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/ports.sh"
+[ -f "$PORTS_LIB" ] && . "$PORTS_LIB"
+
+for SESSION_DIR in "$REGISTRY/${PREFIX}-android-pr"*/; do
+  [ -d "$SESSION_DIR" ] || continue
+  STAMP_FILE="$SESSION_DIR/released-at"
+  [ -f "$STAMP_FILE" ] || continue          # active or crashed: not ours to judge
+
+  RELEASED_AT=$(cat "$STAMP_FILE" 2>/dev/null || echo "")
+  case "$RELEASED_AT" in
+    ''|*[!0-9]*) continue ;;
+  esac
+  [ $((NOW - RELEASED_AT)) -ge "$TTL_SECONDS" ] || continue
+
+  SESSION_NAME=$(basename "$SESSION_DIR")
+  SERIAL=$(cat "$SESSION_DIR/serial" 2>/dev/null || echo "")
+
+  # Someone re-booted this emulator out of band: leave the whole session alone.
+  if [ -n "$SERIAL" ] && adb devices 2>/dev/null | grep -q "^$SERIAL[[:space:]]"; then
+    echo "reap: skipping $SESSION_NAME - $SERIAL is attached, someone is using it" >&2
+    continue
+  fi
+
+  if type release_metro_port >/dev/null 2>&1; then
+    release_metro_port "$REGISTRY" "$(cat "$SESSION_DIR/port" 2>/dev/null || echo "")" "$SESSION_NAME"
+    CONSOLE_PORT=$(cat "$SESSION_DIR/console-port" 2>/dev/null || echo "")
+    AVD=$(cat "$SESSION_DIR/avd" 2>/dev/null || echo "")
+    [ -n "$CONSOLE_PORT" ] && release_slot "$REGISTRY" emu-ports "$CONSOLE_PORT" "$SESSION_NAME"
+    [ -n "$AVD" ] && release_slot "$REGISTRY" avds "$AVD" "$SESSION_NAME"
+  fi
+
+  rm -rf "$SESSION_DIR"
+  echo "reaped $SESSION_NAME - released $(( (NOW - RELEASED_AT) / 3600 ))h ago"
+done
+
+exit 0

--- a/.claude/skills/react-native-android-emulator/scripts/release-session.sh
+++ b/.claude/skills/react-native-android-emulator/scripts/release-session.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Release one PR's Android session and prove nothing else was disturbed.
+#
+# Only ever touches: the emulator whose PID this session recorded, the Metro
+# process whose PID this session recorded, and this session's reservations.
+# Then it diffs the attached-device list against the pre-flight snapshot and
+# fails loudly if anything that was attached before is gone - the Android twin
+# of the iOS collateral-damage assertion.
+#
+# Usage: release-session.sh <pr-number> [--delete]
+#   default leaves the emulator shut down and the session on disk (cheap
+#           retakes); reap-stale.sh sweeps it after DEMO_SIM_TTL_HOURS (72h)
+#   --delete drops the session directory immediately
+
+set -euo pipefail
+
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+T_RELEASE=$(tel_now)
+
+PORTS_LIB="$(dirname "${BASH_SOURCE[0]}")/../../react-native-ios-simulator/lib/ports.sh"
+[ -f "$PORTS_LIB" ] || { echo "FATAL: missing $PORTS_LIB" >&2; exit 1; }
+. "$PORTS_LIB"
+
+PR="${1:?usage: release-session.sh <pr-number> [--delete]}"
+DELETE="${2:-}"
+
+case "$PR" in
+  ''|*[!0-9]*) echo "FATAL: pr-number must be numeric, got '$PR'" >&2; exit 1 ;;
+esac
+
+REGISTRY="${DEMO_SIM_REGISTRY:-$HOME/.claude/rn-sim-sessions}"
+SESSION_NAME="${DEMO_EMU_PREFIX:-${DEMO_SIM_PREFIX:-rn-demo}}-android-pr${PR}"
+SESSION_DIR="$REGISTRY/${SESSION_NAME}"
+
+[ -d "$SESSION_DIR" ] || { echo "FATAL: no claimed Android session for PR #$PR" >&2; exit 1; }
+
+SERIAL=$(cat "$SESSION_DIR/serial" 2>/dev/null || echo "")
+PORT=$(cat "$SESSION_DIR/port" 2>/dev/null || echo "")
+CONSOLE_PORT=$(cat "$SESSION_DIR/console-port" 2>/dev/null || echo "")
+AVD=$(cat "$SESSION_DIR/avd" 2>/dev/null || echo "")
+EMU_PID=$(cat "$SESSION_DIR/emulator.pid" 2>/dev/null || echo "")
+
+# --- Ownership gate ----------------------------------------------------------
+# An emulator we did not start is never ours to kill, however the manifest
+# looks. Two independent checks: the recorded PID must still be an emulator we
+# own, and the live AVD identity must match what we reserved.
+if [ -n "$SERIAL" ] && adb devices | grep -q "^$SERIAL[[:space:]]"; then
+  LIVE_AVD=$(adb -s "$SERIAL" emu avd name 2>/dev/null | head -1 | tr -d '\r' || true)
+  if [ -n "$LIVE_AVD" ] && [ -n "$AVD" ] && [ "$LIVE_AVD" != "$AVD" ]; then
+    echo "FATAL: refusing to touch $SERIAL - it runs AVD '$LIVE_AVD', not the '$AVD' this session reserved" >&2
+    exit 1
+  fi
+  if [ -z "$EMU_PID" ] || ! kill -0 "$EMU_PID" 2>/dev/null; then
+    echo "note: $SERIAL is attached but this session's emulator process is gone; leaving it alone" >&2
+    SERIAL=""
+  fi
+fi
+
+# --- Metro -------------------------------------------------------------------
+# By recorded PID only, never pkill: that would kill the user's 8081 bundler
+# and every other agent's.
+METRO_PID=$(cat "$SESSION_DIR/metro.pid" 2>/dev/null || echo "")
+if [ -n "$METRO_PID" ] && kill -0 "$METRO_PID" 2>/dev/null; then
+  kill "$METRO_PID" 2>/dev/null || true
+  sleep 1
+  kill -0 "$METRO_PID" 2>/dev/null && kill -9 "$METRO_PID" 2>/dev/null || true
+  echo "stopped Metro pid $METRO_PID (port $PORT)"
+fi
+
+# --- Emulator ----------------------------------------------------------------
+if [ -n "$SERIAL" ]; then
+  adb -s "$SERIAL" emu kill >/dev/null 2>&1 || true
+  # Give it a moment to detach before the postflight diff reads the list.
+  for _ in $(seq 30); do
+    adb devices | grep -q "^$SERIAL[[:space:]]" || break
+    sleep 1
+  done
+  if [ -n "$EMU_PID" ] && kill -0 "$EMU_PID" 2>/dev/null; then
+    kill "$EMU_PID" 2>/dev/null || true
+  fi
+  echo "shut down $SERIAL (AVD $AVD)"
+fi
+
+# --- Reservations ------------------------------------------------------------
+release_metro_port "$REGISTRY" "$PORT" "$SESSION_NAME"
+[ -n "$CONSOLE_PORT" ] && release_slot "$REGISTRY" emu-ports "$CONSOLE_PORT" "$SESSION_NAME"
+[ -n "$AVD" ] && release_slot "$REGISTRY" avds "$AVD" "$SESSION_NAME"
+
+# --- Collateral-damage assertion ---------------------------------------------
+# Every device attached at claim time must still be attached, minus our own.
+PRE="$SESSION_DIR/preflight-devices.txt"
+if [ -f "$PRE" ]; then
+  NOW="$SESSION_DIR/postflight-devices.txt"
+  adb devices | tail -n +2 | awk 'NF>=2 {print $1}' > "$NOW" 2>/dev/null || : > "$NOW"
+  MISSING=""
+  while IFS= read -r dev; do
+    [ -n "$dev" ] || continue
+    [ "$dev" = "$SERIAL" ] && continue
+    grep -qx "$dev" "$NOW" || MISSING="$MISSING $dev"
+  done < "$PRE"
+  if [ -n "$MISSING" ]; then
+    echo "COLLATERAL DAMAGE - these were attached before this session and are not now:$MISSING" >&2
+    exit 1
+  fi
+  echo "verified: no other emulator was shut down by this session"
+fi
+
+# --- Retention ---------------------------------------------------------------
+if [ "$DELETE" = "--delete" ]; then
+  rm -rf "$SESSION_DIR"
+else
+  date +%s > "$SESSION_DIR/released-at"
+  echo "session kept for ${DEMO_SIM_TTL_HOURS:-72}h"
+fi
+"$(dirname "${BASH_SOURCE[0]}")/reap-stale.sh" >/dev/null 2>&1 || true
+
+DEMO_SIM_NAME="$SESSION_NAME" tel_emit android.release.total "$T_RELEASE" \
+  deleted="$([ "$DELETE" = "--delete" ] && echo 1 || echo 0)"

--- a/.claude/skills/react-native-android-emulator/tests/fixtures/bin/adb
+++ b/.claude/skills/react-native-android-emulator/tests/fixtures/bin/adb
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Fake `adb` for the Android session tests.
+#
+# Models attached devices as lines in $FAKE_ADB_DEVICES (`serial|avd|state`) and
+# the device filesystem under $FAKE_ANDROID_ROOT, so the prefs push can be
+# asserted as real bytes landing in a real path rather than "a command ran".
+#
+# Every invocation is logged to $FAKE_ARGS_LOG. Like the capture skills' fakes,
+# `-s <serial>` is mandatory for device-scoped verbs: that is what makes "the
+# scripts always pin a device" a testable invariant rather than a convention.
+
+set -uo pipefail
+
+ARGS_LOG="${FAKE_ARGS_LOG:-/dev/null}"
+DEVICES="${FAKE_ADB_DEVICES:?FAKE_ADB_DEVICES not set}"
+ROOT="${FAKE_ANDROID_ROOT:?FAKE_ANDROID_ROOT not set}"
+echo "adb $*" >> "$ARGS_LOG"
+
+touch "$DEVICES"
+
+# Global (non device-scoped) verbs first.
+case "${1:-}" in
+  devices)
+    echo "List of devices attached"
+    awk -F'|' 'NF>=3 {print $1"\t"$3}' "$DEVICES"
+    exit 0
+    ;;
+  start-server|kill-server)
+    echo "fake adb: refusing '$1' - it disrupts every other agent's session" >&2
+    exit 70
+    ;;
+esac
+
+[ "${1:-}" = "-s" ] || { echo "fake adb: refusing to run without -s <serial>" >&2; exit 70; }
+SERIAL="${2:?}"
+shift 2
+
+grep -q "^${SERIAL}|" "$DEVICES" || { echo "adb: device '$SERIAL' not found" >&2; exit 1; }
+AVD_OF_SERIAL=$(awk -F'|' -v s="$SERIAL" '$1==s {print $2}' "$DEVICES")
+
+case "${1:-}" in
+  emu)
+    case "${2:-}" in
+      kill)
+        # Detach it, exactly like a real `emu kill`.
+        grep -v "^${SERIAL}|" "$DEVICES" > "$DEVICES.tmp" && mv "$DEVICES.tmp" "$DEVICES"
+        echo "OK"
+        ;;
+      avd)
+        [ "${3:-}" = "name" ] || { echo "fake adb: unsupported emu avd verb" >&2; exit 64; }
+        echo "$AVD_OF_SERIAL"
+        echo "OK"
+        ;;
+      *) echo "fake adb: unsupported emu verb '${2:-}'" >&2; exit 64 ;;
+    esac
+    ;;
+
+  wait-for-device) exit 0 ;;
+
+  shell)
+    shift
+    case "${1:-}" in
+      getprop)
+        case "${2:-}" in
+          sys.boot_completed) echo "${FAKE_BOOT_COMPLETED:-1}" ;;
+          *) echo "" ;;
+        esac
+        ;;
+      run-as)
+        APP="${2:?}"; shift 2
+        # A real run-as fails on a non-debuggable build; model that so the
+        # script's error path is reachable.
+        [ -n "${FAKE_RUN_AS_DENIED:-}" ] && { echo "run-as: package not debuggable: $APP" >&2; exit 1; }
+        case "${1:-}" in
+          mkdir) mkdir -p "$ROOT/data/data/$APP/shared_prefs" 2>/dev/null; exit 0 ;;
+          cp)
+            SRC="${2:?}"; DST="${3:?}"
+            mkdir -p "$ROOT$(dirname "$DST")"
+            cp "$ROOT$SRC" "$ROOT$DST" 2>/dev/null || { echo "cp: $SRC: No such file" >&2; exit 1; }
+            ;;
+          *) echo "fake adb: unsupported run-as verb '${1:-}'" >&2; exit 64 ;;
+        esac
+        ;;
+      am)
+        [ "${2:-}" = "force-stop" ] && { echo "force-stop ${3:-}" >> "$ARGS_LOG"; exit 0; }
+        exit 0
+        ;;
+      rm) shift; rm -f "$ROOT${*: -1}" 2>/dev/null; exit 0 ;;
+      pm) exit 0 ;;
+      *) echo "fake adb: unsupported shell verb '${1:-}'" >&2; exit 64 ;;
+    esac
+    ;;
+
+  push)
+    SRC="${2:?}"; DST="${3:?}"
+    mkdir -p "$ROOT$(dirname "$DST")"
+    cp "$SRC" "$ROOT$DST" || exit 1
+    ;;
+
+  install) exit 0 ;;
+
+  *) echo "fake adb: unsupported verb '${1:-}'" >&2; exit 64 ;;
+esac

--- a/.claude/skills/react-native-android-emulator/tests/fixtures/bin/emulator
+++ b/.claude/skills/react-native-android-emulator/tests/fixtures/bin/emulator
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Fake `emulator` for the Android session tests.
+#
+# `-list-avds` reports $FAKE_AVDS (newline-separated). Booting attaches a device
+# to the fake adb's device list as `emulator-<port>|<avd>|device`, which is the
+# whole point: it proves the claim's serial really is derived from the console
+# port it reserved, not from whatever happened to be attached.
+#
+# Refuses to boot an AVD that is already attached - a real emulator locks its
+# AVD, and a fake that allowed it would let the "one session per AVD" guarantee
+# pass vacuously.
+
+set -uo pipefail
+
+ARGS_LOG="${FAKE_ARGS_LOG:-/dev/null}"
+DEVICES="${FAKE_ADB_DEVICES:?FAKE_ADB_DEVICES not set}"
+echo "emulator $*" >> "$ARGS_LOG"
+
+if [ "${1:-}" = "-list-avds" ]; then
+  printf '%s\n' ${FAKE_AVDS:-Pixel_Test_A Pixel_Test_B}
+  exit 0
+fi
+
+AVD=""; PORT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -avd) AVD="${2:?}"; shift 2 ;;
+    -port) PORT="${2:?}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+[ -n "$AVD" ] || { echo "fake emulator: no -avd given" >&2; exit 64; }
+[ -n "$PORT" ] || { echo "fake emulator: no -port given (the serial must be ours by construction)" >&2; exit 64; }
+
+touch "$DEVICES"
+if awk -F'|' -v a="$AVD" '$2==a {found=1} END {exit !found}' "$DEVICES"; then
+  echo "emulator: ERROR: Running multiple emulators with the same AVD '$AVD' is not supported" >&2
+  exit 1
+fi
+
+[ -n "${FAKE_EMULATOR_BOOT_FAILS:-}" ] && { echo "emulator: boot failed" >&2; exit 1; }
+
+printf '%s|%s|device\n' "emulator-$PORT" "$AVD" >> "$DEVICES"
+
+# A real emulator stays in the foreground until killed; the claim backgrounds it
+# and records the PID, so the fake must stay alive to be killable.
+while [ -f "$DEVICES" ] && grep -q "^emulator-$PORT|" "$DEVICES"; do
+  sleep 0.2
+done

--- a/.claude/skills/react-native-android-emulator/tests/run.sh
+++ b/.claude/skills/react-native-android-emulator/tests/run.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Integration tests for the Android session scripts.
+#
+# Creates no real emulator: fake `adb` and `emulator` go first on PATH and the
+# session registry is redirected into a temp dir. Safe to run at any time,
+# including while other agents are mid-run.
+#
+#   ./tests/run.sh
+
+set -uo pipefail
+
+TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$TESTS_DIR/../scripts"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rn-android-tests.XXXXXX")"
+
+export PATH="$TESTS_DIR/fixtures/bin:$PATH"
+export FAKE_ADB_DEVICES="$WORK/devices.txt"
+export FAKE_ANDROID_ROOT="$WORK/android-root"
+export FAKE_ARGS_LOG="$WORK/args.log"
+export DEMO_SIM_REGISTRY="$WORK/registry"
+export FAKE_AVDS="Pixel_Test_A Pixel_Test_B"
+# Trust only what each test sets: a live claimed session in the invoking shell
+# would otherwise leak into every assertion.
+unset DEMO_ANDROID_SERIAL DEMO_UDID DEMO_PORT DEMO_SESSION_DIR DEMO_APP_ID_ANDROID \
+      DEMO_SIM_PREFIX DEMO_EMU_PREFIX DEMO_REQUIRED_ENV 2>/dev/null || true
+
+PASS=0; FAIL=0; STRAYS=()
+
+cleanup() {
+  for pid in "${STRAYS[@]:-}"; do [ -n "${pid:-}" ] && kill "$pid" 2>/dev/null; done
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+ok()  { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m %s\n       %s\n' "$1" "$2"; }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected '$2', got '$3'"; fi; }
+
+# The baseline is deliberately hostile: a FOREIGN emulator is already attached
+# and must survive every test, exactly like the user's simulator in the iOS suite.
+reset_world() {
+  rm -rf "$DEMO_SIM_REGISTRY" "$FAKE_ANDROID_ROOT"
+  mkdir -p "$FAKE_ANDROID_ROOT"
+  : > "$FAKE_ARGS_LOG"
+  printf 'emulator-5584|Someone_Elses_AVD|device\n' > "$FAKE_ADB_DEVICES"
+}
+attached() { grep -q "^$1|" "$FAKE_ADB_DEVICES" && echo yes || echo no; }
+
+echo
+echo "android session claim"
+
+reset_world
+out=$("$SCRIPTS/claim-session.sh" 3712 2>&1) && eval "$out"
+check "claim exits zero" "0" "$?"
+check "reserves a Metro port in the shared range" "yes" \
+  "$([ "${DEMO_PORT:-0}" -ge 8100 ] && [ "${DEMO_PORT:-0}" -le 8499 ] && echo yes || echo "no (${DEMO_PORT:-unset})")"
+CONSOLE=$(cat "$DEMO_SESSION_DIR/console-port")
+check "the serial is derived from the reserved console port" "emulator-$CONSOLE" "$DEMO_ANDROID_SERIAL"
+check "the emulator it booted is attached" "yes" "$(attached "$DEMO_ANDROID_SERIAL")"
+check "it booted the AVD it reserved" "yes" \
+  "$(grep -q -- "-avd $(cat "$DEMO_SESSION_DIR/avd") -port $CONSOLE" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+check "the foreign emulator was left alone" "yes" "$(attached emulator-5584)"
+check "the emulator pid is recorded (release kills only this)" "yes" \
+  "$([ -s "$DEMO_SESSION_DIR/emulator.pid" ] && echo yes || echo no)"
+check "the claim records where it was claimed from" "yes" \
+  "$([ -s "$DEMO_SESSION_DIR/head-sha" ] && [ -s "$DEMO_SESSION_DIR/worktree" ] && echo yes || echo no)"
+
+PORT_1="$DEMO_PORT"; SERIAL_1="$DEMO_ANDROID_SERIAL"; AVD_1=$(cat "$DEMO_SESSION_DIR/avd")
+
+# --- idempotency -------------------------------------------------------------
+eval "$("$SCRIPTS/claim-session.sh" 3712)"
+check "re-claim returns the same port" "$PORT_1" "$DEMO_PORT"
+check "re-claim reuses the same emulator" "$SERIAL_1" "$DEMO_ANDROID_SERIAL"
+check "re-claim did not boot a second emulator" "1" \
+  "$(grep -c -- "-avd $AVD_1 -port" "$FAKE_ARGS_LOG")"
+
+# --- a second session gets its own everything --------------------------------
+eval "$("$SCRIPTS/claim-session.sh" 4113)"
+check "a second session gets a different port" "different" \
+  "$([ "$DEMO_PORT" != "$PORT_1" ] && echo different || echo "same ($DEMO_PORT)")"
+check "a second session gets a different serial" "different" \
+  "$([ "$DEMO_ANDROID_SERIAL" != "$SERIAL_1" ] && echo different || echo "same")"
+check "a second session gets a different AVD" "different" \
+  "$([ "$(cat "$DEMO_SESSION_DIR/avd")" != "$AVD_1" ] && echo different || echo "same")"
+
+# --- AVD exhaustion fails loudly rather than adopting -------------------------
+# Only two AVDs exist in this world and both are now reserved.
+out=$("$SCRIPTS/claim-session.sh" 5000 2>&1); rc=$?
+check "a third session fails rather than adopting an emulator" "1" "$rc"
+check "and says Android concurrency is bounded by AVD count" "yes" \
+  "$(echo "$out" | grep -qi "bounded by AVD count" && echo yes || echo no)"
+check "and it did not touch the foreign emulator" "yes" "$(attached emulator-5584)"
+
+"$SCRIPTS/release-session.sh" 3712 --delete >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 4113 --delete >/dev/null 2>&1
+
+# --- an explicitly named AVD --------------------------------------------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712 Pixel_Test_B)"
+check "an explicitly named AVD is honored" "Pixel_Test_B" "$(cat "$DEMO_SESSION_DIR/avd")"
+"$SCRIPTS/claim-session.sh" 4113 Pixel_Test_B >/dev/null 2>&1
+check "the same AVD cannot be claimed twice" "1" "$?"
+"$SCRIPTS/claim-session.sh" 4114 No_Such_AVD >/dev/null 2>&1
+check "a nonexistent AVD is rejected" "1" "$?"
+
+# --- rejects nonsense ---------------------------------------------------------
+"$SCRIPTS/claim-session.sh" not-a-number >/dev/null 2>&1
+check "rejects a non-numeric PR number" "1" "$?"
+
+echo
+echo "release safety"
+
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+"$SCRIPTS/release-session.sh" 3712 --delete >/dev/null 2>&1
+check "clean release exits zero" "0" "$?"
+check "our emulator is gone" "no" "$(attached "$DEMO_ANDROID_SERIAL")"
+check "the foreign emulator survives" "yes" "$(attached emulator-5584)"
+check "the port reservation is freed" "absent" \
+  "$([ -d "$DEMO_SIM_REGISTRY/ports/$DEMO_PORT" ] && echo present || echo absent)"
+check "the AVD reservation is freed" "absent" \
+  "$([ -d "$DEMO_SIM_REGISTRY/avds/$(cat "$DEMO_SESSION_DIR/avd" 2>/dev/null || echo x)" ] && echo present || echo absent)"
+
+# --- refuses an emulator running a different AVD than we reserved -------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+# Someone else's emulator now occupies our serial (AVD name differs).
+python3 - "$FAKE_ADB_DEVICES" "$DEMO_ANDROID_SERIAL" <<'PY'
+import sys
+path, serial = sys.argv[1], sys.argv[2]
+rows = [l for l in open(path) if l.strip()]
+with open(path, "w") as f:
+    for l in rows:
+        f.write("%s|Hijacked_AVD|device\n" % serial if l.startswith(serial + "|") else l)
+PY
+out=$("$SCRIPTS/release-session.sh" 3712 --delete 2>&1); rc=$?
+check "release refuses a serial running a foreign AVD" "1" "$rc"
+check "and names the mismatch" "yes" \
+  "$(echo "$out" | grep -q "Hijacked_AVD" && echo yes || echo no)"
+check "the hijacked emulator is left running" "yes" "$(attached "$DEMO_ANDROID_SERIAL")"
+
+# --- collateral damage detection ---------------------------------------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+adb -s emulator-5584 emu kill >/dev/null 2>&1     # the mistake we must catch
+out=$("$SCRIPTS/release-session.sh" 3712 --delete 2>&1); rc=$?
+check "detects a foreign emulator was killed" "1" "$rc"
+check "names the damaged device" "yes" \
+  "$(echo "$out" | grep -q "emulator-5584" && echo yes || echo no)"
+
+# --- Metro is killed by PID, never by pattern --------------------------------
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+sleep 120 & OURS=$!;   STRAYS+=($OURS); disown $OURS 2>/dev/null
+sleep 120 & THEIRS=$!; STRAYS+=($THEIRS); disown $THEIRS 2>/dev/null
+echo "$OURS" > "$DEMO_SESSION_DIR/metro.pid"
+"$SCRIPTS/release-session.sh" 3712 --delete >/dev/null 2>&1
+sleep 0.5
+check "stops the Metro it recorded" "gone" "$(kill -0 $OURS 2>/dev/null && echo alive || echo gone)"
+check "leaves another agent's process alone" "alive" "$(kill -0 $THEIRS 2>/dev/null && echo alive || echo gone)"
+
+"$SCRIPTS/release-session.sh" 9999 >/dev/null 2>&1
+check "release without a claim fails loudly" "1" "$?"
+
+echo
+echo "cross-platform port sharing"
+
+# The whole reason the registry is shared: an iOS session and an Android session
+# must never land on the same Metro port.
+reset_world
+IOS_SCRIPTS="$TESTS_DIR/../../react-native-ios-simulator/scripts"
+IOS_FIXTURES="$TESTS_DIR/../../react-native-ios-simulator/tests/fixtures/bin"
+export FAKE_DEVICES="$WORK/ios-devices.txt"
+export FAKE_APP_ROOT="$WORK/ios-apps"
+printf 'USER-SIM|iPhone 16 Pro|Booted\n' > "$FAKE_DEVICES"
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+ANDROID_PORT="$DEMO_PORT"
+IOS_PORT=$(PATH="$IOS_FIXTURES:$PATH" "$IOS_SCRIPTS/claim-session.sh" 3712 2>/dev/null | grep '^export DEMO_PORT=' | cut -d= -f2)
+check "an iOS claim with the same PR number gets a different port" "different" \
+  "$([ -n "$IOS_PORT" ] && [ "$IOS_PORT" != "$ANDROID_PORT" ] && echo different || echo "same ($IOS_PORT vs $ANDROID_PORT)")"
+
+echo
+echo "pointing the app at this session's Metro"
+
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+: > "$FAKE_ARGS_LOG"
+DEMO_APP_ID_ANDROID=com.example.demoapp "$SCRIPTS/point-app-at-metro.sh" >/dev/null 2>&1
+check "point-app-at-metro exits zero" "0" "$?"
+PREFS="$FAKE_ANDROID_ROOT/data/data/com.example.demoapp/shared_prefs/com.example.demoapp_preferences.xml"
+check "the preference file lands in the app's shared_prefs" "yes" \
+  "$([ -f "$PREFS" ] && echo yes || echo no)"
+check "it points at 10.0.2.2 and the CLAIMED port, not 8081" "yes" \
+  "$(grep -q "10.0.2.2:$DEMO_PORT" "$PREFS" 2>/dev/null && echo yes || echo no)"
+check "the pref carries the key the framework reads" "yes" \
+  "$(grep -q 'name="debug_http_host"' "$PREFS" 2>/dev/null && echo yes || echo no)"
+# The value is only read at process start, so without this the write is inert.
+check "the app is force-stopped so the new value is read" "yes" \
+  "$(grep -q "force-stop com.example.demoapp" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+# Pushing a file rather than printf-ing XML through run-as is what keeps the
+# XML header intact.
+check "the prefs travel as a pushed file, not inline text" "yes" \
+  "$(grep -q "push .* /data/local/tmp/debug_http_host.xml" "$FAKE_ARGS_LOG" && echo yes || echo no)"
+check "every adb call is pinned with -s" "0" \
+  "$(grep "^adb " "$FAKE_ARGS_LOG" | grep -v "^adb devices" | grep -cv -- "-s $DEMO_ANDROID_SERIAL")"
+
+DEMO_APP_ID_ANDROID= "$SCRIPTS/point-app-at-metro.sh" >/dev/null 2>&1
+check "refuses without an app id" "1" "$?"
+out=$(DEMO_PORT= DEMO_APP_ID_ANDROID=com.example.demoapp "$SCRIPTS/point-app-at-metro.sh" 2>&1); rc=$?
+check "refuses without a claimed port" "1" "$rc"
+check "and explains that the app would dial 8081 instead" "yes" \
+  "$(echo "$out" | grep -q "8081" && echo yes || echo no)"
+FAKE_RUN_AS_DENIED=1 DEMO_APP_ID_ANDROID=com.example.demoapp "$SCRIPTS/point-app-at-metro.sh" >/dev/null 2>&1
+check "a non-debuggable build fails loudly" "1" "$?"
+
+echo
+echo "reaper"
+
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+SESSION_1="$DEMO_SESSION_DIR"; AVD_1=$(cat "$SESSION_1/avd")
+"$SCRIPTS/release-session.sh" 3712 >/dev/null 2>&1
+echo 1 > "$SESSION_1/released-at"            # expired long ago
+"$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "the reaper sweeps an expired session" "absent" \
+  "$([ -d "$SESSION_1" ] && echo present || echo absent)"
+check "and frees its AVD reservation" "absent" \
+  "$([ -d "$DEMO_SIM_REGISTRY/avds/$AVD_1" ] && echo present || echo absent)"
+
+# A session whose emulator is still attached is never swept, however old.
+reset_world
+eval "$("$SCRIPTS/claim-session.sh" 3712)" >/dev/null 2>&1
+echo 1 > "$DEMO_SESSION_DIR/released-at"
+"$SCRIPTS/reap-stale.sh" >/dev/null 2>&1
+check "the reaper skips a session whose emulator is still attached" "present" \
+  "$([ -d "$DEMO_SESSION_DIR" ] && echo present || echo absent)"
+
+echo
+echo "documented behavior matches the scripts"
+
+SKILL_MD="$TESTS_DIR/../SKILL.md"
+check "SKILL.md pre-approves this skill's commands (allowed-tools)" "yes" \
+  "$(head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(adb \*)" && head -5 "$SKILL_MD" | grep "allowed-tools:" | grep -q -- "Bash(emulator \*)" && echo yes || echo no)"
+check "SKILL.md explains the 10.0.2.2 default that breaks naive sessions" "yes" \
+  "$(grep -q "10.0.2.2" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md corrects the adb reverse folklore rather than repeating it" "yes" \
+  "$(grep -qi "adb reverse" "$SKILL_MD" && grep -qi "device-localhost" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md documents the force-stop requirement" "yes" \
+  "$(grep -q "force-stop" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md points at verify-session.sh rather than assuming success" "yes" \
+  "$(grep -q "verify-session.sh" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md warns that clearState wipes the Metro pointer" "yes" \
+  "$(grep -qi "clearState" "$SKILL_MD" && grep -q "debug_http_host" "$SKILL_MD" && echo yes || echo no)"
+check "SKILL.md is honest that account-gated screens have no Android path yet" "yes" \
+  "$(grep -qi "account-gated screens cannot be demoed" "$SKILL_MD" && echo yes || echo no)"
+
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
+
+echo
+echo "-------------------------------------"
+printf '%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/.claude/skills/react-native-demo-screenshots/tests/run.sh
+++ b/.claude/skills/react-native-demo-screenshots/tests/run.sh
@@ -302,6 +302,15 @@ DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
 check "a planted 3s shot delay is visible to the bench clock" "yes" \
   "$(python3 -c "print('yes' if float('$DUR') >= 5 else 'no (${DUR}s)')")"
 
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
+
 echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/.claude/skills/react-native-demo-videos/SKILL.md
+++ b/.claude/skills/react-native-demo-videos/SKILL.md
@@ -268,7 +268,7 @@ threshold with a TEMP constant and say so in the PR comment.
 ## After Editing the Scripts
 
 ```bash
-"$SKILL/tests/run.sh"     # 105 assertions, ~50s, exits non-zero on failure
+"$SKILL/tests/run.sh"     # 110 assertions, ~50s, exits non-zero on failure
 ```
 
 Fakes `xcrun`, `adb` (the full screenrecord start/kill -2/pull lifecycle) and

--- a/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
+++ b/.claude/skills/react-native-demo-videos/scripts/record-flow.sh
@@ -107,25 +107,45 @@ else
 fi
 rm -f "$OUT"
 
-# --- The clearState guard (iOS only) -----------------------------------------
-# clearState wipes the app data container, which is where the persisted
-# RCT_jsLocation Metro redirect lives; the next launchApp then silently loads
-# the user's 8081 bundler and the recording shows a stuck splash. Launch
-# arguments are immune (they live in the process argument domain, per launch),
-# so a clearState flow must re-pass the redirect on EVERY launchApp:
+# --- The clearState guard ----------------------------------------------------
+# clearState wipes the app data container - which on BOTH platforms is where
+# this session's Metro pointer lives:
 #
-#   - launchApp:
-#       clearState: true
-#       arguments:
-#         RCT_jsLocation: "localhost:${DEMO_PORT}"
+#   iOS      the persisted RCT_jsLocation default. Launch arguments are immune
+#            (process argument domain, per launch), so a clearState flow must
+#            re-pass the redirect on EVERY launchApp:
 #
-# Android is exempt: Metro reaches an emulator over adb reverse, not app data.
-if [ "$PLATFORM" = ios ] && [ -z "$ALLOW_CLEAR_STATE" ]; then
-  if grep -q "clearState" "$FLOW" && ! grep -q "RCT_jsLocation" "$FLOW"; then
+#              - launchApp:
+#                  clearState: true
+#                  arguments:
+#                    RCT_jsLocation: "localhost:${DEMO_PORT}"
+#
+#   Android  the debug_http_host SharedPreference written by
+#            point-app-at-metro.sh. There is no launch-argument equivalent, so
+#            the remedy is to re-run that script after the clearing launch.
+#
+# Either way the failure is silent and identical: the next launch dials the
+# default dev server - 8081, which on a shared Mac is another agent's Metro -
+# and the recording shows a stuck splash or, worse, somebody else's build.
+#
+# (This used to exempt Android on the belief that "Metro reaches an emulator
+# over adb reverse, not app data". Both halves were wrong: an emulator resolves
+# the dev server to 10.0.2.2:8081 and never consults a reverse tunnel, and once
+# the claimed port lives in debug_http_host the pointer IS app data.)
+if [ -z "$ALLOW_CLEAR_STATE" ] && grep -q "clearState" "$FLOW"; then
+  if [ "$PLATFORM" = ios ] && ! grep -q "RCT_jsLocation" "$FLOW"; then
     die "flow clears app state without re-passing the Metro redirect.
        clearState wipes the persisted RCT_jsLocation default, so every launchApp
        in this flow must carry: arguments: { RCT_jsLocation: \"localhost:\${DEMO_PORT}\" }
        (or use reset-app.sh from the simulator skill instead; --allow-clear-state waives this check)"
+  fi
+  if [ "$PLATFORM" = android ] && ! grep -q "point-app-at-metro" "$FLOW"; then
+    die "flow clears app state, which deletes the debug_http_host preference
+       pointing this emulator at Metro on port ${DEMO_PORT:-<claimed>}. The next launch would
+       dial 10.0.2.2:8081 - another agent's bundler - and record their build or a
+       stuck splash. Re-run point-app-at-metro.sh after the clearing launch, and
+       note that here (a '# point-app-at-metro' comment in the flow acknowledges it);
+       --allow-clear-state waives this check."
   fi
 fi
 
@@ -137,17 +157,21 @@ fi
 T_WARMUP=$(tel_now)
 # The warmup is only needed once per device per Maestro version - the driver
 # it installs persists. Three ways to know it already happened, checked in
-# order of directness (iOS only: the session markers live in the iOS session
-# dir, and an Android emulator never shares a device with an iOS session):
+# order of directness:
 #   manual   DEMO_SKIP_WARMUP=1, the caller's own judgment
-#   session  an earlier maestro run in this session left the warmed marker
+#   session  an earlier maestro run in this session left the warmed marker.
+#            Platform-neutral now that Android sessions have a session dir of
+#            their own - Android used to pay the full ~20s on EVERY recording
+#            purely because it had nowhere to keep the marker.
 #   golden   the clone carries a driver baked by bless-golden.sh, and the
 #            stamped maestro version still matches - after a CLI upgrade the
-#            driver silently re-installs, so a mismatch must warm up again
+#            driver silently re-installs, so a mismatch must warm up again.
+#            iOS-only: the golden is a simulator clone, and an AVD has no
+#            equivalent yet.
 WARM_REASON=""
 if [ -n "$SKIP_WARMUP" ]; then
   WARM_REASON="manual"
-elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/maestro-warmed" ]; then
+elif [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/maestro-warmed" ]; then
   WARM_REASON="session"
 elif [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/golden-stamp" ]; then
   STAMP_MV=$(grep '^maestro-version=' "$DEMO_SESSION_DIR/golden-stamp" 2>/dev/null | cut -d= -f2- || true)
@@ -167,7 +191,7 @@ if [ -z "$WARM_REASON" ]; then
   if [ -f "$WARMUP" ]; then
     echo "warming up the maestro driver..."
     maestro test --udid "$DEVICE" -e APP_ID="$APP_ID" "$WARMUP" >/dev/null 2>&1
-    [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ] && touch "$DEMO_SESSION_DIR/maestro-warmed" 2>/dev/null
+    [ -n "${DEMO_SESSION_DIR:-}" ] && touch "$DEMO_SESSION_DIR/maestro-warmed" 2>/dev/null
   fi
   tel_emit vid.record.warmup "$T_WARMUP" platform="$PLATFORM" skipped=0
 else
@@ -288,7 +312,7 @@ tel_emit vid.record.flow "$T_FLOW" platform="$PLATFORM" rc="$FLOW_RC" \
   ok="$([ "$FLOW_RC" -eq 0 ] && echo 1 || echo 0)"
 # A successful flow proves the driver works - later recordings in this
 # session need no warmup even if this one's was skipped manually.
-if [ "$FLOW_RC" -eq 0 ] && [ "$PLATFORM" = ios ] && [ -n "${DEMO_SESSION_DIR:-}" ]; then
+if [ "$FLOW_RC" -eq 0 ] && [ -n "${DEMO_SESSION_DIR:-}" ]; then
   touch "$DEMO_SESSION_DIR/maestro-warmed" 2>/dev/null || true
 fi
 

--- a/.claude/skills/react-native-demo-videos/tests/run.sh
+++ b/.claude/skills/react-native-demo-videos/tests/run.sh
@@ -249,10 +249,35 @@ DEMO_UDID=DEMO-UDID DEMO_ANDROID_SERIAL=emulator-5554 \
   "$SCRIPTS/record-flow.sh" pick "$WORK/flow.yaml" "$WORK/droid-out" --serial emulator-5554 >/dev/null 2>&1
 check "--serial disambiguates to android" "0" "$?"
 
+# Android is NOT exempt from the clearState guard: since the claimed port lives
+# in the debug_http_host preference, clearing app state deletes the Metro
+# pointer and the next launch dials 10.0.2.2:8081 - another agent's bundler.
+# (The old exemption rested on "Metro reaches an emulator over adb reverse",
+# which is wrong twice over: an emulator resolves to 10.0.2.2 and never
+# consults a reverse tunnel.)
+reset_droid
+out=$(DEMO_ANDROID_SERIAL=emulator-5554 \
+  "$SCRIPTS/record-flow.sh" droidclear "$WORK/clearflow.yaml" "$WORK/droid-out" 2>&1)
+check "android clearState without re-pointing is refused" "1" "$?"
+check "the refusal names the preference that gets wiped" "yes" \
+  "$(echo "$out" | grep -q "debug_http_host" && echo yes || echo no)"
+
+reset_droid
+cat > "$WORK/droid-clearflow-ok.yaml" <<'YAML'
+appId: ${APP_ID}
+---
+# point-app-at-metro is re-run after this clearing launch
+- launchApp:
+    clearState: true
+YAML
+DEMO_ANDROID_SERIAL=emulator-5554 \
+  "$SCRIPTS/record-flow.sh" droidclearok "$WORK/droid-clearflow-ok.yaml" "$WORK/droid-out" >/dev/null 2>&1
+check "acknowledging the re-point in the flow satisfies the guard" "0" "$?"
+
 reset_droid
 DEMO_ANDROID_SERIAL=emulator-5554 \
-  "$SCRIPTS/record-flow.sh" droidclear "$WORK/clearflow.yaml" "$WORK/droid-out" >/dev/null 2>&1
-check "android skips the clearState guard (adb reverse, not app data)" "0" "$?"
+  "$SCRIPTS/record-flow.sh" droidclearwaive "$WORK/clearflow.yaml" "$WORK/droid-out" --allow-clear-state >/dev/null 2>&1
+check "--allow-clear-state waives it on android too" "0" "$?"
 
 out=$(DEMO_APP_ID_ANDROID= DEMO_ANDROID_SERIAL=emulator-5554 \
   "$SCRIPTS/record-flow.sh" noapp "$WORK/flow.yaml" "$WORK/droid-out" 2>&1)
@@ -400,6 +425,19 @@ DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
 check "the maestro version probe runs once per session, not per recording" "1" \
   "$(grep -c "maestro --version" "$FAKE_ARGS_LOG")"
 
+# Android used to pay the full ~20s warmup on EVERY recording, purely because
+# it had no session dir to keep the marker in. It has one now.
+reset_droid; rm -rf "$WSESS"; mkdir -p "$WSESS"
+DEMO_SESSION_DIR="$WSESS" DEMO_ANDROID_SERIAL=emulator-5554 \
+  "$SCRIPTS/record-flow.sh" droidwarm1 "$WORK/flow.yaml" "$WORK/droid-out" >/dev/null 2>&1
+check "the first android recording of a session warms up" "1" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+reset_droid
+DEMO_SESSION_DIR="$WSESS" DEMO_ANDROID_SERIAL=emulator-5554 \
+  "$SCRIPTS/record-flow.sh" droidwarm2 "$WORK/flow.yaml" "$WORK/droid-out" >/dev/null 2>&1
+check "the second android recording in the same session skips it" "0" \
+  "$(grep -c "_warmup.yaml" "$FAKE_ARGS_LOG")"
+
 reset_logs; rm -rf "$WSESS"; mkdir -p "$WSESS"
 DEMO_SKIP_WARMUP=1 DEMO_SESSION_DIR="$WSESS" DEMO_UDID=DEMO-UDID \
   "$SCRIPTS/record-flow.sh" warm5 "$WORK/flow.yaml" "$WORK/out" >/dev/null 2>&1
@@ -474,6 +512,15 @@ T0=$(py_now)
 DUR=$(python3 -c "print('%.1f' % (float('$(py_now)') - float('$T0')))")
 check "gif encode of the 2s clip stays under the runaway budget (15s)" "yes" \
   "$(python3 -c "print('yes' if float('$DUR') < 15 else 'no (${DUR}s)')")"
+
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
 
 echo
 echo "-------------------------------------"

--- a/.claude/skills/react-native-ios-simulator/lib/ports.sh
+++ b/.claude/skills/react-native-ios-simulator/lib/ports.sh
@@ -1,0 +1,89 @@
+# Machine-wide reservations shared by every demo session, on every platform.
+# Source this; never execute it.
+#
+# The registry is the one place that knows which Metro ports, emulator console
+# ports and AVDs are spoken for. It has to be shared across platforms: an iOS
+# session on 8192 and an Android session on 8192 is exactly the collision the
+# registry exists to prevent, and two implementations of "reserve a port" would
+# be two chances to get the atomicity wrong.
+#
+# Unlike lib/telemetry.sh, this lib is load-bearing: a caller that cannot source
+# it must fail loudly rather than degrade, because an unreserved port is a
+# session that silently steals another agent's bundler.
+#
+#   reserve_metro_port <registry> <owner> <seed>   -> echoes the port, or fails
+#   release_metro_port <registry> <port> <owner>   -> frees it if still ours
+#   reserve_slot <registry> <namespace> <name> <owner>  -> 0 won, 1 taken
+#   release_slot <registry> <namespace> <name> <owner>
+#
+# `owner` is the session's stable label (the iOS device name, the Android
+# session name) - the same string release checks before freeing anything.
+
+# Reserve one Metro port. Deterministic starting point per seed (so re-runs are
+# stable), then walk upward. mkdir is atomic on every filesystem we care about:
+# whoever creates the directory owns the port. 8081 is never in range - that is
+# the user's Metro.
+reserve_metro_port() {
+  local registry="${1:?reserve_metro_port needs a registry}"
+  local owner="${2:?reserve_metro_port needs an owner}"
+  local seed="${3:?reserve_metro_port needs a numeric seed}"
+  local base=$((8100 + (seed % 400)))
+  local candidate stale_pid
+  mkdir -p "$registry/ports" 2>/dev/null || true
+  for offset in $(seq 0 60); do
+    candidate=$((base + offset))
+    [ "$candidate" -eq 8081 ] && continue
+    if mkdir "$registry/ports/$candidate" 2>/dev/null; then
+      echo "$owner" > "$registry/ports/$candidate/owner"
+      # Re-check after winning the reservation: another process outside this
+      # registry (a stray Metro, an unrelated dev server) may already hold it.
+      if lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
+        rm -rf "$registry/ports/$candidate"
+        continue
+      fi
+      echo "$candidate"; return 0
+    fi
+    # Reclaim a reservation whose owning session no longer exists - but only
+    # ever our own: another session's dead-looking reservation is not ours to
+    # judge.
+    stale_pid=$(cat "$registry/ports/$candidate/metro.pid" 2>/dev/null || echo "")
+    if [ -n "$stale_pid" ] && ! kill -0 "$stale_pid" 2>/dev/null; then
+      if [ "$(cat "$registry/ports/$candidate/owner" 2>/dev/null)" = "$owner" ]; then
+        echo "$candidate"; return 0
+      fi
+    fi
+  done
+  echo "FATAL: no free port in $base..$((base + 60))" >&2
+  return 1
+}
+
+release_metro_port() {
+  local registry="${1:?}" port="${2:-}" owner="${3:?}"
+  [ -n "$port" ] || return 0
+  if [ "$(cat "$registry/ports/$port/owner" 2>/dev/null)" = "$owner" ]; then
+    rm -rf "$registry/ports/$port"
+  fi
+  return 0
+}
+
+# Reserve a named slot (an emulator console port, an AVD). Same atomic-mkdir
+# rule; the caller loops over candidates when it wants "any free one".
+reserve_slot() {
+  local registry="${1:?}" ns="${2:?}" name="${3:?}" owner="${4:?}"
+  mkdir -p "$registry/$ns" 2>/dev/null || true
+  if mkdir "$registry/$ns/$name" 2>/dev/null; then
+    echo "$owner" > "$registry/$ns/$name/owner"
+    return 0
+  fi
+  # An idempotent re-claim by the same owner is not a collision.
+  [ "$(cat "$registry/$ns/$name/owner" 2>/dev/null)" = "$owner" ] && return 0
+  return 1
+}
+
+release_slot() {
+  local registry="${1:?}" ns="${2:?}" name="${3:?}" owner="${4:?}"
+  if [ "$(cat "$registry/$ns/$name/owner" 2>/dev/null)" = "$owner" ]; then
+    rm -rf "$registry/$ns/$name"
+  fi
+  return 0
+}

--- a/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/claim-session.sh
@@ -63,41 +63,29 @@ rm -f "$SESSION_DIR/released-at"
 xcrun simctl list devices booted -j > "$SESSION_DIR/preflight-booted.json"
 PREFLIGHT_COUNT=$(grep -c '"udid"' "$SESSION_DIR/preflight-booted.json" || true)
 
+# --- Where the demo runs from ------------------------------------------------
+# Recorded so verify-session.sh can catch the trap that once manufactured a
+# phantom regression: the checkout moving to another branch mid-session, after
+# which Metro serves code that is not the code under test.
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  git rev-parse --show-toplevel > "$SESSION_DIR/worktree"
+  git rev-parse HEAD > "$SESSION_DIR/head-sha"
+fi
+
 # --- Port reservation --------------------------------------------------------
-# Deterministic starting point per PR (so re-runs are stable), then walk upward.
-# mkdir is atomic on every filesystem we care about: whoever creates the
-# directory owns the port. 8081 is never in range - that is the user's Metro.
-reserve_port() {
-  local base=$((8100 + (PR % 400)))
-  local candidate stale_pid
-  for offset in $(seq 0 60); do
-    candidate=$((base + offset))
-    [ "$candidate" -eq 8081 ] && continue
-    if mkdir "$REGISTRY/ports/$candidate" 2>/dev/null; then
-      echo "$SIM_NAME" > "$REGISTRY/ports/$candidate/owner"
-      # Re-check after winning the reservation: another process outside this
-      # registry (a stray Metro, an unrelated dev server) may already hold it.
-      if lsof -nP -iTCP:"$candidate" -sTCP:LISTEN >/dev/null 2>&1; then
-        rm -rf "$REGISTRY/ports/$candidate"
-        continue
-      fi
-      echo "$candidate"; return 0
-    fi
-    # Reclaim a reservation whose owning session no longer exists.
-    stale_pid=$(cat "$REGISTRY/ports/$candidate/metro.pid" 2>/dev/null || echo "")
-    if [ -n "$stale_pid" ] && ! kill -0 "$stale_pid" 2>/dev/null; then
-      if [ "$(cat "$REGISTRY/ports/$candidate/owner" 2>/dev/null)" = "$SIM_NAME" ]; then
-        echo "$candidate"; return 0
-      fi
-    fi
-  done
-  echo "FATAL: no free port in $base..$((base + 60))" >&2; exit 1
-}
+# The reservation itself lives in lib/ports.sh because the registry is shared
+# with the Android skill: an iOS session and an Android session on one port is
+# the collision the registry exists to prevent, and a second implementation
+# would be a second chance to get the atomicity wrong. Load-bearing, so a
+# missing lib fails loudly rather than degrading.
+PORTS_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/ports.sh"
+[ -f "$PORTS_LIB" ] || { echo "FATAL: missing $PORTS_LIB - an unreserved port would silently steal another agent's bundler" >&2; exit 1; }
+. "$PORTS_LIB"
 
 if [ -f "$SESSION_DIR/port" ]; then
   PORT=$(cat "$SESSION_DIR/port")   # idempotent re-claim
 else
-  PORT=$(reserve_port)
+  PORT=$(reserve_metro_port "$REGISTRY" "$SIM_NAME" "$PR") || exit 1
   echo "$PORT" > "$SESSION_DIR/port"
 fi
 

--- a/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
+++ b/.claude/skills/react-native-ios-simulator/scripts/metro-demo.config.js
@@ -47,8 +47,34 @@ if (typeof appConfig !== "object" || appConfig === null || typeof appConfig.then
   )
 }
 
+// Escape hatch for a worktree whose node_modules is shared with (or symlinked
+// to) another checkout: Metro resolves from the project root outward, so a
+// worktree without its own real node_modules fails with
+// `UnableToResolveError: <pkg> could not be found`. Pointing nodeModulesPaths
+// and watchFolders at the real directory fixes it.
+//
+// Opt-in on purpose - the skill's primary advice is still a real node_modules
+// copy, which is proven and avoids a second failure mode Metro has with
+// symlinked module trees (`_lruCache is not a constructor`).
+//
+// Note the resolver spread: this file's top-level spread is shallow, so a bare
+// `resolver: {...}` key would silently drop the app's own extraNodeModules,
+// sourceExts and resolverMainFields (svg transform, stream/zlib shims - the
+// app renders wrong rather than failing loudly).
+const sharedModules = process.env.DEMO_NODE_MODULES
+const resolverOverride = sharedModules
+  ? {
+      resolver: {
+        ...appConfig.resolver,
+        nodeModulesPaths: [...((appConfig.resolver || {}).nodeModulesPaths || []), sharedModules],
+      },
+      watchFolders: [...(appConfig.watchFolders || []), sharedModules],
+    }
+  : {}
+
 module.exports = {
   ...appConfig,
+  ...resolverOverride,
   transformer: {
     ...appConfig.transformer,
     // @react-native/metro-config require.resolve()s this to an ABSOLUTE path,

--- a/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/release-session.sh
@@ -87,9 +87,12 @@ if [ -n "$UDID" ]; then
 fi
 
 # --- Port release ------------------------------------------------------------
-if [ -n "$PORT" ] && [ "$(cat "$REGISTRY/ports/$PORT/owner" 2>/dev/null)" = "$EXPECTED_NAME" ]; then
-  rm -rf "$REGISTRY/ports/$PORT"
-fi
+# Same shared lib the claim reserves through - the owner check lives in one
+# place, so a session can never free a reservation it does not hold.
+PORTS_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/ports.sh"
+[ -f "$PORTS_LIB" ] || { echo "FATAL: missing $PORTS_LIB" >&2; exit 1; }
+. "$PORTS_LIB"
+release_metro_port "$REGISTRY" "$PORT" "$EXPECTED_NAME"
 
 # --- Collateral-damage assertion ---------------------------------------------
 # Every device booted at claim time must still be booted, minus our own.

--- a/.claude/skills/react-native-ios-simulator/scripts/verify-session.sh
+++ b/.claude/skills/react-native-ios-simulator/scripts/verify-session.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# Prove the session is what it claims to be, instead of assuming it.
+#
+# Two failures cost whole sessions before this existed, and both are silent:
+#
+#   1. The app never reaches YOUR Metro. On Android an emulator dials
+#      10.0.2.2:8081 by default, so a session on a claimed port sees zero
+#      requests - indistinguishable from a broken bundler. On iOS the same
+#      shape appears when the persisted RCT_jsLocation redirect was wiped.
+#      This asserts Metro actually served a bundle, by watching the dev
+#      server's own /events stream - the same channel reload-app.sh uses to
+#      confirm a reload.
+#
+#   2. The checkout moved. A shared clone switched to another branch mid-session
+#      means Metro serves code that is not the code under test; that once
+#      manufactured a phantom "Rendered fewer hooks than expected" regression
+#      and cost hours. The claim records worktree + HEAD; this compares them.
+#
+# Platform-neutral: it talks to Metro and to git, never to a device.
+#
+# Usage: verify-session.sh [--port N] [--timeout S] [--skip-bundle] [--skip-head]
+#   --port         defaults to $DEMO_PORT
+#   --timeout      seconds to wait for bundle activity (default 45)
+#   --skip-bundle  only check HEAD drift and the 8081 neighbour
+#   --skip-head    only check the bundle request
+#
+# Run it AFTER launching the app. Exit 0 means: your Metro served your app,
+# from the checkout you claimed.
+
+set -euo pipefail
+
+TEL_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/telemetry.sh"
+{ [ -f "$TEL_LIB" ] && . "$TEL_LIB"; } 2>/dev/null || true
+type tel_emit >/dev/null 2>&1 || { tel_now() { echo 0; }; tel_emit() { :; }; tel_span() { while [ $# -gt 0 ] && [ "$1" != "--" ]; do shift; done; [ $# -gt 0 ] && shift; "$@"; }; }
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+PORT="${DEMO_PORT:-}"
+TIMEOUT="${VERIFY_TIMEOUT:-45}"
+SKIP_BUNDLE=""
+SKIP_HEAD=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port)        PORT="${2:?--port needs a value}"; shift 2 ;;
+    --timeout)     TIMEOUT="${2:?--timeout needs a value}"; shift 2 ;;
+    --skip-bundle) SKIP_BUNDLE=1; shift ;;
+    --skip-head)   SKIP_HEAD=1; shift ;;
+    *) die "unknown argument '$1' (usage: verify-session.sh [--port N] [--timeout S] [--skip-bundle] [--skip-head])" ;;
+  esac
+done
+
+[ -n "$PORT" ] || die "no port: eval a claim-session.sh first, or pass --port"
+case "$PORT" in ''|*[!0-9]*) die "port must be numeric, got '$PORT'" ;; esac
+
+T_VERIFY=$(tel_now)
+FAILED=""
+
+# --- 1. HEAD drift -----------------------------------------------------------
+# The session dir remembers where the demo was claimed from. If that checkout
+# has moved, everything Metro serves from here on is a different branch's code.
+if [ -z "$SKIP_HEAD" ] && [ -n "${DEMO_SESSION_DIR:-}" ] && [ -f "$DEMO_SESSION_DIR/head-sha" ]; then
+  CLAIMED_SHA=$(cat "$DEMO_SESSION_DIR/head-sha")
+  CLAIMED_TREE=$(cat "$DEMO_SESSION_DIR/worktree" 2>/dev/null || echo "")
+  if [ -n "$CLAIMED_TREE" ] && [ -d "$CLAIMED_TREE" ]; then
+    CURRENT_SHA=$(git -C "$CLAIMED_TREE" rev-parse HEAD 2>/dev/null || echo "")
+    if [ -n "$CURRENT_SHA" ] && [ "$CURRENT_SHA" != "$CLAIMED_SHA" ]; then
+      echo "CHECKOUT DRIFT: $CLAIMED_TREE was at ${CLAIMED_SHA:0:9} when this session was claimed, and is now at ${CURRENT_SHA:0:9}." >&2
+      echo "       Metro has been serving a different branch's code. Anything captured since the switch is evidence about the wrong tree -" >&2
+      echo "       this is how a phantom regression gets attributed to the change under test. Re-claim from a detached worktree." >&2
+      FAILED=1
+    else
+      echo "checkout: $CLAIMED_TREE still at ${CLAIMED_SHA:0:9}"
+    fi
+  fi
+fi
+
+# --- 2. Who else is on 8081 --------------------------------------------------
+# Informational, never fatal: it explains WHY this session runs on its own port.
+if lsof -nP -iTCP:8081 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "note: port 8081 is held by another process (the user's Metro, or another agent's) - this session's port is $PORT"
+fi
+
+# --- 3. Did Metro actually serve our app? ------------------------------------
+if [ -z "$SKIP_BUNDLE" ]; then
+  curl -sf "http://localhost:$PORT/status" >/dev/null 2>&1 \
+    || die "nothing is listening on $PORT - start Metro for this session first"
+
+  BUNDLE_SEEN=$(PORT="$PORT" TIMEOUT="$TIMEOUT" python3 <<'PY'
+import base64, json, os, socket, struct, sys, time
+
+port, timeout = int(os.environ["PORT"]), float(os.environ["TIMEOUT"])
+
+# Minimal RFC 6455 client - same shape as reload-app.sh, kept dependency-free
+# so this works from any cwd with no node_modules.
+def ws_connect(path):
+    s = socket.create_connection(("127.0.0.1", port), timeout=5)
+    key = base64.b64encode(os.urandom(16)).decode()
+    s.sendall((
+        "GET %s HTTP/1.1\r\nHost: 127.0.0.1:%d\r\nUpgrade: websocket\r\n"
+        "Connection: Upgrade\r\nSec-WebSocket-Key: %s\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n" % (path, port, key)
+    ).encode())
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise ConnectionError("closed during handshake")
+        buf += chunk
+    head, leftover = buf.split(b"\r\n\r\n", 1)
+    if b" 101" not in head.split(b"\r\n", 1)[0]:
+        raise ConnectionError("handshake refused")
+    return s, leftover
+
+def parse_frame(buf):
+    if len(buf) < 2:
+        return None
+    opcode, b2 = buf[0] & 0x0F, buf[1]
+    n, off = b2 & 0x7F, 2
+    if n == 126:
+        if len(buf) < 4: return None
+        n, off = struct.unpack(">H", buf[2:4])[0], 4
+    elif n == 127:
+        if len(buf) < 10: return None
+        n, off = struct.unpack(">Q", buf[2:10])[0], 10
+    if b2 & 0x80:
+        if len(buf) < off + 4 + n: return None
+        mask, payload = buf[off:off+4], buf[off+4:off+4+n]
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        return opcode, payload, buf[off+4+n:]
+    if len(buf) < off + n: return None
+    return opcode, buf[off:off+n], buf[off+n:]
+
+try:
+    sock, buf = ws_connect("/events")
+except OSError as e:
+    print("ERROR:%s" % e)
+    sys.exit(0)
+
+sock.settimeout(0.5)
+deadline = time.time() + timeout
+while time.time() < deadline:
+    frame = parse_frame(buf)
+    while frame:
+        opcode, payload, buf = frame
+        if opcode == 0x8:
+            break
+        if opcode == 0x1:
+            try:
+                etype = json.loads(payload).get("type", "")
+            except ValueError:
+                etype = ""
+            # bundle_build_done fires for cache-warm serves too, which is
+            # exactly the common case for a second launch.
+            if etype in ("bundle_build_started", "bundle_build_done", "bundle_transform_progressed"):
+                print("SEEN")
+                sys.exit(0)
+        frame = parse_frame(buf)
+    try:
+        chunk = sock.recv(4096)
+    except socket.timeout:
+        continue
+    if not chunk:
+        break
+    buf += chunk
+print("NONE")
+PY
+  )
+
+  case "$BUNDLE_SEEN" in
+    SEEN)
+      echo "bundle: Metro on $PORT served a bundle request - the app is talking to this session"
+      ;;
+    ERROR:*)
+      echo "FATAL: could not watch Metro's /events on $PORT (${BUNDLE_SEEN#ERROR:})" >&2
+      FAILED=1
+      ;;
+    *)
+      echo "NO BUNDLE REQUEST on port $PORT within ${TIMEOUT}s. The app is not talking to this session's Metro." >&2
+      echo "       Likely causes, in the order they usually bite:" >&2
+      echo "         1. the app is pointed elsewhere - on Android an emulator dials 10.0.2.2:8081 unless" >&2
+      echo "            point-app-at-metro.sh has set debug_http_host (and force-stopped the app afterwards);" >&2
+      echo "            on iOS the persisted RCT_jsLocation redirect was wiped (clearState) - use reset-app.sh;" >&2
+      echo "         2. the app is not running, or crashed before requesting a bundle;" >&2
+      echo "         3. it IS running against a different Metro - check who holds 8081." >&2
+      FAILED=1
+      ;;
+  esac
+fi
+
+tel_emit session.verify.total "$T_VERIFY" port="$PORT" \
+  ok="$([ -z "$FAILED" ] && echo 1 || echo 0)"
+
+[ -z "$FAILED" ] || exit 1
+echo "session verified"

--- a/.claude/skills/react-native-ios-simulator/tests/run.sh
+++ b/.claude/skills/react-native-ios-simulator/tests/run.sh
@@ -1067,6 +1067,15 @@ check "a reload opens exactly two websocket connections" "2" \
   "$(grep -c "^connect " "$WS_LOG")"
 kill "$WS_PID" 2>/dev/null
 
+# The count in SKILL.md is documentation that rots silently - it drifted to 105
+# against 97 actual once. Comparing it here makes the drift a red build instead
+# of a number nobody checks.
+DOC_COUNT=$(grep -o '# [0-9]\+ assertions' "$TESTS_DIR/../SKILL.md" 2>/dev/null | head -1 | grep -o '[0-9]\+' || echo "")
+ACTUAL_COUNT=$((PASS + FAIL))
+if [ -n "$DOC_COUNT" ] && [ "$DOC_COUNT" != "$ACTUAL_COUNT" ]; then
+  bad "SKILL.md documents the suite's own size" "$DOC_COUNT assertions" "$ACTUAL_COUNT"
+fi
+
 echo
 echo "-------------------------------------"
 printf '%d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Fixes #4092 (the Android half). Stacked on #4149 (`feat/blink-staging-skill`) — only the last commit is this PR. Prompted by [the capture-session report on #4092](https://github.com/blinkbitcoin/blink-mobile/issues/4092#issuecomment-5295033865): an Android-only fix (#4159) could not be demoed at all, because **Android had no session claim**.

## The failure this closes

The docs said only "pin the serial of an emulator you started" and nothing about the Metro port. On a Mac where several agents each hold a bundler, that doesn't run slowly — it **silently produces a broken session**: a red *Unable to load script* with **zero requests in your Metro log**, which reads like a broken bundler rather than a request that went somewhere else. That ambiguity is what cost the reporting session hours.

## `react-native-android-emulator` (new skill)

Ownership can't use the iOS trick of a per-session device *name*, so it rests on three facts recorded at claim and re-checked at release:

| Fact | Why it's sound |
|---|---|
| reserved **console port**, passed as `emulator -port N` | fixes the serial at `emulator-N` — **ours by construction**, not by convention |
| the **emulator PID** we started | release kills that and nothing else (never `pkill`, never `adb emu kill` on a serial we merely found) |
| the **AVD**, reserved by atomic mkdir | an AVD can't run twice; cross-checked live with `adb emu avd name` |

Ports come from a new shared `lib/ports.sh` — lifted verbatim out of the iOS claim, which is why the iOS suite stayed at 199 assertions **unedited**. Sharing is the point: an iOS session and an Android session on one port is exactly the collision the registry exists to prevent (asserted). Unlike iOS, concurrency is bounded by AVD count, so when all are reserved the claim **fails with the list** rather than adopting somebody's emulator.

## Three corrections the report needed before they became permanent docs

Each checked against source, because folklore in a SKILL.md outlives the session that wrote it:

1. **`adb reverse` is not "a dead end on an emulator."** It works fine, and RN's own CLI runs it unconditionally. The real mechanism is upstream: `AndroidInfoHelpers.kt:94-101` resolves the dev server to `10.0.2.2:8081` on a stock emulator (a `Build.FINGERPRINT` heuristic), and reverse forwarding binds *device*-localhost — **the tunnel is aimed at a door nobody knocks on**. Documenting it as "doesn't work" would leave the next agent unable to reason about the case where it *is* the answer.
2. **The shared Metro cache does not need HEAD in its key.** Entries are content-addressed (`Transformer.js:73-108`: `partialKey` ++ `sha1(file contents)`). Adding HEAD would fork the cache per commit and destroy the cross-branch reuse measured at 23.4s → 4.3s in #4131.
3. **`resolver.unstable_enableSymlinks` no longer exists** in the Metro that actually runs (0.84.4 via `community-cli-plugin`, not the 0.80.8 top-level copy). Symlinks are followed unconditionally and the option is a silent no-op — `resolver.nodeModulesPaths` + `watchFolders` are the real knobs, now behind an opt-in `DEMO_NODE_MODULES`.

`point-app-at-metro.sh` therefore uses `debug_http_host = 10.0.2.2:<claimed port>`, pushed as a **file** (inline `printf` through `run-as` mangles the XML header) and followed by a **force-stop** — not superstition: `PackagerConnectionSettings` caches the resolved host in a `companion object`, so a value written after auto-detection has run is ignored until the process restarts.

## A trap this PR would otherwise have created

Once the claimed port lives in `debug_http_host`, **Android's Metro pointer is app data** — so a `clearState` flow silently drops the emulator back to `10.0.2.2:8081`, another agent's Metro. The `clearState` guard is now platform-neutral (it exempted Android on a comment that was wrong twice over). Android also **inherits the ~20 s warmup skip for free**, since it finally has a session dir to hold the marker — it was iOS-gated only for lack of one.

## `verify-session.sh` — never assume

Platform-neutral, reusing the `/events` websocket client from `reload-app.sh`: asserts Metro **actually served a bundle** on the claimed port, names a foreign Metro on 8081, and catches **checkout drift** (the shared clone moving branches mid-session — the thing that manufactured a phantom `Rendered fewer hooks` regression). Both claims now record worktree + HEAD.

## Tests

**6 suites, 482 assertions**, all green. The Android suite's baseline is deliberately hostile — a *foreign* emulator attached that must survive every test — and the guarantees are mutation-checked: booting without `-port`, dropping the force-stop, and skipping the AVD ownership check each turn the relevant assertions red.

Also killed a class of doc rot: every suite now compares its own `PASS+FAIL` against the count documented in its SKILL.md and fails on drift. It caught a stale 105-vs-110 on its first run — a number I had bumped by hand, and the one number nothing checked.

## Live verification

Claim proven end-to-end on this machine: `Pixel_9a` booted on the reserved console port as `emulator-5554`, Metro on the claimed 8192, and the claim printed exactly the diagnostic the lost session needed — *"port 8081 is held by another process… an emulator otherwise dials 10.0.2.2:8081 and loads somebody else's bundle."*

**The app-reaches-my-Metro chain is now proven end to end** — the thing the reporting session could never achieve:

```
$ point-app-at-metro.sh
com.galoyapp on emulator-5554 now points at 10.0.2.2:8192

$ adb shell run-as com.galoyapp cat …/com.galoyapp_preferences.xml
<map><string name="debug_http_host">10.0.2.2:8192</string></map>

$ verify-session.sh
checkout: …/wt-bless still at 4b5e2e38e
note: port 8081 is held by another process — this session's port is 8192
bundle: Metro on 8192 served a bundle request - the app is talking to this session
session verified
```

The app then rendered the real Blink UI (Create new account / Log in) from that bundle, on a fresh `assembleDebug` APK installed on the claimed emulator. Release was clean: `stopped Metro pid 89827 (port 8192)` / `shut down emulator-5554 (AVD Pixel_9a)` / `verified: no other emulator was shut down by this session`, with every reservation freed.

Telemetry from that session, for the record — claim is dominated by emulator boot, which is why the golden follow-up matters:

| span | duration |
|---|---|
| `android.claim.boot` (Pixel_9a cold) | 12.3 s |
| `android.claim.total` | 12.9 s |
| `android.point_at_metro.total` | 0.2 s |
| `session.verify.total` | 1.3 s |

## Follow-ups filed

- **#4169** — Android golden (logged-in AVD snapshot restored per session), with the unknowns that kept it out of this PR. Until it exists, account-gated screens have no honest Android recording path, and the SKILL.md says so plainly.
- **#4170** — the `webView` `Rendered fewer hooks than expected` crash, typed Bug: it reproduces on `origin/main` via every synthesized entry point, so it is an app bug the demo merely surfaced.
