### PR TITLE
fix(a11y): cap how far text follows the OS text-size setting

### DIFF
--- a/__tests__/components/galoy-icon-button.spec.tsx
+++ b/__tests__/components/galoy-icon-button.spec.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react-native"
+
+import { ThemeProvider } from "@rn-vui/themed"
+
+import { GaloyIconButton } from "@app/components/atomic/galoy-icon-button"
+import theme from "@app/rne-theme/theme"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
+
+const renderButton = (text?: string) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <GaloyIconButton name="receive" size="large" text={text} />
+    </ThemeProvider>,
+  )
+
+describe("GaloyIconButton", () => {
+  it("shows the label it was given", () => {
+    renderButton("Receive")
+
+    expect(screen.getByText("Receive")).toBeTruthy()
+  })
+
+  /**
+   * These labels name the home screen's primary actions, and they sit in a column barely
+   * wider than the word. Uncapped, the OS text setting truncates them to "Re…", "Se…" and
+   * "Sc…", which is the failure #4129 opens with: the actions stop being identifiable.
+   * The label inherits the ceiling from the theme rather than declaring its own.
+   */
+  it("caps how far the OS text size carries its label", () => {
+    renderButton("Receive")
+
+    expect(screen.getByText("Receive").props.maxFontSizeMultiplier).toBe(
+      MAX_FONT_SIZE_MULTIPLIER,
+    )
+  })
+
+  it("renders the icon alone when there is no label", () => {
+    renderButton()
+
+    expect(screen.queryByText("Receive")).toBeNull()
+  })
+})

--- a/__tests__/rne-theme/capped-font-scale.spec.ts
+++ b/__tests__/rne-theme/capped-font-scale.spec.ts
@@ -1,0 +1,53 @@
+import { PixelRatio } from "react-native"
+
+import { cappedFontScale, MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
+
+/**
+ * A box measured for the default text stops holding it the moment the OS grows the glyphs
+ * inside: the amount loses its top half to a clipped row, a word breaks in two, a chip cuts
+ * "Never" to "Nev". Multiplying the measurement by this keeps the proportions the layout
+ * was drawn with, and stops where the text stops.
+ */
+const withFontScale = (scale: number, assert: () => void) => {
+  const fontScale = jest.spyOn(PixelRatio, "getFontScale").mockReturnValue(scale)
+  try {
+    assert()
+  } finally {
+    fontScale.mockRestore()
+  }
+}
+
+describe("cappedFontScale", () => {
+  it("leaves a box its own size at the default text size", () => {
+    withFontScale(1, () => {
+      expect(cappedFontScale()).toBe(1)
+    })
+  })
+
+  /** The point of it: what the layout was drawn with survives, only larger. */
+  it("grows a box by as much as the text grew", () => {
+    withFontScale(1.2, () => {
+      expect(80 * cappedFontScale()).toBeCloseTo(96, 5)
+    })
+  })
+
+  it("stops growing where the text stops", () => {
+    withFontScale(3, () => {
+      expect(cappedFontScale()).toBe(MAX_FONT_SIZE_MULTIPLIER)
+    })
+  })
+
+  /** Right at the ceiling both agree, so nothing jumps as the OS crosses it. */
+  it("meets the ceiling exactly", () => {
+    withFontScale(MAX_FONT_SIZE_MULTIPLIER, () => {
+      expect(cappedFontScale()).toBe(MAX_FONT_SIZE_MULTIPLIER)
+    })
+  })
+
+  /** A phone set below the default still reports honestly: this caps growth, not shrinking. */
+  it("follows a text size smaller than the default", () => {
+    withFontScale(0.85, () => {
+      expect(cappedFontScale()).toBe(0.85)
+    })
+  })
+})

--- a/__tests__/rne-theme/text-scaling-coverage.spec.ts
+++ b/__tests__/rne-theme/text-scaling-coverage.spec.ts
@@ -21,27 +21,82 @@ const sourceFiles = (dir: string): string[] =>
     return entry.isFile() && entry.name.endsWith(".tsx") ? [entryPath] : []
   })
 
-/** The local name React Native's `Text` carries in this file, or null if it imports none. */
-const reactNativeTextName = (source: string): string | null => {
-  const rnImport = /import\s*\{([^}]*)\}\s*from\s*"react-native"/s.exec(source)
-  if (!rnImport) return null
+/**
+ * The local name a React Native component carries in this file, or null if it imports none.
+ * Both of these render text the theme cannot reach: the label and the field the user types
+ * into, placeholder included.
+ */
+const reactNativeName = (source: string, component: string): string | null => {
+  /** Every react-native import, not the first: a file may split its values across two, and
+   *  reading only one silently exempts the rest of the file from the walk. */
+  const rnImports = [...source.matchAll(/import\s*\{([^}]*)\}\s*from\s*"react-native"/gs)]
 
-  const imported = /(?:^|,)\s*Text(?:\s+as\s+(\w+))?\s*(?:,|$)/s.exec(rnImport[1])
-  if (!imported) return null
+  const imported = new RegExp(
+    `(?:^|,)\\s*${component}(?:\\s+as\\s+(\\w+))?\\s*(?:,|$)`,
+    "s",
+  )
 
-  return imported[1] ?? "Text"
+  for (const rnImport of rnImports) {
+    const match = imported.exec(rnImport[1])
+    if (match) return match[1] ?? component
+  }
+
+  return null
 }
 
-/** Every opening tag of that component, with the props it was given. */
+/**
+ * Every JSX opening tag of that component. A type position names the same component
+ * without rendering anything (`useRef<TextInput>`, `Array<TextInput | null>`), and the
+ * difference is what sits before the angle bracket: a generic is always opened by the
+ * identifier it belongs to, where JSX never is.
+ */
 const openingTags = (source: string, name: string): string[] => {
-  const tags = new RegExp(`<${name}(\\s[^>]*)?>`, "gs")
-  return [...source.matchAll(tags)].map((match) => match[0])
+  const starts = new RegExp(`(^|[^\\w.])<${name}(?=[\\s/>])`, "gs")
+
+  return [...source.matchAll(starts)].flatMap((start) => {
+    const from = start.index + start[0].length
+
+    /**
+     * Scanned rather than matched to the next `>`: a prop can hold one of its own, and an
+     * arrow in a handler would end the tag early and hide every prop after it, reporting a
+     * capped component as uncapped. Braces are what tell them apart.
+     */
+    let depth = 0
+    for (let at = from; at < source.length; at += 1) {
+      const char = source[at]
+      if (char === "{") depth += 1
+      else if (char === "}") depth -= 1
+      else if (char === ">" && depth === 0) return [source.slice(from, at)]
+    }
+
+    return []
+  })
 }
 
-describe("text scaling coverage", () => {
-  const offenders = sourceFiles(APP_DIR).flatMap((file) => {
+/**
+ * The theme reaches components imported from `@rn-vui/themed` and nothing else, so the same
+ * component taken from `@rn-vui/base` renders outside the policy: a Button drawn from there
+ * grows its title past the ceiling, and a SearchBar its placeholder. They carry it as props
+ * instead, which is what these two look for.
+ */
+const uncappedFromBase = (): string[] =>
+  sourceFiles(APP_DIR).flatMap((file) => {
     const source = fs.readFileSync(file, "utf8")
-    const name = reactNativeTextName(source)
+    const baseImport = /import\s*\{([^}]*)\}\s*from\s*"@rn-vui\/base"/s.exec(source)
+    if (!baseImport) return []
+
+    const uncapped = ["Button", "SearchBar"]
+      .filter((component) => new RegExp(`\\b${component}\\b`).test(baseImport[1]))
+      .flatMap((component) => openingTags(source, component))
+      .filter((tag) => !tag.includes("maxFontSizeMultiplier"))
+
+    return uncapped.length > 0 ? [path.relative(APP_DIR, file)] : []
+  })
+
+const uncappedIn = (component: string): string[] =>
+  sourceFiles(APP_DIR).flatMap((file) => {
+    const source = fs.readFileSync(file, "utf8")
+    const name = reactNativeName(source, component)
     if (!name) return []
 
     const uncapped = openingTags(source, name).filter(
@@ -49,6 +104,13 @@ describe("text scaling coverage", () => {
     )
     return uncapped.length > 0 ? [path.relative(APP_DIR, file)] : []
   })
+
+describe("text scaling coverage", () => {
+  const offenders = [
+    ...uncappedIn("Text"),
+    ...uncappedIn("TextInput"),
+    ...uncappedFromBase(),
+  ]
 
   /**
    * Fails with the files to fix rather than a bare boolean: whoever adds the next screen
@@ -65,5 +127,43 @@ describe("text scaling coverage", () => {
 
   it("holds a ceiling to cap them to", () => {
     expect(MAX_FONT_SIZE_MULTIPLIER).toBeGreaterThan(1)
+  })
+})
+
+/**
+ * The walk is only worth what it reads: a tag it cuts short hides the props that follow,
+ * and a component it never recognises is exempt without anyone noticing. Both failures
+ * are silent in the walk above, so they are pinned here.
+ */
+describe("the walk's own reading", () => {
+  it("keeps a tag whole past an arrow in one of its props", () => {
+    const source = `<Text onPress={() => close()} maxFontSizeMultiplier={CAP}>hi</Text>`
+
+    expect(openingTags(source, "Text")[0]).toContain("maxFontSizeMultiplier")
+  })
+
+  it("reads a tag broken across lines", () => {
+    const source = `<Text\n  style={styles.a}\n  maxFontSizeMultiplier={CAP}\n>\n  hi\n</Text>`
+
+    expect(openingTags(source, "Text")[0]).toContain("maxFontSizeMultiplier")
+  })
+
+  /** A type position renders nothing; counting it would report a file that has no tag. */
+  it("passes over the component named as a type", () => {
+    const source = `const ref = useRef<TextInput>(null)`
+
+    expect(openingTags(source, "TextInput")).toEqual([])
+  })
+
+  it("finds the component however the file spreads its react-native imports", () => {
+    const source = `import { View } from "react-native"\nimport { Text as RNText } from "react-native"`
+
+    expect(reactNativeName(source, "Text")).toBe("RNText")
+  })
+
+  it("names nothing for a file that imports no such component", () => {
+    const source = `import { View } from "react-native"`
+
+    expect(reactNativeName(source, "Text")).toBeNull()
   })
 })

--- a/__tests__/rne-theme/text-scaling-coverage.spec.ts
+++ b/__tests__/rne-theme/text-scaling-coverage.spec.ts
@@ -1,0 +1,69 @@
+import fs from "fs"
+import path from "path"
+
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
+
+/**
+ * The ceiling reaches every themed `Text` through the theme, but React Native's own `Text`
+ * is outside that reach: a component built on it follows the OS text size without limit
+ * unless it carries the ceiling itself. That is how the app kept growing new screens that
+ * clip and truncate at the larger accessibility sizes, one component at a time.
+ *
+ * So this walks the source rather than a rendered tree: it is the check that makes the
+ * policy hold for screens nobody has written yet, which no per-component test can do.
+ */
+const APP_DIR = path.join(__dirname, "..", "..", "app")
+
+const sourceFiles = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(entryPath)
+    return entry.isFile() && entry.name.endsWith(".tsx") ? [entryPath] : []
+  })
+
+/** The local name React Native's `Text` carries in this file, or null if it imports none. */
+const reactNativeTextName = (source: string): string | null => {
+  const rnImport = /import\s*\{([^}]*)\}\s*from\s*"react-native"/s.exec(source)
+  if (!rnImport) return null
+
+  const imported = /(?:^|,)\s*Text(?:\s+as\s+(\w+))?\s*(?:,|$)/s.exec(rnImport[1])
+  if (!imported) return null
+
+  return imported[1] ?? "Text"
+}
+
+/** Every opening tag of that component, with the props it was given. */
+const openingTags = (source: string, name: string): string[] => {
+  const tags = new RegExp(`<${name}(\\s[^>]*)?>`, "gs")
+  return [...source.matchAll(tags)].map((match) => match[0])
+}
+
+describe("text scaling coverage", () => {
+  const offenders = sourceFiles(APP_DIR).flatMap((file) => {
+    const source = fs.readFileSync(file, "utf8")
+    const name = reactNativeTextName(source)
+    if (!name) return []
+
+    const uncapped = openingTags(source, name).filter(
+      (tag) => !tag.includes("maxFontSizeMultiplier"),
+    )
+    return uncapped.length > 0 ? [path.relative(APP_DIR, file)] : []
+  })
+
+  /**
+   * Fails with the files to fix rather than a bare boolean: whoever adds the next screen
+   * reads the failure, not this test.
+   */
+  it("caps every text the theme cannot reach", () => {
+    expect(offenders).toEqual([])
+  })
+
+  /** The walk itself has to be looking at something, or an empty list proves nothing. */
+  it("reads the app's own sources", () => {
+    expect(sourceFiles(APP_DIR).length).toBeGreaterThan(100)
+  })
+
+  it("holds a ceiling to cap them to", () => {
+    expect(MAX_FONT_SIZE_MULTIPLIER).toBeGreaterThan(1)
+  })
+})

--- a/__tests__/rne-theme/text-scaling.spec.tsx
+++ b/__tests__/rne-theme/text-scaling.spec.tsx
@@ -1,0 +1,62 @@
+import * as React from "react"
+import { render, screen } from "@testing-library/react-native"
+
+import { Text, ThemeProvider } from "@rn-vui/themed"
+
+import theme from "@app/rne-theme/theme"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
+
+/**
+ * The app has no text-size control of its own, so every screen follows the OS setting
+ * directly. The ceiling that keeps that from breaking layouts lives on the theme, which is
+ * what makes it a policy rather than another per-screen patch: these assert that a screen
+ * inherits it without asking, and that a component may still overrule it.
+ */
+const renderThemed = (children: React.ReactNode) =>
+  render(<ThemeProvider theme={theme}>{children}</ThemeProvider>)
+
+describe("text scaling ceiling", () => {
+  it("caps how far the OS text size carries any themed text", () => {
+    renderThemed(<Text testID="subject">Balances</Text>)
+
+    expect(screen.getByTestId("subject").props.maxFontSizeMultiplier).toBe(
+      MAX_FONT_SIZE_MULTIPLIER,
+    )
+  })
+
+  /** Every preset, since a screen picks one by role and none of them is exempt. */
+  const presets = ["h1", "h2", "p1", "p2", "p3", "p4"] as const
+  presets.forEach((type) => {
+    it(`caps the ${type} preset the same`, () => {
+      renderThemed(
+        <Text testID="subject" type={type}>
+          Balances
+        </Text>,
+      )
+
+      expect(screen.getByTestId("subject").props.maxFontSizeMultiplier).toBe(
+        MAX_FONT_SIZE_MULTIPLIER,
+      )
+    })
+  })
+
+  /**
+   * The ceiling is a default, not a rule the app cannot bend: a fixed-height slot may need
+   * a stricter one, and a screen built to reflow may earn a looser one. The theme's props
+   * are merged under the component's, so the component wins.
+   */
+  it("yields to a component that sets its own ceiling", () => {
+    renderThemed(
+      <Text testID="subject" maxFontSizeMultiplier={1}>
+        Balances
+      </Text>,
+    )
+
+    expect(screen.getByTestId("subject").props.maxFontSizeMultiplier).toBe(1)
+  })
+
+  /** Text still follows the OS below the ceiling; this caps growth, never scaling. */
+  it("leaves the text free to scale up to the ceiling", () => {
+    expect(MAX_FONT_SIZE_MULTIPLIER).toBeGreaterThan(1)
+  })
+})

--- a/__tests__/rne-theme/text-scaling.spec.tsx
+++ b/__tests__/rne-theme/text-scaling.spec.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { PixelRatio, Platform, StyleSheet } from "react-native"
 import { render, screen } from "@testing-library/react-native"
 
 import { Text, ThemeProvider } from "@rn-vui/themed"
@@ -58,5 +59,57 @@ describe("text scaling ceiling", () => {
   /** Text still follows the OS below the ceiling; this caps growth, never scaling. */
   it("leaves the text free to scale up to the ceiling", () => {
     expect(MAX_FONT_SIZE_MULTIPLIER).toBeGreaterThan(1)
+  })
+})
+
+/**
+ * Android scales an explicit lineHeight by the OS font scale without applying the ceiling
+ * the font itself respects, so past the ceiling the glyphs stop growing while the line box
+ * keeps going: a currency pill turns square around text that no longer fits it. The theme
+ * divides the line height back down so the box lands where the font does.
+ */
+describe("the line box the ceiling cannot reach on its own", () => {
+  const P3_LINE_HEIGHT = 18
+  const lineHeightOf = (): number => {
+    render(
+      <ThemeProvider theme={theme}>
+        <Text testID="subject" type="p3">
+          Bitcoin
+        </Text>
+      </ThemeProvider>,
+    )
+    return StyleSheet.flatten(screen.getByTestId("subject").props.style).lineHeight
+  }
+
+  const withFontScale = (scale: number, assert: () => void) => {
+    const fontScale = jest.spyOn(PixelRatio, "getFontScale").mockReturnValue(scale)
+    try {
+      assert()
+    } finally {
+      fontScale.mockRestore()
+    }
+  }
+
+  it("leaves the line box alone below the ceiling", () => {
+    withFontScale(1.2, () => {
+      expect(lineHeightOf()).toBe(P3_LINE_HEIGHT)
+    })
+  })
+
+  it("holds the line box at the ceiling past it", () => {
+    withFontScale(3, () => {
+      /** What Android multiplies back by the scale, landing at ceiling * lineHeight. */
+      const corrected =
+        Platform.OS === "android" ? (MAX_FONT_SIZE_MULTIPLIER / 3) * 18 : 18
+      expect(lineHeightOf()).toBeCloseTo(corrected, 5)
+    })
+  })
+
+  /** iOS clamps the line box itself, so correcting it there would squeeze the lines twice. */
+  it("corrects only where the platform needs it", () => {
+    withFontScale(3, () => {
+      const isCorrected = lineHeightOf() < P3_LINE_HEIGHT
+      expect(isCorrected).toBe(Platform.OS === "android")
+    })
   })
 })

--- a/app/components/amount-badge/amount-badge.tsx
+++ b/app/components/amount-badge/amount-badge.tsx
@@ -1,11 +1,12 @@
 import * as React from "react"
-// RN's Text, not the themed one: only the plain component honours
-// maxFontSizeMultiplier, and capping the scale is the point of this badge.
+// RN's Text, not the themed one, so the theme's ceiling does not reach it: the badge
+// carries the shared ceiling itself, since capping the scale is the point of this slot.
 import { Animated, Pressable, Text } from "react-native"
 import { makeStyles } from "@rn-vui/themed"
 
 import { useDropInOutAnimation } from "@app/components/animations"
 import { GaloyIcon, type IconNamesType } from "@app/components/atomic/galoy-icon"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 /** Exported: whoever arbitrates the badge slot must keep a badge mounted for
  *  exactly `durationOut` after it hides, or its exit animation is cut off. */
@@ -15,11 +16,6 @@ export const AMOUNT_BADGE_ANIMATION = {
   durationIn: 180,
   durationOut: 180,
 } as const
-
-/** The badge sits in a fixed-height slot between the balance and the wallet
- *  cards; uncapped Dynamic Type overruns it (#4120). Same ceiling as the
- *  balance above it. */
-const MAX_BADGE_FONT_SIZE_MULTIPLIER = 1.4
 
 /** Matches chain.svg's native 18x18 viewBox. */
 const ICON_SIZE = 18
@@ -104,7 +100,7 @@ export const AmountBadge: React.FC<Props> = ({
               style={styles.text}
               numberOfLines={1}
               ellipsizeMode="tail"
-              maxFontSizeMultiplier={MAX_BADGE_FONT_SIZE_MULTIPLIER}
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             >
               {amountText}
             </Text>

--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Pressable, StyleSheet, TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
@@ -68,6 +69,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
               {primaryCurrencyFormattedAmount || "0"}
             </Text>
             <TextInput
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
               value=""
               showSoftInputOnFocus={false}
               onChangeText={(e) => {

--- a/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
+++ b/app/components/atomic/galoy-primary-button/galoy-primary-button.tsx
@@ -1,5 +1,6 @@
 import React, { FC, PropsWithChildren } from "react"
 
+import { cappedLineHeight } from "@app/rne-theme/text-scaling"
 import { testProps } from "@app/utils/testProps"
 import { TouchableHighlight } from "@app/utils/touchable-wrapper"
 import { Button, ButtonProps, makeStyles, useTheme } from "@rn-vui/themed"
@@ -31,7 +32,7 @@ export const GaloyPrimaryButton: FC<PropsWithChildren<ButtonProps>> = (props) =>
 const useStyles = makeStyles(({ colors }) => ({
   titleStyle: {
     fontSize: 20,
-    lineHeight: 24,
+    lineHeight: cappedLineHeight(24),
     fontWeight: "600",
     color: colors.white,
   },

--- a/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
+++ b/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
@@ -16,10 +16,14 @@ import Animated, {
 import { testProps } from "@app/utils/testProps"
 import { Text, makeStyles, useTheme } from "@rn-vui/themed"
 
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
+
 import { GaloyIcon } from "../galoy-icon"
 
 const BUTTON_WIDTH = Dimensions.get("screen").width - 40
 const SWIPE_RANGE = BUTTON_WIDTH - 50
+/** The knob's diameter, which the label has to stay clear of. */
+const SWIPE_KNOB_SIZE = 60
 const isRTL = I18nManager.isRTL
 
 type SwipeButtonPropsType = {
@@ -125,7 +129,10 @@ const GaloySliderButton = ({
         </GestureDetector>
       )}
       {!disabled && (
-        <Animated.Text style={[styles.swipeText, AnimatedStyles.swipeText]}>
+        <Animated.Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={[styles.swipeText, AnimatedStyles.swipeText]}
+        >
           {initialText}
         </Animated.Text>
       )}
@@ -155,8 +162,8 @@ const useStyles = makeStyles(({ colors }) => ({
   swipeButton: {
     position: "absolute",
     left: 0,
-    height: 60,
-    width: 60,
+    height: SWIPE_KNOB_SIZE,
+    width: SWIPE_KNOB_SIZE,
     borderRadius: 30,
     zIndex: 3,
     alignItems: "center",
@@ -167,6 +174,14 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   swipeText: {
     alignSelf: "center",
+    /** The knob rides over the left of the track, so the label keeps clear of it rather
+     *  than running underneath: at the larger text sizes it grew into the knob and read as
+     *  a half word. Wrapping inside what is left still fits the track's height. */
+    /** Only the left needs clearing: the knob rests there and the label reads to its
+     *  right. Padding both sides would cost the label twice the room on a small screen. */
+    paddingLeft: SWIPE_KNOB_SIZE + 10,
+    paddingRight: 12,
+    textAlign: "center",
     fontSize: 14,
     fontWeight: "400",
     zIndex: 2,

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -8,11 +8,8 @@ import { HiddenBalancePlaceholder } from "@app/components/hidden-balance-placeho
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { BalanceMode } from "@app/hooks/use-balance-mode"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { testProps } from "@app/utils/testProps"
-
-/** The 32pt balance sits directly under the fixed-size home header chrome;
- *  uncapped Dynamic Type makes it overrun the username row above. */
-const MAX_BALANCE_FONT_SIZE_MULTIPLIER = 1.4
 
 const Loader = () => {
   const styles = useStyles()
@@ -72,7 +69,7 @@ export const BalanceHeader: React.FC<Props> = ({
                 {...testProps("balance-value")}
                 style={styles.primaryBalanceText}
                 allowFontScaling
-                maxFontSizeMultiplier={MAX_BALANCE_FONT_SIZE_MULTIPLIER}
+                maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
                 adjustsFontSizeToFit
               >
                 {formattedBalance}
@@ -88,7 +85,12 @@ export const BalanceHeader: React.FC<Props> = ({
           style={styles.modeToggle}
           {...testProps("balance-mode-toggle")}
         >
-          <Text style={styles.modeToggleText}>{modeLabel}</Text>
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={styles.modeToggleText}
+          >
+            {modeLabel}
+          </Text>
         </Pressable>
       ) : null}
     </View>

--- a/app/components/card-screen/input-field.tsx
+++ b/app/components/card-screen/input-field.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon, IconNamesType } from "@app/components/atomic/galoy-icon"
@@ -141,6 +142,7 @@ export const InputField: React.FC<InputFieldProps> = ({
         <Text style={styles.label}>{label}</Text>
         <View style={[styles.valueContainer, disabled && styles.valueContainerDisabled]}>
           <TextInput
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             style={[styles.value, styles.editableInput]}
             value={displayValue}
             onChangeText={(text) => {

--- a/app/components/currency-tag/currency-tag.tsx
+++ b/app/components/currency-tag/currency-tag.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react"
 import { Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { WalletCurrency } from "@app/graphql/generated"
 import { makeStyles, useTheme } from "@rn-vui/themed"
@@ -46,6 +47,7 @@ export const CurrencyTag: FC<CurrencyTagProps> = ({ walletCurrency }) => {
       }}
     >
       <Text
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
         style={{
           ...styles.currencyText,
           color: currencyStyling[walletCurrency].textColor,

--- a/app/components/map-component/place-search-modal.tsx
+++ b/app/components/map-component/place-search-modal.tsx
@@ -7,6 +7,7 @@ import {
   TextInput,
   View,
 } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import {
@@ -183,6 +184,7 @@ export const PlaceSearchModal: React.FC<Props> = ({
       <View style={styles.screen}>
         <View style={styles.field}>
           <TextInput
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             testID="place-search-input"
             ref={inputRef}
             style={styles.input}

--- a/app/components/mnemonic-word-input/mnemonic-word-input.tsx
+++ b/app/components/mnemonic-word-input/mnemonic-word-input.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, useImperativeHandle, useRef } from "react"
 import { TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
@@ -46,6 +47,7 @@ export const MnemonicWordInput = forwardRef<
         {index + 1}.
       </Text>
       <TextInput
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
         ref={inputRef}
         style={styles.input}
         placeholder={placeholder}

--- a/app/components/mountain-header/mountain-header.tsx
+++ b/app/components/mountain-header/mountain-header.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { View, Text } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { makeStyles } from "@rn-vui/themed"
@@ -49,8 +50,18 @@ export const MountainHeader = ({ amount, color, isAvailable }: Props) => {
       <View style={styles.topView}>
         {isAvailable ? (
           <View style={styles.amountContainer}>
-            <Text style={styles.headerSection}>{LL.EarnScreen.youEarned()}</Text>
-            <Text style={styles.titleSection}>{amount} sats</Text>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.headerSection}
+            >
+              {LL.EarnScreen.youEarned()}
+            </Text>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.titleSection}
+            >
+              {amount} sats
+            </Text>
           </View>
         ) : (
           <></>

--- a/app/components/note-input/note-input.tsx
+++ b/app/components/note-input/note-input.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from "react"
 import { View, TextInput, StyleProp, ViewStyle, TouchableOpacity } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { testProps } from "@app/utils/testProps"
@@ -44,6 +45,7 @@ export const NoteInput: React.FC<NoteInputProps> = ({
     <View style={[styles.fieldBackground, style]}>
       <View style={styles.noteContainer}>
         <TextInput
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           {...testProps("add-note")}
           style={[styles.noteInput, { fontSize }]}
           placeholder={LL.NoteInput.addNote()}

--- a/app/components/notification-badge/index.tsx
+++ b/app/components/notification-badge/index.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Text as RNText, ViewStyle } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import Animated, { useSharedValue, useAnimatedStyle } from "react-native-reanimated"
 import { makeStyles } from "@rn-vui/themed"
 import { useIsFocused } from "@react-navigation/native"
@@ -55,7 +56,12 @@ export const NotificationBadge: React.FC<NotificationProps> = ({
 
   return (
     <Animated.View pointerEvents="none" style={[styles.pill, animatedStyle, style]}>
-      <RNText numberOfLines={1} ellipsizeMode="tail" style={styles.pillText}>
+      <RNText
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        style={styles.pillText}
+      >
         {text}
       </RNText>
     </Animated.View>

--- a/app/components/numbered-steps-list/numbered-steps-list.tsx
+++ b/app/components/numbered-steps-list/numbered-steps-list.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles } from "@rn-vui/themed"
 
@@ -14,8 +15,16 @@ export const NumberedStepsList: React.FC<NumberedStepsListProps> = ({ steps }) =
     <View style={styles.container}>
       {steps.map((content, index) => (
         <View key={index} style={styles.row}>
-          <Text style={[styles.base, styles.number]}>{`${index + 1}.`}</Text>
-          <Text style={[styles.base, styles.text]}>{content}</Text>
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={[styles.base, styles.number]}
+          >{`${index + 1}.`}</Text>
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={[styles.base, styles.text]}
+          >
+            {content}
+          </Text>
         </View>
       ))}
     </View>

--- a/app/components/password-input/password-input.tsx
+++ b/app/components/password-input/password-input.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { Pressable, TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { Text, makeStyles, useTheme } from "@rn-vui/themed"
 
@@ -33,6 +34,7 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
       <Text style={styles.label}>{label}</Text>
       <View style={styles.inputContainer}>
         <TextInput
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           style={styles.input}
           value={value}
           onChangeText={onChangeText}

--- a/app/components/phone-input/phone-input.tsx
+++ b/app/components/phone-input/phone-input.tsx
@@ -156,6 +156,7 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
           isDisabled && styles.disabledInput,
           inputContainerStyle,
         ]}
+        inputStyle={styles.input}
         renderErrorMessage={false}
         textContentType="telephoneNumber"
         keyboardType="phone-pad"
@@ -198,6 +199,12 @@ const useStyles = makeStyles(({ colors }, props: { bgColor?: string }) => ({
     paddingHorizontal: 10,
     backgroundColor: props.bgColor || colors.grey5,
     borderRadius: 8,
+  },
+  /** The paste control shares the row with the number, and the field only clips at its own
+   *  edge: without a gap the two read as one string once the OS text size grows the number
+   *  into it. Reserving it costs nothing at the sizes where the number already fits. */
+  input: {
+    paddingRight: 8,
   },
   disabledInput: { opacity: 0.6 },
 }))

--- a/app/components/price-history/price-history.tsx
+++ b/app/components/price-history/price-history.tsx
@@ -7,6 +7,7 @@ import {
   TextInput,
   type TextInputProps,
 } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { CartesianChart, Line, useChartPressState } from "victory-native"
 import Reanimated, {
   useAnimatedProps,
@@ -195,6 +196,7 @@ export const PriceHistory = () => {
       </View>
       <View style={styles.pricesContainer}>
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           {...testProps(LL.PriceHistoryScreen.oneDay())}
           title={LL.PriceHistoryScreen.oneDay()}
           /* eslint @typescript-eslint/ban-ts-comment: "off" */
@@ -205,6 +207,7 @@ export const PriceHistory = () => {
           onPress={() => setGraphRange(GraphRange.ONE_DAY)}
         />
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           {...testProps(LL.PriceHistoryScreen.oneWeek())}
           title={LL.PriceHistoryScreen.oneWeek()}
           // @ts-ignore-next-line no-implicit-any error
@@ -214,6 +217,7 @@ export const PriceHistory = () => {
           onPress={() => setGraphRange(GraphRange.ONE_WEEK)}
         />
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           {...testProps(LL.PriceHistoryScreen.oneMonth())}
           title={LL.PriceHistoryScreen.oneMonth()}
           // @ts-ignore-next-line no-implicit-any error
@@ -223,6 +227,7 @@ export const PriceHistory = () => {
           onPress={() => setGraphRange(GraphRange.ONE_MONTH)}
         />
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           {...testProps(LL.PriceHistoryScreen.oneYear())}
           title={LL.PriceHistoryScreen.oneYear()}
           // @ts-ignore-next-line no-implicit-any error
@@ -232,6 +237,7 @@ export const PriceHistory = () => {
           onPress={() => setGraphRange(GraphRange.ONE_YEAR)}
         />
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           {...testProps(LL.PriceHistoryScreen.fiveYears())}
           title={LL.PriceHistoryScreen.fiveYears()}
           // @ts-ignore-next-line no-implicit-any error
@@ -264,6 +270,7 @@ function AnimatedText({ text, ...rest }: AnimatedTextProps) {
   return (
     <AnimText
       {...rest}
+      maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
       value={text.value}
       // @ts-ignore
       animatedProps={animProps}

--- a/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
+++ b/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { View, TextInput } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { gql } from "@apollo/client"
 import { useAppConfig, useSaveSessionProfile } from "@app/hooks"
@@ -200,6 +201,7 @@ export const SetLightningAddressModalUI = ({
         <View style={styles.bodyStyle}>
           <View style={styles.textInputContainerStyle}>
             <TextInput
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
               autoCorrect={false}
               autoComplete="off"
               style={styles.textInputStyle}

--- a/app/components/transaction-date/transaction-date.tsx
+++ b/app/components/transaction-date/transaction-date.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Text } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { TxStatus } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -63,7 +64,15 @@ export const TransactionDate = ({
 }: TransactionDateProps) => {
   const { LL, locale } = useI18nContext()
   if (status === "PENDING") {
-    return <Text>{LL.common.pending().toUpperCase()}</Text>
+    return (
+      <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+        {LL.common.pending().toUpperCase()}
+      </Text>
+    )
   }
-  return <Text>{formatDateForTransaction({ createdAt, locale, includeTime })}</Text>
+  return (
+    <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+      {formatDateForTransaction({ createdAt, locale, includeTime })}
+    </Text>
+  )
 }

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -56,6 +56,7 @@ import {
 import { WebViewScreen } from "@app/screens/webview/webview"
 import { testProps } from "@app/utils/testProps"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
+import { HeaderTitle } from "@react-navigation/elements"
 import {
   createNativeStackNavigator,
   NativeStackNavigationProp,
@@ -175,7 +176,7 @@ import { useMigrationBlocker } from "@app/screens/account-migration/hooks/use-mi
 import { useResumeCompletedMigration } from "@app/screens/account-migration/hooks/use-resume-completed-migration"
 import { WindDownReceiveGate } from "@app/screens/account-migration/wind-down-receive-gate"
 import { AcceptTermsAndConditionsScreen } from "@app/screens/accept-t-and-c"
-import { StyleSheet, Text as RNText, TouchableOpacity } from "react-native"
+import { StyleSheet, Text as RNText, TextStyle, TouchableOpacity } from "react-native"
 
 import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { RouteProp, useNavigation } from "@react-navigation/native"
@@ -220,6 +221,31 @@ const tabBarLabelStyles = StyleSheet.create({
  * Built once, like the header controls above, so the option keeps one identity across
  * renders rather than remounting every label.
  */
+/**
+ * The header title is drawn by the navigator too, and it is the widest single line in the
+ * app: at the largest OS text sizes it grows until a screen name clips mid-word
+ * ("Lightning in…"). Wrapping the library's own title keeps its placement, font and tint
+ * exactly as they are, and adds only the ceiling the rest of the app follows.
+ *
+ * Built once for the same reason as the controls above.
+ */
+const renderHeaderTitle = (props: { children: string; tintColor?: string }) => (
+  <HeaderTitle {...props} maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} />
+)
+
+/** Frozen once, like the renderers below, so the heading keeps one style object. */
+const earnsHeaderTitleStyle: TextStyle = { fontWeight: "bold", fontSize: 18 }
+
+/** The earns section's own heading: the shared renderer with the weight and size that
+ *  screen declares, since a title renderer leaves `headerTitleStyle` unread. */
+const renderEarnsHeaderTitle = (props: { children: string; tintColor?: string }) => (
+  <HeaderTitle
+    {...props}
+    maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+    style={earnsHeaderTitleStyle}
+  />
+)
+
 const renderTabBarLabel = ({ color, children }: { color: string; children: string }) => (
   <RNText
     style={[tabBarLabelStyles.label, { color }]}
@@ -317,6 +343,7 @@ export const RootStack = () => {
         headerBackTitle: LL.common.back(),
         headerStyle: styles.headerStyle,
         headerTitleStyle: styles.title,
+        headerTitle: renderHeaderTitle,
         headerTintColor: colors.black,
         headerShadowVisible: false,
         headerLeft: defaultHeaderBack,
@@ -472,10 +499,10 @@ export const RootStack = () => {
         options={{
           headerStyle: { backgroundColor: colors._blue },
           headerTintColor: colors._white,
-          headerTitleStyle: {
-            fontWeight: "bold",
-            fontSize: 18,
-          },
+          /** A `headerTitle` renderer takes over from `headerTitleStyle`, which native
+           *  stack then ignores, so this screen states its own heading rather than losing
+           *  the weight and size it was given. */
+          headerTitle: renderEarnsHeaderTitle,
         }}
       />
       <RootNavigator.Screen
@@ -1046,6 +1073,7 @@ export const OnboardingNavigator = () => {
         headerBackTitle: LL.common.back(),
         headerStyle: styles.headerStyle,
         headerTitleStyle: styles.title,
+        headerTitle: renderHeaderTitle,
         headerTintColor: colors.black,
         headerShadowVisible: false,
       }}
@@ -1101,6 +1129,7 @@ export const ContactNavigator = () => {
         headerBackTitle: LL.common.back(),
         headerStyle: styles.headerStyle,
         headerTitleStyle: styles.title,
+        headerTitle: renderHeaderTitle,
         headerTintColor: colors.black,
         headerShadowVisible: false,
         headerLeft: defaultHeaderBack,
@@ -1159,6 +1188,7 @@ export const PhoneLoginNavigator = () => {
         headerBackTitle: LL.common.back(),
         headerStyle: styles.headerStyle,
         headerTitleStyle: styles.title,
+        headerTitle: renderHeaderTitle,
         headerTintColor: colors.black,
         headerShadowVisible: false,
         headerLeft: defaultHeaderBack,

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -175,7 +175,9 @@ import { useMigrationBlocker } from "@app/screens/account-migration/hooks/use-mi
 import { useResumeCompletedMigration } from "@app/screens/account-migration/hooks/use-resume-completed-migration"
 import { WindDownReceiveGate } from "@app/screens/account-migration/wind-down-receive-gate"
 import { AcceptTermsAndConditionsScreen } from "@app/screens/accept-t-and-c"
-import { TouchableOpacity } from "react-native"
+import { StyleSheet, Text as RNText, TouchableOpacity } from "react-native"
+
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { ApiScreen } from "@app/screens/settings-screen/api-screen"
 import { ApiKeyCreateScreen } from "@app/screens/settings-screen/api/api-key-create-screen"
@@ -197,6 +199,36 @@ const defaultHeaderBack = headerBackControl()
 /** Same reasoning as `defaultHeaderBack`: built once so the screens that refuse a back
  *  press hand `headerLeft` a stable identity instead of minting one per render. */
 const suppressedHeaderBack = headerBackControl({ canGoBack: false })
+
+const tabBarLabelStyles = StyleSheet.create({
+  label: {
+    paddingBottom: 6,
+    fontSize: 12,
+    fontWeight: "bold",
+    width: "100%",
+    textAlign: "center",
+  },
+})
+
+/**
+ * The tab labels are drawn by the navigator's own Text, which the theme's ceiling never
+ * reaches, and they sit in a bar of fixed height: at the largest OS text sizes they grow
+ * out of it and clip to "Hom..", "Peop..". Rendering the label here is what lets them carry
+ * the same ceiling as the rest of the app, and it replaces `tabBarLabelStyle`, which the
+ * navigator only applies to the label it renders itself.
+ *
+ * Built once, like the header controls above, so the option keeps one identity across
+ * renders rather than remounting every label.
+ */
+const renderTabBarLabel = ({ color, children }: { color: string; children: string }) => (
+  <RNText
+    style={[tabBarLabelStyles.label, { color }]}
+    maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+    numberOfLines={1}
+  >
+    {children}
+  </RNText>
+)
 
 /**
  * The swipe stays blocked for every entry: leaving by gesture is undirected, so the arrow is
@@ -1188,12 +1220,7 @@ export const PrimaryNavigator = () => {
             paddingBottom: insets.bottom,
           },
         ],
-        tabBarLabelStyle: {
-          paddingBottom: 6,
-          fontSize: 12,
-          fontWeight: "bold",
-          width: "100%",
-        },
+        tabBarLabel: renderTabBarLabel,
         tabBarHideOnKeyboard: true,
       }}
     >

--- a/app/rne-theme/text-scaling.ts
+++ b/app/rne-theme/text-scaling.ts
@@ -1,0 +1,15 @@
+/**
+ * How far text may follow the OS text-size setting. Blink has no text-size control of its
+ * own, so every screen inherits the system font scale directly, and past this point the
+ * layouts stop merely growing: fixed-height rows clip, labels truncate to two characters,
+ * and pills crowd out the amounts beside them.
+ *
+ * The theme applies it to every themed `Text`, so a new screen inherits the ceiling instead
+ * of having to remember it, and a component that needs a different one passes its own
+ * `maxFontSizeMultiplier`, which wins: the theme's props are merged UNDER a component's.
+ * Components built on React Native's own `Text` are outside that reach and pass it here.
+ *
+ * It sits apart from the theme it feeds so that reading the ceiling never means building
+ * the theme: components that only need the number would otherwise pull the whole thing in.
+ */
+export const MAX_FONT_SIZE_MULTIPLIER = 1.4

--- a/app/rne-theme/text-scaling.ts
+++ b/app/rne-theme/text-scaling.ts
@@ -1,3 +1,5 @@
+import { PixelRatio, Platform } from "react-native"
+
 /**
  * How far text may follow the OS text-size setting. Blink has no text-size control of its
  * own, so every screen inherits the system font scale directly, and past this point the
@@ -13,3 +15,25 @@
  * the theme: components that only need the number would otherwise pull the whole thing in.
  */
 export const MAX_FONT_SIZE_MULTIPLIER = 1.4
+
+/**
+ * How far a box that holds text has to grow to keep holding it: the OS scale, capped the
+ * same way the text inside it is. A width or height measured for the default size stops
+ * fitting the moment the glyphs grow, and the text breaks mid-word or clips rather than the
+ * box giving way. Multiply the fixed measurement by this and it keeps the proportions it
+ * was drawn with, at every OS setting.
+ */
+export const cappedFontScale = (): number =>
+  Math.min(PixelRatio.getFontScale(), MAX_FONT_SIZE_MULTIPLIER)
+
+/**
+ * A line height that stops where the text does. Android scales an explicit `lineHeight` by
+ * the OS font scale but never applies the ceiling the font itself respects, so past the
+ * ceiling the glyphs hold still while the line box keeps growing and the text floats in a
+ * row twice its height. Dividing it back leaves the box at `lineHeight * min(scale,
+ * ceiling)`. iOS clamps both already, so it is handed back untouched.
+ */
+export const cappedLineHeight = (lineHeight: number): number =>
+  Platform.OS === "android"
+    ? (lineHeight * cappedFontScale()) / PixelRatio.getFontScale()
+    : lineHeight

--- a/app/rne-theme/theme.ts
+++ b/app/rne-theme/theme.ts
@@ -3,14 +3,25 @@ import { StyleProp, TextStyle } from "react-native"
 import { createTheme } from "@rn-vui/themed"
 
 import { light, dark } from "./colors"
-import { MAX_FONT_SIZE_MULTIPLIER } from "./text-scaling"
+import { cappedLineHeight, MAX_FONT_SIZE_MULTIPLIER } from "./text-scaling"
 
 const theme = createTheme({
   lightColors: light,
   darkColors: dark,
   mode: "light",
   components: {
+    /** rn-vui's Input forwards what it does not consume to the TextInput underneath, so
+     *  the ceiling reaches typed text and placeholders the same way it reaches labels. */
+    Input: {
+      maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER,
+    },
     Button: {
+      /** A button draws its title with rn-vui's own Text, which the theme's Text entry
+       *  never reaches, so the ceiling travels through the props that Text receives.
+       *  Without it the primary action is the one label that keeps growing. */
+      titleProps: {
+        maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER,
+      },
       containerStyle: {
         borderRadius: 50,
       },
@@ -30,32 +41,32 @@ const theme = createTheme({
         ? {
             h1: {
               fontSize: 24,
-              lineHeight: 32,
+              lineHeight: cappedLineHeight(32),
               fontWeight: props.bold ? "600" : "400",
             },
             h2: {
               fontSize: 20,
-              lineHeight: 24,
+              lineHeight: cappedLineHeight(24),
               fontWeight: props.bold ? "600" : "400",
             },
             p1: {
               fontSize: 18,
-              lineHeight: 24,
+              lineHeight: cappedLineHeight(24),
               fontWeight: props.bold ? "600" : "400",
             },
             p2: {
               fontSize: 16,
-              lineHeight: 24,
+              lineHeight: cappedLineHeight(24),
               fontWeight: props.bold ? "600" : "400",
             },
             p3: {
               fontSize: 14,
-              lineHeight: 18,
+              lineHeight: cappedLineHeight(18),
               fontWeight: props.bold ? "600" : "400",
             },
             p4: {
               fontSize: 12,
-              lineHeight: 18,
+              lineHeight: cappedLineHeight(18),
               fontWeight: props.bold ? "600" : "400",
             },
           }[props.type]

--- a/app/rne-theme/theme.ts
+++ b/app/rne-theme/theme.ts
@@ -3,6 +3,7 @@ import { StyleProp, TextStyle } from "react-native"
 import { createTheme } from "@rn-vui/themed"
 
 import { light, dark } from "./colors"
+import { MAX_FONT_SIZE_MULTIPLIER } from "./text-scaling"
 
 const theme = createTheme({
   lightColors: light,
@@ -61,6 +62,7 @@ const theme = createTheme({
         : {}
 
       return {
+        maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER,
         style: {
           ...universalStyle,
           ...sizeStyle,

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { Text } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles, useTheme } from "@rn-vui/themed"
 import { useNavigation } from "@react-navigation/native"
@@ -279,7 +280,9 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
         iconBackgroundColor={colors._warningLight}
         footer={screenFooter}
       >
-        <Text style={styles.message}>{message}</Text>
+        <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.message}>
+          {message}
+        </Text>
       </StatusScreenLayout>
     </Screen>
   )

--- a/app/screens/authentication-screen/pin-screen.tsx
+++ b/app/screens/authentication-screen/pin-screen.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { useCallback, useState } from "react"
 import { Alert, Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -186,10 +187,22 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
       </View>
       <View style={styles.helperTextContainer}>
         {/* Both lines, so a countdown never hides how many tries are left. */}
-        <Text style={styles.helperText}>{attemptsText()}</Text>
-        {noticeText ? <Text style={styles.helperText}>{noticeText}</Text> : null}
+        <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.helperText}>
+          {attemptsText()}
+        </Text>
+        {noticeText ? (
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={styles.helperText}
+          >
+            {noticeText}
+          </Text>
+        ) : null}
         {lockout.isLocked ? (
-          <Text style={styles.helperText}>
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={styles.helperText}
+          >
             {LL.PinScreen.tryAgainIn({ seconds: lockout.remainingSeconds })}
           </Text>
         ) : null}

--- a/app/screens/authentication-screen/pin-screen.tsx
+++ b/app/screens/authentication-screen/pin-screen.tsx
@@ -152,6 +152,7 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
     return (
       <View style={styles.pinPadButtonContainer}>
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           buttonStyle={styles.pinPadButton}
           titleStyle={styles.pinPadButtonTitle}
           disabled={lockout.isInputDisabled}
@@ -228,6 +229,7 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
           {buttonComponentForDigit("0")}
           <View style={styles.pinPadButtonContainer}>
             <Button
+              titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
               testID="pinPadBackspace"
               buttonStyle={styles.pinPadButton}
               disabled={lockout.isInputDisabled}

--- a/app/screens/card-screen/card-settings-screen/close-card-modal.tsx
+++ b/app/screens/card-screen/card-settings-screen/close-card-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { Alert, TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import CustomModal from "@app/components/custom-modal/custom-modal"
@@ -66,6 +67,7 @@ export const CloseCardModal: React.FC<CloseCardModalProps> = ({
             })}
           </Text>
           <TextInput
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             autoCapitalize="none"
             style={styles.textInput}
             onChangeText={setConfirmText}

--- a/app/screens/conversion-flow/conversion-details-screen.tsx
+++ b/app/screens/conversion-flow/conversion-details-screen.tsx
@@ -39,6 +39,7 @@ import {
 } from "@app/types/amounts"
 
 import { Screen } from "@app/components/screen"
+import { cappedFontScale } from "@app/rne-theme/text-scaling"
 import { testProps } from "@app/utils/testProps"
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { useDollarBalanceRestrictionGuard } from "@app/hooks/use-dollar-balance-restriction-guard"
@@ -908,7 +909,9 @@ const useStyles = makeStyles(({ colors }, currencyInput: boolean) => ({
     flexDirection: "column",
     marginHorizontal: 20,
     marginTop: 16,
-    ...(currencyInput ? { minHeight: 70 } : {}),
+    /** The selector clips what overflows it, so the row that holds the amount has to grow
+     *  with the amount: fixed, the figure loses its top half at the larger text sizes. */
+    ...(currencyInput ? { minHeight: 70 * cappedFontScale() } : {}),
   },
   walletSelectorContainer: {
     flexDirection: "column",

--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { ScrollView, TouchableOpacity } from "react-native-gesture-handler"
 import { SvgProps } from "react-native-svg"
 
@@ -151,7 +152,9 @@ const EarnMapScreenContent: React.FC = () => {
 
     return (
       <>
-        <Text style={styles.finishText}>{LL.EarnScreen.finishText()}</Text>
+        <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.finishText}>
+          {LL.EarnScreen.finishText()}
+        </Text>
         {length % 2 ? <LeftFinish /> : <RightFinish />}
       </>
     )
@@ -243,7 +246,12 @@ const EarnMapScreenContent: React.FC = () => {
               <View style={styles.fullView}>
                 <ProgressBar progress={progressSection} />
                 <Icon style={styles.icon} width={50} height={50} />
-                <Text style={styles.textStyleBox}>{text}</Text>
+                <Text
+                  maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+                  style={styles.textStyleBox}
+                >
+                  {text}
+                </Text>
               </View>
             </TouchableOpacity>
           </View>
@@ -322,7 +330,10 @@ const EarnMapScreenContent: React.FC = () => {
                 {progress === 0 && <BottomStart height={159} width={BADGER_WIDTH} />}
               </View>
               <View style={styles.bottomSectionInner}>
-                <Text style={styles.bottomSectionText}>
+                <Text
+                  maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+                  style={styles.bottomSectionText}
+                >
                   {rewardsAvailable
                     ? LL.EarnScreen.motivatingBadger()
                     : LL.EarnScreen.motivatingBadgerNoRewards()}
@@ -342,7 +353,10 @@ const EarnMapScreenContent: React.FC = () => {
         backgroundModalColor={colors.white}
         body={
           <View style={styles.modalBody}>
-            <Text style={styles.modalBodyText}>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.modalBodyText}
+            >
               {LL.EarnScreen.customMessages.oneSectionADay.message()}
             </Text>
           </View>

--- a/app/screens/earns-screen/earn-svg-factory.tsx
+++ b/app/screens/earns-screen/earn-svg-factory.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Dimensions, Text } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import WhatIsFiat from "./01-fiat-currency-01.svg"
 import LimitedSupply from "./01-limited-supply-01.svg"
@@ -427,6 +428,10 @@ export const SVGs = ({ name, width, theme }: ISVGs): React.ReactNode => {
       return <AnsoffMatrix width={rWidth} />
 
     default:
-      return <Text>{name} does not exist</Text>
+      return (
+        <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
+          {name} does not exist
+        </Text>
+      )
   }
 }

--- a/app/screens/earns-screen/earns-quiz.tsx
+++ b/app/screens/earns-screen/earns-quiz.tsx
@@ -508,6 +508,7 @@ export const EarnQuiz = ({ route }: Props) => {
           <View>
             {recordedAnswer.indexOf(0) === -1 ? null : (
               <Button
+                titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
                 title={LL.EarnScreen.keepDigging()}
                 type="outline"
                 onPress={async () => close()}
@@ -546,6 +547,7 @@ export const EarnQuiz = ({ route }: Props) => {
                   : LL.EarnScreen.sectionsCompleted()}
               </Text>
               <Button
+                titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
                 title={LL.EarnScreen.reviewQuiz()}
                 type="clear"
                 titleStyle={styles.completedTitleStyle}
@@ -554,6 +556,7 @@ export const EarnQuiz = ({ route }: Props) => {
             </>
           )) || (
             <Button
+              titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
               title={
                 isAvailable
                   ? LL.EarnScreen.earnSats({

--- a/app/screens/earns-screen/earns-quiz.tsx
+++ b/app/screens/earns-screen/earns-quiz.tsx
@@ -8,6 +8,7 @@ import {
   TouchableWithoutFeedback,
   Pressable,
 } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { ScrollView } from "react-native-gesture-handler"
 import Modal from "react-native-modal"
 import { SafeAreaView } from "react-native-safe-area-context"
@@ -439,14 +440,27 @@ export const EarnQuiz = ({ route }: Props) => {
         <TouchableOpacity onPress={() => addRecordedAnswer(i)}>
           <View style={styles.buttonRow}>
             <View style={buttonStyleHelper(i)}>
-              <Text style={styles.quizButtonTitleStyle}>{mappingLetter[j]}</Text>
+              <Text
+                maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+                style={styles.quizButtonTitleStyle}
+              >
+                {mappingLetter[j]}
+              </Text>
             </View>
-            <Text style={styles.answerChoiceText}>{answers[i]}</Text>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.answerChoiceText}
+            >
+              {answers[i]}
+            </Text>
           </View>
         </TouchableOpacity>
         {recordedAnswer.length > 0 &&
         recordedAnswer.indexOf(i) === recordedAnswer.length - 1 ? (
-          <Text style={i === 0 ? styles.correctAnswerText : styles.incorrectAnswerText}>
+          <Text
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+            style={i === 0 ? styles.correctAnswerText : styles.incorrectAnswerText}
+          >
             {feedback[i]}
           </Text>
         ) : null}
@@ -485,7 +499,9 @@ export const EarnQuiz = ({ route }: Props) => {
             contentContainerStyle={styles.answersView}
           >
             <Pressable style={styles.answersViewInner}>
-              <Text style={styles.title}>{question ?? title}</Text>
+              <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.title}>
+                {question ?? title}
+              </Text>
               {answersShuffled}
             </Pressable>
           </ScrollView>
@@ -507,8 +523,12 @@ export const EarnQuiz = ({ route }: Props) => {
         <ScrollView persistentScrollbar showsVerticalScrollIndicator bounces>
           <View style={styles.svgContainer}>{SVGs({ name: id, theme: "dark" })}</View>
           <View style={styles.textContainer}>
-            <Text style={styles.title}>{title}</Text>
-            <Text style={styles.text}>{text}</Text>
+            <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.title}>
+              {title}
+            </Text>
+            <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.text}>
+              {text}
+            </Text>
           </View>
         </ScrollView>
       </SafeAreaView>
@@ -517,7 +537,10 @@ export const EarnQuiz = ({ route }: Props) => {
         <View style={{ paddingVertical: 12 }}>
           {(completed && (
             <>
-              <Text style={styles.textEarn}>
+              <Text
+                maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+                style={styles.textEarn}
+              >
                 {isAvailable
                   ? LL.EarnScreen.quizComplete({ formattedNumber: amount })
                   : LL.EarnScreen.sectionsCompleted()}
@@ -552,7 +575,10 @@ export const EarnQuiz = ({ route }: Props) => {
         backgroundModalColor={colors.white}
         body={
           <View style={styles.modalBody}>
-            <Text style={styles.modalBodyText}>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.modalBodyText}
+            >
               {getModalErrorMessages(quizErrorCode as ValidateQuizCodeErrorsType).message}
             </Text>
           </View>

--- a/app/screens/earns-screen/earns-section.tsx
+++ b/app/screens/earns-screen/earns-section.tsx
@@ -258,6 +258,7 @@ export const EarnSection = ({ route }: Props) => {
               {item.title}
             </Text>
             <Button
+              titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
               onPress={() => open(item.id)}
               disabled={!item.enabled}
               disabledStyle={styles.buttonStyleDisabled}

--- a/app/screens/earns-screen/earns-section.tsx
+++ b/app/screens/earns-screen/earns-section.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { useState } from "react"
 import { Dimensions, Text, View, Alert } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { TouchableOpacity } from "react-native-gesture-handler"
 import { useSharedValue } from "react-native-reanimated"
 import Carousel from "react-native-reanimated-carousel"
@@ -249,7 +250,11 @@ export const EarnSection = ({ route }: Props) => {
             </View>
           </TouchableOpacity>
           <View>
-            <Text style={styles.itemTitle} numberOfLines={3}>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.itemTitle}
+              numberOfLines={3}
+            >
               {item.title}
             </Text>
             <Button
@@ -285,8 +290,15 @@ export const EarnSection = ({ route }: Props) => {
         </View>
         {!item.enabled && (
           <>
-            <Text style={styles.unlockQuestion}>{LL.EarnScreen.unlockQuestion()}</Text>
-            <Text style={styles.unlock}>{item.nonEnabledMessage}</Text>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.unlockQuestion}
+            >
+              {LL.EarnScreen.unlockQuestion()}
+            </Text>
+            <Text maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} style={styles.unlock}>
+              {item.nonEnabledMessage}
+            </Text>
           </>
         )}
       </>

--- a/app/screens/earns-screen/section-completed.tsx
+++ b/app/screens/earns-screen/section-completed.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RouteProp, useNavigation } from "@react-navigation/native"
@@ -81,8 +82,18 @@ export const SectionCompleted: React.FC<Props> = ({ route }) => {
       <View style={styles.container}>
         <View style={styles.divider} />
         <BadgerShovelBitcoin />
-        <Text style={styles.headerSection}>{LL.EarnScreen.sectionsCompleted()}</Text>
-        <Text style={styles.titleSection}>{sectionTitle}</Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.headerSection}
+        >
+          {LL.EarnScreen.sectionsCompleted()}
+        </Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.titleSection}
+        >
+          {sectionTitle}
+        </Text>
         <Button
           title={LL.EarnScreen.keepDigging()}
           type="solid"

--- a/app/screens/earns-screen/section-completed.tsx
+++ b/app/screens/earns-screen/section-completed.tsx
@@ -95,6 +95,7 @@ export const SectionCompleted: React.FC<Props> = ({ route }) => {
           {sectionTitle}
         </Text>
         <Button
+          titleProps={{ maxFontSizeMultiplier: MAX_FONT_SIZE_MULTIPLIER }}
           title={LL.EarnScreen.keepDigging()}
           type="solid"
           buttonStyle={styles.buttonStyle}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -113,9 +113,6 @@ const ANY_POSITIVE_CENT_MINIMUM = 1
  *  area anchored 15pt up); content needs at least that much bottom padding for
  *  the last bulletin to be readable at max scroll. */
 const SCROLL_BOTTOM_CLEARANCE = 100
-/** Header chrome (username row, balance) sits between fixed-size icon buttons;
- *  uncapped Dynamic Type pushes the settings menu out of reach. */
-const MAX_HEADER_FONT_SIZE_MULTIPLIER = 1.4
 
 gql`
   query homeAuthed {
@@ -881,11 +878,7 @@ export const HomeScreen: React.FC = () => {
             {!loading && usernameTitle && (
               <Pressable onPress={canSwitchAccount ? handleSwitchPress : null}>
                 <View style={styles.profileContainer}>
-                  <Text
-                    {...testProps("home-username")}
-                    type="p2"
-                    maxFontSizeMultiplier={MAX_HEADER_FONT_SIZE_MULTIPLIER}
-                  >
+                  <Text {...testProps("home-username")} type="p2">
                     {usernameTitle}
                   </Text>
                   {canSwitchAccount && <GaloyIcon name={"caret-down"} size={18} />}

--- a/app/screens/lightning-address-screen/set-lightning-address-screen.tsx
+++ b/app/screens/lightning-address-screen/set-lightning-address-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react"
 import { View, TextInput, Keyboard, Modal } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { Text, makeStyles, useTheme } from "@rn-vui/themed"
@@ -198,6 +199,7 @@ export const SetLightningAddressScreen: React.FC<{
 
         <View style={styles.textInputContainerStyle}>
           <TextInput
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             autoCorrect={false}
             autoComplete="off"
             style={styles.textInputStyle}

--- a/app/screens/people-screen/circles/circles-card-people-home.tsx
+++ b/app/screens/people-screen/circles/circles-card-people-home.tsx
@@ -8,6 +8,7 @@ import { PressableCard } from "@app/components/pressable-card"
 import { useCirclesQuery } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { PeopleStackParamList } from "@app/navigation/stack-param-lists"
+import { cappedFontScale } from "@app/rne-theme/text-scaling"
 import { useFocusEffect, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, Text } from "@rn-vui/themed"
@@ -150,7 +151,9 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   pointsText: {
     paddingBottom: 8,
-    maxWidth: 80,
+    /** Wide enough for the label at the default text size; it grows with the text so the
+     *  same words keep wrapping the same way instead of breaking mid-word. */
+    maxWidth: 80 * cappedFontScale(),
   },
   backdropCircle: {
     position: "absolute",

--- a/app/screens/people-screen/contacts/all-contacts.tsx
+++ b/app/screens/people-screen/contacts/all-contacts.tsx
@@ -158,6 +158,7 @@ export const AllContactsScreen: React.FC = () => {
   if (contacts.length > 0) {
     SearchBarContent = (
       <SearchBar
+        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
         {...testProps(LL.common.search())}
         placeholder={LL.common.search()}
         value={searchText}

--- a/app/screens/people-screen/contacts/all-contacts.tsx
+++ b/app/screens/people-screen/contacts/all-contacts.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { useCallback, useMemo, useState } from "react"
 import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { FlatList } from "react-native-gesture-handler"
 import { gql } from "@apollo/client"
 import { Screen } from "@app/components/screen"
@@ -185,7 +186,12 @@ export const AllContactsScreen: React.FC = () => {
   if (contacts.length > 0) {
     ListEmptyContent = (
       <View style={styles.emptyListNoMatching}>
-        <Text style={styles.emptyListTitle}>{LL.PeopleScreen.noMatchingContacts()}</Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.emptyListTitle}
+        >
+          {LL.PeopleScreen.noMatchingContacts()}
+        </Text>
       </View>
     )
   } else if (loading) {
@@ -198,12 +204,18 @@ export const AllContactsScreen: React.FC = () => {
     ListEmptyContent = (
       <View style={styles.emptyListNoContacts}>
         <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           {...testProps(LL.PeopleScreen.noContactsTitle())}
           style={styles.emptyListTitle}
         >
           {LL.PeopleScreen.noContactsTitle()}
         </Text>
-        <Text style={styles.emptyListText}>{LL.PeopleScreen.noContactsYet()}</Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.emptyListText}
+        >
+          {LL.PeopleScreen.noContactsYet()}
+        </Text>
       </View>
     )
   }

--- a/app/screens/people-screen/contacts/contact-transactions.tsx
+++ b/app/screens/people-screen/contacts/contact-transactions.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { SectionList, Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { gql } from "@apollo/client"
 import {
@@ -71,7 +72,12 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
   const renderSectionHeader = React.useCallback(
     ({ section: { title } }: { section: { title: string } }) => (
       <View style={styles.sectionHeaderContainer}>
-        <Text style={styles.sectionHeaderText}>{title}</Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.sectionHeaderText}
+        >
+          {title}
+        </Text>
       </View>
     ),
     [styles.sectionHeaderContainer, styles.sectionHeaderText],
@@ -111,7 +117,10 @@ export const ContactTransactions = ({ contactUsername }: Props) => {
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
           <View style={styles.noTransactionView}>
-            <Text style={styles.noTransactionText}>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.noTransactionText}
+            >
               {LL.TransactionScreen.noTransaction()}
             </Text>
           </View>

--- a/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx
+++ b/app/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from "react"
 import { TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 import { useNavigation, useRoute, RouteProp } from "@react-navigation/native"
@@ -124,6 +125,7 @@ export const BackupPhraseConfirmScreen: React.FC = () => {
                       {challenge.index + 1}.
                     </Text>
                     <TextInput
+                      maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
                       ref={(ref) => {
                         inputRefs.current[i] = ref
                       }}

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -30,6 +30,7 @@ import { CountryCode, PhoneNumber } from "libphonenumber-js/mobile"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { SearchBar } from "@rn-vui/base"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { makeStyles, useTheme, Text, ListItem } from "@rn-vui/themed"
 
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
@@ -761,6 +762,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
           onResponderRelease={() => onFocusedInput(InputType.Search)}
         >
           <SearchBar
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             {...testProps(LL.SendBitcoinScreen.placeholder())}
             placeholder={LL.SendBitcoinScreen.placeholder()}
             value={

--- a/app/screens/settings-screen/account/settings/delete.tsx
+++ b/app/screens/settings-screen/account/settings/delete.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { Alert, TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import Modal from "react-native-modal"
 
 import { gql } from "@apollo/client"
@@ -199,6 +200,7 @@ export const Delete = () => {
         </View>
         <Text type="p1">{LL.support.typeDelete({ delete: LL.support.delete() })}</Text>
         <TextInput
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
           autoCapitalize="none"
           style={styles.textInput}
           onChangeText={setText}

--- a/app/screens/settings-screen/api/api-key-create-screen.tsx
+++ b/app/screens/settings-screen/api/api-key-create-screen.tsx
@@ -8,6 +8,7 @@ import { Switch } from "@app/components/atomic/switch"
 import { Screen } from "@app/components/screen"
 import { ApiKeysDocument, Scope, useApiKeyCreateMutation } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { cappedFontScale } from "@app/rne-theme/text-scaling"
 import { testProps } from "@app/utils/testProps"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
@@ -191,10 +192,16 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   expiryRow: {
     flexDirection: "row",
+    flexWrap: "wrap",
     columnGap: 10,
+    rowGap: 10,
   },
   expiryPill: {
-    flex: 1,
+    /** Three across at the default text size, and a basis that grows with it: past the
+     *  point where the three no longer fit, they wrap onto another row instead of cutting
+     *  "Never" down to "Nev". */
+    flexGrow: 1,
+    flexBasis: 90 * cappedFontScale(),
     alignItems: "center",
     paddingVertical: 12,
     borderRadius: 8,

--- a/app/screens/settings-screen/self-custodial/delete-account-confirm-modal.tsx
+++ b/app/screens/settings-screen/self-custodial/delete-account-confirm-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
@@ -52,6 +53,7 @@ export const DeleteAccountConfirmModal: React.FC<Props> = ({
             })}
           </Text>
           <TextInput
+            maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
             autoCapitalize="none"
             style={styles.textInput}
             onChangeText={setConfirmText}

--- a/app/screens/transaction-history/transaction-history-screen.tsx
+++ b/app/screens/transaction-history/transaction-history-screen.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { InteractionManager, SectionList, Text, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 import { makeStyles } from "@rn-vui/themed"
 import { gql, useApolloClient } from "@apollo/client"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -443,7 +444,12 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
   const renderSectionHeader = React.useCallback(
     ({ section: { title } }: { section: { title: string } }) => (
       <View style={styles.sectionHeaderContainer}>
-        <Text style={styles.sectionHeaderText}>{title}</Text>
+        <Text
+          maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+          style={styles.sectionHeaderText}
+        >
+          {title}
+        </Text>
       </View>
     ),
     [styles.sectionHeaderContainer, styles.sectionHeaderText],
@@ -530,7 +536,10 @@ export const TransactionHistoryScreen: React.FC<TransactionHistoryScreenProps> =
         renderSectionHeader={renderSectionHeader}
         ListEmptyComponent={
           <View style={styles.noTransactionView}>
-            <Text style={styles.noTransactionText}>
+            <Text
+              maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              style={styles.noTransactionText}
+            >
               {LL.TransactionScreen.noTransaction()}
             </Text>
           </View>

--- a/app/screens/unclaimed-deposits/unclaimed-deposits-screen.tsx
+++ b/app/screens/unclaimed-deposits/unclaimed-deposits-screen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { ActivityIndicator, Pressable, TextInput, View } from "react-native"
+import { MAX_FONT_SIZE_MULTIPLIER } from "@app/rne-theme/text-scaling"
 
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
@@ -148,6 +149,7 @@ export const UnclaimedDepositsScreen: React.FC = () => {
                     </Text>
                     <View style={styles.fieldInput}>
                       <TextInput
+                        maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
                         style={styles.fieldInputText}
                         placeholder={addressPlaceholderFor(network)}
                         placeholderTextColor={colors.grey2}


### PR DESCRIPTION
Relates to #4129.

## What this does

Blink has no text-size control of its own, so every screen follows the OS setting without a limit. Past a point that stops being "bigger text": labels truncate to two characters, pills crowd out the amounts beside them, and rows clip.

This puts one ceiling in the theme instead of another per-screen patch, and carries it into the places the theme cannot reach.

- **The theme** caps every themed `Text`, `Input` and button title. A component that needs a different ceiling passes its own, which wins.
- **Outside its reach**: React Native's own `Text` and `TextInput`, anything imported from `@rn-vui/base`, the tab bar labels and the header titles all carry the ceiling as props.
- **The line box** is corrected on Android, where an explicit `lineHeight` scales past the ceiling the font respects, leaving the text floating in a row twice its height.
- **Boxes measured for the default text** grow with it, so a label wraps the way it was drawn instead of breaking mid-word or clipping.

A source-walking test fails with the files to fix when a new screen renders text the ceiling cannot reach, which is the check the ticket asks for.

## Screenshots

Android emulator, OS text size at 3.0 to show the ceiling acting well past what the OS menu offers (1.3).

### Home

| Before | After |
|---|---|
| <img width="300" alt="before-home-scale-3 0" src="https://github.com/user-attachments/assets/ec1337f8-1db2-438d-88a9-d68d1a42bc6d" /> | <img width="300" alt="after-home-scale-3 0" src="https://github.com/user-attachments/assets/dbae7ddc-c9bf-4300-8be0-a2f717e16249" /> |

### Settings

| Before | After |
|---|---|
| <img width="300" alt="before-settings-scale-3 0" src="https://github.com/user-attachments/assets/eb085d83-eb92-4b5c-a428-26d931725df5" /> | <img width="300" alt="after-settings-scale-3 0" src="https://github.com/user-attachments/assets/18b70229-6211-4978-97c4-eda108983dcb" /> |

### Send

| Before | After |
|---|---|
| <img width="300" alt="before-send-scale-3 0" src="https://github.com/user-attachments/assets/a32e897a-1fcb-466c-9b1b-82d4899cebb7" /> | <img width="300" alt="after-send-scale-3 0" src="https://github.com/user-attachments/assets/dd809ddf-35bd-4e81-ae14-590f8478f098" /> |

### Transfer funds and Confirm transfer

| Before | After |
|---|---|
| <img width="300" alt="before-transfer-funds-scale-3 0" src="https://github.com/user-attachments/assets/1e1ccd4d-7a91-48ca-847a-52a863aa6efd" /> | <img width="300" alt="after-transfer-funds-scale-1 4" src="https://github.com/user-attachments/assets/61274254-c91c-448c-ad10-2dcf22d90623" /> |

## Testing

- 5080 tests across 416 suites, typecheck and lint clean.
- New: the ceiling on every preset and its override, the Android line-box correction, `cappedFontScale`, and the coverage walk including its own reading.
- Device: home, settings, receive, send, people, learn, transfer funds, confirm transfer and new API key walked on an Android emulator at 1.4 and 3.0, and at 1.0 to confirm nothing moved at the default size.

## Not in this PR

**The ceiling is assumed, not agreed.** 1.4 is the value already used ad hoc on the balance and the header, and the ticket asks design whether it is the intended app-wide limit. Changing it is one constant.

The ticket's other three questions are still open, and the second one bounds this PR: which elements may truncate, which must reflow, which must never shrink. Without that rule, layouts that collide only above the ceiling are left alone rather than decided here.

**Known gap**: `cappedLineHeight` reaches the theme's presets and the primary button. There are 191 `lineHeight` declarations elsewhere in `app/`, where the component's own style wins over the theme's; those keep the Android mismatch at sizes past the ceiling.
