### PR TITLE
fix(self-custody): patch uniffi-bindgen-react-native RustBuffer for 32-bit Android

### DIFF
--- a/patches/uniffi-bindgen-react-native+0.29.3-1.patch
+++ b/patches/uniffi-bindgen-react-native+0.29.3-1.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/uniffi-bindgen-react-native/cpp/includes/RustBuffer.h b/node_modules/uniffi-bindgen-react-native/cpp/includes/RustBuffer.h
+index 68fb1d8..c433065 100644
+--- a/node_modules/uniffi-bindgen-react-native/cpp/includes/RustBuffer.h
++++ b/node_modules/uniffi-bindgen-react-native/cpp/includes/RustBuffer.h
+@@ -10,8 +10,11 @@
+ #include "UniffiCallInvoker.h"
+ #include <jsi/jsi.h>
+ 
++// Patched (patch-package): match uniffi-core 0.29's #[repr(C)] RustBuffer
++// layout (u64 capacity, u64 len, ptr data) on 32-bit targets, where size_t
++// is 4 bytes and would otherwise misalign the FFI struct.
+ struct RustBuffer {
+-  size_t capacity;
+-  size_t len;
++  uint64_t capacity;
++  uint64_t len;
+   uint8_t *data;
+ };


### PR DESCRIPTION
Fixes https://github.com/blinkbitcoin/blink-mobile/issues/4172, a deterministic SIGABRT crash when opening the self-custody wallet (Breez Spark SDK) on 32-bit Android processes (armeabi-v7a, x86), seen in the wild on Android 10 devices that ship a 32-bit userspace (e.g. Tecno Spark/Pop/Camon lines) and reproduced on a 32-bit x86 Android 10 emulator. Crash evidence: docs/tecno-crash/tombstone_00..05 (all six identical).

Symptom
-------
signal 6 (SIGABRT) on the React Native JS thread (mqt_v_js) with abort message "null RustBuffer had non-zero capacity" — a Rust panic with panic=abort inside libbreez_sdk_spark_bindings.so (shipped by @breeztech/breez-sdk-spark-react-native@0.22.0). The symbolized backtrace shows the panic firing in std::panicking with the oldest application frame inside bip39::Mnemonic::to_seed_normalized, i.e. it detonates on the very first self-custody call (app/self-custodial/bridge/wallet.ts:31, defaultExternalSigners deriving key material from the wallet mnemonic).

Root cause
----------
The panic is an assertion in uniffi-core 0.29's
RustBuffer::destroy_into_vec():

    if self.data.is_null() {
        assert!(self.capacity == 0, "null RustBuffer had non-zero capacity");

It fires because the C++/JSI bridge and the Rust library disagree on the binary layout of the RustBuffer FFI struct on 32-bit ABIs:

- Rust side (uniffi 0.29, confirmed by disassembling RustBuffer::from_vec at 0xb4d6ec in the shipped x86 .so): #[repr(C)] struct RustBuffer { capacity: u64, len: u64, data: *mut u8 } -> 20 bytes on 32-bit, fields at offsets 0 / 8 / 16
- C++ side (uniffi-bindgen-react-native@0.29.3-1, cpp/includes/RustBuffer.h): struct RustBuffer { size_t capacity; size_t len; uint8_t *data; } -> 12 bytes on 32-bit (size_t is 4 bytes), fields at offsets 0 / 4 / 8

On 64-bit targets size_t == uint64_t so the layouts accidentally match and the bug is latent — which is why only 32-bit devices crash. On 32-bit, a by-value RustBuffer handed to Rust is misread: Rust's u64 capacity spans C++'s cap+len (non-zero garbage) while Rust's data pointer is read from memory C++ never wrote (often NULL) -> data == NULL + capacity != 0 -> assertion -> abort. The by-value return path is equally broken, so every SDK call moving a byte buffer across the boundary is poisoned.

Same class of bug as mozilla/uniffi-rs#2624. Upstream fixed the header in uniffi-bindgen-react-native >= 0.30.0-1 (fields are uint64_t there), but @breeztech/breez-sdk-spark-react-native@0.22.0 (latest published) still depends on ^0.29.3-1.

Fix
---
patch-package patch changing the C++ struct fields from size_t to uint64_t so both sides of the FFI agree on the layout. The prebuilt Rust .so already uses the u64 layout and the bridge C++ is compiled during the app build, so this aligns the two sides without touching the prebuilt library. Applied automatically by the existing postinstall (yarn patch-package --error-on-fail); requires a rebuild of the Android app to take effect.

Screenshot of the fix running in an emulator.

<img width="526" height="1000" alt="image" src="https://github.com/user-attachments/assets/d4cba389-6c58-40ae-aeed-62593e68241a" />


Follow-ups
----------
- Report upstream to Breez so the SDK is rebuilt against uniffi-bindgen-react-native >= 0.30 (this breaks every 32-bit user of their React Native SDK); drop this patch once the dependency is updated.
- Consider dropping armeabi-v7a from abiFilters (android/app/build.gradle) or gating the self-custody feature behind a 64-bit ABI check until the upstream fix lands.