### PR TITLE
fix(security): never delete the PIN on a lockout-triggered logout

### DIFF
--- a/__tests__/hooks/use-logout.spec.ts
+++ b/__tests__/hooks/use-logout.spec.ts
@@ -98,6 +98,25 @@ describe("useLogout", () => {
     expect(mockResetState).toHaveBeenCalledTimes(1)
   })
 
+  it("preserves the PIN when the caller asks to (a lockout-triggered logout)", async () => {
+    // A logout forced by exhausting PIN attempts must not delete the very
+    // lock it is enforcing: getIsPinEnabled() is just "is a PIN stored", so
+    // removing it here would leave the next screen ungated. Everything else
+    // "logout" wipes (session, biometrics, device state) still applies.
+    const { result } = renderHook(() => useLogout())
+
+    await act(async () => {
+      await result.current.logout({ preservePin: true })
+    })
+
+    expect(mockRemovePin).not.toHaveBeenCalled()
+    expect(mockRemoveIsBiometricsEnabled).toHaveBeenCalledTimes(1)
+    expect(mockRemovePinAttempts).toHaveBeenCalledTimes(1)
+    expect(mockRemoveSessionProfiles).toHaveBeenCalledTimes(1)
+    expect(mockClearToken).toHaveBeenCalledTimes(1)
+    expect(mockResetState).toHaveBeenCalledTimes(1)
+  })
+
   it("profile logout (explicit token) removes only that profile, not the active keychain token", async () => {
     mockGetActiveToken.mockResolvedValue("current-session-token")
     const { result } = renderHook(() => useLogout())

--- a/__tests__/screens/authentication-screen/pin-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/pin-screen.spec.tsx
@@ -13,6 +13,8 @@ import { flushEffects } from "../../helpers/flush-effects"
 const mockReset = jest.fn()
 const mockGoBack = jest.fn()
 const mockSetAppUnlocked = jest.fn()
+const mockLogout = jest.fn()
+const mockGetPinAttemptsOrZero = jest.fn().mockResolvedValue(0)
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
@@ -25,20 +27,22 @@ jest.mock("@app/navigation/navigation-container-wrapper", () => ({
 
 jest.mock("@app/hooks/use-logout", () => ({
   __esModule: true,
-  default: () => ({ logout: jest.fn() }),
+  default: () => ({ logout: mockLogout }),
 }))
 
 jest.mock("@app/utils/storage/secureStorage", () => ({
   __esModule: true,
   default: {
     getPinOrEmptyString: jest.fn().mockResolvedValue("1234"),
-    getPinAttemptsOrZero: jest.fn().mockResolvedValue(0),
+    getPinAttemptsOrZero: () => mockGetPinAttemptsOrZero(),
     resetPinAttempts: jest.fn(),
     setPinAttempts: jest.fn(),
     /** Read by the account registry the screen renders under. */
     getSessionProfiles: jest.fn().mockResolvedValue([]),
   },
 }))
+
+jest.mock("@app/utils/sleep", () => ({ sleep: jest.fn().mockResolvedValue(undefined) }))
 
 const CORRECT_PIN = "1234"
 const WRONG_PIN = "9999"
@@ -162,5 +166,38 @@ describe("PinScreen", () => {
     expect(mockSetAppUnlocked).not.toHaveBeenCalled()
     expect(mockGoBack).not.toHaveBeenCalled()
     expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  describe("exhausting the attempt budget", () => {
+    it("logs out without deleting the PIN, so the attacker lands back on a gate, not Home", async () => {
+      // Regression for the multi-account/anon-wallet bypass: a bare logout()
+      // call here deletes the PIN, which is the only thing gating re-entry
+      // (getIsPinEnabled() is just "is a PIN stored"). A third wrong guess
+      // must never resolve onto Primary directly.
+      mockGetPinAttemptsOrZero.mockResolvedValue(2)
+      renderScreen(false)
+      await flushEffects()
+
+      await enterPin(WRONG_PIN)
+
+      expect(mockLogout).toHaveBeenCalledWith({ preservePin: true })
+      expect(mockReset).not.toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "Primary" }],
+      })
+    })
+
+    it("routes back through the authentication gate instead of Primary", async () => {
+      mockGetPinAttemptsOrZero.mockResolvedValue(2)
+      renderScreen(false)
+      await flushEffects()
+
+      await enterPin(WRONG_PIN)
+
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "authenticationCheck" }],
+      })
+    })
   })
 })

--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -15,6 +15,12 @@ type LogoutOptions = {
   stateToDefault?: boolean
   token?: string
   isValidToken?: boolean
+  /**
+   * Keep the device PIN in place. A PIN-exhaustion logout must not delete
+   * the PIN it exists to enforce — getIsPinEnabled() is just "is a PIN
+   * stored", so removing it here would leave the very next screen ungated.
+   */
+  preservePin?: boolean
 }
 
 gql`
@@ -36,6 +42,7 @@ const useLogout = () => {
       stateToDefault = true,
       token,
       isValidToken = true,
+      preservePin = false,
     }: LogoutOptions = {}): Promise<void> => {
       try {
         // Isolated: a failed push-token fetch must never skip the local
@@ -65,7 +72,9 @@ const useLogout = () => {
         } else {
           await AsyncStorage.multiRemove([SCHEMA_VERSION_KEY])
           await KeyStoreWrapper.removeIsBiometricsEnabled()
-          await KeyStoreWrapper.removePin()
+          if (!preservePin) {
+            await KeyStoreWrapper.removePin()
+          }
           await KeyStoreWrapper.removePinAttempts()
           await KeyStoreWrapper.removeSessionProfiles()
           await clearToken()

--- a/app/screens/authentication-screen/pin-screen.tsx
+++ b/app/screens/authentication-screen/pin-screen.tsx
@@ -68,11 +68,16 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
       }
     } else {
       setHelperText(LL.PinScreen.tooManyAttempts())
-      await logout()
+      // The PIN must survive its own lockout: it is the only thing that
+      // gates the next screen (getIsPinEnabled() is just "is a PIN
+      // stored"), so deleting it here — and landing straight on Primary —
+      // would hand an attacker who never typed a correct PIN a working
+      // wallet the moment the lock supposedly kicks in.
+      await logout({ preservePin: true })
       await sleep(1000)
       navigation.reset({
         index: 0,
-        routes: [{ name: "Primary" }],
+        routes: [{ name: "authenticationCheck" }],
       })
     }
   }


### PR DESCRIPTION
Stacked on #4199 (the revert). Re-opens and fixes blinkbitcoin/blink-wip#1140, this time test-first.

## Root cause

`PinScreen`'s third-strike handler calls the generic `useLogout()` with no arguments. Its no-token branch — used for every "full" logout, not just this one — unconditionally calls `KeyStoreWrapper.removePin()`. `getIsPinEnabled()` is defined as nothing more than "does a PIN exist in the keystore" (`app/utils/storage/secureStorage.ts:40`), so removing the PIN silently turns the app-lock off. `AuthenticationCheckScreen`'s next mount reads `isPinEnabled === false` and routes straight to `Primary` — no re-authentication of any kind.

This is what the screen recording on #4199 shows: three wrong PINs, waiting out the 30s and 60s lockouts as designed, the third strike fires "Too many failed attempts. Logging out.", and two seconds later the app is on the Home screen of a funded wallet. It's not a flaw in a lockout schedule — the pre-#4162 code had this exact hole with only 3 instant guesses standing between an attacker and it. #4162 made the hole harder to reach; it didn't close it.

## Fix

- `useLogout()` gets a `preservePin` option. When set, the no-token branch skips `removePin()` but still does everything else "logout" already does — clears biometrics, session profiles, the attempt counter, and the auth token.
- `PinScreen`'s exhausted-attempts branch calls `logout({ preservePin: true })`.
- That branch also stops resetting straight to `Primary`. It now resets to `authenticationCheck`, so the gate is re-evaluated rather than assumed open — defense in depth if this class of bug recurs elsewhere.

## Tests (written first, confirmed red against the pre-fix code)

- `useLogout` (`__tests__/hooks/use-logout.spec.ts`): a new case asserts `preservePin: true` leaves `removePin` uncalled while every other wipe (biometrics, session profiles, attempt counter, token) still happens.
- `PinScreen` (`__tests__/screens/authentication-screen/pin-screen.spec.tsx`): a new `"exhausting the attempt budget"` block asserts the third wrong guess calls `logout({ preservePin: true })` and resets to `authenticationCheck`, never `Primary`.

`npx jest __tests__/hooks/use-logout.spec.ts __tests__/screens/authentication-screen` — 38/38 passing. `eslint`/`tsc` clean on the touched files.

## Scope note

This closes the reproduced bypass (PIN deleted → open gate) for a single-account device. blinkbitcoin/blink-wip#1140's original report also raised a multi-account variant — "first account has a PIN, others don't" — that I have not reproduced or traced; `PIN`/`isPinEnabled` are a single global keystore entry, not per-account, so it's a related but distinct question about how account switching interacts with the (now-preserved) device-level PIN. Flagging for follow-up rather than folding an untraced claim into this fix.

## Next

- Land #4199 first (the revert of #4162), then rebase this onto `main`.
- Once this lands, blink-wip#1140's original goal (escalating lockout so the budget isn't spent in 3 instant guesses) can be re-proposed as a separate PR built on top of a logout path that's actually terminal.