### PR TITLE
fix(transaction-history): stop the unseen-highlight spec racing the render chain

### DIFF
--- a/__tests__/helpers/wait-for-stable-render.spec.tsx
+++ b/__tests__/helpers/wait-for-stable-render.spec.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { Text, View } from "react-native"
+import { render, waitFor } from "@testing-library/react-native"
+
+import { waitForStableRender } from "./wait-for-stable-render"
+
+/**
+ * Renders "A", flips to "B" on the next timer turn, then back to "A" — the
+ * A -> B -> A shape that makes `waitFor` on the final value return too early.
+ */
+const Flipper = ({ flips }: { flips: number }) => {
+  const [value, setValue] = React.useState("A")
+  const [done, setDone] = React.useState(0)
+
+  React.useEffect(() => {
+    if (done >= flips) return undefined
+
+    const timer = setTimeout(() => {
+      setValue((current) => (current === "A" ? "B" : "A"))
+      setDone((current) => current + 1)
+    }, 0)
+
+    return () => clearTimeout(timer)
+  }, [done, flips])
+
+  return (
+    <View>
+      <Text testID="value">{value}</Text>
+      <Text testID="flips-done">{String(done)}</Text>
+    </View>
+  )
+}
+
+/**
+ * Never stops re-rendering, but its structure and text never change — only the
+ * callback identity handed to the child does. That is the churn the snapshot
+ * deliberately ignores; counting it would make this tree "unstable" forever.
+ */
+const ChurningCallback = () => {
+  const [renders, setRenders] = React.useState(0)
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setRenders((current) => current + 1), 0)
+    return () => clearTimeout(timer)
+  }, [renders])
+
+  return (
+    <View>
+      <Text testID="value" onPress={() => undefined}>
+        A
+      </Text>
+    </View>
+  )
+}
+
+/** Changes nothing but a primitive prop, which the snapshot does track. */
+const PropFlipper = () => {
+  const [disabled, setDisabled] = React.useState(true)
+
+  React.useEffect(() => {
+    if (!disabled) return undefined
+
+    const timer = setTimeout(() => setDisabled(false), 0)
+    return () => clearTimeout(timer)
+  }, [disabled])
+
+  return (
+    <View>
+      <Text testID="value" accessibilityState={{ disabled }} disabled={disabled}>
+        A
+      </Text>
+    </View>
+  )
+}
+
+describe("waitForStableRender", () => {
+  it("returns only once the tree has stopped changing", async () => {
+    const screen = render(<Flipper flips={2} />)
+
+    await waitForStableRender(screen)
+
+    expect(screen.getByTestId("value").props.children).toBe("A")
+    expect(screen.getByTestId("flips-done").props.children).toBe("2")
+  })
+
+  it("waits past an intermediate frame that carries the expected value", async () => {
+    const screen = render(<Flipper flips={2} />)
+
+    // The trap this helper exists for: the settled value is also the value of
+    // the very first frame, so `waitFor` on it returns before the flip and the
+    // assertion that follows races the rest of the chain.
+    await waitFor(() => {
+      expect(screen.getByTestId("value").props.children).toBe("A")
+    })
+    // Returned mid-chain: the flips are not done, so anything asserted here is
+    // read off an unsettled tree.
+    expect(Number(screen.getByTestId("flips-done").props.children)).toBeLessThan(2)
+
+    await waitForStableRender(screen)
+
+    expect(screen.getByTestId("value").props.children).toBe("A")
+    expect(screen.getByTestId("flips-done").props.children).toBe("2")
+  })
+
+  it("does not count a re-rendered callback identity as a change", async () => {
+    const screen = render(<ChurningCallback />)
+
+    await expect(waitForStableRender(screen, { maxFlushes: 6 })).resolves.toBeUndefined()
+  })
+
+  it("waits for a primitive prop to settle", async () => {
+    const screen = render(<PropFlipper />)
+
+    await waitForStableRender(screen)
+
+    expect(screen.getByTestId("value").props.disabled).toBe(false)
+  })
+
+  it("throws instead of hanging when the tree never settles", async () => {
+    const screen = render(<Flipper flips={Number.POSITIVE_INFINITY} />)
+
+    await expect(waitForStableRender(screen, { maxFlushes: 6 })).rejects.toThrow(
+      "still changed after 6 flushes",
+    )
+
+    screen.unmount()
+  })
+})

--- a/__tests__/helpers/wait-for-stable-render.ts
+++ b/__tests__/helpers/wait-for-stable-render.ts
@@ -1,0 +1,123 @@
+import { act } from "@testing-library/react-native"
+
+type RenderedScreen = {
+  toJSON: () => unknown
+}
+
+type RenderedNode = {
+  type: string
+  props?: Record<string, unknown>
+  children?: Array<RenderedNode | string | number> | null
+}
+
+/**
+ * A cheap fingerprint of everything a test can observe: element types, text,
+ * and primitive props (testID, accessibility state, disabled...).
+ *
+ * Serializing the whole tree is not an option — rendered props hold navigation
+ * objects, React contexts and circular back-references, which blow up both
+ * `JSON.stringify` and `pretty-format`. Object- and function-valued props are
+ * skipped on purpose: a callback that gets a new identity on every render is not
+ * a change the test can see, and counting it would keep the tree "unstable"
+ * forever.
+ */
+const describeNode = (
+  node: RenderedNode | RenderedNode[] | string | number | null,
+): string => {
+  if (node === null || node === undefined) return ""
+  if (typeof node === "string" || typeof node === "number") return String(node)
+  if (Array.isArray(node)) return node.map(describeNode).join("")
+
+  const props = Object.entries(node.props ?? {})
+    .filter(([, value]) => value === null || typeof value !== "object")
+    .filter(([, value]) => typeof value !== "function")
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => ` ${key}=${String(value)}`)
+    .join("")
+
+  const children = (node.children ?? []).map(describeNode).join("")
+
+  return `<${node.type}${props}>${children}</${node.type}>`
+}
+
+const snapshot = (screen: RenderedScreen): string =>
+  describeNode(screen.toJSON() as RenderedNode | RenderedNode[] | null)
+
+type Options = {
+  /** Identical consecutive snapshots required before the tree counts as settled. */
+  stableFlushes?: number
+  /** Upper bound on flushes, so a never-settling tree fails fast and loudly. */
+  maxFlushes?: number
+}
+
+/**
+ * One turn of the event loop inside `act()`, draining both the timer phase (a
+ * pending `setTimeout(..., 0)`) and the check phase (`setImmediate`), so a tree
+ * waiting on either one is not mistaken for a settled tree.
+ */
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0)
+    })
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve)
+    })
+  })
+}
+
+/**
+ * Flush effects until the rendered tree stops changing, then let the test assert.
+ *
+ * `await waitFor(() => expect(getByTestId(x)).toBeTruthy())` only proves the
+ * element exists. It says nothing about the effect chain behind it having
+ * finished, so an assertion placed *after* such a wait reads whichever frame the
+ * machine happened to be on — which is why those tests pass on a laptop and fail
+ * on a loaded CI runner.
+ *
+ * `waitFor` on the asserted value itself fixes the common case. It does not help
+ * when the value the test expects is also produced by an intermediate frame: a
+ * screen that renders A → B → A settles on A, but `waitFor(A)` returns on the
+ * first frame and never sees the flip. Waiting for the tree to go quiet does.
+ * The same goes for asserting something is *absent* — every frame before it
+ * arrives satisfies that.
+ *
+ * This composes with `waitFor`, it does not replace it. "Nothing changed over
+ * the last few turns of the event loop" cannot distinguish a settled tree from
+ * one still waiting on a slow response, so wait for the thing you need to be
+ * there first, then settle, then assert:
+ *
+ *   const screen = render(<ContextForScreen>{...}</ContextForScreen>)
+ *   await waitFor(() => expect(screen.getByTestId("row")).toBeTruthy())
+ *   await waitForStableRender(screen)
+ *   expect(screen.getByTestId("row").props.children).toContain("no-highlight")
+ *
+ * Prefer `flushEffects()` when a single flush is provably enough, and plain
+ * `waitFor` on the value when no intermediate frame can carry it.
+ */
+export const waitForStableRender = async (
+  screen: RenderedScreen,
+  { stableFlushes = 3, maxFlushes = 25 }: Options = {},
+): Promise<void> => {
+  let previous = snapshot(screen)
+  let identical = 0
+
+  for (let attempt = 0; attempt < maxFlushes; attempt += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await flush()
+    const current = snapshot(screen)
+
+    if (current === previous) {
+      identical += 1
+      if (identical >= stableFlushes) return
+    } else {
+      identical = 0
+      previous = current
+    }
+  }
+
+  throw new Error(
+    `waitForStableRender: the tree still changed after ${maxFlushes} flushes. ` +
+      `Last rendered output:\n${previous}`,
+  )
+}

--- a/__tests__/hooks/use-account-registry.spec.tsx
+++ b/__tests__/hooks/use-account-registry.spec.tsx
@@ -84,6 +84,52 @@ describe("useAccountRegistry", () => {
     expect(result.current.loading).toBe(false)
   })
 
+  it("keeps the newest self-custodial read when an older one resolves late", async () => {
+    mockUseIsAuthed.mockReturnValue(true)
+
+    let resolveStale: (value: unknown) => void = () => undefined
+    let resolveFresh: (value: unknown) => void = () => undefined
+    mockListSelfCustodialAccounts
+      .mockReturnValueOnce({ status: "ok", entries: [] })
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStale = resolve
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFresh = resolve
+        }),
+      )
+
+    const { result } = renderHook(() => useAccountRegistry(), {
+      wrapper: AccountRegistryProvider,
+    })
+    await flushAsyncEffects()
+
+    await act(async () => {
+      result.current.reloadSelfCustodialAccounts()
+      result.current.reloadSelfCustodialAccounts()
+      resolveFresh({
+        status: "ok",
+        entries: [{ id: "fresh-id", lightningAddress: null }],
+      })
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      resolveStale({
+        status: "ok",
+        entries: [{ id: "stale-id", lightningAddress: null }],
+      })
+      await Promise.resolve()
+    })
+
+    expect(result.current.selfCustodialEntries).toEqual([
+      { id: "fresh-id", lightningAddress: null },
+    ])
+  })
+
   it("returns custodial account when authenticated", async () => {
     mockUseIsAuthed.mockReturnValue(true)
 

--- a/__tests__/screens/transaction-history-screen.spec.tsx
+++ b/__tests__/screens/transaction-history-screen.spec.tsx
@@ -12,6 +12,8 @@ import {
 } from "@app/graphql/generated"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 
+import { waitForStableRender } from "../helpers/wait-for-stable-render"
+
 import { ContextForScreen } from "./helper"
 
 let currentMocks: MockedResponse[] = []
@@ -346,6 +348,7 @@ describe("TransactionHistoryScreen", () => {
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
     })
+    await waitForStableRender(screen)
 
     const dropdown = screen.getByTestId("wallet-filter-dropdown")
     await act(() => fireEvent.press(dropdown))
@@ -354,12 +357,23 @@ describe("TransactionHistoryScreen", () => {
 
     await act(() => fireEvent.press(btcOption))
 
+    // Wait for the refetched row, then settle: the dropped row is asserted by
+    // absence, and `waitFor` alone would pass on any frame that has not
+    // rendered it *yet*.
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
         "507f1f77bcf86cd799439011",
       )
-      expect(screen.queryByTestId("transaction-by-index-1")).toBeNull()
     })
+    await waitFor(() => {
+      expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
+    })
+    await waitForStableRender(screen)
+
+    expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
+      "507f1f77bcf86cd799439011",
+    )
+    expect(screen.queryByTestId("transaction-by-index-1")).toBeNull()
   })
 
   it("filters only BTC by route param", async () => {
@@ -379,9 +393,7 @@ describe("TransactionHistoryScreen", () => {
       </ContextForScreen>,
     )
 
-    await waitFor(() => {
-      expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
-    })
+    await waitForStableRender(screen)
 
     expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
       "507f1f77bcf86cd799439011",
@@ -409,6 +421,7 @@ describe("TransactionHistoryScreen", () => {
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
     })
+    await waitForStableRender(screen)
 
     const dropdown = screen.getByTestId("wallet-filter-dropdown")
     await act(() => fireEvent.press(dropdown))
@@ -420,8 +433,13 @@ describe("TransactionHistoryScreen", () => {
       expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
         "507f1f77bcf86cd799439012",
       )
-      expect(screen.queryByTestId("transaction-by-index-1")).toBeNull()
     })
+    await waitForStableRender(screen)
+
+    expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
+      "507f1f77bcf86cd799439012",
+    )
+    expect(screen.queryByTestId("transaction-by-index-1")).toBeNull()
   })
 
   it("highlights none when lastSeen ids are missing", async () => {
@@ -441,9 +459,21 @@ describe("TransactionHistoryScreen", () => {
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
     })
+    // With no lastSeen ids the screen passes through a transient highlight: the
+    // baseline materialises empty, the mapper's "never seen => highlight the
+    // newest" rule fires, then markTxSeen writes the ids into the cache and the
+    // highlight settles off again. Waiting for the rows to merely *exist* lands
+    // on whichever of those frames the machine is on, so settle the tree first.
+    await waitForStableRender(screen)
 
     expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
+      "507f1f77bcf86cd799439012",
+    )
+    expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
       "no-highlight",
+    )
+    expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
+      "507f1f77bcf86cd799439011",
     )
     expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
       "no-highlight",
@@ -470,6 +500,9 @@ describe("TransactionHistoryScreen", () => {
     await waitFor(() => {
       expect(screen.getByTestId("transaction-by-index-0")).toBeTruthy()
     })
+    // Settling first is what makes this assertion mean "the highlight survives
+    // markTxSeen writing the cache back", rather than "some frame had it".
+    await waitForStableRender(screen)
 
     // min(lastSeenBtcId,lastSeenUsdId) = ...9015 and both are unseen => highlighted
     expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
@@ -478,15 +511,5 @@ describe("TransactionHistoryScreen", () => {
     expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
       "highlight",
     )
-
-    // ensure highlight doesn't flip off after `markTxSeen` updates cache
-    await waitFor(() => {
-      expect(screen.getByTestId("transaction-by-index-0").props.children).toContain(
-        "highlight",
-      )
-      expect(screen.getByTestId("transaction-by-index-1").props.children).toContain(
-        "highlight",
-      )
-    })
   })
 })

--- a/app/hooks/use-account-registry.tsx
+++ b/app/hooks/use-account-registry.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react"
@@ -88,9 +89,20 @@ export const AccountRegistryProvider = ({ children }: { children: ReactNode }) =
   const [selfCustodialHydrating, setSelfCustodialHydrating] = useState(true)
   const [profilesHydrating, setProfilesHydrating] = useState(true)
 
+  // Consumers can call the reload below at any time, so a read that is still in
+  // flight may resolve after a newer one has already answered. Applying it then
+  // would clobber fresher entries with stale ones, so late answers are dropped.
+  const reloadRequestRef = useRef(0)
+
   const reloadSelfCustodialAccounts = useCallback(async () => {
+    const request = reloadRequestRef.current + 1
+    reloadRequestRef.current = request
+
     setSelfCustodialHydrating(true)
     const result = await listSelfCustodialAccounts()
+
+    if (reloadRequestRef.current !== request) return
+
     if (result.status === StorageReadStatus.Ok) {
       setSelfCustodialEntries(result.entries)
     }


### PR DESCRIPTION
## The flake

`TransactionHistoryScreen › highlights none when lastSeen ids are missing` fails intermittently on CI:

```
Expected substring: "no-highlight"
Received string:    "507f1f77bcf86cd799439012:highlight"
```

Seen on [run 32070613689](https://github.com/blinkbitcoin/blink-mobile/actions/runs/32070613689), where all three `jest.retryTimes` attempts failed the same way — the tell that this is a lost race, not a random mock leak.

## Root cause

With no lastSeen ids the screen renders the same rows three different ways in quick succession. Instrumenting the screen locally prints the sequence:

| render | baseline | lastSeen in cache | rows |
|---|---|---|---|
| … | `null` | `""` / `""` | no rows yet |
| 4 | `{btcId:"", usdId:""}` | `""` / `""` | **highlighted** — the mapper's "never seen ⇒ highlight the newest" rule ([`transaction-highlight.ts:26-29`](https://github.com/blinkbitcoin/blink-mobile/blob/8242efe5c/app/custodial/mappers/transaction-highlight.ts#L26-L29)) |
| 5 | `{btcId:"", usdId:""}` | `…011` / `…012` | not highlighted — `markTxSeen` wrote the ids into the cache |
| 6 | `{btcId:"…011", usdId:"…012"}` | `…011` / `…012` | settled |

The spec waited only for the row to *exist* and then asserted **outside** `waitFor`, so it read render 4, 5 or 6 depending on how many effect flushes `waitFor`'s real-timer polling had performed — i.e. on runner load. Locally React batches renders 4-6 inside `render()`'s own `act`, which is why it never reproduces on a laptop.

## The fix

`__tests__/helpers/wait-for-stable-render.ts` — flush effects until the rendered tree stops changing, then assert.

Judgement calls, and what was rejected:

- **`waitFor` on the expected value instead** — rejected. It fixes the common case but not this one: when an intermediate frame carries the same value the test expects (A → B → A), `waitFor` returns on the first frame and never sees the flip. Same for asserting absence: every frame before the element arrives satisfies it. The helper's own spec demonstrates this — `waitFor` returns with the chain provably unfinished.
- **Replacing `waitFor` with the helper** — rejected after it broke the filter tests. "Nothing changed over the last few event-loop turns" cannot distinguish a settled tree from one still waiting on a slow query. The two compose: wait for what must be there, settle, then assert. That rule is in the docblock.
- **Snapshotting the tree with `JSON.stringify` / `pretty-format`** — rejected, both blow up on rendered props (circular context refs; `RangeError: Invalid string length`). The snapshot covers element types, text and *primitive* props only. Callback identities are skipped on purpose: a fresh closure per render is not a change a test can see, and counting it would make every tree "unstable" forever. Both decisions are pinned by tests.
- **Changing the screen or the mapper** — rejected. The transient highlight is existing behaviour, the settled state is already `no-highlight`, and the mapper's never-seen rule is pinned by its own unit spec. This PR only stops the test reading a frame the chain is still mid-way through.
- **Leaning on `jest.retryTimes`** — it stays as a safety net, but it never rescued this one.

The helper is applied to the rest of the spec's transient-sensitive assertions too, including "highlight doesn't flip off after `markTxSeen`", which was expressing the same intent with a duplicated trailing `waitFor`.

## Second commit

`reloadSelfCustodialAccounts` is exposed through the account-registry context, so a consumer can start a second read while the first is still awaiting AsyncStorage; whichever resolved last won, so a stale answer could overwrite fresher entries. Each read now carries a request number and only the newest is applied. Removing the guard makes the new test fail.

I also tried guarding the same read against resolving after unmount, and dropped it: React 19 ignores those updates silently, so the test for it passed with and without the guard. Worth being explicit that this does **not** silence the `act(...)` warnings in the CI logs — those come from updates while the provider is still mounted after a test body returns, which is what #4008's `skipHydration` addresses.

## Verification

- `__tests__/screens`, `__tests__/hooks`, `__tests__/custodial`, `__tests__/self-custodial/mappers`: **340 suites / 4084 tests green**, no retries fired.
- The target spec 10× with `CI=1` under saturating CPU load: 10/10 green, no retries.
- Each new test checked against its own falsification: reverting the guard fails the stale-read test; the `waitFor`-returns-early case is asserted directly.
- `tsc --noEmit` clean (the one `supercluster` error is pre-existing and unrelated), eslint clean.
