### PR TITLE
fix(deposits): read back the deposit before calling a claim failed

### DIFF
--- a/__tests__/screens/unclaimed-deposits/use-deposit-actions.spec.ts
+++ b/__tests__/screens/unclaimed-deposits/use-deposit-actions.spec.ts
@@ -15,15 +15,11 @@ const mockRefundDeposit = jest.fn()
 const mockGetClaimFee = jest.fn()
 const mockToastShow = jest.fn()
 
+/** Held in a mock so one test can take the wallet away and see what the hook does. */
+const mockUsePayments = jest.fn()
+
 jest.mock("@app/hooks/use-payments", () => ({
-  usePayments: () => ({
-    listPendingDeposits: mockListPendingDeposits,
-    claimDeposit: {
-      claimDeposit: mockClaimDeposit,
-      refundDeposit: mockRefundDeposit,
-      getClaimFee: mockGetClaimFee,
-    },
-  }),
+  usePayments: () => mockUsePayments(),
 }))
 
 jest.mock("@app/i18n/i18n-react", () => ({
@@ -40,6 +36,14 @@ jest.mock("@app/i18n/i18n-react", () => ({
         claimFailed: ({ error }: { error: string }) => `Claim failed: ${error}`,
         claimSuccess: () => "Deposit claimed",
         error: () => "Error",
+      },
+      /** The real translator reads these, so the hook renders sentences, not codes. */
+      SelfCustodialError: {
+        insufficientFunds: () => "Not enough funds",
+        belowMinimum: () => "Below the minimum",
+        networkError: () => "Network connection problem",
+        invalidInput: () => "The payment details look invalid",
+        generic: () => "Something went wrong. Please try again.",
       },
     },
   }),
@@ -62,9 +66,57 @@ const buildDeposit = (overrides: Partial<PendingDeposit> = {}): PendingDeposit =
 describe("useDepositActions", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockUsePayments.mockReturnValue({
+      listPendingDeposits: mockListPendingDeposits,
+      claimDeposit: {
+        claimDeposit: mockClaimDeposit,
+        refundDeposit: mockRefundDeposit,
+        getClaimFee: mockGetClaimFee,
+      },
+    })
     mockListPendingDeposits.mockResolvedValue({ deposits: [] })
     mockRefundDeposit.mockResolvedValue({ status: PaymentResultStatus.Success })
     mockClaimDeposit.mockResolvedValue({ status: PaymentResultStatus.Success })
+  })
+
+  describe("without a connected wallet", () => {
+    beforeEach(() => {
+      mockUsePayments.mockReturnValue({
+        listPendingDeposits: undefined,
+        claimDeposit: undefined,
+      })
+    })
+
+    it("says so instead of claiming into nothing", async () => {
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(buildDeposit())
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Error" }),
+      )
+      expect(mockClaimDeposit).not.toHaveBeenCalled()
+    })
+
+    it("holds an empty list rather than reading one it cannot read", async () => {
+      const { result } = renderHook(() => useDepositActions())
+      await act(async () => {})
+
+      expect(result.current.deposits).toEqual([])
+      expect(mockListPendingDeposits).not.toHaveBeenCalled()
+    })
+
+    it("does not attempt a refund", async () => {
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(buildDeposit(), "bc1qaddr", 3)
+      })
+
+      expect(mockRefundDeposit).not.toHaveBeenCalled()
+    })
   })
 
   describe("handleRefund — fee rate validation", () => {
@@ -121,6 +173,94 @@ describe("useDepositActions", () => {
         destinationAddress: "bc1qaddr",
         feeRateSatPerVb: 12,
       })
+    })
+
+    it("explains a refund refused because the deposit is below dust", async () => {
+      mockRefundDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(
+          buildDeposit({ errorReason: DepositErrorReason.BelowDust }),
+          "bc1qaddr",
+          5,
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Below dust" }),
+      )
+    })
+
+    it("explains a refund refused because the network fee is too high", async () => {
+      mockRefundDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(
+          buildDeposit({
+            errorReason: DepositErrorReason.FeeExceeded,
+            requiredFeeSats: 420,
+          }),
+          "bc1qaddr",
+          5,
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Fee exceeded 420" }),
+      )
+    })
+
+    it("names a zero fee when a refund refusal carries no figure", async () => {
+      mockRefundDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(
+          buildDeposit({ errorReason: DepositErrorReason.FeeExceeded }),
+          "bc1qaddr",
+          5,
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Fee exceeded 0" }),
+      )
+    })
+
+    it("keeps an empty refund failure message empty", async () => {
+      mockRefundDeposit.mockResolvedValue({
+        status: PaymentResultStatus.Failed,
+        errors: [{ message: "" }],
+      })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(buildDeposit(), "bc1qaddr", 5)
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Refund failed: " }),
+      )
+    })
+
+    it("falls back to a plain error when a refund failure says nothing at all", async () => {
+      mockRefundDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleRefund(buildDeposit(), "bc1qaddr", 5)
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Error" }),
+      )
     })
 
     it("surfaces SDK refund failure as a toast", async () => {
@@ -225,6 +365,145 @@ describe("useDepositActions", () => {
 
       expect(mockToastShow).toHaveBeenCalledWith(
         expect.objectContaining({ message: "Fee exceeded 198" }),
+      )
+    })
+
+    it("tells the reader what happened rather than repeating the SDK's code", async () => {
+      mockClaimDeposit.mockResolvedValue({
+        status: PaymentResultStatus.Failed,
+        errors: [{ message: "sc_generic" }],
+      })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(buildDeposit())
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Claim failed: Something went wrong. Please try again.",
+        }),
+      )
+    })
+
+    it("explains a deposit too small to claim", async () => {
+      mockClaimDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(
+          buildDeposit({ errorReason: DepositErrorReason.BelowDust }),
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Below dust" }),
+      )
+    })
+
+    it("explains a deposit the network no longer holds", async () => {
+      mockClaimDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(
+          buildDeposit({ errorReason: DepositErrorReason.MissingUtxo }),
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Missing UTXO" }),
+      )
+    })
+
+    it("names a zero fee when the SDK reported no figure with its refusal", async () => {
+      mockClaimDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(
+          buildDeposit({ errorReason: DepositErrorReason.FeeExceeded }),
+        )
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Fee exceeded 0" }),
+      )
+    })
+
+    it("keeps an empty failure message empty rather than inventing one", async () => {
+      mockClaimDeposit.mockResolvedValue({
+        status: PaymentResultStatus.Failed,
+        errors: [{ message: "" }],
+      })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(buildDeposit())
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Claim failed: " }),
+      )
+    })
+
+    it("falls back to a plain error when the failure says nothing at all", async () => {
+      mockClaimDeposit.mockResolvedValue({ status: PaymentResultStatus.Failed })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(buildDeposit())
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Error" }),
+      )
+    })
+
+    it("marks the deposit as processing while its claim is in flight", async () => {
+      let settleClaim: (value: unknown) => void = () => {}
+      mockClaimDeposit.mockReturnValue(
+        new Promise((resolve) => {
+          settleClaim = resolve
+        }),
+      )
+
+      const { result } = renderHook(() => useDepositActions())
+      const deposit = buildDeposit()
+
+      act(() => {
+        result.current.handleClaim(deposit)
+      })
+
+      await waitFor(() => expect(result.current.isBusy).toBe(true))
+      expect(result.current.isProcessing(deposit.id, "claim")).toBe(true)
+      expect(result.current.isProcessing("another-deposit", "claim")).toBe(false)
+
+      await act(async () => {
+        settleClaim({ status: PaymentResultStatus.Success })
+      })
+    })
+
+    it("leaves a message that is not a classified code exactly as it came", async () => {
+      mockClaimDeposit.mockResolvedValue({
+        status: PaymentResultStatus.Failed,
+        errors: [{ message: "Invalid depositId: garbage" }],
+      })
+
+      const { result } = renderHook(() => useDepositActions())
+
+      await act(async () => {
+        await result.current.handleClaim(buildDeposit())
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Claim failed: Invalid depositId: garbage" }),
       )
     })
   })

--- a/__tests__/self-custodial/adapters/deposit.spec.ts
+++ b/__tests__/self-custodial/adapters/deposit.spec.ts
@@ -77,6 +77,59 @@ describe("createListPendingDeposits", () => {
     expect(result.deposits[0].requiredFeeSats).toBe(800)
   })
 
+  it("reports a deposit the network no longer holds", async () => {
+    mockListDeposits.mockResolvedValue([
+      {
+        txid: "mno",
+        vout: 0,
+        amountSats: 1000,
+        isMature: true,
+        claimError: { reason: "missing_utxo" },
+        hasRefund: false,
+      },
+    ])
+
+    const result = await createListPendingDeposits(mockSdk)()
+
+    expect(result.deposits[0].status).toBe("error")
+    expect(result.deposits[0].errorReason).toBe("missing_utxo")
+  })
+
+  it("reports a deposit too small to be worth claiming", async () => {
+    mockListDeposits.mockResolvedValue([
+      {
+        txid: "pqr",
+        vout: 0,
+        amountSats: 100,
+        isMature: true,
+        claimError: { reason: "below_dust" },
+        hasRefund: false,
+      },
+    ])
+
+    const result = await createListPendingDeposits(mockSdk)()
+
+    expect(result.deposits[0].errorReason).toBe("below_dust")
+  })
+
+  it("falls back to a generic reason for a claim error it does not name", async () => {
+    mockListDeposits.mockResolvedValue([
+      {
+        txid: "stu",
+        vout: 0,
+        amountSats: 4000,
+        isMature: true,
+        claimError: { reason: "generic", message: "something else" },
+        hasRefund: false,
+      },
+    ])
+
+    const result = await createListPendingDeposits(mockSdk)()
+
+    expect(result.deposits[0].errorReason).toBe("generic")
+    expect(result.deposits[0].errorMessage).toBe("something else")
+  })
+
   it("returns refunded status", async () => {
     mockListDeposits.mockResolvedValue([
       {
@@ -104,6 +157,14 @@ describe("createListPendingDeposits", () => {
     expect(result.deposits).toHaveLength(0)
     expect(result.errors).toHaveLength(1)
   })
+
+  it("describes a rejection that is not an Error at all", async () => {
+    mockListDeposits.mockRejectedValue("bridge unavailable")
+
+    const result = await createListPendingDeposits(mockSdk)()
+
+    expect(result.errors?.[0].message).toBe("List deposits failed: bridge unavailable")
+  })
 })
 
 describe("createClaimDeposit", () => {
@@ -121,14 +182,70 @@ describe("createClaimDeposit", () => {
     )
   })
 
-  it("returns failed on error", async () => {
+  const unclaimed = (txid: string, vout: number) => ({
+    txid,
+    vout,
+    amountSats: 5000,
+    isMature: true,
+    claimError: null,
+    hasRefund: false,
+  })
+
+  it("reports success when the throw came after the deposit was already claimed", async () => {
+    // The SDK raises from the step after the funds settle. Reading the unclaimed list back
+    // is what tells a settled deposit apart from one that truly failed.
+    mockClaimDeposit.mockRejectedValue(new Error("sdkError.SparkError"))
+    mockListDeposits.mockResolvedValue([unclaimed("other", 0)])
+
+    const adapter = createClaimDeposit(mockSdk)
+    const result = await adapter.claimDeposit({ depositId: "abc:0" })
+
+    expect(result.status).toBe("success")
+    expect(result.errors).toBeUndefined()
+  })
+
+  it("returns failed while the deposit is still waiting to be claimed", async () => {
     mockClaimDeposit.mockRejectedValue(new Error("claim failed"))
+    mockListDeposits.mockResolvedValue([unclaimed("abc", 0)])
 
     const adapter = createClaimDeposit(mockSdk)
     const result = await adapter.claimDeposit({ depositId: "abc:0" })
 
     expect(result.status).toBe("failed")
-    expect(result.errors?.[0].message).toContain("claim failed")
+    expect(result.errors?.[0].message).toBe("sc_generic")
+  })
+
+  it("keeps a deposit of the same txid but another vout apart", async () => {
+    mockClaimDeposit.mockRejectedValue(new Error("claim failed"))
+    mockListDeposits.mockResolvedValue([unclaimed("abc", 1)])
+
+    const adapter = createClaimDeposit(mockSdk)
+    const result = await adapter.claimDeposit({ depositId: "abc:0" })
+
+    expect(result.status).toBe("success")
+  })
+
+  it("reports failure when the read-back itself fails, rather than guessing", async () => {
+    // An unknown outcome must not be announced as money arrived: a claim that already
+    // succeeded costs the reader nothing to retry, a phantom success costs them trust.
+    mockClaimDeposit.mockRejectedValue(new Error("claim failed"))
+    mockListDeposits.mockRejectedValue(new Error("listing unavailable"))
+
+    const adapter = createClaimDeposit(mockSdk)
+    const result = await adapter.claimDeposit({ depositId: "abc:0" })
+
+    expect(result.status).toBe("failed")
+    expect(result.errors?.[0].message).toBe("sc_generic")
+  })
+
+  it("classifies the error rather than passing the SDK's own wording on", async () => {
+    mockClaimDeposit.mockRejectedValue(new Error("sdkError.SparkError"))
+    mockListDeposits.mockResolvedValue([unclaimed("abc", 0)])
+
+    const adapter = createClaimDeposit(mockSdk)
+    const result = await adapter.claimDeposit({ depositId: "abc:0" })
+
+    expect(result.errors?.[0].message).not.toContain("sdkError")
   })
 
   it("refunds deposit successfully", async () => {
@@ -142,6 +259,19 @@ describe("createClaimDeposit", () => {
     })
 
     expect(result.status).toBe("success")
+  })
+
+  it("describes a refund rejection that is not an Error at all", async () => {
+    mockRefundDeposit.mockRejectedValue("bridge unavailable")
+
+    const adapter = createClaimDeposit(mockSdk)
+    const result = await adapter.refundDeposit({
+      depositId: "abc:0",
+      destinationAddress: "bc1q...",
+      feeRateSatPerVb: 3,
+    })
+
+    expect(result.errors?.[0].message).toBe("Refund failed: bridge unavailable")
   })
 
   it("returns failed on refund error", async () => {
@@ -257,5 +387,9 @@ describe("parseDepositId", () => {
 
   it("returns null for fractional vout", () => {
     expect(parseDepositId("abc:1.5")).toBeNull()
+  })
+
+  it("returns null for a vout past what a number can hold exactly", () => {
+    expect(parseDepositId("abc:9007199254740993")).toBeNull()
   })
 })

--- a/app/screens/unclaimed-deposits/hooks/use-deposit-actions.ts
+++ b/app/screens/unclaimed-deposits/hooks/use-deposit-actions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 
 import { usePayments } from "@app/hooks/use-payments"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useTranslateSdkError } from "@app/self-custodial/hooks"
 import {
   DepositErrorReason,
   DepositStatus,
@@ -24,12 +25,22 @@ type ActiveAction = {
 
 type PaymentError = { message: string }
 type LL = ReturnType<typeof useI18nContext>["LL"]
+/** Turns a classified self-custodial code into a sentence, and leaves anything else be. */
+type TranslateSdkError = ReturnType<typeof useTranslateSdkError>
 
-const resolveClaimErrorMessage = (
-  deposit: PendingDeposit,
-  errors: PaymentError[] | undefined,
-  LL: LL,
-): string => {
+type ErrorMessageParams = {
+  deposit: PendingDeposit
+  errors: PaymentError[] | undefined
+  LL: LL
+  translateSdkError: TranslateSdkError
+}
+
+const resolveClaimErrorMessage = ({
+  deposit,
+  errors,
+  LL,
+  translateSdkError,
+}: ErrorMessageParams): string => {
   if (deposit.errorReason === DepositErrorReason.BelowDust) {
     return LL.UnclaimedDeposit.belowDustLimit()
   }
@@ -42,16 +53,19 @@ const resolveClaimErrorMessage = (
     return LL.UnclaimedDeposit.missingUtxo()
   }
   if (errors?.length) {
-    return LL.UnclaimedDeposit.claimFailed({ error: errors[0].message })
+    return LL.UnclaimedDeposit.claimFailed({
+      error: translateSdkError(errors[0].message) ?? errors[0].message,
+    })
   }
   return LL.UnclaimedDeposit.error()
 }
 
-const resolveRefundErrorMessage = (
-  deposit: PendingDeposit,
-  errors: PaymentError[] | undefined,
-  LL: LL,
-): string => {
+const resolveRefundErrorMessage = ({
+  deposit,
+  errors,
+  LL,
+  translateSdkError,
+}: ErrorMessageParams): string => {
   if (deposit.errorReason === DepositErrorReason.BelowDust) {
     return LL.UnclaimedDeposit.belowDustLimit()
   }
@@ -61,13 +75,16 @@ const resolveRefundErrorMessage = (
     })
   }
   if (errors?.length) {
-    return LL.UnclaimedDeposit.refundFailed({ error: errors[0].message })
+    return LL.UnclaimedDeposit.refundFailed({
+      error: translateSdkError(errors[0].message) ?? errors[0].message,
+    })
   }
   return LL.UnclaimedDeposit.error()
 }
 
 export const useDepositActions = () => {
   const { LL } = useI18nContext()
+  const translateSdkError = useTranslateSdkError()
   const { listPendingDeposits, claimDeposit } = usePayments()
   const [deposits, setDeposits] = useState<PendingDeposit[]>([])
   const [activeAction, setActiveAction] = useState<ActiveAction | null>(null)
@@ -104,7 +121,12 @@ export const useDepositActions = () => {
           maxFeeSats: deposit.requiredFeeSats,
         })
         if (result.status === PaymentResultStatus.Failed) {
-          const message = resolveClaimErrorMessage(deposit, result.errors, LL)
+          const message = resolveClaimErrorMessage({
+            deposit,
+            errors: result.errors,
+            LL,
+            translateSdkError,
+          })
           toastShow({ message, LL })
           return
         }
@@ -118,7 +140,7 @@ export const useDepositActions = () => {
         setActiveAction(null)
       }
     },
-    [claimDeposit, refresh, LL],
+    [claimDeposit, refresh, LL, translateSdkError],
   )
 
   const handleRefund = useCallback(
@@ -140,7 +162,12 @@ export const useDepositActions = () => {
           feeRateSatPerVb,
         })
         if (result.status === PaymentResultStatus.Failed) {
-          const message = resolveRefundErrorMessage(deposit, result.errors, LL)
+          const message = resolveRefundErrorMessage({
+            deposit,
+            errors: result.errors,
+            LL,
+            translateSdkError,
+          })
           toastShow({ message, LL })
           return false
         }
@@ -155,7 +182,7 @@ export const useDepositActions = () => {
         setActiveAction(null)
       }
     },
-    [claimDeposit, refresh, LL],
+    [claimDeposit, refresh, LL, translateSdkError],
   )
 
   return {

--- a/app/self-custodial/adapters/deposit.ts
+++ b/app/self-custodial/adapters/deposit.ts
@@ -12,11 +12,36 @@ import {
 } from "@app/types/payment"
 
 import { claimDeposit, listDeposits, refundDeposit, type MappedDeposit } from "../bridge"
+import { classifySdkError } from "../sdk-error"
 
 const failed = (message: string): PaymentAdapterResult => ({
   status: PaymentResultStatus.Failed,
   errors: [{ message }],
 })
+
+/**
+ * Whether the deposit is still waiting to be claimed.
+ *
+ * A throw from `claimDeposit` is not proof that the claim failed: the SDK also raises from
+ * the step after the funds have already settled, which is what told a reader
+ * "Claim Failed: sdkError.SparkError" over money that had arrived. The unclaimed list is
+ * the record that settles it, so it is read back before anyone is told anything.
+ *
+ * A listing that itself fails leaves the outcome unknown, and unknown counts as still
+ * unclaimed: announcing a deposit that may never have landed is the worse of the two
+ * mistakes, and the reader can retry a claim that already succeeded for free.
+ */
+const isStillUnclaimed = async (
+  sdk: BreezSdkInterface,
+  { txid, vout }: { txid: string; vout: number },
+): Promise<boolean> => {
+  try {
+    const deposits = await listDeposits(sdk)
+    return deposits.some((deposit) => deposit.txid === txid && deposit.vout === vout)
+  } catch {
+    return true
+  }
+}
 
 const resolveStatus = ({
   isMature,
@@ -60,7 +85,8 @@ export const parseDepositId = (
   const voutStr = depositId.substring(lastColon + 1)
   if (!txid || !/^\d+$/.test(voutStr)) return null
   const vout = Number(voutStr)
-  if (!Number.isSafeInteger(vout) || vout < 0) return null
+  /** Negatives never reach here: the digits-only test above already refused them. */
+  if (!Number.isSafeInteger(vout)) return null
   return { txid, vout }
 }
 
@@ -98,7 +124,12 @@ export const createClaimDeposit = (sdk: BreezSdkInterface): ClaimDepositAdapter 
       await claimDeposit({ sdk, ...parsed, maxFeeSats })
       return { status: PaymentResultStatus.Success }
     } catch (err) {
-      return failed(err instanceof Error ? err.message : `Claim failed: ${err}`)
+      if (!(await isStillUnclaimed(sdk, parsed))) {
+        return { status: PaymentResultStatus.Success }
+      }
+      /** A classified code, so the screen shows the reader a sentence rather than the
+       *  SDK's own wording. The SDK's log listener records the raw error already. */
+      return failed(classifySdkError(err))
     }
   },
 


### PR DESCRIPTION
Closes #4174

## Problem

Claiming an on-chain deposit into a non-custodial account reports `Claim Failed: sdkError.SparkError` while the funds settle in the wallet anyway. Reported on Android 3.0.25 and reproduced by @pretyflaco.

Two separate faults produce that screen:

1. **A throw is treated as proof of failure.** [`createClaimDeposit`](app/self-custodial/adapters/deposit.ts) marks the claim failed the moment `claimDeposit` raises. The SDK also raises from the step *after* the deposit is claimed, so a settled deposit is announced as a failure.
2. **The SDK's own wording reaches the reader.** The raw `err.message` is passed straight into `LL.UnclaimedDeposit.claimFailed`, which is why a user is shown the string `sdkError.SparkError` — a name from a Rust enum, not a sentence.

## Proposed fix

**Let the record decide, not the throw.** When the claim raises, the adapter reads the unclaimed deposit list back. If the deposit is no longer there, it was claimed and the result is success. If it is still listed, the claim genuinely failed.

A read-back that itself fails leaves the outcome unknown, and unknown is reported as a failure on purpose: telling someone their deposit arrived when it may not have is the worse of the two mistakes, and retrying a claim that already succeeded costs them nothing.

**Say it in words.** The failure path now returns a classified `SelfCustodialErrorCode`, and the screen runs it through the existing `useTranslateSdkError` — the same translator the send flow uses — so the toast reads "Something went wrong. Please try again." instead of an SDK enum name. A message that is not a classified code is passed through untouched, so nothing else changes wording.

## Notes for review

A deposit leaves the unclaimed list when it is claimed. A refunded deposit stays on the list with its refund id, so a refund cannot be mistaken for a claim. The narrow remaining case is a refund issued from another device inside the window of a failing claim, which would read as success; the same-device UI serialises the two actions, so it cannot happen from one phone.

`parseDepositId` loses its `vout < 0` test: the digits-only regex on the line above already refuses a sign, so the comparison could never run.

## Test plan

- `yarn jest __tests__/self-custodial/adapters/deposit.spec.ts __tests__/screens/unclaimed-deposits/ --maxWorkers=2`: **115 passed**
- Coverage on both changed files: **100% statements, branches, functions and lines**
- New cases: a throw after the deposit was already claimed reads as success; a throw with the deposit still listed reads as failure; a deposit with the same txid but another vout is not mistaken for it; a failing read-back reports failure rather than guessing; the toast shows a sentence rather than `sdkError.*`
- `yarn check-code` (tsc, eslint, translations, codegen, graphql validation): clean
- Not yet exercised on a device — it needs a real on-chain deposit to a non-custodial account, which is the next step before merging.
