### PR TITLE
fix(migration): surface a recoverable error when the commit screen prerequisites never settle

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-custodial-owner-id.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-custodial-owner-id.spec.ts
@@ -5,7 +5,8 @@ import { AccountType } from "@app/types/wallet"
 
 let mockIsAuthed = true
 let mockActiveAccount: { type: string } | undefined
-let mockQueryResult: { data: unknown; loading: boolean }
+let mockQueryResult: { data: unknown; loading: boolean; error?: unknown }
+const mockRefetch = jest.fn()
 const mockUseMigrationOwnerQuery = jest.fn()
 
 jest.mock("@app/graphql/is-authed-context", () => ({
@@ -26,7 +27,10 @@ describe("useCustodialOwnerId", () => {
     mockIsAuthed = true
     mockActiveAccount = { type: AccountType.Custodial }
     mockQueryResult = { data: undefined, loading: false }
-    mockUseMigrationOwnerQuery.mockImplementation(() => mockQueryResult)
+    mockUseMigrationOwnerQuery.mockImplementation(() => ({
+      ...mockQueryResult,
+      refetch: mockRefetch,
+    }))
   })
 
   it("returns the Galoy account id for a custodial session", () => {
@@ -42,6 +46,7 @@ describe("useCustodialOwnerId", () => {
     expect(mockUseMigrationOwnerQuery).toHaveBeenCalledWith({
       skip: false,
       fetchPolicy: "no-cache",
+      notifyOnNetworkStatusChange: true,
     })
   })
 
@@ -73,17 +78,84 @@ describe("useCustodialOwnerId", () => {
     expect(mockUseMigrationOwnerQuery).toHaveBeenCalledWith({
       skip: true,
       fetchPolicy: "no-cache",
+      notifyOnNetworkStatusChange: true,
     })
   })
 
   it("skips the query until the session is authenticated", () => {
     mockIsAuthed = false
 
-    renderHook(() => useCustodialOwnerId())
+    const { result } = renderHook(() => useCustodialOwnerId())
 
+    expect(result.current.isSkipped).toBe(true)
     expect(mockUseMigrationOwnerQuery).toHaveBeenCalledWith({
       skip: true,
       fetchPolicy: "no-cache",
+      notifyOnNetworkStatusChange: true,
     })
+  })
+
+  /**
+   * A failed request is not the server answering that this account has no owner. Callers
+   * spend the difference on an irreversible step, so a failure travels apart from an
+   * answer: it earns a retry, where an answer with no owner is what they hand to support.
+   */
+  it("names a failed query as the reason the owner is unknown", () => {
+    mockQueryResult = {
+      data: undefined,
+      loading: false,
+      error: { networkError: new Error("offline") },
+    }
+
+    const { result } = renderHook(() => useCustodialOwnerId())
+
+    expect(result.current.ownerId).toBeNull()
+    expect(result.current.hasError).toBe(true)
+    expect(result.current.isSkipped).toBe(false)
+  })
+
+  /** An authenticated custodial session always has an owner, so a server error is a failed
+   *  request like any other, never the answer that this account has none. */
+  it("reports a server error the same as a dropped one", () => {
+    mockQueryResult = {
+      data: { me: null },
+      loading: false,
+      error: { graphQLErrors: [{ message: "nope" }] },
+    }
+
+    const { result } = renderHook(() => useCustodialOwnerId())
+
+    expect(result.current.ownerId).toBeNull()
+    expect(result.current.hasError).toBe(true)
+  })
+
+  it("reports no error on a query that answered", () => {
+    mockQueryResult = {
+      data: { me: { defaultAccount: { id: "galoy-account-1" } } },
+      loading: false,
+    }
+
+    const { result } = renderHook(() => useCustodialOwnerId())
+
+    expect(result.current.hasError).toBe(false)
+  })
+
+  it("hands the query's own refetch to callers", async () => {
+    const { result } = renderHook(() => useCustodialOwnerId())
+
+    await result.current.refetch()
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+  })
+
+  /** A skipped query sits on standby, where a refetch runs it regardless of the skip: the
+   *  one session that must never ask for `me` is the one that stopped being custodial. */
+  it("does not run the query on a refetch while it is skipped", async () => {
+    mockActiveAccount = { type: AccountType.SelfCustodial }
+
+    const { result } = renderHook(() => useCustodialOwnerId())
+    await result.current.refetch()
+
+    expect(mockRefetch).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-checkpoint.spec.ts
@@ -11,6 +11,7 @@ const mockLoadCheckpoint = jest.fn()
 const mockSaveCheckpointToStorage = jest.fn()
 const mockClearCheckpointFromStorage = jest.fn()
 const mockReportError = jest.fn()
+const mockRefetchOwnerId = jest.fn()
 let mockActiveAccount: { id: string; type: string } | undefined
 let mockOwnerId: string | null = "custodial-1"
 let mockFocusCallback: (() => void | (() => void)) | null = null
@@ -47,7 +48,11 @@ jest.mock("@app/hooks/use-account-registry", () => ({
 }))
 
 jest.mock("@app/screens/account-migration/hooks/use-custodial-owner-id", () => ({
-  useCustodialOwnerId: () => ({ ownerId: mockOwnerId, loading: false }),
+  useCustodialOwnerId: () => ({
+    ownerId: mockOwnerId,
+    loading: false,
+    refetch: mockRefetchOwnerId,
+  }),
 }))
 
 jest.mock("@app/hooks/use-app-config", () => ({
@@ -56,16 +61,19 @@ jest.mock("@app/hooks/use-app-config", () => ({
   }),
 }))
 
+const resetCheckpointMocks = () => {
+  jest.clearAllMocks()
+  mockActiveAccount = { id: "custodial-1", type: "custodial" }
+  mockOwnerId = "custodial-1"
+  mockRefetchOwnerId.mockResolvedValue(undefined)
+  mockFocusCallback = null
+  mockLoadCheckpoint.mockResolvedValue(null)
+  mockSaveCheckpointToStorage.mockResolvedValue(undefined)
+  mockClearCheckpointFromStorage.mockResolvedValue(undefined)
+}
+
 describe("useMigrationCheckpoint", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockActiveAccount = { id: "custodial-1", type: "custodial" }
-    mockOwnerId = "custodial-1"
-    mockFocusCallback = null
-    mockLoadCheckpoint.mockResolvedValue(null)
-    mockSaveCheckpointToStorage.mockResolvedValue(undefined)
-    mockClearCheckpointFromStorage.mockResolvedValue(undefined)
-  })
+  beforeEach(resetCheckpointMocks)
 
   it("starts with null checkpoint and loading true", async () => {
     const { result } = renderHook(() => useMigrationCheckpoint())
@@ -777,6 +785,59 @@ describe("useMigrationCheckpoint", () => {
 
     await act(async () => {
       resolveLoad!(null)
+    })
+  })
+})
+
+describe("useMigrationCheckpoint owner recovery", () => {
+  beforeEach(resetCheckpointMocks)
+
+  /** The ids are keyed by an owner this hook resolves on its OWN uncached query, which can
+   *  fail while a caller's separate instance is healthy. A retry that only reloaded storage
+   *  would leave that lookup failed and the ids null for good, since nothing else re-runs
+   *  it short of remounting the screen. */
+  it("reruns the owner query on refetch, not only the storage read", async () => {
+    mockOwnerId = null
+    /** A fresh object per read, the way parsing storage gives one: the same reference back
+     *  would let React skip the render that picks the recovered owner up. */
+    mockLoadCheckpoint.mockImplementation(() =>
+      Promise.resolve({
+        step: MigrationCheckpoint.BackupAlerts,
+        savedAt: Date.now(),
+        accountId: "sc-account-2",
+        custodialAccountId: "custodial-1",
+      }),
+    )
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.accountId).toBeNull()
+
+    mockRefetchOwnerId.mockImplementation(() => {
+      mockOwnerId = "custodial-1"
+      return Promise.resolve()
+    })
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(mockRefetchOwnerId).toHaveBeenCalled()
+    expect(result.current.accountId).toBe("sc-account-2")
+  })
+
+  /** The retry stays one promise that resolves whatever failed: the gate Promise.alls it,
+   *  and an owner query rejecting there would double-report a failure hasError already
+   *  carries. */
+  it("resolves instead of rejecting when the refetched owner query fails again", async () => {
+    mockOwnerId = null
+    mockRefetchOwnerId.mockRejectedValue(new Error("offline"))
+
+    const { result } = renderHook(() => useMigrationCheckpoint())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await expect(result.current.refetch()).resolves.toBeUndefined()
     })
   })
 })

--- a/__tests__/screens/account-migration/hooks/use-migration-ln-address-transfer.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-ln-address-transfer.spec.ts
@@ -1,7 +1,10 @@
 import { act, renderHook } from "@testing-library/react-native"
 
 import { MigrationLnAddressTransferStatus } from "@app/graphql/generated"
-import { useMigrationLnAddressTransfer } from "@app/screens/account-migration/hooks/use-migration-ln-address-transfer"
+import {
+  LN_ADDRESS_TRANSFER_TIMEOUT_MS,
+  useMigrationLnAddressTransfer,
+} from "@app/screens/account-migration/hooks/use-migration-ln-address-transfer"
 import { MigrationSdkStatus } from "@app/self-custodial/migration-transfer-request"
 
 import { flushEffects } from "../../../helpers/flush-effects"
@@ -368,6 +371,10 @@ describe("useMigrationLnAddressTransfer", () => {
 
     expect(result.current.isTransferred).toBe(true)
     expect(result.current.isRejected).toBe(false)
+    /** Every settled kind, not just the rejection: a superseded answer landing in any of
+     *  them would hand a completed re-point to support. */
+    expect(result.current.isAccountMissing).toBe(false)
+    expect(result.current.hasConnectionIssue).toBe(false)
   })
 
   /** The shared retry button fires every source; a completed re-point must not re-run the
@@ -381,6 +388,105 @@ describe("useMigrationLnAddressTransfer", () => {
     await flushEffects()
 
     expect(mockTransfer).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The SDK connect-and-sign can stall under its storage-dir lock without ever throwing,
+   * and an attempt that never answers reports nothing at all: the commit screen would hold
+   * Approve off for good with no message and no retry. The bounded wait turns that silence
+   * into the same recoverable offer a dropped connection gets.
+   */
+  it("offers the retry when the re-point stalls without ever answering", async () => {
+    jest.useFakeTimers()
+    try {
+      mockBuildProof.mockReturnValue(
+        new Promise(() => {
+          /** Never settles: the stall this bound exists for. */
+        }),
+      )
+      const { result } = renderTransfer()
+
+      await act(async () => {
+        jest.advanceTimersByTime(LN_ADDRESS_TRANSFER_TIMEOUT_MS)
+      })
+
+      expect(result.current.hasConnectionIssue).toBe(true)
+      expect(result.current.isRejected).toBe(false)
+      expect(result.current.isTransferred).toBe(false)
+      expect(mockReportError).toHaveBeenCalledWith(
+        "Migration ln-address stalled",
+        expect.any(Error),
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  /**
+   * The proof is built before `run`'s own try, so a keychain that throws rejects it. That
+   * is a settled failure a retry only replays, not a wait that ran out, and support must
+   * not be told the attempt stalled when it threw.
+   *
+   * A stall stays retryable however often it happens: the attempt may still be in the air,
+   * and the screen keeps its contact-support button on throughout, so a retry that cannot
+   * land is never the user's only way out.
+   */
+  it("hands a throw before the mutation to support rather than reporting a stall", async () => {
+    mockBuildProof.mockRejectedValue(new Error("keychain unavailable"))
+
+    const { result } = renderTransfer()
+    await flushEffects()
+
+    expect(result.current.isRejected).toBe(true)
+    expect(result.current.hasConnectionIssue).toBe(false)
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Migration ln-address threw",
+      expect.any(Error),
+    )
+  })
+
+  /**
+   * An id that flickers null mid-flight re-runs the effect, which cannot fire again
+   * (the attempt number is already claimed). Dropping the in-flight answer too would
+   * leave every flag false for good: no transfer, no rejection, no retry offered, and
+   * Approve disabled with nothing on screen. The answer lands as long as the hook is
+   * mounted.
+   */
+  it("settles on the answer of an attempt whose ids flickered mid-flight", async () => {
+    let settleProof: (value: unknown) => void = () => undefined
+    mockBuildProof.mockReturnValue(
+      new Promise((resolve) => {
+        settleProof = resolve
+      }),
+    )
+    const { result, rerender } = renderHook(
+      ({ custodialAccountId }: { custodialAccountId: string | null }) =>
+        useMigrationLnAddressTransfer({
+          custodialAccountId,
+          selfCustodialAccountId: "sc-1",
+          skip: false,
+        }),
+      { initialProps: { custodialAccountId: "owner-1" as string | null } },
+    )
+
+    rerender({ custodialAccountId: null })
+    rerender({ custodialAccountId: "owner-1" })
+
+    settleProof(okProof)
+    await flushEffects()
+
+    expect(result.current.isTransferred).toBe(true)
+    expect(mockTransfer).toHaveBeenCalledTimes(1)
+  })
+
+  /** The bound is not a deadline the happy path races: an attempt that answers in time
+   *  settles on its own answer and never reports a stall. */
+  it("does not report a stall on an attempt that answered in time", async () => {
+    const { result } = renderTransfer()
+    await flushEffects()
+
+    expect(result.current.isTransferred).toBe(true)
+    expect(mockReportError).not.toHaveBeenCalled()
   })
 
   it("does not retry a settled rejection", async () => {

--- a/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/balances-overview-screen.spec.tsx
@@ -112,11 +112,16 @@ let mockLnAddressTransfer = {
   retry: mockLnRetry,
 }
 
+let mockCheckpointHasError = false
+const mockRefetchCheckpoint = jest.fn()
+
 jest.mock("@app/screens/account-migration/hooks", () => ({
   ...jest.requireActual("@app/screens/account-migration/hooks"),
   useMigrationCheckpoint: () => ({
     accountId: mockCheckpointAccountId,
     loading: mockCheckpointLoading,
+    hasError: mockCheckpointHasError,
+    refetch: mockRefetchCheckpoint,
     saveCheckpoint: mockSaveCheckpoint,
   }),
 }))
@@ -128,9 +133,30 @@ jest.mock("@app/self-custodial/hooks/use-self-custodial-account-mode", () => ({
   }),
 }))
 
+let mockOwnerIdLoading = false
+let mockOwnerIdSkipped = false
+let mockOwnerIdError = false
+const mockRefetchOwnerId = jest.fn()
+
 jest.mock("@app/screens/account-migration/hooks/use-custodial-owner-id", () => ({
-  useCustodialOwnerId: () => ({ ownerId: mockOwnerId, loading: false }),
+  useCustodialOwnerId: () => ({
+    ownerId: mockOwnerId,
+    loading: mockOwnerIdLoading,
+    isSkipped: mockOwnerIdSkipped,
+    hasError: mockOwnerIdError,
+    refetch: mockRefetchOwnerId,
+  }),
 }))
+
+/** The re-point as it stands before it has answered: nothing moved, nothing failed. The
+ *  state every id that never arrived leaves it in, since it cannot fire without them. */
+const unsettledLnTransfer = () => ({
+  isTransferred: false,
+  isRejected: false,
+  isAccountMissing: false,
+  hasConnectionIssue: false,
+  retry: mockLnRetry,
+})
 
 const mockUseLnAddressTransfer = jest.fn()
 jest.mock(
@@ -216,6 +242,12 @@ const resetScreenMocks = () => {
   mockCheckpointAccountId = "sc-account-1"
   mockStoredModes = {}
   mockOwnerId = "owner-1"
+  mockOwnerIdLoading = false
+  mockOwnerIdSkipped = false
+  mockOwnerIdError = false
+  mockCheckpointHasError = false
+  mockRefetchOwnerId.mockResolvedValue(undefined)
+  mockRefetchCheckpoint.mockResolvedValue(undefined)
   mockLnAddressTransfer = {
     isTransferred: true,
     isRejected: false,
@@ -1013,6 +1045,203 @@ describe("MigrationBalancesOverviewScreen lightning-address re-point gating", ()
     fireEvent.press(screen.getByTestId("migration-balances-overview-retry"))
 
     expect(mockLnRetry).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The re-point never fires without both ids, and a hook that never fires reports neither
+   * a failure nor a connection issue, so an id that settled missing used to leave Approve
+   * disabled for good with nothing on screen to act on: no message, no retry, and a
+   * swallowed hardware back. Support is the only honest destination.
+   */
+  it("hands over to support when the custodial owner id settles missing", async () => {
+    mockOwnerId = null
+    /** The re-point cannot have moved anything without the id it signs its proof with. */
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).toHaveBeenCalledWith("accountMigrationContactSupport", {
+      reason: "custodial-owner-missing",
+      origin: "commit",
+    })
+  })
+
+  /** Softer than the owner's rule on purpose: the checkpoint keys its id by an owner it
+   *  resolves through its own instance of the query, which can fail while this screen's is
+   *  healthy, so a null read there is not proof no account was provisioned. */
+  it("offers the retry rather than support when no self-custodial account was provisioned", async () => {
+    mockCheckpointAccountId = null
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByTestId("migration-balances-overview-retry")).toBeTruthy()
+  })
+
+  /** An id still in flight is a wait, not a failure: handing over on it would send every
+   *  user whose owner query is a beat slow to support in the one step they cannot undo. */
+  it("keeps waiting instead of handing over while the owner id is still loading", async () => {
+    mockOwnerId = null
+    mockOwnerIdLoading = true
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByTestId("migration-balances-overview-approve")).toBeDisabled()
+  })
+
+  /**
+   * A session that ended (or an active account that is no longer the custodial one) skips
+   * the owner query, which then reports neither loading nor an answer, and nulls the
+   * checkpoint's id with it. Reading that silence as a missing id would hand a user whose
+   * token merely expired to support, in the one step they cannot take back.
+   */
+  it("keeps waiting instead of handing over when the owner query was skipped", async () => {
+    mockOwnerId = null
+    mockOwnerIdSkipped = true
+    mockCheckpointAccountId = null
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  /**
+   * A dropped owner query settles with no id and no loading, which reads exactly like an
+   * account that has no owner. Handing over on it would send a user whose request merely
+   * failed to support, in the one step they cannot take back, so the network kind offers
+   * the retry the rest of the screen's sources already do.
+   */
+  it("offers the retry instead of support when the owner query failed", async () => {
+    mockOwnerId = null
+    mockOwnerIdError = true
+    /** The checkpoint keys its own id by the owner, so the same dropped query nulls both:
+     *  guarding only the owner's half would let the provisioned account's reason through. */
+    mockCheckpointAccountId = null
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByTestId("migration-balances-overview-retry")).toBeTruthy()
+  })
+
+  /** The checkpoint is healed alongside the owner: a storage read that failed is one of
+   *  the reasons the ids are unreadable, and the retry must clear all of them. */
+  it("refetches the checkpoint alongside the owner when the retry is pressed", async () => {
+    mockOwnerId = null
+    mockOwnerIdError = true
+    mockCheckpointAccountId = null
+    mockLnAddressTransfer = unsettledLnTransfer()
+    mockUseMigrationQuery.mockReturnValue({
+      ...migrationQueryResult({
+        balanceSats: 1000,
+        feeSats: 10,
+        feeCoveredByBlink: false,
+        receiveSats: 990,
+      }),
+      refetch: mockRefetchMigration,
+    })
+    mockUseWalletOverviewScreenQuery.mockReturnValue({
+      ...walletOverviewQueryResult({ btcBalance: 1000, usdBalance: 0 }),
+      refetch: mockRefetchWallets,
+    })
+
+    renderScreen()
+    await flushEffects()
+
+    fireEvent.press(screen.getByTestId("migration-balances-overview-retry"))
+
+    expect(mockRefetchCheckpoint).toHaveBeenCalledTimes(1)
+  })
+
+  it("refetches the owner id alongside the rest when the retry is pressed", async () => {
+    mockOwnerId = null
+    mockOwnerIdError = true
+    mockLnAddressTransfer = unsettledLnTransfer()
+    mockUseMigrationQuery.mockReturnValue({
+      ...migrationQueryResult({
+        balanceSats: 1000,
+        feeSats: 10,
+        feeCoveredByBlink: false,
+        receiveSats: 990,
+      }),
+      refetch: mockRefetchMigration,
+    })
+    mockUseWalletOverviewScreenQuery.mockReturnValue({
+      ...walletOverviewQueryResult({ btcBalance: 1000, usdBalance: 0 }),
+      refetch: mockRefetchWallets,
+    })
+
+    renderScreen()
+    await flushEffects()
+
+    fireEvent.press(screen.getByTestId("migration-balances-overview-retry"))
+
+    expect(mockRefetchOwnerId).toHaveBeenCalledTimes(1)
+  })
+
+  /**
+   * The retry takes Approve's place on this screen, so a source that no longer holds
+   * anything back must not claim it: past the re-point the ids are spent, and offering a
+   * retry then would hide a commit the user is ready to make behind an error about
+   * nothing.
+   */
+  it("keeps Approve rather than the retry when a spent id source fails", async () => {
+    mockCheckpointHasError = true
+
+    renderScreen()
+    await flushEffects()
+
+    expect(screen.queryByTestId("migration-balances-overview-retry")).toBeNull()
+    expect(screen.getByTestId("migration-balances-overview-approve")).not.toBeDisabled()
+  })
+
+  /** Past the re-point the ids have done their work, and the session that carried them is
+   *  about to be discarded by the completion swap: an owner that goes missing then is not
+   *  a failure to hand a finished re-point to support over. */
+  it("does not hand over for a missing owner once the address has moved", async () => {
+    mockOwnerId = null
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByTestId("migration-balances-overview-approve")).not.toBeDisabled()
+  })
+
+  /** A checkpoint the device could not read is not a migration without a provisioned
+   *  account: the flag exists so an unreadable store is never mistaken for a wiped one. */
+  it("offers the retry when the checkpoint could not be read", async () => {
+    mockCheckpointAccountId = null
+    mockCheckpointHasError = true
+    mockLnAddressTransfer = unsettledLnTransfer()
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(screen.getByTestId("migration-balances-overview-retry")).toBeTruthy()
+  })
+
+  /** The ids are only judged once the re-point is unblocked: a preview still in flight
+   *  owns the screen's failure story, and a not-yet-loaded id is not a missing one. */
+  it("does not blame a missing owner id while the preview is in flight", async () => {
+    mockOwnerId = null
+    mockUseMigrationQuery.mockReturnValue({ data: undefined, loading: true })
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })
 

--- a/app/screens/account-migration/hooks/use-custodial-owner-id.ts
+++ b/app/screens/account-migration/hooks/use-custodial-owner-id.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react"
+
 import { gql } from "@apollo/client"
 
 import { useMigrationOwnerQuery } from "@app/graphql/generated"
@@ -21,6 +23,21 @@ type UseCustodialOwnerId = {
    *  constant. Null for a non-custodial session or before the query resolves. */
   ownerId: string | null
   loading: boolean
+  /** Whether the query never ran, because nobody is authenticated or the active account is
+   *  not the custodial one. A skipped query reports neither loading nor an answer, so
+   *  callers that treat a settled null as a failure must exclude it: a session that just
+   *  ended is not an account without an owner. */
+  isSkipped: boolean
+  /**
+   * Whether the query failed, by any cause. Deliberately NOT split into network and
+   * settled kinds the way the preview is: there the settled kind is the server answering
+   * that this account has no migration, which is final, while an authenticated custodial
+   * session always has an owner, so every error here is a request that failed rather than
+   * an answer. Callers spend it on a retry; only a query that answered without an owner
+   * is a failure worth handing to support.
+   */
+  hasError: boolean
+  refetch: () => Promise<unknown>
 }
 
 /**
@@ -34,14 +51,29 @@ export const useCustodialOwnerId = (): UseCustodialOwnerId => {
   const { activeAccount } = useAccountRegistry()
   const isCustodial = activeAccount?.type === AccountType.Custodial
 
-  /** no-cache: a cached me could serve the previous account's owner id after a switch. */
-  const { data, loading } = useMigrationOwnerQuery({
-    skip: !isAuthed || !isCustodial,
+  const isSkipped = !isAuthed || !isCustodial
+
+  /** no-cache: a cached me could serve the previous account's owner id after a switch.
+   *  notifyOnNetworkStatusChange reopens `loading` for a refetch, so a caller reading a
+   *  settled null as a missing owner never reads one mid-retry. */
+  const { data, loading, error, refetch } = useMigrationOwnerQuery({
+    skip: isSkipped,
     fetchPolicy: "no-cache",
+    notifyOnNetworkStatusChange: true,
   })
+
+  /** A skipped query is on standby, where a refetch would run it anyway: the one session
+   *  that must never ask for `me` is the one that stopped being custodial. */
+  const refetchWhenRunning = useCallback(
+    () => (isSkipped ? Promise.resolve() : refetch()),
+    [isSkipped, refetch],
+  )
 
   return {
     ownerId: isCustodial ? data?.me?.defaultAccount?.id ?? null : null,
     loading: isCustodial && loading,
+    isSkipped,
+    hasError: Boolean(error),
+    refetch: refetchWhenRunning,
   }
 }

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -31,7 +31,11 @@ type SaveCheckpointOptions = {
  * resume state without instantiating a navigator-bound hook.
  */
 export const useMigrationCheckpointState = () => {
-  const { ownerId, loading: ownerLoading } = useCustodialOwnerId()
+  const {
+    ownerId,
+    loading: ownerLoading,
+    refetch: refetchOwnerId,
+  } = useCustodialOwnerId()
   const [stored, setStored] = useState<StoredCheckpoint | null>(null)
   const [loading, setLoading] = useState(true)
   const [hasError, setHasError] = useState(false)
@@ -67,6 +71,15 @@ export const useMigrationCheckpointState = () => {
         }),
     [storageKey],
   )
+
+  /** The owner query joins the reload because the ids below are keyed by it, and this hook
+   *  resolves it on its OWN uncached instance: it can fail while a caller's separate
+   *  instance is healthy, and then every id reads null with nothing but the storage read to
+   *  retry. Reloading storage alone would replay that same null forever. Swallowed like the
+   *  load, so the caller keeps one promise that resolves whatever failed. */
+  const reload = useCallback(async (): Promise<void> => {
+    await Promise.all([load(), refetchOwnerId().catch(() => undefined)])
+  }, [load, refetchOwnerId])
 
   const reloadCheckpoint = useCallback(() => {
     isFocusedRef.current = true
@@ -158,7 +171,7 @@ export const useMigrationCheckpointState = () => {
     hasError,
     /** Imperative reload for retry screens. Leaves the focus flag alone on purpose: a
      *  retry resolving after blur still drops its update, same as the focus reload. */
-    refetch: load,
+    refetch: reload,
     saveCheckpoint,
     clearCheckpoint,
     hasResumableCheckpoint,

--- a/app/screens/account-migration/hooks/use-migration-ln-address-transfer.ts
+++ b/app/screens/account-migration/hooks/use-migration-ln-address-transfer.ts
@@ -14,6 +14,7 @@ import {
   MigrationSdkStatus,
 } from "@app/self-custodial/migration-transfer-request"
 import { reportError } from "@app/utils/error-logging"
+import { withTimeout } from "@app/utils/with-timeout"
 
 import {
   buildMigrationProofChallenge,
@@ -35,6 +36,16 @@ gql`
     }
   }
 `
+
+/**
+ * How long the re-point may take before the screen treats it as unsettled. The proof is
+ * built through the SDK, which connects and signs under a per-storage-dir lock and can
+ * stall without ever throwing; an attempt that never answers used to leave Approve
+ * disabled with nothing on screen to act on, since only a settled outcome reports
+ * anything. Generous enough for a cold connect on a slow network, short enough that the
+ * user is offered the retry rather than left reading a dead button.
+ */
+export const LN_ADDRESS_TRANSFER_TIMEOUT_MS = 45_000
 
 type UseMigrationLnAddressTransferArgs = {
   custodialAccountId: string | null
@@ -61,6 +72,9 @@ const LnAddressOutcome = {
   ConnectionIssue: "connection-issue",
   AccountMissing: "account-missing",
   Rejected: "rejected",
+  /** The bound ran out before the attempt answered. Carried apart from the kinds above so
+   *  the report it earns is filed where superseded answers are already dropped. */
+  Stalled: "stalled",
 } as const
 
 type LnAddressOutcome = (typeof LnAddressOutcome)[keyof typeof LnAddressOutcome]
@@ -93,9 +107,26 @@ export const useMigrationLnAddressTransfer = ({
    *  or turn a failure into a loop. */
   const firedAttemptRef = useRef(-1)
 
-  /** Only an unsettled connection issue retries: a settled rejection or a missing device key
-   *  would replay the same answer, and a completed transfer would re-run the expensive
-   *  connect-and-sign for nothing (the shared retry fires for any of the screen's sources). */
+  /** An outcome may only be dropped once there is no one left to report it to. Claimed on
+   *  mount, not just released on unmount, so a remount that reuses the ref (a double mount
+   *  under StrictMode or a fast refresh) does not start out reporting to nobody. */
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  /**
+   * Only an unsettled connection issue retries: a settled rejection or a missing device key
+   * would replay the same answer, and a completed transfer would re-run the expensive
+   * connect-and-sign for nothing (the shared retry fires for any of the screen's sources).
+   *
+   * An attempt still in the air is deliberately NOT excluded: after a stall the next one
+   * queues behind it on the per-directory lock, which is exactly what lets a merely slow
+   * connect-and-sign be followed by an attempt that lands once it finishes.
+   */
   const retry = useCallback(() => {
     if (isRejected || isTransferred || isAccountMissing) return
     setHasConnectionIssue(false)
@@ -191,19 +222,58 @@ export const useMigrationLnAddressTransfer = ({
     if (!custodialAccountId || !selfCustodialAccountId) return
 
     firedAttemptRef.current = attempt
-    let isActive = true
 
-    run(custodialAccountId, selfCustodialAccountId).then((outcome) => {
-      if (!isActive) return
+    /** `run` settles every failure it can name, but the proof is built before its own try:
+     *  a keychain that throws rejects it, which is a settled failure a retry only replays,
+     *  not the wait running out. Named apart so the bound below is the only thing left that
+     *  can reject, and so support is never told an attempt stalled that in fact threw. */
+    const settledAttempt = run(custodialAccountId, selfCustodialAccountId).catch(
+      (err) => {
+        reportError("Migration ln-address threw", err)
+        return LnAddressOutcome.Rejected
+      },
+    )
+
+    const attemptWithinBound = withTimeout(
+      settledAttempt,
+      LN_ADDRESS_TRANSFER_TIMEOUT_MS,
+      "Migration ln-address re-point",
+    ).catch(() => LnAddressOutcome.Stalled)
+
+    /**
+     * Dropped only when something newer owns the answer: the hook is gone, or a later
+     * attempt was claimed and this one is superseded. Not when the effect merely re-ran,
+     * which an id flickering null mid-flight does: the re-run cannot fire again against
+     * the claimed attempt number, so dropping the answer already in the air would leave
+     * every flag false for good, the exact silence this hook exists to report, and one no
+     * bound can rescue since the timeout's own outcome would go with it.
+     *
+     * A stall is reported here rather than where it is raised, so one incident files one
+     * report: an attempt left behind by a retry or an unmount still times out, and the
+     * answer nobody reads has nothing to tell support.
+     *
+     * It settles as a connection issue however often it happens, never as a rejection: the
+     * attempt may still be in the air, and the screen that reads this keeps its own
+     * contact-support button on screen throughout, so a retry that cannot land is never the
+     * user's only way out.
+     */
+    attemptWithinBound.then((outcome) => {
+      if (!isMountedRef.current || firedAttemptRef.current !== attempt) return
+
+      if (outcome === LnAddressOutcome.Stalled) {
+        reportError(
+          "Migration ln-address stalled",
+          new Error(`Re-point did not answer within ${LN_ADDRESS_TRANSFER_TIMEOUT_MS}ms`),
+        )
+        setHasConnectionIssue(true)
+        return
+      }
+
       if (outcome === LnAddressOutcome.Transferred) setIsTransferred(true)
       else if (outcome === LnAddressOutcome.ConnectionIssue) setHasConnectionIssue(true)
       else if (outcome === LnAddressOutcome.AccountMissing) setIsAccountMissing(true)
       else setIsRejected(true)
     })
-
-    return () => {
-      isActive = false
-    }
   }, [skip, attempt, custodialAccountId, selfCustodialAccountId, run])
 
   return { isTransferred, isRejected, isAccountMissing, hasConnectionIssue, retry }

--- a/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/balances-overview-screen.tsx
@@ -49,6 +49,8 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
   const {
     accountId: selfCustodialAccountId,
     loading: checkpointLoading,
+    hasError: hasCheckpointError,
+    refetch: refetchCheckpoint,
     saveCheckpoint,
   } = useMigrationCheckpoint()
   /** The commit screen must never present unknown balances as zeros: until the preview
@@ -88,7 +90,13 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
     skip: !preview.isReady || isMigrationFailed || hasDollarBalance,
   })
 
-  const { ownerId } = useCustodialOwnerId()
+  const {
+    ownerId,
+    loading: isOwnerIdLoading,
+    isSkipped: isOwnerIdSkipped,
+    hasError: hasOwnerIdError,
+    refetch: refetchOwnerId,
+  } = useCustodialOwnerId()
 
   /** The re-point runs here, only once the start is confirmed so a rejected start never
    *  moves the address irreversibly. It needs the custodial session the completion swap
@@ -133,6 +141,49 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
     ? MigrationSupportReason.LnAddressTransferFailed
     : null
   const lnAddressFailureReason = lnAddressMissingReason ?? lnAddressRejectedReason
+
+  /**
+   * The re-point fires for neither id, and reports nothing when it does not fire, so an id
+   * that has SETTLED missing is a settled failure rather than a wait: left as a wait it
+   * holds Approve off for good with no message and no retry, which is the dead end the
+   * commit screen has no way back out of. Judged only once the re-point is unblocked, so an
+   * id still loading behind a preview or a start in flight is never mistaken for a missing
+   * one.
+   */
+  const isCustodialOwnerMissing = !ownerId && !isOwnerIdLoading
+  const settledMissingIdReason = isCustodialOwnerMissing
+    ? MigrationSupportReason.CustodialOwnerMissing
+    : null
+
+  /**
+   * The provisioned account is held to a softer standard than the owner, and offered the
+   * retry rather than the handover: the checkpoint keys its id by an owner it resolves
+   * through its OWN instance of an uncached query, which can fail while this screen's
+   * instance is healthy, and a null read through that failure is indistinguishable here
+   * from a migration that never provisioned one. Support is one tap away throughout, so
+   * the retry costs a user who really has no account nothing but a press, where a handover
+   * would cost one whose lookup merely dropped their migration.
+   */
+  const isProvisionedAccountMissing = !selfCustodialAccountId && !checkpointLoading
+  /**
+   * The owner is judged missing only on an answer. A query that never ran (the session
+   * ended, or the active account is no longer the custodial one) and one that failed both
+   * report a null id without either being an answer, and reading that silence as a missing
+   * owner would hand a user to support over an expired token or a lost request, in the one
+   * step they cannot take back. The preview's own skip guard exists for exactly this.
+   */
+  const isOwnerIdUnanswered = isOwnerIdSkipped || hasOwnerIdError
+  /** And only while the re-point still needs them. Once the address has moved the ids have
+   *  done their work, and the session that carried them is about to be discarded by the
+   *  completion swap: judging them past that point would hand a finished re-point to
+   *  support. */
+  const areTransferIdsNeeded = !lnAddressTransfer.isTransferred
+  const isMissingOwnerJudgeable =
+    !isLnRepointBlocked && !isOwnerIdUnanswered && areTransferIdsNeeded
+  const missingOwnerFailureReason = isMissingOwnerJudgeable
+    ? settledMissingIdReason
+    : null
+
   /** A migration already failed server-side leads the handover: nothing else on this screen
    *  matters once the phase is FAILED. */
   const failedReason = isMigrationFailed ? MigrationSupportReason.TransferFailed : null
@@ -140,6 +191,7 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
     failedReason ??
     startFailureReason ??
     lnAddressFailureReason ??
+    missingOwnerFailureReason ??
     preview.unavailableReason
 
   const hasReportedHandoverRef = useRef(false)
@@ -173,20 +225,39 @@ export const MigrationBalancesOverviewScreen: React.FC = () => {
 
   /** Either source losing the network earns the same retry, and it refreshes both:
    *  figures without a started migration are as useless as the reverse. */
+  /** The id sources join the retry only while the re-point still needs them: past it they
+   *  hold nothing back, and the retry replaces Approve on this screen, so offering it then
+   *  would hide a commit the user is ready to make behind an error about nothing. */
+  const isIdSourceRetryable =
+    areTransferIdsNeeded &&
+    (hasOwnerIdError || hasCheckpointError || isProvisionedAccountMissing)
   const isRetryable =
     preview.isRetryable ||
     migrationStart.hasConnectionIssue ||
-    lnAddressTransfer.hasConnectionIssue
+    lnAddressTransfer.hasConnectionIssue ||
+    isIdSourceRetryable
 
   const { retry: retryPreview } = preview
   const { retry: retryMigrationStart } = migrationStart
   const { retry: retryLnAddressTransfer } = lnAddressTransfer
 
+  /** The owner and the checkpoint join the shared retry because the re-point cannot fire
+   *  without the ids they carry: refreshing everything else around a lookup that failed
+   *  would replay the same dead screen. Their rejections carry nothing the hooks' own state
+   *  does not already report, so they are swallowed like the preview's. */
   const handleRetry = useCallback(() => {
     retryPreview()
     retryMigrationStart()
     retryLnAddressTransfer()
-  }, [retryPreview, retryMigrationStart, retryLnAddressTransfer])
+    refetchOwnerId().catch(() => undefined)
+    refetchCheckpoint().catch(() => undefined)
+  }, [
+    retryPreview,
+    retryMigrationStart,
+    retryLnAddressTransfer,
+    refetchOwnerId,
+    refetchCheckpoint,
+  ])
 
   /** Approve commits against a server-side flow, so it stays off until the server has
    *  confirmed one exists and the lightning address has moved, not merely until the

--- a/app/types/migration.ts
+++ b/app/types/migration.ts
@@ -38,6 +38,11 @@ export const MigrationSupportReason = {
   StartRefused: "start-refused",
   /** The checkpoint reached the transfer with no provisioned self-custodial account. */
   SelfCustodialAccountMissing: "self-custodial-account-missing",
+  /** The commit screen settled without the custodial owner id the lightning-address
+   *  re-point signs its proof against (the session is no longer custodial, or the owner
+   *  query answered with nothing). The re-point cannot fire at all without it, so it is a
+   *  settled failure rather than a wait that resolves itself. */
+  CustodialOwnerMissing: "custodial-owner-missing",
   /** The migration finished server-side, but the destination self-custodial account is no
    *  longer on this device (its key is gone, e.g. after a reinstall), so the resume swap
    *  cannot run and no retry brings it back. */


### PR DESCRIPTION
Relates to #4189.

## Problem

The migration commit screen (`balances-overview-screen.tsx`) enables Approve only once four prerequisites are satisfied. Two of them could stay unsatisfied forever without reporting anything:

- The lightning-address re-point builds its proof through the SDK, which connects and signs under a per-storage-dir lock and can stall without ever throwing. An attempt that never answers sets no flag at all.
- The re-point returns early and silently when either account id is null, and the custodial owner id is null whenever its query answers without one.

In both cases the user is left on a screen showing their balances with a permanently disabled Approve, no message, no retry, and the hardware back swallowed. That is the state reported in #4189, where telemetry shows no lightning-address-transfer execution for the retry.

Reproduced on an Android emulator by forcing the owner id to never arrive: balances rendered, Approve grey, taps did nothing.

## Changes

**Bound the re-point** (`use-migration-ln-address-transfer.ts`). An attempt that does not answer within 45s settles as a connection issue, which the screen already renders as a message plus a retry. A throw raised before the mutation (the keychain read sits outside `run`'s own try) is reported and settled apart from a stall, so support is never told an attempt stalled when it threw. An attempt whose ids flicker null mid-flight no longer has its answer dropped: the effect re-runs but cannot fire again against the claimed attempt number, so discarding the answer already in the air left every flag false for good.

**Report why the owner is unknown** (`use-custodial-owner-id.ts`). The hook now distinguishes a query that never ran (`isSkipped`) from one that failed (`hasError`) from one that answered, and exposes a `refetch` that stays inert while skipped. A failure is deliberately not split into network and server kinds: an authenticated custodial session always has an owner, so every error is a request that failed rather than an answer.

**Give every outcome a destination** (`balances-overview-screen.tsx`, `types/migration.ts`). An owner query that answered with no owner hands over to support under a new `custodial-owner-missing` reason. Everything else offers the retry, which now also refetches the owner and the checkpoint.

The rule the screen follows: hand over only on an answer, retry on anything else. Contact support stays on screen throughout, so no path is a dead end.

## Deliberately not a handover

A missing provisioned account offers the retry rather than support. The checkpoint keys its id by an owner it resolves through its own instance of an uncached query, which can fail while this screen's instance is healthy, so a null read there is not proof that no account was provisioned. A retry costs a user who really has none a single press; a handover would cost one whose lookup merely dropped their migration, at the point of no return.

The id sources also drop out of `isRetryable` once the re-point has completed. Past that point they hold nothing back, and the retry replaces Approve on this screen, so offering it would hide a commit the user is ready to make.

## Testing

- 805 tests across 54 suites, typecheck and lint clean.
- 16 new tests covering the stall, the throw, the flickering ids, the skipped and failed owner query, the unreadable checkpoint, and the retry wiring.
- The three new guards were mutation-tested: removing each one by hand fails tests.
- Device: the handover was verified on an emulator, reaching the support screen with the reason, account id, username and phone filled in. The 45s path is covered by tests only.

## Not covered here

The backend half of #4189 stays open: why `resumeMigrationFlow` cannot find its state after a reset, and whether another retry is safe. One client-side answer the ticket asks for: the app holds no migration flow identifier. `migrationStart` takes no arguments, the re-point and the commit send only a proof of possession, and the checkpoint stores the step, the provisioned account and the expected receive figure. Stale client identifiers can be ruled out.

Full regression coverage for reset, restart, preview, transfer, commit needs a backend harness that does not exist on the app side.
