### PR TITLE
fix(send): strip trunk leading zero when building phone destination (#2604)

### DIFF
--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -97,9 +97,11 @@ jest.mock("@app/screens/send-bitcoin-screen/payment-destination", () => ({
   parseDestination: jest.fn(),
 }))
 
+type MockDeviceLocation = { countryCode: string | undefined; loading: boolean }
+let mockDeviceLocation: MockDeviceLocation = { countryCode: "SV", loading: false }
 jest.mock("@app/hooks/use-device-location", () => ({
   __esModule: true,
-  default: () => ({ countryCode: "SV", loading: false }),
+  default: () => mockDeviceLocation,
 }))
 
 jest.mock("@app/hooks/use-app-config", () => ({
@@ -196,6 +198,7 @@ describe("SendBitcoinDestinationScreen", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDeviceLocation = { countryCode: "SV", loading: false }
     loadLocale("en")
     LL = i18nObject("en")
     useActiveWalletMock.mockReturnValue({
@@ -435,6 +438,44 @@ describe("SendBitcoinDestinationScreen", () => {
       return
     }
     expect(parseDestinationMock).not.toHaveBeenCalled()
+
+    await flushEffects()
+  })
+
+  it("strips the trunk leading zero from a national number before validating (issue #2604)", async () => {
+    mockDeviceLocation = { countryCode: "FR", loading: false }
+
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: "lnurl",
+        isMerchant: false,
+        lnurlParams: createLnurlPayParams("+33612345678"),
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+
+    fireEvent.changeText(screen.getByLabelText("telephoneNumber"), "0612345678")
+    await flushAsync()
+    fireEvent.press(screen.getByLabelText(LL.common.next()))
+    await flushAsync()
+
+    // the trunk "0" must be dropped, not kept alongside the "+33" country code
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "+33612345678" }),
+    )
+    expect(parseDestinationMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "+330612345678" }),
+    )
 
     await flushEffects()
   })
@@ -1299,6 +1340,7 @@ describe("SendBitcoinDestinationScreen paste buttons", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDeviceLocation = { countryCode: "SV", loading: false }
     loadLocale("en")
     LL = i18nObject("en")
   })

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -1006,13 +1006,19 @@ const PhoneInputSection: React.FC<PhoneInputSectionProps> = ({
       return
 
     const { rawPhoneNumber } = defaultPhoneInputInfo
-    const rawInput = `+${defaultPhoneInputInfo?.countryCallingCode}${rawPhoneNumber}`
+    const parsedPhone = parseValidPhone(rawPhoneNumber)
+    // Prefer the parser's normalized E.164 number so a national number typed
+    // with a trunk prefix (e.g. France's "06...") isn't sent as "+3306..."
+    const rawInput =
+      parsedPhone && parsedPhone.isValid()
+        ? parsedPhone.number
+        : `+${defaultPhoneInputInfo?.countryCallingCode}${rawPhoneNumber}`
 
     handleChangeText(rawInput)
     updateMatchingContacts(rawPhoneNumber)
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultPhoneInputInfo, handleChangeText, updateMatchingContacts])
+  }, [defaultPhoneInputInfo, handleChangeText, updateMatchingContacts, parseValidPhone])
 
   useEffect(() => {
     if (!rawPhoneNumber) return


### PR DESCRIPTION
The phone send-destination input built the LNURL/lookup string by
naively concatenating "+{countryCallingCode}{rawPhoneNumber}", so a
national number typed with a trunk prefix (e.g. France's "06...")
was sent as the invalid "+3306..." instead of "+336...". This made
the lookup mismatch the user's actual registered phone number and
silently fail.

Reuse the already-available libphonenumber-js parser (parseValidPhone)
to normalize to E.164 first, falling back to the previous
concatenation only when parsing doesn't yield a valid number (e.g.
incomplete input while typing).

Fixes #2604