### PR TITLE
fix(navigation): stop screens that replace the header back button from crashing

### DIFF
--- a/__tests__/components/header-back-control/header-back-control.spec.tsx
+++ b/__tests__/components/header-back-control/header-back-control.spec.tsx
@@ -1,0 +1,108 @@
+import React from "react"
+import { Platform, StyleProp, StyleSheet, ViewStyle } from "react-native"
+import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { ThemeProvider } from "@rn-vui/themed"
+
+import theme from "@app/rne-theme/theme"
+import {
+  headerBackControl,
+  InvisibleBackButton,
+} from "@app/components/header-back-control/header-back-control"
+
+import {
+  DefaultTheme as navigationDefaultTheme,
+  ThemeProvider as NavigationThemeProvider,
+} from "@react-navigation/native"
+import { NativeStackHeaderBackProps } from "@react-navigation/native-stack"
+
+/* Guards the contract documented on headerBackControl: what `headerLeft` receives must
+ * be a render function that calls no hooks of its own (#4176). */
+
+const mockGoBack = jest.fn()
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ goBack: mockGoBack }),
+}))
+
+const BACK_BUTTON_LABEL = "Go back"
+
+const originalPlatformOS = Platform.OS
+
+const headerProps: NativeStackHeaderBackProps = { canGoBack: true }
+
+const backButtonStyle = (button: { props: { style?: StyleProp<ViewStyle> } }) =>
+  StyleSheet.flatten(button.props.style)
+
+/* HeaderBackButton reads react-navigation's own theme, which normally comes from the
+ * NavigationContainer the header lives in. */
+const renderHeaderLeft = (element: React.ReactNode) =>
+  render(
+    <NavigationThemeProvider value={navigationDefaultTheme}>
+      <ThemeProvider theme={theme}>{element}</ThemeProvider>
+    </NavigationThemeProvider>,
+  )
+
+describe("headerBackControl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(Platform, "OS", {
+      configurable: true,
+      value: originalPlatformOS,
+    })
+  })
+
+  it("returns an element instead of invoking the button component", () => {
+    const element = headerBackControl()(headerProps)
+
+    expect(React.isValidElement(element)).toBe(true)
+  })
+
+  it("goes back when the themed button is pressed", async () => {
+    const { getByLabelText } = renderHeaderLeft(headerBackControl()(headerProps))
+
+    fireEvent.press(getByLabelText(BACK_BUTTON_LABEL))
+
+    // HeaderBackButton defers its onPress to the next frame.
+    await waitFor(() => expect(mockGoBack).toHaveBeenCalledTimes(1))
+  })
+
+  it("renders the invisible placeholder when going back is not allowed", () => {
+    const element = headerBackControl({ canGoBack: false })(headerProps)
+
+    expect((element as React.ReactElement).type).toBe(InvisibleBackButton)
+  })
+
+  it("keeps the placeholder out of the accessibility tree", () => {
+    const { queryByLabelText } = renderHeaderLeft(
+      headerBackControl({ canGoBack: false })(headerProps),
+    )
+
+    // It only holds the header slot, so a screen reader must never announce it.
+    expect(queryByLabelText(BACK_BUTTON_LABEL)).toBeNull()
+  })
+
+  /* Both cases assert the correction this component owns, not the final on-screen
+   * position: HeaderBackButton's own platform styles are frozen when its module loads,
+   * so they stay on the iOS branch whatever this test does to Platform. */
+  it("adds no inset correction on iOS", () => {
+    const { getByLabelText } = renderHeaderLeft(headerBackControl()(headerProps))
+
+    expect(backButtonStyle(getByLabelText(BACK_BUTTON_LABEL))).toMatchObject({
+      marginLeft: 0,
+    })
+  })
+
+  it("pulls the button left on Android, where the native header adds its own inset", () => {
+    Object.defineProperty(Platform, "OS", { configurable: true, value: "android" })
+
+    const { getByLabelText } = renderHeaderLeft(headerBackControl()(headerProps))
+
+    expect(backButtonStyle(getByLabelText(BACK_BUTTON_LABEL))).toMatchObject({
+      marginLeft: -10,
+    })
+  })
+})

--- a/__tests__/components/header-back-control/header-back-control.spec.tsx
+++ b/__tests__/components/header-back-control/header-back-control.spec.tsx
@@ -20,6 +20,10 @@ import { NativeStackHeaderBackProps } from "@react-navigation/native-stack"
 
 const mockGoBack = jest.fn()
 
+/* Everything but useNavigation stays real, which is what lets these tests render
+ * react-navigation's own ThemeProvider. A jest.spyOn on the module would be narrower
+ * still, but react-navigation v7 ships ESM only: its exports transpile to
+ * non-configurable getters and spying on one throws "Cannot redefine property". */
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
   useNavigation: () => ({ goBack: mockGoBack }),
@@ -36,12 +40,26 @@ const backButtonStyle = (button: { props: { style?: StyleProp<ViewStyle> } }) =>
 
 /* HeaderBackButton reads react-navigation's own theme, which normally comes from the
  * NavigationContainer the header lives in. */
-const renderHeaderLeft = (element: React.ReactNode) =>
-  render(
-    <NavigationThemeProvider value={navigationDefaultTheme}>
-      <ThemeProvider theme={theme}>{element}</ThemeProvider>
-    </NavigationThemeProvider>,
-  )
+const withProviders = (element: React.ReactNode) => (
+  <NavigationThemeProvider value={navigationDefaultTheme}>
+    <ThemeProvider theme={theme}>{element}</ThemeProvider>
+  </NavigationThemeProvider>
+)
+
+const renderHeaderLeft = (element: React.ReactNode) => render(withProviders(element))
+
+/* Stands in for native-stack's useHeaderConfigProps: it calls hooks of its own and then
+ * invokes `headerLeft` inline in the same body, which is what makes a hook called by the
+ * render function land on this fiber. */
+const HeaderConfigHost = ({
+  headerLeft,
+}: {
+  headerLeft: (props: NativeStackHeaderBackProps) => React.ReactNode
+}) => {
+  React.useState(0)
+
+  return <>{headerLeft(headerProps)}</>
+}
 
 describe("headerBackControl", () => {
   beforeEach(() => {
@@ -68,6 +86,52 @@ describe("headerBackControl", () => {
 
     // HeaderBackButton defers its onPress to the next frame.
     await waitFor(() => expect(mockGoBack).toHaveBeenCalledTimes(1))
+  })
+
+  /* The crash #4176 fixed: the KYC webview (webview.tsx) and the account-delete flow
+   * (delete.tsx) both hand `setOptions` a headerLeft that calls no hooks, so whatever this
+   * control puts there first must not call any either. */
+  it("survives a screen replacing the header with a hookless render", () => {
+    const { rerender } = render(
+      withProviders(<HeaderConfigHost headerLeft={headerBackControl()} />),
+    )
+
+    expect(() =>
+      rerender(withProviders(<HeaderConfigHost headerLeft={() => null} />)),
+    ).not.toThrow()
+  })
+
+  it("keeps going back allowed when the route carries no canGoBack param", () => {
+    const { getByLabelText } = renderHeaderLeft(
+      headerBackControl({ canGoBack: undefined })(headerProps),
+    )
+
+    expect(getByLabelText(BACK_BUTTON_LABEL)).toBeTruthy()
+  })
+
+  /* The onboarding screens flip this through setParams while the screen stays mounted
+   * (root-navigator.tsx:993, :1001), so the header has to swap controls mid-life. */
+  it("drops the back button when the route turns canGoBack off", () => {
+    const { queryByLabelText, rerender } = render(
+      withProviders(<HeaderConfigHost headerLeft={headerBackControl()} />),
+    )
+
+    rerender(
+      withProviders(
+        <HeaderConfigHost headerLeft={headerBackControl({ canGoBack: false })} />,
+      ),
+    )
+
+    expect(queryByLabelText(BACK_BUTTON_LABEL)).toBeNull()
+  })
+
+  it("passes the header's own props through to the button", () => {
+    const { getByLabelText } = renderHeaderLeft(
+      headerBackControl()({ ...headerProps, label: "Settings" }),
+    )
+
+    // HeaderBackButton builds its accessibility label from the one the header supplies.
+    expect(getByLabelText("Settings, back")).toBeTruthy()
   })
 
   it("renders the invisible placeholder when going back is not allowed", () => {

--- a/app/components/header-back-control/header-back-control.tsx
+++ b/app/components/header-back-control/header-back-control.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Platform, View } from "react-native"
 import { HeaderBackButton } from "@react-navigation/elements"
 import { useNavigation } from "@react-navigation/native"
+import { NativeStackHeaderBackProps } from "@react-navigation/native-stack"
 import { makeStyles, useTheme } from "@rn-vui/themed"
 
 // native-stack wraps headerLeft in react-native-screens' ScreenStackHeaderLeftView,
@@ -48,8 +49,23 @@ const HeaderBackButtonWithTheme = (
   )
 }
 
-export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams = {}) =>
-  canGoBack ? HeaderBackButtonWithTheme : InvisibleBackButton
+/**
+ * The render function handed to `headerLeft` must never call hooks itself, which is why
+ * it returns an element instead of the button component: native-stack invokes
+ * `headerLeft` inline while it computes the header config (useHeaderConfigProps, called
+ * from NativeStackView's own body), so hooks called there land on that fiber rather than
+ * on the button's. Any screen that then replaces `headerLeft` with a hookless render (the
+ * KYC webview, the account-delete flow) leaves that fiber rendering fewer hooks than the
+ * previous pass, which throws "Rendered fewer hooks than expected" and drops the whole
+ * navigation tree into the app-wide error boundary (#4176).
+ */
+export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams = {}) => {
+  const HeaderBack = (props: NativeStackHeaderBackProps): React.ReactNode =>
+    canGoBack ? <HeaderBackButtonWithTheme {...props} /> : <InvisibleBackButton />
+  HeaderBack.displayName = "HeaderBack"
+
+  return HeaderBack
+}
 
 const useStyles = makeStyles(() => {
   const isAndroid = Platform.OS === "android"

--- a/app/components/header-back-control/header-back-control.tsx
+++ b/app/components/header-back-control/header-back-control.tsx
@@ -53,11 +53,12 @@ const HeaderBackButtonWithTheme = (
  * The render function handed to `headerLeft` must never call hooks itself, which is why
  * it returns an element instead of the button component: native-stack invokes
  * `headerLeft` inline while it computes the header config (useHeaderConfigProps, called
- * from NativeStackView's own body), so hooks called there land on that fiber rather than
- * on the button's. Any screen that then replaces `headerLeft` with a hookless render (the
- * KYC webview, the account-delete flow) leaves that fiber rendering fewer hooks than the
- * previous pass, which throws "Rendered fewer hooks than expected" and drops the whole
- * navigation tree into the app-wide error boundary (#4176).
+ * from SceneView, the per-screen child NativeStackView renders around each route), so
+ * hooks called there land on that fiber rather than on the button's. Any screen that then
+ * replaces `headerLeft` with a hookless render (the KYC webview, the account-delete flow)
+ * leaves that fiber rendering fewer hooks than the previous pass, which throws "Rendered
+ * fewer hooks than expected" and drops the whole navigation tree into the app-wide error
+ * boundary (#4176).
  */
 export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams = {}) => {
   const HeaderBack = (props: NativeStackHeaderBackProps): React.ReactNode =>
@@ -67,6 +68,9 @@ export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams 
   return HeaderBack
 }
 
+/** The platform check sits inside the factory rather than in a module constant so the
+ *  spec can vary `Platform.OS` per case without re-importing the module. makeStyles
+ *  memoizes per hook instance, so a fresh render always re-reads it. */
 const useStyles = makeStyles(() => {
   const isAndroid = Platform.OS === "android"
   const backButtonInsetCorrection = isAndroid ? ANDROID_BACK_BUTTON_INSET_CORRECTION : 0

--- a/app/components/header-back-control/header-back-control.tsx
+++ b/app/components/header-back-control/header-back-control.tsx
@@ -9,7 +9,7 @@ import { makeStyles, useTheme } from "@rn-vui/themed"
 // HeaderBackButton was tuned for the old JS stack (no such inset), so it now sits
 // ~10px too far right. Pull it back on Android to restore the previous position.
 // (Migration to native-stack: PR #3840 / commit 4b6bff263.)
-const BACK_BUTTON_INSET_CORRECTION = Platform.OS === "android" ? -10 : 0
+const ANDROID_BACK_BUTTON_INSET_CORRECTION = -10
 
 export const InvisibleBackButton = (): React.ReactNode => {
   const styles = useStyles()
@@ -20,7 +20,7 @@ export const InvisibleBackButton = (): React.ReactNode => {
       importantForAccessibility="no-hide-descendants"
       style={styles.container}
     >
-      <HeaderBackButton onPress={() => {}} style={styles.backButton} />
+      <HeaderBackButton style={styles.backButton} />
     </View>
   )
 }
@@ -51,11 +51,16 @@ const HeaderBackButtonWithTheme = (
 export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams = {}) =>
   canGoBack ? HeaderBackButtonWithTheme : InvisibleBackButton
 
-const useStyles = makeStyles(() => ({
-  container: {
-    opacity: 0,
-  },
-  backButton: {
-    marginLeft: BACK_BUTTON_INSET_CORRECTION,
-  },
-}))
+const useStyles = makeStyles(() => {
+  const isAndroid = Platform.OS === "android"
+  const backButtonInsetCorrection = isAndroid ? ANDROID_BACK_BUTTON_INSET_CORRECTION : 0
+
+  return {
+    container: {
+      opacity: 0,
+    },
+    backButton: {
+      marginLeft: backButtonInsetCorrection,
+    },
+  }
+})

--- a/app/components/header-back-control/header-back-control.tsx
+++ b/app/components/header-back-control/header-back-control.tsx
@@ -63,7 +63,6 @@ const HeaderBackButtonWithTheme = (
 export const headerBackControl = ({ canGoBack = true }: HeaderBackControlParams = {}) => {
   const HeaderBack = (props: NativeStackHeaderBackProps): React.ReactNode =>
     canGoBack ? <HeaderBackButtonWithTheme {...props} /> : <InvisibleBackButton />
-  HeaderBack.displayName = "HeaderBack"
 
   return HeaderBack
 }

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -186,6 +186,12 @@ const DeveloperScreen: React.ComponentType | null = __DEV__
     require("../screens/developer-screen").DeveloperScreen
   : null
 
+/** Built once so every navigator hands `headerLeft` the same function. Calling the factory
+ *  inside a navigator's screenOptions would mint a new identity on each render, which stays
+ *  invisible only while native-stack invokes headerLeft instead of rendering it as an
+ *  element; the day that changes, the back button would remount on every render. */
+const defaultHeaderBack = headerBackControl()
+
 const RootNavigator = createNativeStackNavigator<RootStackParamList>()
 
 const withOfflineGate = <P extends object>(Screen: React.ComponentType<P>) => {
@@ -249,7 +255,7 @@ export const RootStack = () => {
         headerTitleStyle: styles.title,
         headerTintColor: colors.black,
         headerShadowVisible: false,
-        headerLeft: headerBackControl(),
+        headerLeft: defaultHeaderBack,
       }}
       initialRouteName={hasAccount ? "authenticationCheck" : "getStarted"}
     >
@@ -1023,7 +1029,7 @@ export const ContactNavigator = () => {
         headerTitleStyle: styles.title,
         headerTintColor: colors.black,
         headerShadowVisible: false,
-        headerLeft: headerBackControl(),
+        headerLeft: defaultHeaderBack,
       }}
       initialRouteName="peopleHome"
     >
@@ -1081,7 +1087,7 @@ export const PhoneLoginNavigator = () => {
         headerTitleStyle: styles.title,
         headerTintColor: colors.black,
         headerShadowVisible: false,
-        headerLeft: headerBackControl(),
+        headerLeft: defaultHeaderBack,
       }}
     >
       <StackPhoneValidation.Screen

--- a/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/contact-support-screen.tsx
@@ -140,10 +140,11 @@ export const MigrationContactSupportScreen: React.FC = () => {
    * beneath it swallows back, so the press is intercepted and redirected to the commit
    * point instead. Every other origin pops, which is already what the header control does.
    *
-   * Intercepting through the navigator rather than replacing `headerLeft` is deliberate: a
-   * `headerLeft` render function passed through `setOptions` makes the native stack header
-   * re-render with a different hook count on Android, which crashes the screen outright
-   * ("Rendered fewer hooks than expected") before any of this is reachable.
+   * Intercepting through the navigator rather than replacing `headerLeft` is deliberate:
+   * `beforeRemove` catches every way off the screen (the header button, the hardware back
+   * and the swipe gesture), while a replaced `headerLeft` would only catch the tap.
+   * (Replacing it used to crash outright with "Rendered fewer hooks than expected"; that
+   * was a repo bug in headerBackControl, fixed in #4176, not a native-stack law.)
    */
   const isRedirectingBackRef = useRef(false)
   useEffect(() => {


### PR DESCRIPTION
Closes #4176

## What breaks

`headerBackControl()` handed native-stack the button **component** instead of a render function. native-stack does not render `headerLeft` as a component: it invokes it inline while computing the header config (`useHeaderConfigProps`, called from `NativeStackView`'s own body), so the button's three hooks (`useNavigation`, `useStyles`, `useTheme`) ran on that fiber instead of on its own.

Any screen that then replaces `headerLeft` with a render function that calls no hooks leaves the same fiber rendering three fewer hooks than the previous pass. React throws `Rendered fewer hooks than expected`, and the app-wide error boundary swaps the whole navigation tree for the "issues loading the application data" screen.

Two screens do exactly that:

- the KYC webview, which installs its own back control through `headerLeftNoGlass`, so identity verification takes the app down the moment it opens
- the account-delete flow, which sets `headerLeft: () => null` while the deletion runs

## Reproduced, then verified after the fix

Reproduced on an Android emulator against staging with an account shaped like the reported ones (level 1, no username, zero balance, phone from the same region): Settings, Account, Identity Verification crashed with the exact error the two customers reported. The error boundary's component stack pointed at the fiber that computes the header config, which is what identified the header as the source rather than any KYC code.

After the fix, that same path opens the Sumsub webview, and the header back returns to the onboarding screen. Also exercised on device: Settings, Transaction limits, Fee rates, Account and every back out of them; the four tabs; Receive; and the nested phone-login stack, whose back now pops within its own stack. Zero hook errors and zero JS errors across all of it.

## Scope

Shipping since 3.0.22 (7 Aug), so 3.0.22 through 3.0.26 are affected. It is not region-specific and not an account state, so the reported accounts need no KYC reset: any user who opens the in-app KYC flow hits it.

## Tests

New spec for `headerBackControl` covering the contract (what `headerLeft` receives must be a render function that calls no hooks), the press that dispatches `goBack`, the invisible placeholder staying out of the accessibility tree, and the platform inset. 100% coverage on the changed file across statements, branches, functions and lines. `__tests__/navigation` plus `__tests__/components` stay green: 111 suites, 1182 tests.

## Commits

The cleanup lands first on purpose: it moves the platform check into the stylesheet, which is what makes the inset assertions observable, so the fix commit arrives with its tests already passing and each commit is green on its own.
