### PR TITLE
refactor(theme): name color tokens by purpose, not appearance

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -161,9 +161,52 @@
     "jest/no-identical-title": "error",
     "jest/prefer-to-have-length": "warn",
     "jest/valid-expect": "error",
-    "jest/no-async-promise-executor": "off"
+    "jest/no-async-promise-executor": "off",
+
+    // Design token migration (see app/rne-theme/colors.ts):
+    // (a) legacy appearance-named color tokens are deprecated — warn so existing
+    //     code keeps working but new code uses the semantic tokens instead.
+    // (b) static* tokens never invert with the theme — error outside the
+    //     allowlist in "overrides" below (QR code, camera, earns section,
+    //     and atomic components that paint on colored surfaces).
+    "no-restricted-syntax": [
+      "warn",
+      {
+        "selector": ":matches(MemberExpression[object.name='colors'], MemberExpression[object.property.name='colors']) > Identifier.property[name=/^(white|black|primary[345]?|grey[0-7]|red|error9|blue5|backdropWhite|backdropWhiter|_(white|black|lightGrey|lighterGrey|lightBlue|darkGrey|cardPill|blue|orange|sky|green|primary1|primary2|warningLight))$/]",
+        "message": "Deprecated color token — use the semantic token instead (see app/rne-theme/colors.ts)."
+      },
+      {
+        "selector": ":matches(MemberExpression[object.name='colors'], MemberExpression[object.property.name='colors']) > Identifier.property[name=/^static/]",
+        "message": "static* colors never invert with the theme and are only allowed in the QR/camera/earns allowlist (see .eslintrc.json overrides)."
+      }
+    ]
 
   },
+  "overrides": [
+    {
+      // allowlist for static* tokens: the legacy-name warning stays active here
+      "files": [
+        "app/screens/receive-bitcoin-screen/**",
+        "app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx",
+        "app/components/totp-export/totp-qr.tsx",
+        "app/screens/earns-screen/**",
+        "app/screens/earns-map-screen/**",
+        "app/components/atomic/switch/**",
+        "app/components/atomic/galoy-currency-bubble/**",
+        "app/components/atomic/galoy-currency-bubble-text/**",
+        "app/components/atomic/currency-pill/**"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "warn",
+          {
+            "selector": ":matches(MemberExpression[object.name='colors'], MemberExpression[object.property.name='colors']) > Identifier.property[name=/^(white|black|primary[345]?|grey[0-7]|red|error9|blue5|backdropWhite|backdropWhiter|_(white|black|lightGrey|lighterGrey|lightBlue|darkGrey|cardPill|blue|orange|sky|green|primary1|primary2|warningLight))$/]",
+            "message": "Deprecated color token — use the semantic token instead (see app/rne-theme/colors.ts)."
+          }
+        ]
+      }
+    }
+  ],
   "settings": {
     "react": {
       "version": "detect"

--- a/app/components/atomic/currency-pill/currency-pill.tsx
+++ b/app/components/atomic/currency-pill/currency-pill.tsx
@@ -39,9 +39,9 @@ export const CurrencyPill = ({
     if (variant === "outlined") {
       return {
         defaultText: "",
-        color: colors.grey1,
+        color: colors.textSecondary,
         backgroundColor: colors.transparent,
-        borderColor: colors.grey1,
+        borderColor: colors.textSecondary,
       }
     }
 
@@ -49,21 +49,21 @@ export const CurrencyPill = ({
       case WalletCurrency.Btc:
         return {
           defaultText: LL.common.bitcoin(),
-          color: highlighted ? colors.white : colors._white,
-          backgroundColor: highlighted ? colors.primary : colors.grey3,
+          color: highlighted ? colors.backgroundDefault : colors.staticWhite,
+          backgroundColor: highlighted ? colors.accent : colors.textDisabled,
         }
       case WalletCurrency.Usd:
         return {
           defaultText: LL.common.dollar(),
-          color: highlighted ? colors._white : colors._white,
-          backgroundColor: highlighted ? colors._green : colors.grey3,
+          color: highlighted ? colors.staticWhite : colors.staticWhite,
+          backgroundColor: highlighted ? colors.staticSuccess : colors.textDisabled,
         }
       default:
         return {
           defaultText: currency === "ALL" ? LL.common.all() : "ALL",
-          color: colors.primary,
+          color: colors.accent,
           backgroundColor: colors.transparent,
-          borderColor: colors.primary,
+          borderColor: colors.accent,
         }
     }
   }

--- a/app/components/atomic/galoy-button-field/galoy-button-field.tsx
+++ b/app/components/atomic/galoy-button-field/galoy-button-field.tsx
@@ -37,23 +37,23 @@ export const GaloyButtonField = ({
     switch (true) {
       case error:
         colorStyles = {
-          backgroundColor: colors.error9,
+          backgroundColor: colors.errorBackground,
         }
         break
       case pressed:
         colorStyles = {
-          backgroundColor: colors.primary4,
+          backgroundColor: colors.accent3,
         }
         break
       case disabled:
         colorStyles = {
           opacity: 0.3,
-          backgroundColor: colors.primary5,
+          backgroundColor: colors.accent4,
         }
         break
       default:
         colorStyles = {
-          backgroundColor: colors.primary5,
+          backgroundColor: colors.accent4,
         }
     }
 
@@ -91,7 +91,7 @@ export const GaloyButtonField = ({
             style={styles.iconStyle}
             name={iconName}
             size={20}
-            color={error ? colors.error : colors.primary}
+            color={error ? colors.error : colors.accent}
           />
         )}
       </View>

--- a/app/components/atomic/galoy-currency-bubble-text/galoy-currency-bubble-text.tsx
+++ b/app/components/atomic/galoy-currency-bubble-text/galoy-currency-bubble-text.tsx
@@ -38,9 +38,15 @@ export const GaloyCurrencyBubbleText = ({
       text={isBtc ? BTC_TEXT : USD_TEXT}
       textSize={textSize}
       highlighted={highlighted}
-      color={highlighted ? (isBtc ? colors.white : colors._white) : colors._white}
+      color={
+        highlighted
+          ? isBtc
+            ? colors.backgroundDefault
+            : colors.staticWhite
+          : colors.staticWhite
+      }
       backgroundColor={
-        highlighted ? (isBtc ? colors.primary : colors._green) : colors.grey3
+        highlighted ? (isBtc ? colors.accent : colors.staticSuccess) : colors.textDisabled
       }
       containerSize={containerSize}
     />

--- a/app/components/atomic/galoy-currency-bubble/galoy-currency-bubble.tsx
+++ b/app/components/atomic/galoy-currency-bubble/galoy-currency-bubble.tsx
@@ -24,15 +24,15 @@ export const GaloyCurrencyBubble = ({
     <GaloyIcon
       name="bitcoin"
       size={iconSize}
-      color={highlighted ? colors.white : colors._white}
-      backgroundColor={highlighted ? colors.primary : colors.grey3}
+      color={highlighted ? colors.backgroundDefault : colors.staticWhite}
+      backgroundColor={highlighted ? colors.accent : colors.textDisabled}
     />
   ) : (
     <GaloyIcon
       name="dollar"
       size={iconSize}
-      color={colors._white}
-      backgroundColor={highlighted ? colors._green : colors.grey3}
+      color={colors.staticWhite}
+      backgroundColor={highlighted ? colors.staticSuccess : colors.textDisabled}
     />
   )
 }

--- a/app/components/atomic/galoy-error-box/galoy-error-box.tsx
+++ b/app/components/atomic/galoy-error-box/galoy-error-box.tsx
@@ -16,7 +16,7 @@ export const GaloyErrorBox: React.FC<GaloyErrorBoxProps> = ({ errorMessage, noIc
   } = useTheme()
   const styles = useStyles()
 
-  const color = mode === "light" ? colors.error : colors.black
+  const color = mode === "light" ? colors.error : colors.textOnBackground
 
   return (
     <View style={styles.container}>
@@ -36,7 +36,7 @@ const useStyles = makeStyles(({ colors }) => ({
     paddingHorizontal: 8,
     paddingVertical: 6,
     borderRadius: 8,
-    backgroundColor: colors.error9,
+    backgroundColor: colors.errorBackground,
     zIndex: 1,
   },
   textContainer: {

--- a/app/components/atomic/galoy-icon-button/galoy-icon-button.tsx
+++ b/app/components/atomic/galoy-icon-button/galoy-icon-button.tsx
@@ -73,36 +73,36 @@ export const GaloyIconButton = ({
       case iconOnly && disabled:
         return {
           opacity: 0.7,
-          color: color || colors.primary,
+          color: color || colors.accent,
           backgroundColor: colors.transparent,
         }
       case iconOnly && pressed:
         return {
           opacity: 0.7,
-          color: color || colors.primary,
-          backgroundColor: backgroundColor || colors.grey4,
+          color: color || colors.accent,
+          backgroundColor: backgroundColor || colors.border,
         }
       case iconOnly && !pressed:
         return {
-          color: color || colors.primary,
+          color: color || colors.accent,
           backgroundColor: colors.transparent,
         }
       case !iconOnly && disabled:
         return {
           opacity: 0.7,
-          color: color || colors.primary,
-          backgroundColor: backgroundColor || colors.grey4,
+          color: color || colors.accent,
+          backgroundColor: backgroundColor || colors.border,
         }
       case !iconOnly && pressed:
         return {
           opacity: 0.7,
-          color: color || colors.primary,
-          backgroundColor: backgroundColor || colors.grey4,
+          color: color || colors.accent,
+          backgroundColor: backgroundColor || colors.border,
         }
       case !iconOnly && !pressed:
         return {
-          color: color || colors.primary,
-          backgroundColor: backgroundColor || colors.grey4,
+          color: color || colors.accent,
+          backgroundColor: backgroundColor || colors.border,
         }
       default:
         return {}
@@ -159,7 +159,7 @@ export const GaloyEditButton = ({ disabled, ...remainingProps }: PressableProps)
       height: 32,
       borderRadius: 8,
       opacity: disabled ? 0.7 : 1,
-      backgroundColor: pressed ? colors.grey4 : colors.grey5,
+      backgroundColor: pressed ? colors.border : colors.surfaceInteractive,
       alignItems: "center",
       justifyContent: "center",
     }
@@ -176,7 +176,7 @@ export const GaloyEditButton = ({ disabled, ...remainingProps }: PressableProps)
         <GaloyIcon
           name="pencil"
           size={20}
-          color={colors.primary}
+          color={colors.accent}
           opacity={pressed ? 0.7 : 1}
         />
       )}
@@ -204,7 +204,7 @@ const useStyles = makeStyles(
       width: iconContainerSize,
       height: iconContainerSize,
       borderRadius: iconContainerSize / 2,
-      backgroundColor: isIconOnly ? colors.transparent : customBg || colors.grey4,
+      backgroundColor: isIconOnly ? colors.transparent : customBg || colors.border,
       opacity: 0.7,
       alignItems: "center",
       justifyContent: "center",

--- a/app/components/atomic/galoy-icon/galoy-icon.tsx
+++ b/app/components/atomic/galoy-icon/galoy-icon.tsx
@@ -317,7 +317,7 @@ export const GaloyIcon = ({
     size ??
     (sizeVariant ? ICON_SIZES[sizeVariant] : undefined) ??
     Math.max(width ?? 0, height ?? 0)
-  const resolvedColor = color || colors.black
+  const resolvedColor = color || colors.textOnBackground
 
   const styles = useStyles({
     backgroundColor,

--- a/app/components/atomic/galoy-info/galoy-info.tsx
+++ b/app/components/atomic/galoy-info/galoy-info.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles(({ colors }, props: StyleProps) => ({
     paddingVertical: 6,
     borderTopRightRadius: 8,
     borderBottomRightRadius: 8,
-    backgroundColor: colors.grey5,
+    backgroundColor: colors.surfaceInteractive,
   },
   verticalLine: {
     width: 3,

--- a/app/components/atomic/galoy-input/galoy-input.tsx
+++ b/app/components/atomic/galoy-input/galoy-input.tsx
@@ -5,7 +5,7 @@ import { Input, InputProps, makeStyles } from "@rn-vui/themed"
 
 const useStyles = makeStyles(({ colors }) => ({
   inputContainerFocused: {
-    borderBottomColor: colors.grey3,
+    borderBottomColor: colors.textDisabled,
   },
 }))
 

--- a/app/components/atomic/galoy-input/galoy-redesigned-input.tsx
+++ b/app/components/atomic/galoy-input/galoy-redesigned-input.tsx
@@ -10,11 +10,11 @@ const useStyles = makeStyles(
       paddingTop: 3,
       marginLeft: 0,
       borderRadius: 10,
-      backgroundColor: colors.primary4,
+      backgroundColor: colors.accent3,
     },
     inputContainerFocused: {
-      borderColor: colors.primary,
-      backgroundColor: colors.white,
+      borderColor: colors.accent,
+      backgroundColor: colors.backgroundDefault,
       marginLeft: -7,
       marginRight: -7,
     },
@@ -24,11 +24,11 @@ const useStyles = makeStyles(
     labelComponentStyles: {
       marginBottom: 9,
       fontWeight: "400",
-      color: colors.grey5,
+      color: colors.surfaceInteractive,
       marginLeft: isFocused ? 2 : 10,
     },
     errorMessageStyles: {
-      color: props.caption ? colors.grey5 : colors.error,
+      color: props.caption ? colors.surfaceInteractive : colors.error,
       textTransform: "capitalize",
       marginTop: 9,
       marginLeft: isFocused ? 2 : 10,
@@ -75,7 +75,7 @@ const GaloyInputFunctions = (
           remainingProps.errorMessage ? styles.errorStateStyle : null,
           isFocused ? styles.inputContainerFocused : null,
         ]}
-        placeholderTextColor={colors.grey4}
+        placeholderTextColor={colors.border}
         onFocus={(e) => {
           setIsFocused(true)
           remainingProps.onFocus?.(e)

--- a/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
+++ b/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
@@ -18,7 +18,7 @@ export const GaloyPrimaryButton: FC<PropsWithChildren<ButtonProps>> = (props) =>
       // The library hardcodes a white spinner for solid buttons. In dark theme
       // the title on the orange fill is black, so the spinner drifted from the
       // text it stands in for. Track the title's colour instead.
-      loadingProps={{ color: colors.white }}
+      loadingProps={{ color: colors.backgroundDefault }}
       buttonStyle={styles.buttonStyle}
       titleStyle={styles.titleStyle}
       disabledStyle={styles.disabledStyle}
@@ -33,19 +33,19 @@ const useStyles = makeStyles(({ colors }) => ({
     fontSize: 20,
     lineHeight: 24,
     fontWeight: "600",
-    color: colors.white,
+    color: colors.backgroundDefault,
   },
   disabledTitleStyle: {
-    color: colors.grey5,
+    color: colors.surfaceInteractive,
   },
   buttonStyle: {
     minHeight: 50,
-    backgroundColor: colors.primary,
+    backgroundColor: colors.accent,
   },
   // Translucent by design: the surface a sticky button sits on is responsible
   // for painting itself, so nothing can show through the button.
   disabledStyle: {
     opacity: 0.5,
-    backgroundColor: colors.primary,
+    backgroundColor: colors.accent,
   },
 }))

--- a/app/components/atomic/galoy-secondary-button/galoy-secondary-button.tsx
+++ b/app/components/atomic/galoy-secondary-button/galoy-secondary-button.tsx
@@ -30,7 +30,7 @@ export const GaloySecondaryButton: FunctionComponent<GaloySecondaryButtonProps> 
     <GaloyIcon
       name={iconName}
       size={18}
-      color={grey ? colors.grey3 : colors.primary}
+      color={grey ? colors.textDisabled : colors.accent}
       style={styles.iconStyle}
     />
   ) : null
@@ -48,7 +48,7 @@ export const GaloySecondaryButton: FunctionComponent<GaloySecondaryButtonProps> 
       titleStyle={[styles.buttonTitleStyle, props.titleStyle]}
       disabledTitleStyle={styles.disabledTitleStyle}
       loadingProps={{
-        color: colors.primary,
+        color: colors.accent,
       }}
     />
   )
@@ -63,13 +63,13 @@ const useStyles = makeStyles(({ colors }, props: GaloySecondaryButtonProps) => (
     backgroundColor: colors.transparent,
   },
   buttonTitleStyle: {
-    color: props.grey ? colors.grey3 : colors.primary,
+    color: props.grey ? colors.textDisabled : colors.accent,
     fontSize: 20,
     lineHeight: 24,
     fontWeight: "600",
   },
   disabledTitleStyle: {
-    color: props.grey ? colors.grey3 : colors.primary,
+    color: props.grey ? colors.textDisabled : colors.accent,
   },
   iconStyle: {
     marginRight: props.iconPosition === "right" ? 0 : 10,

--- a/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
+++ b/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
@@ -111,7 +111,7 @@ const GaloySliderButton = ({
             style={[
               styles.swipeButton,
               AnimatedStyles.swipeButton,
-              { backgroundColor: disabled ? colors.disabled : colors.primary },
+              { backgroundColor: disabled ? colors.disabled : colors.accent },
             ]}
             exiting={FadeOut.duration(400)}
             {...testProps("slider")}
@@ -132,7 +132,7 @@ const GaloySliderButton = ({
       {isLoading && (
         <Animated.View entering={FadeIn.duration(400)} style={styles.loadingContainer}>
           <Text style={styles.swipeText}>{loadingText}</Text>
-          <ActivityIndicator size="small" color={colors.primary} />
+          <ActivityIndicator size="small" color={colors.accent} />
         </Animated.View>
       )}
     </View>
@@ -142,9 +142,9 @@ const GaloySliderButton = ({
 const useStyles = makeStyles(({ colors }) => ({
   swipeButtonContainer: {
     height: 60,
-    backgroundColor: colors.grey5,
+    backgroundColor: colors.surfaceInteractive,
     borderRadius: 30,
-    borderColor: colors.grey4,
+    borderColor: colors.border,
     borderWidth: 1,
     justifyContent: "center",
     alignItems: "center",
@@ -170,7 +170,7 @@ const useStyles = makeStyles(({ colors }) => ({
     fontSize: 14,
     fontWeight: "400",
     zIndex: 2,
-    color: colors.grey2,
+    color: colors.textMuted,
   },
   loadingContainer: {
     display: "flex",

--- a/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
+++ b/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
@@ -23,14 +23,14 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
     switch (true) {
       case pressed && outline:
         dynamicStyle = {
-          borderColor: colors.primary,
-          backgroundColor: colors.primary,
+          borderColor: colors.accent,
+          backgroundColor: colors.accent,
           borderWidth: 1.5,
         }
         break
       case pressed && !outline && !clear:
         dynamicStyle = {
-          backgroundColor: colors.primary,
+          backgroundColor: colors.accent,
         }
         break
       case pressed && clear:
@@ -42,7 +42,7 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
         dynamicStyle = {
           opacity: disabled ? 0.7 : 1,
           backgroundColor: colors.transparent,
-          borderColor: colors.primary,
+          borderColor: colors.accent,
           borderWidth: 1.5,
         }
         break
@@ -53,16 +53,16 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
         break
       default:
         dynamicStyle = {
-          backgroundColor: colors.primary,
+          backgroundColor: colors.accent,
         }
     }
 
     return [dynamicStyle, containerStyle, styles.pressableStyle]
   }
 
-  let textColor = colors.white
-  if (outline) textColor = colors.black
-  if (clear) textColor = colors.primary
+  let textColor = colors.backgroundDefault
+  if (outline) textColor = colors.textOnBackground
+  if (clear) textColor = colors.accent
 
   return (
     <Pressable {...remainingProps} style={pressableStyle} disabled={disabled}>

--- a/app/components/atomic/switch/switch.tsx
+++ b/app/components/atomic/switch/switch.tsx
@@ -63,7 +63,7 @@ export const Switch: React.FC<SwitchProps> = ({
     const backgroundColor = interpolateColor(
       progress.value,
       [0, 1],
-      [colors.grey4, colors.primary],
+      [colors.border, colors.accent],
     )
     return {
       backgroundColor,
@@ -112,8 +112,8 @@ const useStyles = makeStyles(({ colors }) => ({
     width: THUMB_SIZE,
     height: THUMB_SIZE,
     borderRadius: THUMB_SIZE / 2,
-    backgroundColor: colors._white,
-    shadowColor: colors._black,
+    backgroundColor: colors.staticWhite,
+    shadowColor: colors.staticBlack,
     shadowOffset: {
       width: 0,
       height: 2,

--- a/app/rne-theme/__tests__/colors.spec.ts
+++ b/app/rne-theme/__tests__/colors.spec.ts
@@ -1,0 +1,67 @@
+import { light, dark } from "../colors"
+
+// During the token migration (see app/rne-theme/colors.ts), every legacy color
+// name is a deprecated alias of a semantic token. These tests guarantee the two
+// name sets can never drift apart while both exist.
+
+const aliasToSemantic: Record<string, string> = {
+  white: "backgroundDefault",
+  black: "textOnBackground",
+  primary: "accent",
+  primary3: "accent2",
+  primary4: "accent3",
+  primary5: "accent4",
+  grey0: "textPrimary",
+  grey1: "textSecondary",
+  grey2: "textMuted",
+  grey3: "textDisabled",
+  grey4: "border",
+  grey5: "surfaceInteractive",
+  grey6: "surfacePressed",
+  grey7: "surfaceStatic",
+  red: "error",
+  error9: "errorBackground",
+  backdropWhite: "backdrop",
+  backdropWhiter: "backdropStrong",
+  _white: "staticWhite",
+  _black: "staticBlack",
+  _lightGrey: "staticLightGrey",
+  _lighterGrey: "staticLighterGrey",
+  _darkGrey: "staticDarkGrey",
+  _cardPill: "staticCardPill",
+  _orange: "staticBrandOrange",
+  _green: "staticSuccess",
+  _primary1: "staticBrandYellow",
+  _primary2: "staticBrandSunset",
+  _warningLight: "staticWarningBackground",
+}
+
+describe("color token aliases", () => {
+  const checkAliases = (palette: Record<string, string>) => {
+    for (const [legacy, semantic] of Object.entries(aliasToSemantic)) {
+      expect(palette[legacy]).toBeDefined()
+      expect(palette[semantic]).toBeDefined()
+      expect(palette[legacy]).toEqual(palette[semantic])
+    }
+  }
+
+  it("every legacy alias matches its semantic token in light mode", () => {
+    checkAliases(light as unknown as Record<string, string>)
+  })
+
+  it("every legacy alias matches its semantic token in dark mode", () => {
+    checkAliases(dark as unknown as Record<string, string>)
+  })
+
+  it("static tokens are identical across modes", () => {
+    for (const [key, value] of Object.entries(light)) {
+      if (key.startsWith("static")) {
+        expect(dark[key as keyof typeof dark]).toEqual(value)
+      }
+    }
+  })
+
+  it("keeps light and dark key sets identical", () => {
+    expect(Object.keys(light).sort()).toEqual(Object.keys(dark).sort())
+  })
+})

--- a/app/rne-theme/colors.ts
+++ b/app/rne-theme/colors.ts
@@ -1,109 +1,170 @@
-const light = {
+// Design tokens are named by purpose, not appearance.
+// The semantic palettes below are the single source of truth for every color value.
+// The legacy names at the bottom are deprecated aliases that reference the semantic
+// values — they exist only so old code keeps working during the migration, and must
+// not be used in new code (enforced by eslint no-restricted-syntax).
+
+// `static*` tokens never invert between light and dark mode. They are only for
+// screens that require no inversion (QR code, camera) or sections that are not
+// dark/light aware (earns). Usage outside the eslint allowlist is an error.
+
+const lightStatic = {
+  staticWhite: "#FFFFFF",
+  staticBlack: "#000000",
+  staticLightGrey: "#CFD9E2",
+  staticLighterGrey: "#E6EBEf",
+  staticDarkGrey: "#1d1d1d",
+  staticCardPill: "#393939",
+  staticBrandOrange: "#FF7e1c",
+  staticSuccess: "#00A700",
+  staticBrandYellow: "#FFBE0B",
+  staticBrandSunset: "#FB5607",
+  staticWarningBackground: "#FFF9E5",
+}
+
+// static tokens are identical in both modes by definition
+const darkStatic = lightStatic
+
+const lightSemantic = {
+  ...lightStatic,
+
   transparent: "rgba(0, 0, 0, 0)",
 
-  _white: "#FFFFFF",
-  _black: "#000000",
-  _lightGrey: "#CFD9E2",
-  _lighterGrey: "#E6EBEf",
-  _lightBlue: "#3553FF",
-  _darkGrey: "#1d1d1d",
-  _cardPill: "#393939",
-  _blue: "#3050C4",
-  _orange: "#FF7e1c",
-  _sky: "#C3CCFF",
-  _green: "#00A700",
-  _primary1: "#FFBE0B",
-  _primary2: "#FB5607",
-  _warningLight: "#FFF9E5",
+  backgroundDefault: "#FFFFFF",
+  textOnBackground: "#000000",
 
-  // adjusted
-  white: "#FFFFFF",
-  black: "#000000",
+  textPrimary: "#3A3C51",
+  textSecondary: "#393939",
+  textMuted: "#9292A0", // 3.07:1 on backgroundDefault — secondary labels only
+  textDisabled: "#AEAEB8",
 
-  primary: "#fc5805",
-  primary3: "#fd800b",
-  primary4: "#fe990d",
-  primary5: "#ffad0d",
+  border: "#E2E2E4",
 
-  blue5: "#4453E2",
+  surfaceInteractive: "#F2F2F4", // tappable surface, at rest
+  surfacePressed: "#E7E7E7", // surfaceInteractive while held — transient only
+  surfaceStatic: "#F9F9F9", // cannot be tapped, ever — cards, banners, read-only
 
-  grey0: "#3A3C51", // grey1
-  grey1: "#393939", // grey3
-  grey2: "#9292A0", // grey4
-  grey3: "#AEAEB8", // grey5
-  grey4: "#E2E2E4", // grey8-ish
-  grey5: "#F2F2F4", // grey9-ish
-  grey6: "#E7E7E7", // grey6-ish
-  grey7: "#F9F9F9", // static card surface
+  accent: "#fc5805",
+  accent2: "#fd800b", // accent2–4 are the mirrored ramp kept for existing gradients
+  accent3: "#fe990d",
+  accent4: "#ffad0d",
+
+  error: "#DC2626",
+  errorBackground: "#FEE2E2",
+
+  warning: "#E18E02",
 
   loaderForeground: "#ecebeb",
   loaderBackground: "#f3f3f3",
 
-  backdropWhite: "rgba(0, 0, 0, 0.06)",
-  backdropWhiter: "rgba(0, 0, 0, 0.12)",
+  backdrop: "rgba(0, 0, 0, 0.06)",
+  backdropStrong: "rgba(0, 0, 0, 0.12)",
+}
 
-  // not adjusted
+const darkSemantic = {
+  ...darkStatic,
+
+  transparent: "rgba(0, 0, 0, 0)",
+
+  backgroundDefault: "#000000",
+  textOnBackground: "#FFFFFF",
+
+  textPrimary: "#FAF9F9",
+  textSecondary: "#E9E8E8",
+  textMuted: "#CCCCCC",
+  textDisabled: "#949494",
+
+  border: "#393939",
+
+  surfaceInteractive: "#1d1d1d",
+  surfacePressed: "#2B2B2B",
+  surfaceStatic: "#0F0F0F",
+
+  accent: "#ffad0d",
+  accent2: "#fe990d",
+  accent3: "#fd800b",
+  accent4: "#fc5805",
+
   error: "#DC2626",
-  error9: "#FEE2E2",
+  errorBackground: "#7F1D1D",
 
-  // same as error
-  red: "#DC2626",
+  warning: "#FFC563",
 
-  warning: "#E18E02",
+  loaderForeground: "#3c3b3b",
+  loaderBackground: "#131313",
+
+  backdrop: "rgba(255, 255, 255, 0.06)",
+  backdropStrong: "rgba(255, 255, 255, 0.12)",
+}
+
+// Deprecated legacy aliases. Every value is a reference into the semantic palette,
+// so the two name sets can never drift apart. Do not add new usages.
+const legacyAliases = (semantic: typeof lightSemantic | typeof darkSemantic) => ({
+  // appearance-named tokens that lied in dark mode
+  white: semantic.backgroundDefault,
+  black: semantic.textOnBackground,
+
+  primary: semantic.accent,
+  primary3: semantic.accent2,
+  primary4: semantic.accent3,
+  primary5: semantic.accent4,
+
+  grey0: semantic.textPrimary,
+  grey1: semantic.textSecondary,
+  grey2: semantic.textMuted,
+  grey3: semantic.textDisabled,
+  grey4: semantic.border,
+  grey5: semantic.surfaceInteractive,
+  grey6: semantic.surfacePressed,
+  grey7: semantic.surfaceStatic,
+
+  red: semantic.error,
+  error9: semantic.errorBackground,
+
+  backdropWhite: semantic.backdrop,
+  backdropWhiter: semantic.backdropStrong,
+
+  // static tokens previously prefixed with `_`
+  _white: semantic.staticWhite,
+  _black: semantic.staticBlack,
+  _lightGrey: semantic.staticLightGrey,
+  _lighterGrey: semantic.staticLighterGrey,
+  _darkGrey: semantic.staticDarkGrey,
+  _cardPill: semantic.staticCardPill,
+  _orange: semantic.staticBrandOrange,
+  _green: semantic.staticSuccess,
+  _primary1: semantic.staticBrandYellow,
+  _primary2: semantic.staticBrandSunset,
+  _warningLight: semantic.staticWarningBackground,
+})
+
+// Flagged for design review (see proposal §2.1/§5): none of the app blues is the
+// brand blue. Scheduled for removal, so they get no semantic alias.
+const legacyBlues = {
+  light: {
+    blue5: "#4453E2",
+    _blue: "#3050C4",
+    _lightBlue: "#3553FF",
+    _sky: "#C3CCFF",
+  },
+  dark: {
+    blue5: "#F0F0F7",
+    _blue: "#3050C4",
+    _lightBlue: "#3553FF",
+    _sky: "#C3CCFF",
+  },
+}
+
+const light = {
+  ...lightSemantic,
+  ...legacyAliases(lightSemantic),
+  ...legacyBlues.light,
 }
 
 const dark = {
-  transparent: "rgba(0, 0, 0, 0)",
-
-  _white: "#FFFFFF",
-  _black: "#000000",
-  _lightGrey: "#CFD9E2",
-  _lighterGrey: "#E6EBEf",
-  _lightBlue: "#3553FF",
-  _darkGrey: "#1d1d1d",
-  _cardPill: "#393939",
-  _blue: "#3050C4",
-  _orange: "#FF7e1c",
-  _sky: "#C3CCFF",
-  _green: "#00A700",
-  _primary1: "#FFBE0B",
-  _primary2: "#FB5607",
-  _warningLight: "#FFF9E5",
-
-  // adjusted
-  white: "#000000",
-  black: "#FFFFFF",
-
-  primary: "#ffad0d",
-  primary3: "#fe990d",
-  primary4: "#fd800b",
-  primary5: "#fc5805",
-
-  blue5: "#F0F0F7",
-
-  grey0: "#FAF9F9", // grey1
-  grey1: "#E9E8E8", // grey2
-  grey2: "#CCCCCC", // grey3
-  grey3: "#949494", // grey5
-  grey4: "#393939", // grey8
-  grey5: "#1d1d1d", // after grey9
-  grey6: "#2B2B2B", // grey6
-  grey7: "#0F0F0F", // static card surface
-
-  loaderBackground: "#131313",
-  loaderForeground: "#3c3b3b",
-
-  backdropWhite: "rgba(255, 255, 255, 0.06)",
-  backdropWhiter: "rgba(255, 255, 255, 0.12)",
-
-  // not adjusted
-  error: "#DC2626",
-  error9: "#7F1D1D",
-
-  // same as error
-  red: "#DC2626",
-
-  warning: "#FFC563",
+  ...darkSemantic,
+  ...legacyAliases(darkSemantic),
+  ...legacyBlues.dark,
 }
 
 export { light, dark }

--- a/app/rne-theme/theme.ts
+++ b/app/rne-theme/theme.ts
@@ -21,7 +21,7 @@ const theme = createTheme({
     },
     Text: (props, { colors }) => {
       const universalStyle = {
-        color: props.color || colors.black,
+        color: props.color || colors.textOnBackground,
         fontFamily: "SourceSansPro-Regular",
       }
 

--- a/app/rne-theme/themed.d.ts
+++ b/app/rne-theme/themed.d.ts
@@ -2,44 +2,117 @@ import "@rn-vui/themed"
 
 declare module "@rn-vui/themed" {
   export interface Colors {
-    red: string
-    transparent: string
+    // Semantic tokens — named by purpose, not appearance.
+    // Use only these (plus loader*/warning/error/transparent) in new code.
+    backgroundDefault: string
+    textOnBackground: string
+    textPrimary: string
+    textSecondary: string
+    textMuted: string
+    textDisabled: string
+    border: string
+    surfaceInteractive: string
+    surfacePressed: string
+    surfaceStatic: string
+    accent: string
+    accent2: string
+    accent3: string
+    accent4: string
+    errorBackground: string
+    backdrop: string
+    backdropStrong: string
 
-    // _ are meant to be static across light and dark
-    // either because they are used in screen that require no inversion
-    // like for the QR code, or camera view
-    // or because they are used in the earn section which is not dark/light mode aware
-
-    _white: string
-    _black: string
-    _lightGrey: string
-    _lighterGrey: string
-    _lightBlue: string
-    _darkGrey: string
-    _cardPill: string
-    _blue: string
-    _orange: string
-    _sky: string
-    _green: string
-    _primary1: string
-    _primary2: string
-    _warningLight: string
-
-    primary3: string
-    primary4: string
-    primary5: string
-    error9: string
-
-    blue5: string
-
-    grey6: string
-    grey7: string
+    // static* tokens never invert between light and dark mode.
+    // Allowed only on screens that require no inversion (QR code, camera)
+    // or in sections that are not dark/light aware (earns) — eslint-enforced.
+    staticWhite: string
+    staticBlack: string
+    staticLightGrey: string
+    staticLighterGrey: string
+    staticDarkGrey: string
+    staticCardPill: string
+    staticBrandOrange: string
+    staticSuccess: string
+    staticBrandYellow: string
+    staticBrandSunset: string
+    staticWarningBackground: string
 
     loaderForeground: string
     loaderBackground: string
 
+    // Deprecated legacy aliases — kept working during the migration, do not use.
+
+    /** @deprecated use backgroundDefault */
+    readonly white: string
+    /** @deprecated use textOnBackground */
+    readonly black: string
+    /** @deprecated use accent */
+    readonly primary: string
+    /** @deprecated use accent2 */
+    primary3: string
+    /** @deprecated use accent3 */
+    primary4: string
+    /** @deprecated use accent4 */
+    primary5: string
+    /** @deprecated use textPrimary */
+    readonly grey0: string
+    /** @deprecated use textSecondary */
+    readonly grey1: string
+    /** @deprecated use textMuted */
+    readonly grey2: string
+    /** @deprecated use textDisabled */
+    readonly grey3: string
+    /** @deprecated use border */
+    readonly grey4: string
+    /** @deprecated use surfaceInteractive */
+    readonly grey5: string
+    /** @deprecated use surfacePressed */
+    grey6: string
+    /** @deprecated use surfaceStatic */
+    grey7: string
+    /** @deprecated use error */
+    red: string
+    /** @deprecated use errorBackground */
+    error9: string
+    /** @deprecated use backdrop */
     backdropWhite: string
+    /** @deprecated use backdropStrong */
     backdropWhiter: string
+
+    /** @deprecated flagged for design review — not the brand blue, do not use */
+    blue5: string
+
+    /** @deprecated use staticWhite */
+    _white: string
+    /** @deprecated use staticBlack */
+    _black: string
+    /** @deprecated use staticLightGrey */
+    _lightGrey: string
+    /** @deprecated use staticLighterGrey */
+    _lighterGrey: string
+    /** @deprecated use staticDarkGrey */
+    _darkGrey: string
+    /** @deprecated use staticCardPill */
+    _cardPill: string
+    /** @deprecated use staticBrandOrange */
+    _orange: string
+    /** @deprecated use staticSuccess */
+    _green: string
+    /** @deprecated use staticBrandYellow */
+    _primary1: string
+    /** @deprecated use staticBrandSunset */
+    _primary2: string
+    /** @deprecated use staticWarningBackground */
+    _warningLight: string
+
+    /** @deprecated flagged for design review — not the brand blue, do not use */
+    _blue: string
+    /** @deprecated flagged for design review — not the brand blue, do not use */
+    _lightBlue: string
+    /** @deprecated flagged for design review — not the brand blue, do not use */
+    _sky: string
+
+    transparent: string
   }
 
   export interface TextProps {

--- a/app/rne-theme/tokens.ts
+++ b/app/rne-theme/tokens.ts
@@ -1,0 +1,19 @@
+// Brand spacing and radius tokens.
+// Compose larger gaps by doubling (60 = 2 * xxxl, 90 = 3 * xxxl).
+// Prefer these over inline numeric literals in new code.
+
+export const spacing = {
+  xs: 3,
+  sm: 5,
+  md: 8,
+  lg: 10,
+  xl: 14,
+  xxl: 20,
+  xxxl: 30,
+} as const
+
+export const radius = {
+  sm: 8,
+  lg: 16,
+  full: 999,
+} as const


### PR DESCRIPTION
## Problem

Color tokens are named after what they look like in light mode (`white`, `black`,
`grey0`…`grey7`). Dark mode swaps the values underneath, so in dark mode `white`
is `#000000` and `black` is `#FFFFFF` — the names lie, and nothing stops a
`_`-prefixed static color from leaking onto a regular screen and shipping a
dark-mode bug.

Tracking issue: blinkbitcoin/blink-wip#1165 (Phases 1–2 of the proposal + pilot).

## What changed

**1. Semantic tokens are now the single source of truth** (`app/rne-theme/colors.ts`).
Every value is defined exactly once under its purpose-named token
(`backgroundDefault`, `textPrimary`, `textMuted`, `border`,
`surfaceInteractive/Pressed/Static`, `accent`…`accent4`, `errorBackground`,
`backdrop`/`backdropStrong`, `static*`…).

**2. Legacy names keep working — transition period.** `white`, `black`, `grey0-7`,
`primary`, `red`, `_`-prefixed statics etc. are deprecated aliases that *reference*
the semantic values. Old code compiles untouched; the two name sets can never drift
apart because a value lives in exactly one place. Legacy keys carry
`/** @deprecated */` in `themed.d.ts` → strikethrough + hover hint in the editor.

**3. Guardrails (`.eslintrc.json`):**
- `no-restricted-syntax` **warns** on any legacy token usage — new code uses
  semantic names, existing code migrates incrementally. Baseline: **1057 warnings**
  (this is the burn-down metric; it can only shrink from here).
- `static*` tokens (never invert with the theme) are an **error** outside an
  allowlist: QR code, camera, earns section, and 4 atomic components that paint on
  colored surfaces — the historical dark-mode breakage points.

**4. New tokens** (`app/rne-theme/tokens.ts`): brand spacing `3/5/8/10/14/20/30`
and radius `8/16/999` — previously no tokens existed.

**5. Pilot rename:** `theme.ts` + all 15 files in `app/components/atomic/`
migrated to semantic names. `blue5` and the `_`-prefixed blues deliberately keep
legacy names — flagged for design review (none is the brand blue).

## Zero pixel change

Every renamed reference resolves to a byte-identical value; only names move.
All visual changes (warning orange, blues, dark background, radii, `grey0`
value) are quarantined in a future phase with design sign-off.

## Test plan

- [x] `yarn check-code` green (tsc + eslint + translations + codegen + graphql)
- [x] New unit tests (`app/rne-theme/__tests__/colors.spec.ts`): legacy↔semantic
      value parity in both modes, static invariance across modes, light/dark
      key-set equality — these fail if the alias layer ever drifts
- [x] Full-repo eslint: 0 errors (1057 transition warnings, expected)
- [ ] CI Tests (jest) green
- [ ] Manual: toggle dark mode on home / send / receive QR — confirm no visual diff

## Notes

- **No behavior change, no migration needed.** Safe to ship behind any release.
- Reviewers: the diff in `colors.ts` is the one to read carefully — the atomic
  component changes are a mechanical rename per the mapping table in the issue.
- Known deviation from the issue's Phase 4 assumption: `white/black/primary/
  grey0-5/error/warning` are declared on RNE's *base* `Colors` interface and can't
  be removed by module augmentation — for those, the lint rule is the permanent
  guard, not a temporary one. App-declared legacy tokens (`red`, `grey6/7`,
  `error9`, `_`-prefixed) do get compiler-enforced deletion later.

## Where we go from here

| Next phase | Content | Gate |
|---|---|---|
| 3 — Codemod | Per-screen mechanical rename of the remaining ~250 files, reviewable chunks (parallelizable) | zero-pixel, CI |
| 4 — Delete app-declared legacy names | `tsc` finds stragglers; lint rule stays for RNE built-ins | CI |
| 5 — Value reconciliation | `grey0→#1d1d1d`, warning orange, blues removal, dark background, radii, Figma-only tokens, primary-button AA fix (white-on-orange 3.21:1 → black label 6.54:1) | **design sign-off + screenshot review — blocked on the open decisions in blinkbitcoin/blink-wip#1165 §5/§7** |
| Typography | Map ~307 inline `fontSize` sites to `Text type` scale; lint ban | design review of non-scale values |

One thing to flag:
Tests gate: I ran check-code (green) but not the full jest suite (yarn test takes a while with --runInBand). CI will run it; say the word if you want me to run it locally first