### PR TITLE
fix(ci): make mac worker disk cleanup thresholds more aggressive

### DIFF
--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -4,10 +4,13 @@ set -euo pipefail
 
 MODE="${1:-check}"
 MIN_FREE_GB="${MIN_BUILD_FREE_GB:-${2:-30}}"
-HARD_MIN_FREE_GB="${MIN_BUILD_HARD_FREE_GB:-10}"
-XCODE_ARTIFACT_MAX_AGE_DAYS="${XCODE_ARTIFACT_MAX_AGE_DAYS:-14}"
-ROOT_DERIVED_DATA_MAX_GB="${ROOT_DERIVED_DATA_MAX_GB:-20}"
-BUILD_CACHE_MAX_GB="${BUILD_CACHE_MAX_GB:-5}"
+# Below this, "pre" fails the build outright instead of just warning: a build
+# that starts this tight on space reliably runs out of disk mid-compile
+# rather than failing fast, which wastes a ~13min build slot on top of it.
+HARD_MIN_FREE_GB="${MIN_BUILD_HARD_FREE_GB:-20}"
+XCODE_ARTIFACT_MAX_AGE_DAYS="${XCODE_ARTIFACT_MAX_AGE_DAYS:-2}"
+ROOT_DERIVED_DATA_MAX_GB="${ROOT_DERIVED_DATA_MAX_GB:-3}"
+BUILD_CACHE_MAX_GB="${BUILD_CACHE_MAX_GB:-1}"
 CI_ROOT="${CI_ROOT:-$(pwd)}"
 DISK_CHECK_PATH="${DISK_CHECK_PATH:-$CI_ROOT}"
 CONCOURSE_WORKDIR="${CONCOURSE_WORKDIR:-/Users/m1/concourse/workdir}"

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -212,6 +212,11 @@ cleanup_workspace_build_outputs() {
   remove_path "$CI_ROOT/repo/android/build"
   remove_path "$CI_ROOT/repo/ios/build"
   remove_path "$CI_ROOT/repo/ios/Blink.ipa"
+  # build.sh always runs `nix develop -c yarn install` before building, so
+  # node_modules is regenerated from scratch every run regardless of what was
+  # here before — safe to drop, and it was sitting at 7.5G unused between
+  # builds in the 2026-08-24 disk-full incident.
+  remove_path "$CI_ROOT/repo/node_modules"
 }
 
 cleanup_xcode_artifacts() {


### PR DESCRIPTION
## Summary
- A prerelease/prod Android build failed today with `No space left on device` 13 minutes into the Gradle build, despite `build.sh` running `macos-build-disk-cleanup.sh pre` beforehand — the purge is capped by design and only hard-fails below a low floor, so a build could start with just enough headroom above that floor and still run out mid-compile instead of failing fast.
- The failure's own disk report showed both an overly loose purge policy and one consumer nothing was touching at all:
  - `XCODE_ARTIFACT_MAX_AGE_DAYS`: 14 → 2 days
  - `ROOT_DERIVED_DATA_MAX_GB`: 20 → 3 GB
  - `BUILD_CACHE_MAX_GB`: 5 → 1 GB
  - `HARD_MIN_FREE_GB` (`MIN_BUILD_HARD_FREE_GB`): 10 → 20 GB, so `pre` mode fails the build task immediately if cleanup can't clear enough space, instead of letting the build proceed and die mid-compile
  - `node_modules` (7.5G in the incident, on the same shared APFS container that ran out of space) is now purged in workspace cleanup — `build.sh` always runs `yarn install` fresh before building, so this is safe to drop rather than let it leak across builds
- Ruled out: the failure log also showed `/Library/Developer/CoreSimulator/Volumes/iOS_23F77` at 16G, but that's mounted on a separate device (`disk5s1`, its own independent capacity) from the container that actually filled up (`disk3s*`, shared by `/`, `/System/Volumes/Data`, `/nix`) — cleaning it wouldn't have helped this failure, so it's left alone.

## Trade-off
More aggressive purging means more cache misses (re-downloaded Yarn/CocoaPods/Gradle deps, rebuilt DerivedData, reinstalled node_modules) on the worker, in exchange for reliably avoiding disk-full build failures. All thresholds are still overridable via job params (`XCODE_ARTIFACT_MAX_AGE_DAYS`, `ROOT_DERIVED_DATA_MAX_GB`, `BUILD_CACHE_MAX_GB`, `MIN_BUILD_HARD_FREE_GB`) if the new defaults prove too aggressive for a specific job.

## Test plan
- [x] `bash -n ci/tasks/macos-build-disk-cleanup.sh` (syntax check)
- [ ] Verify on the next `cleanup-mac-build-worker` scheduled run and next `dev-build`/`prerelease` build that the worker stays above 20GB free and no build fails on disk space