### PR TITLE
chore(graphql): regenerate generated.ts against the staging schema

### DIFF
--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -188,6 +188,20 @@ export const AccountLevel = {
 } as const;
 
 export type AccountLevel = typeof AccountLevel[keyof typeof AccountLevel];
+/** Daily transaction limits enforced for a given account level. */
+export type AccountLevelLimits = {
+  readonly __typename: 'AccountLevelLimits';
+  /** Max amount that can be converted between currencies among an account's own wallets. */
+  readonly convert: Scalars['CentAmount']['output'];
+  /** Max amount that can be sent to other internal accounts. */
+  readonly internalSend: Scalars['CentAmount']['output'];
+  /** The rolling time interval in seconds that the limits apply for. */
+  readonly interval: Scalars['Seconds']['output'];
+  readonly level: AccountLevel;
+  /** Max amount that can be withdrawn to external onchain or lightning destinations. */
+  readonly withdrawal: Scalars['CentAmount']['output'];
+};
+
 export type AccountLimit = {
   /** The rolling time interval in seconds that the limits would apply for. */
   readonly interval?: Maybe<Scalars['Seconds']['output']>;
@@ -952,6 +966,8 @@ export type FeesInformation = {
 /** Provides global settings for the application which might have an impact for the user. */
 export type Globals = {
   readonly __typename: 'Globals';
+  /** Daily transaction limits enforced for each account level, in USD cents. */
+  readonly accountLimitsByLevel: ReadonlyArray<AccountLevelLimits>;
   /** Current block height and block hash */
   readonly blockInfo?: Maybe<BlockInfo>;
   readonly buildInformation: BuildInformation;
@@ -10437,6 +10453,7 @@ export type ResolversTypes = {
   AccountEnableNotificationCategoryInput: AccountEnableNotificationCategoryInput;
   AccountEnableNotificationChannelInput: AccountEnableNotificationChannelInput;
   AccountLevel: AccountLevel;
+  AccountLevelLimits: ResolverTypeWrapper<AccountLevelLimits>;
   AccountLimit: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AccountLimit']>;
   AccountLimits: ResolverTypeWrapper<AccountLimits>;
   AccountMigration: ResolverTypeWrapper<AccountMigration>;
@@ -10747,6 +10764,7 @@ export type ResolversParentTypes = {
   AccountDisableNotificationChannelInput: AccountDisableNotificationChannelInput;
   AccountEnableNotificationCategoryInput: AccountEnableNotificationCategoryInput;
   AccountEnableNotificationChannelInput: AccountEnableNotificationChannelInput;
+  AccountLevelLimits: AccountLevelLimits;
   AccountLimit: ResolversInterfaceTypes<ResolversParentTypes>['AccountLimit'];
   AccountLimits: AccountLimits;
   AccountMigration: AccountMigration;
@@ -11048,6 +11066,15 @@ export type AccountResolvers<ContextType = any, ParentType extends ResolversPare
 export type AccountDeletePayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['AccountDeletePayload'] = ResolversParentTypes['AccountDeletePayload']> = {
   errors?: Resolver<ReadonlyArray<ResolversTypes['Error']>, ParentType, ContextType>;
   success?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type AccountLevelLimitsResolvers<ContextType = any, ParentType extends ResolversParentTypes['AccountLevelLimits'] = ResolversParentTypes['AccountLevelLimits']> = {
+  convert?: Resolver<ResolversTypes['CentAmount'], ParentType, ContextType>;
+  internalSend?: Resolver<ResolversTypes['CentAmount'], ParentType, ContextType>;
+  interval?: Resolver<ResolversTypes['Seconds'], ParentType, ContextType>;
+  level?: Resolver<ResolversTypes['AccountLevel'], ParentType, ContextType>;
+  withdrawal?: Resolver<ResolversTypes['CentAmount'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -11533,6 +11560,7 @@ export type FeesInformationResolvers<ContextType = any, ParentType extends Resol
 };
 
 export type GlobalsResolvers<ContextType = any, ParentType extends ResolversParentTypes['Globals'] = ResolversParentTypes['Globals']> = {
+  accountLimitsByLevel?: Resolver<ReadonlyArray<ResolversTypes['AccountLevelLimits']>, ParentType, ContextType>;
   blockInfo?: Resolver<Maybe<ResolversTypes['BlockInfo']>, ParentType, ContextType>;
   buildInformation?: Resolver<ResolversTypes['BuildInformation'], ParentType, ContextType>;
   feesInformation?: Resolver<ResolversTypes['FeesInformation'], ParentType, ContextType>;
@@ -12488,6 +12516,7 @@ export type WelcomeProfileResolvers<ContextType = any, ParentType extends Resolv
 export type Resolvers<ContextType = any> = {
   Account?: AccountResolvers<ContextType>;
   AccountDeletePayload?: AccountDeletePayloadResolvers<ContextType>;
+  AccountLevelLimits?: AccountLevelLimitsResolvers<ContextType>;
   AccountLimit?: AccountLimitResolvers<ContextType>;
   AccountLimits?: AccountLimitsResolvers<ContextType>;
   AccountMigration?: AccountMigrationResolvers<ContextType>;


### PR DESCRIPTION
## Problem

Every open PR fails `Check Code`, whatever it touches:

```
Error: app/graphql/generated.ts has changes, run `yarn dev:codegen` and re-commit
```

`codegen.yml:2` reads the schema from the **live** `https://api.staging.blink.sv/graphql`,
so the `check:codegen` guard compares the committed `app/graphql/generated.ts` against
whatever staging happens to be serving at the moment CI runs. When staging deploys a
schema change, the committed file is instantly stale and the guard reddens every branch —
including branches that touch no GraphQL at all.

That is worse than noisy. A check that fails for reasons unrelated to the diff under
review is not a signal, and it trains reviewers to wave a red build through.

**Confirmed it is not any one branch:** checking out **main's own** `generated.ts` and
running `npx graphql-codegen --config codegen.yml` produces the same 29-line diff, so main
itself is behind staging.

## Fix

`yarn dev:codegen`, committed. The drift is `AccountLevelLimits` and
`Globals.accountLimitsByLevel` — the account-limits work now live on staging.

**Purely additive: 29 insertions, zero removals.** No type the app consumes today changes
shape, which is what makes this safe to land on its own.

## Verification

- Regenerated, then ran codegen **a second time** on the result: no diff. That is precisely
  what the CI guard asserts, so `Check Code` will pass.
- `tsc --noEmit` clean; ESLint clean on the generated file.
- 217 tests green across `__tests__/graphql`, `send-confirmation` and `home` — the specs
  leaning hardest on generated types.

## This is a snapshot, not a cure

The next staging schema deploy reopens the identical gap, and someone gets to rediscover it
from a mystifying red build on an unrelated PR. A durable fix is to pin codegen to a
committed SDL and refresh it deliberately:

- the repo already ships `supergraph.graphql`, and `codegen.yml:3` carries a commented-out
  `# schema: "./supergraph.graphql"` — so this was considered at some point
- codegen then becomes deterministic and reproducible offline; a backend deploy can no
  longer redden unrelated PRs, and schema updates arrive as a reviewable diff in the PR
  that intends them
- the trade is that picking up new backend fields becomes a deliberate step rather than
  automatic, which for a mobile client is arguably the correct default

Deliberately **not** doing that here — it changes how the team picks up schema changes and
deserves its own discussion, whereas this unblocks CI today. Happy to open it as a
follow-up if there is appetite.
