### PR TITLE
fix(phone-auth): stop the country selector from taking half the phone row

### DIFF
--- a/__tests__/components/phone-input/phone-input.spec.tsx
+++ b/__tests__/components/phone-input/phone-input.spec.tsx
@@ -82,12 +82,15 @@ describe("PhoneInput", () => {
     )
 
     /** The phone auth screens each grew their own copy of this button and ended up with
-     *  two halves fighting over the row, which left the number unreadably narrow. Exactly
-     *  one of them may grow, and here it is the field. */
+     *  two halves fighting over the row, which left the number unreadably narrow. This
+     *  copy never had the defect, so the test guards it forward rather than proving a
+     *  fix: exactly one of the two may grow, and here it is the field. */
     const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
     const button = StyleSheet.flatten(props.buttonStyle as StyleProp<ViewStyle>)
     expect(button.flex).toBeUndefined()
     expect(button.flexGrow).toBeUndefined()
+    expect(button.width).toBeUndefined()
+    expect(button.flexBasis).toBeUndefined()
 
     const field = StyleSheet.flatten(UNSAFE_getByType(ThemedInput).props.containerStyle)
     expect(field.flex).toBe(1)

--- a/__tests__/components/phone-input/phone-input.spec.tsx
+++ b/__tests__/components/phone-input/phone-input.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { StyleProp, TextInput, ViewStyle } from "react-native"
+import { StyleProp, StyleSheet, TextInput, ViewStyle } from "react-native"
 import { Input, ThemeProvider, createTheme } from "@rn-vui/themed"
 import { act, fireEvent, render } from "@testing-library/react-native"
 
@@ -36,6 +36,7 @@ const DIMMED_STYLE = { opacity: 0.6 }
 /** The query needs a plain component type, and rn-vui types `Input`'s ref as the bare
  *  TextInput underneath it, which does not fit one. Only the style prop is read here. */
 const ThemedInput = Input as unknown as React.ComponentType<{
+  containerStyle: StyleProp<ViewStyle>
   inputContainerStyle: StyleProp<ViewStyle>
 }>
 
@@ -72,6 +73,24 @@ describe("PhoneInput", () => {
     renderInput(<PhoneInput value="" onChangeText={jest.fn()} />)
 
     expect(mockCountryCodePicker).not.toHaveBeenCalled()
+  })
+
+  it("leaves the row's free space to the phone field, not to the country button", () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = renderInput(
+      <PhoneInput value="" onChangeText={jest.fn()} />,
+    )
+
+    /** The phone auth screens each grew their own copy of this button and ended up with
+     *  two halves fighting over the row, which left the number unreadably narrow. Exactly
+     *  one of them may grow, and here it is the field. */
+    const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+    const button = StyleSheet.flatten(props.buttonStyle as StyleProp<ViewStyle>)
+    expect(button.flex).toBeUndefined()
+    expect(button.flexGrow).toBeUndefined()
+
+    const field = StyleSheet.flatten(UNSAFE_getByType(ThemedInput).props.containerStyle)
+    expect(field.flex).toBe(1)
   })
 
   it("dims both halves of the field when the caller disables it", () => {

--- a/__tests__/screens/phone-auth-screen/phone-login-input.spec.tsx
+++ b/__tests__/screens/phone-auth-screen/phone-login-input.spec.tsx
@@ -1,0 +1,132 @@
+import React from "react"
+import { StyleProp, StyleSheet, ViewStyle } from "react-native"
+import { Input } from "@rn-vui/themed"
+import { render } from "@testing-library/react-native"
+import type { RouteProp } from "@react-navigation/native"
+
+import { PhoneCodeChannelType } from "@app/graphql/generated"
+import type { PhoneValidationStackParamList } from "@app/navigation/stack-param-lists"
+import { PhoneLoginInitiateType } from "@app/screens/phone-auth-screen/phone-login-initiate-type"
+import { PhoneLoginInitiateScreen } from "@app/screens/phone-auth-screen/phone-login-input"
+import { RequestPhoneCodeStatus } from "@app/screens/phone-auth-screen/request-phone-code-login"
+
+import { flushEffects } from "../../helpers/flush-effects"
+import { ContextForScreen } from "../helper"
+
+const mockCountryCodePicker = jest.fn()
+jest.mock("@app/components/phone-input/country-code-picker", () => ({
+  CountryCodePicker: (props: Record<string, unknown>) => {
+    mockCountryCodePicker(props)
+    return null
+  },
+}))
+
+/** Two leaves of the real hook module, kept out of the way so the partial mock below can
+ *  still hand the screen its genuine status and error constants: app-check reaches for a
+ *  native module no test has, and the location lookup warns about missing API keys. */
+jest.mock("@app/screens/get-started-screen/use-device-token", () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock("@app/hooks/use-device-location", () => ({
+  __esModule: true,
+  default: () => ({ countryCode: undefined, loading: false }),
+}))
+
+const mockRequestPhoneCodeLogin = jest.fn()
+jest.mock("@app/screens/phone-auth-screen/request-phone-code-login", () => ({
+  ...jest.requireActual("@app/screens/phone-auth-screen/request-phone-code-login"),
+  useRequestPhoneCodeLogin: () => mockRequestPhoneCodeLogin(),
+}))
+
+const route = {
+  key: "phoneLoginInitiate",
+  name: "phoneLoginInitiate",
+  params: {
+    type: PhoneLoginInitiateType.Login,
+    channel: PhoneCodeChannelType.Sms,
+    title: "Use SMS",
+  },
+} as unknown as RouteProp<PhoneValidationStackParamList, "phoneLoginInitiate">
+
+/** rn-vui types `Input`'s ref as the bare TextInput underneath it, which does not fit a
+ *  component type. Only the container style is read here. */
+const ThemedInput = Input as unknown as React.ComponentType<{
+  containerStyle: StyleProp<ViewStyle>
+}>
+
+const renderScreen = async () => {
+  const screen = render(
+    <ContextForScreen>
+      <PhoneLoginInitiateScreen route={route} />
+    </ContextForScreen>,
+  )
+  await flushEffects()
+  return screen
+}
+
+const countryButtonStyle = () => {
+  const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+  return StyleSheet.flatten(props.buttonStyle as StyleProp<ViewStyle>)
+}
+
+describe("PhoneLoginInitiateScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequestPhoneCodeLogin.mockReturnValue({
+      status: RequestPhoneCodeStatus.InputtingPhoneNumber,
+      setStatus: jest.fn(),
+      phoneInputInfo: {
+        countryCode: "SV",
+        countryCallingCode: "503",
+        formattedPhoneNumber: "",
+        rawPhoneNumber: "",
+      },
+      validatedPhoneNumber: undefined,
+      error: undefined,
+      userSubmitPhoneNumber: jest.fn(),
+      phoneCodeChannel: PhoneCodeChannelType.Sms,
+      isTelegramSupported: true,
+      isWhatsAppSupported: true,
+      isSmsSupported: true,
+      captchaLoading: false,
+      setCountryCode: jest.fn(),
+      setPhoneNumber: jest.fn(),
+      supportedCountries: ["SV", "US"],
+      loadingSupportedCountries: false,
+    })
+  })
+
+  it("renders both halves of the phone row", async () => {
+    const { getByTestId } = await renderScreen()
+
+    expect(mockCountryCodePicker).toHaveBeenCalled()
+    expect(getByTestId("telephoneNumber")).toBeTruthy()
+  })
+
+  it("leaves the row's free space to the phone field, not to the country button", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = await renderScreen()
+
+    /** Both halves growing is what broke the layout: the button took half the row and the
+     *  number was squeezed into what was left. Exactly one of them may grow. */
+    const button = countryButtonStyle()
+    expect(button.flex).toBeUndefined()
+    expect(button.flexGrow).toBeUndefined()
+
+    const field = StyleSheet.flatten(UNSAFE_getByType(ThemedInput).props.containerStyle)
+    expect(field.flex).toBe(1)
+  })
+
+  it("sizes the country button to the flag and the calling code", async () => {
+    await renderScreen()
+
+    /** A floor, not a width: it only keeps the button from twitching between a "+1" and a
+     *  "+503". Anything that pins a wider size would push the number out again. */
+    const button = countryButtonStyle()
+    expect(button.minWidth).toBe(110)
+    expect(button.width).toBeUndefined()
+    expect(button.flexBasis).toBeUndefined()
+  })
+})

--- a/__tests__/screens/phone-auth-screen/phone-login-input.spec.tsx
+++ b/__tests__/screens/phone-auth-screen/phone-login-input.spec.tsx
@@ -8,7 +8,10 @@ import { PhoneCodeChannelType } from "@app/graphql/generated"
 import type { PhoneValidationStackParamList } from "@app/navigation/stack-param-lists"
 import { PhoneLoginInitiateType } from "@app/screens/phone-auth-screen/phone-login-initiate-type"
 import { PhoneLoginInitiateScreen } from "@app/screens/phone-auth-screen/phone-login-input"
-import { RequestPhoneCodeStatus } from "@app/screens/phone-auth-screen/request-phone-code-login"
+import {
+  RequestPhoneCodeStatus,
+  type UseRequestPhoneCodeReturn,
+} from "@app/screens/phone-auth-screen/request-phone-code-login"
 
 import { flushEffects } from "../../helpers/flush-effects"
 import { ContextForScreen } from "../helper"
@@ -34,7 +37,10 @@ jest.mock("@app/hooks/use-device-location", () => ({
   default: () => ({ countryCode: undefined, loading: false }),
 }))
 
-const mockRequestPhoneCodeLogin = jest.fn()
+/** Typed against the hook's own return contract, so renaming a field the screen reads
+ *  fails here at compile time instead of leaving these tests green over a screen that
+ *  silently falls back to its defaults. */
+const mockRequestPhoneCodeLogin: jest.Mock<UseRequestPhoneCodeReturn> = jest.fn()
 jest.mock("@app/screens/phone-auth-screen/request-phone-code-login", () => ({
   ...jest.requireActual("@app/screens/phone-auth-screen/request-phone-code-login"),
   useRequestPhoneCodeLogin: () => mockRequestPhoneCodeLogin(),

--- a/__tests__/screens/phone-auth-screen/phone-registration-input.spec.tsx
+++ b/__tests__/screens/phone-auth-screen/phone-registration-input.spec.tsx
@@ -1,0 +1,109 @@
+import React from "react"
+import { StyleProp, StyleSheet, ViewStyle } from "react-native"
+import { Input } from "@rn-vui/themed"
+import { render } from "@testing-library/react-native"
+
+import { PhoneCodeChannelType } from "@app/graphql/generated"
+import { PhoneRegistrationInitiateScreen } from "@app/screens/phone-auth-screen/phone-registration-input"
+import { RequestPhoneCodeStatus } from "@app/screens/phone-auth-screen/request-phone-code-registration"
+
+import { flushEffects } from "../../helpers/flush-effects"
+import { ContextForScreen } from "../helper"
+
+const mockCountryCodePicker = jest.fn()
+jest.mock("@app/components/phone-input/country-code-picker", () => ({
+  CountryCodePicker: (props: Record<string, unknown>) => {
+    mockCountryCodePicker(props)
+    return null
+  },
+}))
+
+/** The real hook module is loaded for its status and error constants, so the location
+ *  lookup it pulls in is stubbed to keep its missing-API-key warning out of the run. */
+jest.mock("@app/hooks/use-device-location", () => ({
+  __esModule: true,
+  default: () => ({ countryCode: undefined, loading: false }),
+}))
+
+const mockRequestPhoneCodeRegistration = jest.fn()
+jest.mock("@app/screens/phone-auth-screen/request-phone-code-registration", () => ({
+  ...jest.requireActual("@app/screens/phone-auth-screen/request-phone-code-registration"),
+  useRequestPhoneCodeRegistration: () => mockRequestPhoneCodeRegistration(),
+}))
+
+/** rn-vui types `Input`'s ref as the bare TextInput underneath it, which does not fit a
+ *  component type. Only the container style is read here. */
+const ThemedInput = Input as unknown as React.ComponentType<{
+  containerStyle: StyleProp<ViewStyle>
+}>
+
+const renderScreen = async () => {
+  const screen = render(
+    <ContextForScreen>
+      <PhoneRegistrationInitiateScreen />
+    </ContextForScreen>,
+  )
+  await flushEffects()
+  return screen
+}
+
+const countryButtonStyle = () => {
+  const [props] = mockCountryCodePicker.mock.calls.at(-1) ?? []
+  return StyleSheet.flatten(props.buttonStyle as StyleProp<ViewStyle>)
+}
+
+describe("PhoneRegistrationInitiateScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequestPhoneCodeRegistration.mockReturnValue({
+      status: RequestPhoneCodeStatus.InputtingPhoneNumber,
+      setStatus: jest.fn(),
+      phoneInputInfo: {
+        countryCode: "SV",
+        countryCallingCode: "503",
+        formattedPhoneNumber: "",
+        rawPhoneNumber: "",
+      },
+      validatedPhoneNumber: undefined,
+      error: undefined,
+      userSubmitPhoneNumber: jest.fn(),
+      phoneCodeChannel: PhoneCodeChannelType.Sms,
+      isWhatsAppSupported: true,
+      isSmsSupported: true,
+      setCountryCode: jest.fn(),
+      setPhoneNumber: jest.fn(),
+      supportedCountries: ["SV", "US"],
+    })
+  })
+
+  it("renders both halves of the phone row", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = await renderScreen()
+
+    expect(mockCountryCodePicker).toHaveBeenCalled()
+    expect(UNSAFE_getByType(ThemedInput)).toBeTruthy()
+  })
+
+  it("leaves the row's free space to the phone field, not to the country button", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
+    const { UNSAFE_getByType } = await renderScreen()
+
+    /** The registration screen carried its own copy of the login screen's row styles, so
+     *  it grew the country button in the same way and needs the same guard. */
+    const button = countryButtonStyle()
+    expect(button.flex).toBeUndefined()
+    expect(button.flexGrow).toBeUndefined()
+
+    const field = StyleSheet.flatten(UNSAFE_getByType(ThemedInput).props.containerStyle)
+    expect(field.flex).toBe(1)
+  })
+
+  it("sizes the country button to the flag and the calling code", async () => {
+    await renderScreen()
+
+    const button = countryButtonStyle()
+    expect(button.minWidth).toBe(110)
+    expect(button.width).toBeUndefined()
+    expect(button.flexBasis).toBeUndefined()
+  })
+})

--- a/__tests__/screens/phone-auth-screen/phone-registration-input.spec.tsx
+++ b/__tests__/screens/phone-auth-screen/phone-registration-input.spec.tsx
@@ -5,7 +5,10 @@ import { render } from "@testing-library/react-native"
 
 import { PhoneCodeChannelType } from "@app/graphql/generated"
 import { PhoneRegistrationInitiateScreen } from "@app/screens/phone-auth-screen/phone-registration-input"
-import { RequestPhoneCodeStatus } from "@app/screens/phone-auth-screen/request-phone-code-registration"
+import {
+  RequestPhoneCodeStatus,
+  type UseRequestPhoneCodeReturn,
+} from "@app/screens/phone-auth-screen/request-phone-code-registration"
 
 import { flushEffects } from "../../helpers/flush-effects"
 import { ContextForScreen } from "../helper"
@@ -25,7 +28,10 @@ jest.mock("@app/hooks/use-device-location", () => ({
   default: () => ({ countryCode: undefined, loading: false }),
 }))
 
-const mockRequestPhoneCodeRegistration = jest.fn()
+/** Typed against the hook's own return contract, so renaming a field the screen reads
+ *  fails here at compile time instead of leaving these tests green over a screen that
+ *  silently falls back to its defaults. */
+const mockRequestPhoneCodeRegistration: jest.Mock<UseRequestPhoneCodeReturn> = jest.fn()
 jest.mock("@app/screens/phone-auth-screen/request-phone-code-registration", () => ({
   ...jest.requireActual("@app/screens/phone-auth-screen/request-phone-code-registration"),
   useRequestPhoneCodeRegistration: () => mockRequestPhoneCodeRegistration(),
@@ -77,11 +83,13 @@ describe("PhoneRegistrationInitiateScreen", () => {
   })
 
   it("renders both halves of the phone row", async () => {
-    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
-    const { UNSAFE_getByType } = await renderScreen()
+    const { getByTestId } = await renderScreen()
 
+    /** Reached by the same test id as the login screen's field. Querying the rn-vui
+     *  component type instead would break on any upgrade that re-wraps `Input`, and would
+     *  leave the field unreachable from e2e and accessibility tooling. */
     expect(mockCountryCodePicker).toHaveBeenCalled()
-    expect(UNSAFE_getByType(ThemedInput)).toBeTruthy()
+    expect(getByTestId("telephoneNumber")).toBeTruthy()
   })
 
   it("leaves the row's free space to the phone field, not to the country button", async () => {

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -54,6 +54,10 @@ const useStyles = makeStyles(({ colors }) => ({
   },
 
   codeTextStyle: {},
+  /** No `flex` here on purpose: the phone field beside it already takes the row's free
+   *  space, so growing this button too would split the row in half and leave the number
+   *  too narrow to read. The width follows the flag and the calling code, and `minWidth`
+   *  only keeps it from twitching between a "+1" and a "+503". */
   countryPickerButtonStyle: {
     minWidth: 110,
     borderColor: colors.primary5,
@@ -63,7 +67,6 @@ const useStyles = makeStyles(({ colors }) => ({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
-    flex: 1,
   },
   bottom: {
     flex: 1,

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -56,8 +56,9 @@ const useStyles = makeStyles(({ colors }) => ({
   codeTextStyle: {},
   /** No `flex` here on purpose: the phone field beside it already takes the row's free
    *  space, so growing this button too would split the row in half and leave the number
-   *  too narrow to read. The width follows the flag and the calling code, and `minWidth`
-   *  only keeps it from twitching between a "+1" and a "+503". */
+   *  too narrow to read. A flag and a calling code come to a little under `minWidth` at
+   *  the default text size, so in practice the floor is the width, and what it buys is a
+   *  button that does not twitch between a "+1" and a "+503". */
   countryPickerButtonStyle: {
     minWidth: 110,
     borderColor: colors.primary5,

--- a/app/screens/phone-auth-screen/phone-registration-input.tsx
+++ b/app/screens/phone-auth-screen/phone-registration-input.tsx
@@ -11,6 +11,7 @@ import { GaloySecondaryButton } from "@app/components/atomic/galoy-secondary-but
 import { ContactSupportButton } from "@app/components/contact-support-button/contact-support-button"
 import { PhoneCodeChannelType } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { testProps } from "@app/utils/testProps"
 import { makeStyles, useTheme, Text, Input } from "@rn-vui/themed"
 
 import { Screen } from "../../components/screen"
@@ -157,6 +158,7 @@ export const PhoneRegistrationInitiateScreen: React.FC = () => {
             buttonStyle={styles.countryPickerButtonStyle}
           />
           <Input
+            {...testProps("telephoneNumber")}
             placeholder={PLACEHOLDER_PHONE_NUMBER}
             containerStyle={styles.inputComponentContainerStyle}
             inputContainerStyle={styles.inputContainerStyle}
@@ -219,8 +221,9 @@ const useStyles = makeStyles(({ colors }) => ({
   codeTextStyle: {},
   /** No `flex` here on purpose: the phone field beside it already takes the row's free
    *  space, so growing this button too would split the row in half and leave the number
-   *  too narrow to read. The width follows the flag and the calling code, and `minWidth`
-   *  only keeps it from twitching between a "+1" and a "+503". */
+   *  too narrow to read. A flag and a calling code come to a little under `minWidth` at
+   *  the default text size, so in practice the floor is the width, and what it buys is a
+   *  button that does not twitch between a "+1" and a "+503". */
   countryPickerButtonStyle: {
     minWidth: 110,
     borderColor: colors.primary5,

--- a/app/screens/phone-auth-screen/phone-registration-input.tsx
+++ b/app/screens/phone-auth-screen/phone-registration-input.tsx
@@ -217,6 +217,10 @@ const useStyles = makeStyles(({ colors }) => ({
   },
 
   codeTextStyle: {},
+  /** No `flex` here on purpose: the phone field beside it already takes the row's free
+   *  space, so growing this button too would split the row in half and leave the number
+   *  too narrow to read. The width follows the flag and the calling code, and `minWidth`
+   *  only keeps it from twitching between a "+1" and a "+503". */
   countryPickerButtonStyle: {
     minWidth: 110,
     borderColor: colors.primary5,
@@ -226,7 +230,6 @@ const useStyles = makeStyles(({ colors }) => ({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
-    flex: 1,
   },
   inputComponentContainerStyle: {
     flex: 1,


### PR DESCRIPTION
Closes #4175

## Problem

On the **Use SMS** screen the country code button took roughly half the row, leaving the phone number field too narrow to read the number being typed.

## Before / after

| Before | After |
| --- | --- |
| <img width="320" alt="Use SMS screen with the country code button taking half the row" src="https://github.com/user-attachments/assets/1589a265-de25-4fe5-b5fa-a08d5f742657" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/5ba2121a-ff75-4993-8cf2-95cb2202981f" /> |

## Root cause

The row is a `flexDirection: "row"` container with two children, and **both** carried `flex: 1`:

- the country button, through `countryPickerButtonStyle`
- the phone field, through `inputComponentContainerStyle`

Two siblings with `flex: 1` split the free space evenly, so the button grew to half the row no matter how little content it had.

### Why it only broke recently

That `flex: 1` is older than the bug. It was dead code until #4147, and that commit is what brought it to life.

Before #4147 both screens used `TouchableOpacity` from `react-native-gesture-handler`, whose `GenericTouchable.render()` splits the styles across two nodes:

```jsx
<BaseButton style={this.props.containerStyle}>   // outer node, the row's actual flex child
  <Animated.View style={this.props.style}>       // inner node, where flex: 1 landed
```

The screens passed only `style` and never `containerStyle`, so the outer node carried no style at all: `flexGrow: 0`, sized to its content. The `flex: 1` sat on the inner view, where all it did was fill an already content-sized parent. A no-op.

#4147 moved the button into the shared `CountryCodePicker`, which uses `TouchableOpacity` from `react-native`. That one applies `style` to the outer view itself, so the `flex: 1` became live for the first time and the row started splitting in half.

The shared `app/components/phone-input/phone-input.tsx` already used React Native's `TouchableOpacity` before #4147, so a `flex: 1` there would have been visibly broken from the start. That is why that copy never had one, and why only the two auth screens regressed.

The screen behind the "Use SMS" title is `phone-login-input.tsx` (the title comes from `login-method-screen.tsx`). `phone-registration-input.tsx` carries a verbatim copy of the same stylesheet and had the identical bug, so it is fixed here too.

## Fix

Removed `flex: 1` from `countryPickerButtonStyle` in both screens. `minWidth: 110` stays as the floor that keeps the button from twitching between a `+1` and a `+503`, and the phone field is the only child that grows.

This restores the exact geometry the row had before #4147:

| | Button content | Rendered width |
| --- | --- | --- |
| Before #4147 | `+503` only, since the flag rendered `null` (the bug #4147 fixed), about 64pt | 110pt, the floor |
| After #4147 | flag + `+503`, with `flex: 1` now live | about half the row |
| With this fix | flag + `+503`, about 104pt | 110pt, the floor |

The button lands back at the width it always had, and the restored flag now fits inside it.

## Tests

32 passing, no console noise.

- `__tests__/screens/phone-auth-screen/phone-login-input.spec.tsx` — new
- `__tests__/screens/phone-auth-screen/phone-registration-input.spec.tsx` — new

Both pin that exactly one child of the row grows, and that nothing pins the button wider through `width` or `flexBasis`.

- `__tests__/components/phone-input/phone-input.spec.tsx` — one test added so the third copy of this row cannot drift into the same bug.

The guard is not vacuous: putting `flex: 1` back fails `leaves the row's free space to the phone field, not to the country button` with `Received: 1`.

## Out of scope

Found while reviewing, filed rather than folded in here:

- The shared `PhoneInput` button has no `minWidth` floor, so it changes width between countries on the send-bitcoin destination screen. Adding the floor there makes that button *wider* for short calling codes, so it needs a device check first.
- With `flex` gone the button has no upper bound, and RN defaults `flexShrink` to `0`. The flag does not scale (the library passes `allowFontScaling={false}`), so only the calling code grows: at 2x font scale the button reaches about 144pt and the field still gets about 116pt on a 320pt screen. A `maxFontSizeMultiplier` on the calling code text is the real fix.
- The registration screen never refocuses the number field after the country modal closes, unlike the login screen and `PhoneInput`.
- This row is hand-rolled in three places. Routing both auth screens through `PhoneInput` would collapse the duplication and make the `110` floor a single named constant.
- The row's gap uses `marginLeft`, which does not flip under RTL.
