### PR TITLE
fix(multi-account): stop a failed session-profile read from deleting other profiles' tokens

### DIFF
--- a/__tests__/graphql/network-error-component.spec.tsx
+++ b/__tests__/graphql/network-error-component.spec.tsx
@@ -39,6 +39,13 @@ const mockNavigation = {
   reset: mockReset,
 }
 
+const storeProfiles = (profiles: unknown[]) => {
+  ;(KeyStoreWrapper.readSessionProfiles as jest.Mock).mockResolvedValue({
+    status: "found",
+    profiles,
+  })
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
   ;(useNetworkError as jest.Mock).mockReturnValue({
@@ -64,6 +71,7 @@ beforeEach(() => {
     saveToken: mockSaveToken,
   })
   ;(useNavigation as jest.Mock).mockReturnValue(mockNavigation)
+  storeProfiles([])
 
   jest.spyOn(Alert, "alert").mockImplementation((title, message, buttons) => {
     buttons?.[0]?.onPress?.()
@@ -122,7 +130,7 @@ describe("NetworkErrorComponent", () => {
   })
 
   it("handles InvalidAuthentication with multiple profiles - switches account", async () => {
-    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockResolvedValue([
+    storeProfiles([
       { token: "current-token", username: "user1" },
       { token: "other-token", username: "user2" },
     ])
@@ -158,9 +166,7 @@ describe("NetworkErrorComponent", () => {
   })
 
   it("handles InvalidAuthentication with one profile - shows alert and navigates to getStarted", async () => {
-    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockResolvedValue([
-      { token: "current-token", username: "user1" },
-    ])
+    storeProfiles([{ token: "current-token", username: "user1" }])
 
     const { rerender } = render(<NetworkErrorComponent />)
 
@@ -174,6 +180,8 @@ describe("NetworkErrorComponent", () => {
 
     await waitFor(() => {
       expect(Alert.alert).toHaveBeenCalled()
+      // Readable store, genuinely the last profile: the list goes with it.
+      expect(mockLogout).toHaveBeenCalledWith({ preserveStoredCredentials: false })
       expect(mockReset).toHaveBeenCalledWith({
         index: 0,
         routes: [{ name: "getStarted" }],
@@ -199,7 +207,9 @@ describe("NetworkErrorComponent", () => {
 
     await waitFor(
       () => {
-        expect(mockLogout).toHaveBeenCalledWith()
+        // A 401 with no active token can be a stale one arriving mid-switch,
+        // so what is stored stays put.
+        expect(mockLogout).toHaveBeenCalledWith({ preserveStoredCredentials: true })
         expect(mockReset).toHaveBeenCalledWith({
           index: 0,
           routes: [{ name: "getStarted" }],
@@ -262,13 +272,10 @@ describe("NetworkErrorComponent", () => {
   })
 
   it("falls back to logout on error during token expiry handling", async () => {
-    // The component logs the simulated storage failure via console.error;
-    // capture it so the expected error doesn't pollute CI logs (and assert it
-    // actually happened).
+    // The component logs the simulated failure via console.error; capture it so
+    // the expected error doesn't pollute CI logs (and assert it happened).
     const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {})
-    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockRejectedValue(
-      new Error("Storage error"),
-    )
+    mockLogout.mockRejectedValueOnce(new Error("Storage error"))
 
     const { rerender } = render(<NetworkErrorComponent />)
 
@@ -281,7 +288,8 @@ describe("NetworkErrorComponent", () => {
     rerender(<NetworkErrorComponent />)
 
     await waitFor(() => {
-      expect(mockLogout).toHaveBeenCalledWith()
+      // The teardown threw, so the saved list is kept rather than erased blind.
+      expect(mockLogout).toHaveBeenCalledWith({ preserveStoredCredentials: true })
       expect(mockReset).toHaveBeenCalledWith({
         index: 0,
         routes: [{ name: "getStarted" }],
@@ -293,5 +301,39 @@ describe("NetworkErrorComponent", () => {
       expect.objectContaining({ message: "Storage error" }),
     )
     consoleErrorSpy.mockRestore()
+  })
+
+  // The untokened logout erases every saved session. Reaching it because the
+  // store could not be read would delete the profiles the read never saw.
+  it("never runs the session-erasing logout when the profile store is unreadable", async () => {
+    ;(KeyStoreWrapper.readSessionProfiles as jest.Mock).mockResolvedValue({
+      status: "failed",
+      err: new Error("keystore locked"),
+    })
+
+    const { rerender } = render(<NetworkErrorComponent />)
+
+    ;(useNetworkError as jest.Mock).mockReturnValue({
+      networkError: { statusCode: 401 },
+      token: "current-token",
+      clearNetworkError: mockClearNetworkError,
+    })
+
+    rerender(<NetworkErrorComponent />)
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalled()
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "getStarted" }],
+      })
+    })
+    expect(mockLogout).toHaveBeenCalledWith({ preserveStoredCredentials: true })
+    // The dead session's own token was still deactivated.
+    expect(mockLogout).toHaveBeenCalledWith({
+      stateToDefault: false,
+      token: "current-token",
+      isValidToken: false,
+    })
   })
 })

--- a/__tests__/hooks/use-logout.spec.ts
+++ b/__tests__/hooks/use-logout.spec.ts
@@ -6,6 +6,9 @@ import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 const mockClearToken = jest.fn()
 const mockResetState = jest.fn()
 const mockLogoutMutation = jest.fn()
+const mockGetDeviceToken = jest.fn()
+const mockAsyncStorage = { multiRemove: jest.fn() }
+const mockReportError = jest.fn()
 
 jest.mock("@app/store/persistent-state", () => ({
   usePersistentStateContext: () => ({
@@ -22,9 +25,17 @@ jest.mock("@app/utils/analytics", () => ({
   logLogout: jest.fn(),
 }))
 
+jest.mock("@react-native-firebase/messaging", () => () => ({
+  getToken: () => mockGetDeviceToken(),
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
 jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
-  default: { multiRemove: jest.fn().mockResolvedValue(undefined) },
+  default: { multiRemove: (...args: unknown[]) => mockAsyncStorage.multiRemove(...args) },
 }))
 
 jest.mock("@app/utils/storage/secureStorage", () => ({
@@ -55,6 +66,8 @@ beforeEach(() => {
   mockedStore.clearPinFailureState.mockResolvedValue(true)
   mockedStore.removeSessionProfiles.mockResolvedValue(true)
   mockedStore.getActiveToken.mockResolvedValue("")
+  mockGetDeviceToken.mockResolvedValue("")
+  mockAsyncStorage.multiRemove.mockResolvedValue(undefined)
   mockLogoutMutation.mockResolvedValue({ data: {} })
 })
 
@@ -74,6 +87,88 @@ describe("useLogout", () => {
     expect(mockedStore.clearPinFailureState.mock.invocationCallOrder[0]).toBeLessThan(
       mockResetState.mock.invocationCallOrder[0],
     )
+  })
+
+  it("erases the saved session profiles by default", async () => {
+    await logoutOnce()
+
+    expect(mockedStore.removeSessionProfiles).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps everything the device stored when asked to, and still ends the session", async () => {
+    // The caller could not read the store, so the list it would erase is the
+    // one it never saw. The PIN goes with it: a live token left behind without
+    // the lock that guarded it is worse than either alone. Dropping the schema
+    // marker would undo the whole thing, since the next boot would read as a
+    // fresh install and sweep the profiles anyway.
+    await logoutOnce({ preserveStoredCredentials: true })
+
+    expect(mockedStore.removeSessionProfiles).not.toHaveBeenCalled()
+    expect(mockedStore.removePin).not.toHaveBeenCalled()
+    expect(mockedStore.removeIsBiometricsEnabled).not.toHaveBeenCalled()
+    expect(mockedStore.clearPinFailureState).not.toHaveBeenCalled()
+    expect(mockAsyncStorage.multiRemove).not.toHaveBeenCalled()
+    // The active session still ends.
+    expect(mockClearToken).toHaveBeenCalledTimes(1)
+    expect(mockResetState).toHaveBeenCalledTimes(1)
+  })
+
+  it("drops the keychain token when the session signed out is the active one", async () => {
+    mockedStore.getActiveToken.mockResolvedValue("active-token")
+
+    await logoutOnce({ token: "active-token" })
+
+    expect(mockClearToken).toHaveBeenCalledTimes(1)
+  })
+
+  it("revokes the session server-side when there is a device token to send", async () => {
+    mockGetDeviceToken.mockResolvedValue("device-token")
+
+    await logoutOnce({ token: "active-token" })
+
+    expect(mockLogoutMutation).toHaveBeenCalledWith(
+      expect.objectContaining({ variables: { input: { deviceToken: "device-token" } } }),
+    )
+  })
+
+  it("reports a failed device-token fetch and signs out anyway", async () => {
+    mockGetDeviceToken.mockRejectedValue(new Error("messaging unavailable"))
+
+    await logoutOnce({ token: "active-token" })
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "logout device token fetch",
+      expect.any(Error),
+    )
+    expect(mockLogoutMutation).not.toHaveBeenCalled()
+    expect(mockResetState).toHaveBeenCalledTimes(1)
+  })
+
+  it("gives up on a hanging revocation instead of blocking the sign-out", async () => {
+    const consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation(() => {})
+    jest.useFakeTimers()
+    mockGetDeviceToken.mockResolvedValue("device-token")
+    mockLogoutMutation.mockReturnValue(new Promise(() => {}))
+
+    const { result } = renderHook(() => useLogout())
+    const signOut = result.current.logout({ token: "active-token" })
+    await jest.advanceTimersByTimeAsync(2000)
+    await signOut
+
+    expect(mockResetState).toHaveBeenCalledTimes(1)
+    jest.useRealTimers()
+    consoleDebugSpy.mockRestore()
+  })
+
+  it("reports a teardown failure and still resets the state", async () => {
+    const consoleDebugSpy = jest.spyOn(console, "debug").mockImplementation(() => {})
+    mockedStore.removePin.mockRejectedValue(new Error("keystore locked"))
+
+    await logoutOnce()
+
+    expect(mockReportError).toHaveBeenCalledWith("logout", expect.any(Error))
+    expect(mockResetState).toHaveBeenCalledTimes(1)
+    consoleDebugSpy.mockRestore()
   })
 
   it("leaves this device's PIN alone when another session's token is logged out", async () => {

--- a/__tests__/hooks/use-save-session-profile.spec.ts
+++ b/__tests__/hooks/use-save-session-profile.spec.ts
@@ -7,7 +7,7 @@ import { useSaveSessionProfile } from "@app/hooks/use-save-session-profile"
 const mockSaveToken = jest.fn()
 const mockUpdateState = jest.fn()
 const mockFetchUsername = jest.fn()
-const mockGetSessionProfiles = jest.fn()
+const mockReadSessionProfiles = jest.fn()
 const mockSaveSessionProfiles = jest.fn()
 const mockResetUpgradeModal = jest.fn()
 const mockUpdateDeviceSessionCount = jest.fn()
@@ -52,7 +52,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
 jest.mock("@app/utils/storage/secureStorage", () => ({
   __esModule: true,
   default: {
-    getSessionProfiles: (...args: unknown[]) => mockGetSessionProfiles(...args),
+    readSessionProfiles: (...args: unknown[]) => mockReadSessionProfiles(...args),
     saveSessionProfiles: (...args: unknown[]) => mockSaveSessionProfiles(...args),
   },
 }))
@@ -72,11 +72,15 @@ const setUserMe = (me: {
   mockFetchUsername.mockResolvedValue({ data: { me } })
 }
 
+const storeProfiles = (profiles: unknown[]) => {
+  mockReadSessionProfiles.mockResolvedValue({ status: "found", profiles })
+}
+
 describe("useSaveSessionProfile", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockSaveToken.mockResolvedValue(undefined)
-    mockGetSessionProfiles.mockResolvedValue([])
+    storeProfiles([])
     mockSaveSessionProfiles.mockResolvedValue(true)
   })
 
@@ -88,7 +92,7 @@ describe("useSaveSessionProfile", () => {
 
       expect(mockSaveToken).not.toHaveBeenCalled()
       expect(mockUpdateState).not.toHaveBeenCalled()
-      expect(mockGetSessionProfiles).not.toHaveBeenCalled()
+      expect(mockReadSessionProfiles).not.toHaveBeenCalled()
     })
 
     it("writes activeAccountId = DefaultAccountId.Custodial after saving the token", async () => {
@@ -152,9 +156,7 @@ describe("useSaveSessionProfile", () => {
     })
 
     it("returns early without saving the new profile when the token is already stored", async () => {
-      mockGetSessionProfiles.mockResolvedValue([
-        { token: "existing-token", accountId: "acct-1", selected: true },
-      ])
+      storeProfiles([{ token: "existing-token", accountId: "acct-1", selected: true }])
 
       const { result } = renderHook(() => useSaveSessionProfile())
 
@@ -187,9 +189,7 @@ describe("useSaveSessionProfile", () => {
 
     it("re-fetches and replaces a degraded profile (no accountId) instead of returning early", async () => {
       setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-1" } })
-      mockGetSessionProfiles.mockResolvedValue([
-        { token: "new-token", identifier: "Blink user", selected: true },
-      ])
+      storeProfiles([{ token: "new-token", identifier: "Blink user", selected: true }])
 
       const { result } = renderHook(() => useSaveSessionProfile())
 
@@ -205,9 +205,7 @@ describe("useSaveSessionProfile", () => {
 
     it("saves a brand-new profile alongside the deselected previous ones", async () => {
       setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-new" } })
-      mockGetSessionProfiles.mockResolvedValue([
-        { token: "old-token", accountId: "acct-old", selected: true },
-      ])
+      storeProfiles([{ token: "old-token", accountId: "acct-old", selected: true }])
 
       const { result } = renderHook(() => useSaveSessionProfile())
 
@@ -224,7 +222,7 @@ describe("useSaveSessionProfile", () => {
 
     it("re-selects the existing profile when the user signs in again with a fresh token", async () => {
       setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-existing" } })
-      mockGetSessionProfiles.mockResolvedValue([
+      storeProfiles([
         { token: "stale-token", accountId: "acct-existing", selected: false },
         { token: "other-token", accountId: "acct-other", selected: true },
       ])
@@ -243,12 +241,58 @@ describe("useSaveSessionProfile", () => {
       expect(existing.token).toBe("fresh-token")
       expect(other.selected).toBe(false)
     })
+
+    it("writes nothing when the profiles read fails, so the other sessions survive", async () => {
+      setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-new" } })
+      mockReadSessionProfiles.mockResolvedValue({
+        status: "failed",
+        err: new Error("keystore locked"),
+      })
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.saveProfile("new-token")
+
+      expect(mockSaveSessionProfiles).not.toHaveBeenCalled()
+      expect(mockRecordError).toHaveBeenCalledTimes(1)
+      // The login itself still stands: only the profile list is left alone
+      expect(mockSaveToken).toHaveBeenCalledWith("new-token")
+      // and its own side effects run, since they belong to the login
+      expect(mockResetUpgradeModal).toHaveBeenCalledTimes(1)
+      expect(mockUpdateDeviceSessionCount).toHaveBeenCalledWith(expect.anything(), {
+        reset: true,
+      })
+    })
+
+    it("writes nothing when /me resolves without a user", async () => {
+      mockFetchUsername.mockResolvedValue({ data: { me: null } })
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.saveProfile("new-token")
+
+      expect(mockSaveSessionProfiles).not.toHaveBeenCalled()
+    })
+
+    it("saves the first profile when nothing is stored yet", async () => {
+      setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-new" } })
+      mockReadSessionProfiles.mockResolvedValue({ status: "absent" })
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.saveProfile("new-token")
+
+      expect(mockSaveSessionProfiles).toHaveBeenCalledTimes(1)
+      const saved = mockSaveSessionProfiles.mock.calls[0][0]
+      expect(saved).toHaveLength(1)
+      expect(saved[0].accountId).toBe("acct-new")
+    })
   })
 
   describe("updateCurrentProfile", () => {
     it("heals a degraded profile by token match once defaultAccount resolves", async () => {
       setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-1" } })
-      mockGetSessionProfiles.mockResolvedValue([
+      storeProfiles([
         { token: "current-token", identifier: "Blink user", selected: true },
       ])
 
@@ -261,6 +305,58 @@ describe("useSaveSessionProfile", () => {
       expect(saved).toHaveLength(1)
       expect(saved[0].accountId).toBe("acct-1")
       expect(saved[0].identifier).toBe("alice")
+    })
+
+    it("leaves a profile that matches neither the account nor the token untouched", async () => {
+      setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-1" } })
+      const other = { token: "other-token", accountId: "acct-other", selected: false }
+      storeProfiles([other])
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.updateCurrentProfile()
+
+      expect(mockSaveSessionProfiles).toHaveBeenCalledWith([other])
+    })
+
+    it("writes nothing when the current profile cannot be fetched", async () => {
+      mockFetchUsername.mockResolvedValue({ data: { me: null } })
+      storeProfiles([{ token: "current-token", accountId: "acct-1", selected: true }])
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.updateCurrentProfile()
+
+      expect(mockSaveSessionProfiles).not.toHaveBeenCalled()
+    })
+
+    it("writes nothing when the profiles read fails, so the other sessions survive", async () => {
+      setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-1" } })
+      mockReadSessionProfiles.mockResolvedValue({
+        status: "failed",
+        err: new Error("keystore locked"),
+      })
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.updateCurrentProfile()
+
+      expect(mockSaveSessionProfiles).not.toHaveBeenCalled()
+      expect(mockRecordError).toHaveBeenCalledTimes(1)
+      // The read comes first, so the /me round trip is skipped too
+      expect(mockFetchUsername).not.toHaveBeenCalled()
+    })
+
+    it("writes nothing when no profiles are stored, since there is none to update", async () => {
+      setUserMe({ id: "u1", username: "alice", defaultAccount: { id: "acct-1" } })
+      mockReadSessionProfiles.mockResolvedValue({ status: "absent" })
+
+      const { result } = renderHook(() => useSaveSessionProfile())
+
+      await result.current.updateCurrentProfile()
+
+      expect(mockSaveSessionProfiles).not.toHaveBeenCalled()
+      expect(mockFetchUsername).not.toHaveBeenCalled()
     })
   })
 })

--- a/__tests__/hooks/use-switch-to-next-profile.spec.ts
+++ b/__tests__/hooks/use-switch-to-next-profile.spec.ts
@@ -1,12 +1,16 @@
 import { act, renderHook } from "@testing-library/react-native"
 
-import { useSwitchToNextProfile } from "@app/hooks/use-switch-to-next-profile"
+import {
+  SwitchProfileOutcome,
+  useSwitchToNextProfile,
+} from "@app/hooks/use-switch-to-next-profile"
 
 const mockLogout = jest.fn()
 const mockSaveToken = jest.fn()
 const mockNavigate = jest.fn()
 const mockToastShow = jest.fn()
-const mockGetSessionProfiles = jest.fn()
+const mockReportError = jest.fn()
+const mockReadSessionProfiles = jest.fn()
 
 jest.mock("@app/hooks/use-logout", () => ({
   __esModule: true,
@@ -31,12 +35,20 @@ jest.mock("@app/utils/toast", () => ({
   toastShow: (...args: unknown[]) => mockToastShow(...args),
 }))
 
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
 jest.mock("@app/utils/storage/secureStorage", () => ({
   __esModule: true,
   default: {
-    getSessionProfiles: (...args: unknown[]) => mockGetSessionProfiles(...args),
+    readSessionProfiles: (...args: unknown[]) => mockReadSessionProfiles(...args),
   },
 }))
+
+const storeProfiles = (profiles: unknown[]) => {
+  mockReadSessionProfiles.mockResolvedValue({ status: "found", profiles })
+}
 
 const profileA = { token: "tok-a", username: "alice", accountId: "acct-a" }
 const profileB = { token: "tok-b", username: "bob", accountId: "acct-b" }
@@ -49,15 +61,15 @@ describe("useSwitchToNextProfile", () => {
   })
 
   it("deactivates the old token before saving the next profile's token", async () => {
-    mockGetSessionProfiles.mockResolvedValue([profileA, profileB])
+    storeProfiles([profileA, profileB])
 
     const { result } = renderHook(() => useSwitchToNextProfile())
-    let nextProfile
+    let switchResult
     await act(async () => {
-      nextProfile = await result.current.switchToNextProfile("tok-a")
+      switchResult = await result.current.switchToNextProfile("tok-a")
     })
 
-    expect(nextProfile).toEqual(profileB)
+    expect(switchResult).toBe(SwitchProfileOutcome.Switched)
     // No server revocation for a session the caller has already invalidated.
     expect(mockLogout).toHaveBeenCalledWith({
       stateToDefault: false,
@@ -75,15 +87,15 @@ describe("useSwitchToNextProfile", () => {
   })
 
   it("still deactivates the old session when there is no next profile, but saves nothing", async () => {
-    mockGetSessionProfiles.mockResolvedValue([profileA])
+    storeProfiles([profileA])
 
     const { result } = renderHook(() => useSwitchToNextProfile())
-    let nextProfile
+    let switchResult
     await act(async () => {
-      nextProfile = await result.current.switchToNextProfile("tok-a")
+      switchResult = await result.current.switchToNextProfile("tok-a")
     })
 
-    expect(nextProfile).toBeUndefined()
+    expect(switchResult).toBe(SwitchProfileOutcome.NoOtherProfile)
     expect(mockLogout).toHaveBeenCalledWith({
       stateToDefault: false,
       token: "tok-a",
@@ -92,5 +104,44 @@ describe("useSwitchToNextProfile", () => {
     expect(mockSaveToken).not.toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()
     expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
+  // An unreadable store must never reach the caller as "no other profile":
+  // callers answer that with a full logout, which erases every saved session.
+  it("reports the store as unreadable instead of claiming there is no next profile", async () => {
+    mockReadSessionProfiles.mockResolvedValue({
+      status: "failed",
+      err: new Error("keystore locked"),
+    })
+
+    const { result } = renderHook(() => useSwitchToNextProfile())
+    let switchResult
+    await act(async () => {
+      switchResult = await result.current.switchToNextProfile("tok-a")
+    })
+
+    expect(switchResult).toBe(SwitchProfileOutcome.ProfilesUnreadable)
+    expect(mockReportError).toHaveBeenCalledTimes(1)
+    // The dead session still goes, scoped to its own token.
+    expect(mockLogout).toHaveBeenCalledWith({
+      stateToDefault: false,
+      token: "tok-a",
+      isValidToken: false,
+    })
+    expect(mockSaveToken).not.toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("treats an empty store as no next profile", async () => {
+    mockReadSessionProfiles.mockResolvedValue({ status: "absent" })
+
+    const { result } = renderHook(() => useSwitchToNextProfile())
+    let switchResult
+    await act(async () => {
+      switchResult = await result.current.switchToNextProfile("tok-a")
+    })
+
+    expect(switchResult).toBe(SwitchProfileOutcome.NoOtherProfile)
+    expect(mockSaveToken).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/screens/settings-screen/account/settings/delete.spec.tsx
+++ b/__tests__/screens/settings-screen/account/settings/delete.spec.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider, createTheme } from "@rn-vui/themed"
 
 import { dark, light } from "@app/rne-theme/colors"
 import { Delete } from "@app/screens/settings-screen/account/settings/delete"
+import { SwitchProfileOutcome } from "@app/hooks/use-switch-to-next-profile"
 
 const mockDeleteAccount = jest.fn()
 const mockSetAccountIsBeingDeleted = jest.fn()
@@ -42,6 +43,7 @@ jest.mock("@app/hooks", () => ({
 }))
 
 jest.mock("@app/hooks/use-switch-to-next-profile", () => ({
+  ...jest.requireActual("@app/hooks/use-switch-to-next-profile"),
   useSwitchToNextProfile: () => ({ switchToNextProfile: mockSwitchToNextProfile }),
 }))
 
@@ -159,7 +161,7 @@ describe("Delete", () => {
     mockDeleteAccount.mockResolvedValue({
       data: { accountDelete: { success: true, errors: [] } },
     })
-    mockSwitchToNextProfile.mockResolvedValue({ token: "next-token" })
+    mockSwitchToNextProfile.mockResolvedValue(SwitchProfileOutcome.Switched)
     jest
       .spyOn(Alert, "alert")
       .mockImplementation((title, body, buttons) =>
@@ -277,11 +279,35 @@ describe("Delete", () => {
     })
 
     it("signs out and returns to get-started when it was the last profile", async () => {
-      mockSwitchToNextProfile.mockResolvedValue(null)
+      mockSwitchToNextProfile.mockResolvedValue(SwitchProfileOutcome.NoOtherProfile)
       await openDeletionModal()
       await confirmDeletion()
 
-      expect(mockLogout).toHaveBeenCalledWith({ stateToDefault: true })
+      expect(mockLogout).toHaveBeenCalledWith({
+        stateToDefault: true,
+        preserveStoredCredentials: false,
+      })
+
+      await pressAlertButton(alertCalls.length - 1, "OK")
+
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: "getStarted" }],
+      })
+    })
+
+    /** The logout erases every saved session, so it must not run when
+     *  the store could not be read: the profiles it would delete are the ones
+     *  the read never saw. Everything else still signs out. */
+    it("keeps the saved profiles when the store is unreadable, and signs out of the rest", async () => {
+      mockSwitchToNextProfile.mockResolvedValue(SwitchProfileOutcome.ProfilesUnreadable)
+      await openDeletionModal()
+      await confirmDeletion()
+
+      expect(mockLogout).toHaveBeenCalledWith({
+        stateToDefault: true,
+        preserveStoredCredentials: true,
+      })
 
       await pressAlertButton(alertCalls.length - 1, "OK")
 

--- a/__tests__/utils/secure-storage.spec.ts
+++ b/__tests__/utils/secure-storage.spec.ts
@@ -569,6 +569,11 @@ describe("KeyStoreWrapper session-profile methods", () => {
     name: "Bob",
   } as unknown as ProfileProps
 
+  // Both native modules reject a missing key rather than resolving empty, and
+  // only this code separates "nothing stored" from "the read went wrong".
+  const keyNotFound = () =>
+    Object.assign(new Error("key does not present"), { code: "404" })
+
   describe("saveSessionProfiles", () => {
     it("serializes profiles to JSON and writes them with ALWAYS_THIS_DEVICE_ONLY", async () => {
       mockSet.mockResolvedValue(undefined)
@@ -590,6 +595,18 @@ describe("KeyStoreWrapper session-profile methods", () => {
 
       expect(result).toBe(false)
     })
+
+    it("returns false without writing when the profiles cannot be serialized", async () => {
+      const circular: Record<string, unknown> = { token: "tok-a" }
+      circular.self = circular
+
+      const result = await KeyStoreWrapper.saveSessionProfiles([
+        circular as unknown as ProfileProps,
+      ])
+
+      expect(result).toBe(false)
+      expect(mockSet).not.toHaveBeenCalled()
+    })
   })
 
   describe("getSessionProfiles", () => {
@@ -603,7 +620,7 @@ describe("KeyStoreWrapper session-profile methods", () => {
     })
 
     it("returns an empty array when the key is missing", async () => {
-      mockGet.mockRejectedValue(new Error("not found"))
+      mockGet.mockRejectedValue(keyNotFound())
 
       const result = await KeyStoreWrapper.getSessionProfiles()
 
@@ -616,6 +633,68 @@ describe("KeyStoreWrapper session-profile methods", () => {
       const result = await KeyStoreWrapper.getSessionProfiles()
 
       expect(result).toEqual([])
+    })
+
+    it("collapses a failed read to an empty array", async () => {
+      mockGet.mockRejectedValue(new Error("keystore locked"))
+
+      const result = await KeyStoreWrapper.getSessionProfiles()
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("readSessionProfiles", () => {
+    it("returns the stored profiles as found", async () => {
+      mockGet.mockResolvedValue(JSON.stringify([profileA, profileB]))
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "found", profiles: [profileA, profileB] })
+      expect(mockGet).toHaveBeenCalledWith("sessionProfiles")
+    })
+
+    it("reports absent when the key is not there", async () => {
+      mockGet.mockRejectedValue(keyNotFound())
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "absent" })
+    })
+
+    it("reports absent when the stored payload is empty", async () => {
+      mockGet.mockResolvedValue("")
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "absent" })
+    })
+
+    it("reports failed when the read fails for any reason other than a missing key", async () => {
+      const err = new Error("keystore locked")
+      mockGet.mockRejectedValue(err)
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "failed", err })
+    })
+
+    // A payload nobody can parse holds no session to protect, so it is reported
+    // absent and the next write heals the slot rather than being refused forever.
+    it("reports absent when the stored payload will not parse", async () => {
+      mockGet.mockResolvedValue("{ truncated")
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "absent" })
+    })
+
+    it("reports absent when the stored payload parses to something other than an array", async () => {
+      mockGet.mockResolvedValue(JSON.stringify({ token: "tok-a" }))
+
+      const result = await KeyStoreWrapper.readSessionProfiles()
+
+      expect(result).toEqual({ status: "absent" })
     })
   })
 
@@ -674,6 +753,26 @@ describe("KeyStoreWrapper session-profile methods", () => {
       const result = await KeyStoreWrapper.removeSessionProfileByToken("tok-a")
 
       expect(result).toBe(false)
+    })
+
+    it("writes nothing when the read fails, leaving the other profiles stored", async () => {
+      mockGet.mockRejectedValue(new Error("keystore locked"))
+      mockSet.mockResolvedValue(undefined)
+
+      const result = await KeyStoreWrapper.removeSessionProfileByToken("tok-a")
+
+      expect(result).toBe(false)
+      expect(mockSet).not.toHaveBeenCalled()
+    })
+
+    it("writes nothing when no profiles are stored", async () => {
+      mockGet.mockRejectedValue(keyNotFound())
+      mockSet.mockResolvedValue(undefined)
+
+      const result = await KeyStoreWrapper.removeSessionProfileByToken("tok-a")
+
+      expect(result).toBe(true)
+      expect(mockSet).not.toHaveBeenCalled()
     })
   })
 })

--- a/app/graphql/network-error-component.tsx
+++ b/app/graphql/network-error-component.tsx
@@ -9,7 +9,10 @@ import { toastShow } from "@app/utils/toast"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
-import { useSwitchToNextProfile } from "@app/hooks/use-switch-to-next-profile"
+import {
+  SwitchProfileOutcome,
+  useSwitchToNextProfile,
+} from "@app/hooks/use-switch-to-next-profile"
 
 import { NetworkErrorCode } from "./error-code"
 import { useNetworkError } from "./network-error-context"
@@ -43,7 +46,10 @@ export const NetworkErrorComponent: React.FC = () => {
       if (!currentToken) {
         // Stale 401 from in-flight queries while the user is on self-custodial.
         if (isSelfCustodialActive) return
-        await logout()
+        // No active token right now says nothing about what is stored: a 401
+        // arriving mid-switch lands here, and erasing on it would take the
+        // account the user is switching to.
+        await logout({ preserveStoredCredentials: true })
         navigation.reset({
           index: 0,
           routes: [{ name: "getStarted" }],
@@ -59,17 +65,22 @@ export const NetworkErrorComponent: React.FC = () => {
         return
       }
 
-      const nextProfile = await switchToNextProfile(networkErrorToken)
-      if (nextProfile) {
+      const outcome = await switchToNextProfile(networkErrorToken)
+      if (outcome === SwitchProfileOutcome.Switched) {
         return
       }
 
       // Custodial session is dead but the user is on self-custodial; skip re-login modal.
       if (isSelfCustodialActive) return
 
+      // The logout below erases every saved session, which is only correct when
+      // we know there is none left. An unreadable store is ignorance, not that
+      // knowledge, so keep the list and sign out of everything else.
+      const isStoreUnreadable = outcome === SwitchProfileOutcome.ProfilesUnreadable
+
       if (!showedAlert) {
         setShowedAlert(true)
-        await logout()
+        await logout({ preserveStoredCredentials: isStoreUnreadable })
         Alert.alert(LL.common.reauth(), "", [
           {
             text: LL.common.ok(),
@@ -85,7 +96,10 @@ export const NetworkErrorComponent: React.FC = () => {
       }
     } catch (error) {
       console.error("Error handling token expiry:", error)
-      await logout()
+      // Same rule as above, and this branch knows even less: something threw
+      // mid-teardown, so the saved list stays rather than being erased on a
+      // guess. A stale entry costs one failed switch; erasing costs sessions.
+      await logout({ preserveStoredCredentials: true })
       navigation.reset({
         index: 0,
         routes: [{ name: "getStarted" }],

--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -15,6 +15,22 @@ type LogoutOptions = {
   stateToDefault?: boolean
   token?: string
   isValidToken?: boolean
+  /**
+   * Signs out of the active session and leaves everything the device has
+   * stored alone: the saved profiles, the PIN, the biometrics flag and the
+   * schema marker. For the one case where "there is nothing left" is not
+   * knowledge but ignorance — the keystore could not be read, so erasing would
+   * delete sessions we never saw.
+   *
+   * The group cannot be split. Profiles without the PIN would leave live
+   * bearer tokens behind with the lock that guarded them gone, and dropping
+   * the schema marker alone makes the next boot read as a fresh install, whose
+   * reinstall sweep erases the profiles anyway.
+   *
+   * Only the untokened path reads this; a call that passes a token is already
+   * scoped to that one session and destroys nothing else.
+   */
+  preserveStoredCredentials?: boolean
 }
 
 gql`
@@ -36,6 +52,7 @@ const useLogout = () => {
       stateToDefault = true,
       token,
       isValidToken = true,
+      preserveStoredCredentials = false,
     }: LogoutOptions = {}): Promise<void> => {
       try {
         // Isolated: a failed push-token fetch must never skip the local
@@ -63,11 +80,13 @@ const useLogout = () => {
           }
           context = { headers: { authorization: `Bearer ${token}` } }
         } else {
-          await AsyncStorage.multiRemove([SCHEMA_VERSION_KEY])
-          await KeyStoreWrapper.removeIsBiometricsEnabled()
-          await KeyStoreWrapper.removePin()
-          await KeyStoreWrapper.clearPinFailureState()
-          await KeyStoreWrapper.removeSessionProfiles()
+          if (!preserveStoredCredentials) {
+            await AsyncStorage.multiRemove([SCHEMA_VERSION_KEY])
+            await KeyStoreWrapper.removeIsBiometricsEnabled()
+            await KeyStoreWrapper.removePin()
+            await KeyStoreWrapper.clearPinFailureState()
+            await KeyStoreWrapper.removeSessionProfiles()
+          }
           await clearToken()
         }
 

--- a/app/hooks/use-save-session-profile.ts
+++ b/app/hooks/use-save-session-profile.ts
@@ -5,7 +5,7 @@ import { updateDeviceSessionCount } from "@app/graphql/client-only-query"
 import { useGetUsernamesLazyQuery } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { reportError } from "@app/utils/error-logging"
-import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+import KeyStoreWrapper, { SessionProfilesRead } from "@app/utils/storage/secureStorage"
 
 import { usePersistentStateContext } from "../store/persistent-state"
 import { DefaultAccountId } from "../types/wallet"
@@ -85,6 +85,18 @@ export const useSaveSessionProfile = () => {
     [blinkUserText, hostName],
   )
 
+  /**
+   * The stored profiles, reported as found, absent or failed. Callers that
+   * write the list back must not treat a failed read as an empty store:
+   * profiles carry their sessions' tokens, so a list rewritten from an assumed
+   * emptiness signs every other saved account out.
+   */
+  const readProfiles = useCallback(async (): Promise<SessionProfilesRead> => {
+    const read = await KeyStoreWrapper.readSessionProfiles()
+    if (read.status === "failed") reportError("read session profiles", read.err)
+    return read
+  }, [])
+
   const saveProfile = useCallback(
     async (token: string): Promise<void> => {
       if (!token) return
@@ -95,7 +107,8 @@ export const useSaveSessionProfile = () => {
         return { ...prev, activeAccountId: DefaultAccountId.Custodial }
       })
 
-      const profiles = await KeyStoreWrapper.getSessionProfiles()
+      const read = await readProfiles()
+      const profiles = read.status === "found" ? read.profiles : []
 
       // A profile stored without accountId was saved while defaultAccount was
       // still missing; fall through and re-fetch so this login heals it
@@ -107,6 +120,10 @@ export const useSaveSessionProfile = () => {
 
       resetUpgradeModal()
       updateDeviceSessionCount(client, { reset: true })
+
+      // Only the write is skipped when the store could not be read: the login
+      // above stands, and the resets belong to it rather than to the list.
+      if (read.status === "failed") return
 
       const others = profiles.filter((p) => p.token !== token)
       const exists =
@@ -125,11 +142,25 @@ export const useSaveSessionProfile = () => {
 
       await KeyStoreWrapper.saveSessionProfiles(updatedProfiles)
     },
-    [saveToken, updateState, tryFetchUserProps, fetchUsername, resetUpgradeModal, client],
+    [
+      saveToken,
+      updateState,
+      readProfiles,
+      tryFetchUserProps,
+      fetchUsername,
+      resetUpgradeModal,
+      client,
+    ],
   )
 
   const updateCurrentProfile = useCallback(async (): Promise<void> => {
-    const profiles = await KeyStoreWrapper.getSessionProfiles()
+    // This method only rewrites entries that already exist, so anything but a
+    // list in hand means there is nothing to update — and writing one back
+    // would be indistinguishable from a wipe.
+    const read = await readProfiles()
+    if (read.status !== "found") return
+    const profiles = read.profiles
+
     const currentProfile = await tryFetchUserProps({ token: currentToken, fetchUsername })
     if (!currentProfile) return
     const updatedProfiles = profiles.map((p) => {
@@ -139,7 +170,7 @@ export const useSaveSessionProfile = () => {
       return sameAccount || p.token === currentProfile.token ? currentProfile : p
     })
     await KeyStoreWrapper.saveSessionProfiles(updatedProfiles)
-  }, [fetchUsername, tryFetchUserProps, currentToken])
+  }, [readProfiles, fetchUsername, tryFetchUserProps, currentToken])
 
   return {
     saveProfile,

--- a/app/hooks/use-switch-to-next-profile.ts
+++ b/app/hooks/use-switch-to-next-profile.ts
@@ -5,11 +5,26 @@ import { useAppConfig } from "@app/hooks"
 import useLogout from "@app/hooks/use-logout"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { reportError } from "@app/utils/error-logging"
 import { toastShow } from "@app/utils/toast"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
+/**
+ * Why this is not just `ProfileProps | undefined`: callers answer "no other
+ * profile" with a full logout, which erases every saved session. Collapsing a
+ * failed read into that answer would delete the very profiles the read could
+ * not see, so the unreadable case has to reach the caller as its own outcome.
+ */
+export const SwitchProfileOutcome = {
+  Switched: "switched",
+  NoOtherProfile: "noOtherProfile",
+  ProfilesUnreadable: "profilesUnreadable",
+} as const
+export type SwitchProfileOutcome =
+  (typeof SwitchProfileOutcome)[keyof typeof SwitchProfileOutcome]
+
 type UseSwitchToNextProfileResult = {
-  switchToNextProfile: (tokenToDeactivate: string) => Promise<ProfileProps | undefined>
+  switchToNextProfile: (tokenToDeactivate: string) => Promise<SwitchProfileOutcome>
 }
 
 export const useSwitchToNextProfile = (): UseSwitchToNextProfileResult => {
@@ -20,26 +35,34 @@ export const useSwitchToNextProfile = (): UseSwitchToNextProfileResult => {
 
   const switchToNextProfile = async (
     tokenToDeactivate: string,
-  ): Promise<ProfileProps | undefined> => {
-    const profiles = await KeyStoreWrapper.getSessionProfiles()
+  ): Promise<SwitchProfileOutcome> => {
+    const read = await KeyStoreWrapper.readSessionProfiles()
+    const profiles = read.status === "found" ? read.profiles : []
     const nextProfile = profiles.find((profile) => profile.token !== tokenToDeactivate)
 
+    // The dead session goes either way: this deactivation is scoped to its own
+    // token and never rewrites the list from an empty read.
     await logout({
       stateToDefault: false,
       token: tokenToDeactivate,
       isValidToken: false,
     })
 
-    if (nextProfile) {
-      await saveToken(nextProfile.token)
-      toastShow({
-        type: "success",
-        message: LL.ProfileScreen.switchAccount(),
-        LL,
-      })
-      navigation.navigate("Primary")
+    if (read.status === "failed") {
+      reportError("switch to next profile", read.err)
+      return SwitchProfileOutcome.ProfilesUnreadable
     }
-    return nextProfile
+
+    if (!nextProfile) return SwitchProfileOutcome.NoOtherProfile
+
+    await saveToken(nextProfile.token)
+    toastShow({
+      type: "success",
+      message: LL.ProfileScreen.switchAccount(),
+      LL,
+    })
+    navigation.navigate("Primary")
+    return SwitchProfileOutcome.Switched
   }
 
   return { switchToNextProfile }

--- a/app/screens/settings-screen/account/settings/delete.tsx
+++ b/app/screens/settings-screen/account/settings/delete.tsx
@@ -19,7 +19,10 @@ import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { useTheme, Text, makeStyles } from "@rn-vui/themed"
 
-import { useSwitchToNextProfile } from "@app/hooks/use-switch-to-next-profile"
+import {
+  SwitchProfileOutcome,
+  useSwitchToNextProfile,
+} from "@app/hooks/use-switch-to-next-profile"
 
 import { SettingsButton } from "../../button"
 import { useAccountDeleteContext } from "../account-delete-context"
@@ -134,16 +137,27 @@ export const Delete = () => {
       if (res.data?.accountDelete?.success) {
         setAccountIsBeingDeleted(false)
 
-        const nextProfile = await switchToNextProfile(accountToDeleteToken)
-        if (!nextProfile) {
-          await logout({ stateToDefault: true })
+        const outcome = await switchToNextProfile(accountToDeleteToken)
+        const hasSwitched = outcome === SwitchProfileOutcome.Switched
+        if (!hasSwitched) {
+          // The logout erases every saved session, which is only correct once
+          // we know there is none left. An unreadable store is ignorance, not
+          // that knowledge, so keep the list and sign out of everything else.
+          // Known cost: the same failed read left the deleted account in that
+          // list, so it can still be offered and will 401 once. Cheaper than
+          // erasing sessions that were only invisible.
+          const isStoreUnreadable = outcome === SwitchProfileOutcome.ProfilesUnreadable
+          await logout({
+            stateToDefault: true,
+            preserveStoredCredentials: isStoreUnreadable,
+          })
         }
 
         Alert.alert(LL.support.bye(), LL.support.deleteAccountConfirmation(), [
           {
             text: LL.common.ok(),
             onPress: () => {
-              if (!nextProfile) {
+              if (!hasSwitched) {
                 navigation.reset({
                   index: 0,
                   routes: [{ name: "getStarted" }],

--- a/app/utils/storage/secureStorage.ts
+++ b/app/utils/storage/secureStorage.ts
@@ -17,9 +17,25 @@ export type ActiveTokenRead =
   | { status: "absent" }
   | { status: "failed"; err: unknown }
 
+/**
+ * The outcome of a session-profiles read, with "nothing stored" kept distinct
+ * from "the read failed" — see readSessionProfiles.
+ */
+export type SessionProfilesRead =
+  | { status: "found"; profiles: ProfileProps[] }
+  | { status: "absent" }
+  | { status: "failed"; err: unknown }
+
 // Both native modules reject a missing key with code "404" (ios/RNSecureKeyStore.m
 // `get`, android RNSecureKeyStoreModule#get). Every other code means the read
 // itself went wrong.
+//
+// True on Android only. The iOS module discards the OSStatus from
+// SecItemCopyMatching (`searchKeychainCopyMatching` returns nil for any failure)
+// and `get` rejects nil with "404", so an entitlement or decode error is
+// indistinguishable from a missing key there. Every caller that branches on this
+// therefore degrades to "absent" on iOS; the distinction becomes real when the
+// slots move to react-native-keychain (blink-wip#1161).
 const KEY_NOT_FOUND_CODE = "404"
 
 const isKeyNotFound = (err: unknown): boolean =>
@@ -281,14 +297,47 @@ export default class KeyStoreWrapper {
     }
   }
 
-  public static async getSessionProfiles(): Promise<ProfileProps[]> {
-    const data = await KeyStoreWrapper.read(KeyStoreWrapper.SESSION_PROFILES)
-    if (!data) return []
+  /**
+   * A missing key is a rejection, not an empty read, so "no profiles stored"
+   * and "the keystore is unhappy" arrive the same way and only the error code
+   * tells them apart — the same distinction readActiveToken draws. Callers that
+   * write the list back must use this instead of getSessionProfiles: an empty
+   * list scored from a failed read deletes every profile, and profiles carry
+   * their sessions' tokens.
+   *
+   * Platform caveat: this only separates the two cases on Android — see the
+   * note above KEY_NOT_FOUND_CODE.
+   *
+   * A payload that will not parse, or that parses to something other than an
+   * array, is reported as absent rather than failed: it holds nothing a caller
+   * could preserve, so refusing to overwrite it would protect no session while
+   * permanently disabling multi-account — nothing else ever clears this key.
+   * Reporting it absent lets the next login heal the slot.
+   */
+  public static async readSessionProfiles(): Promise<SessionProfilesRead> {
+    const read = await KeyStoreWrapper.readWithStatus(KeyStoreWrapper.SESSION_PROFILES)
+    if (read.status !== "found") return read
+    // An empty payload is a slot that holds nothing, not a broken one.
+    if (!read.value) return { status: "absent" }
+
     try {
-      return JSON.parse(data)
+      const parsed = JSON.parse(read.value)
+      return Array.isArray(parsed)
+        ? { status: "found", profiles: parsed }
+        : { status: "absent" }
     } catch {
-      return []
+      return { status: "absent" }
     }
+  }
+
+  /**
+   * Collapses absent and failed to an empty list: convenient, and safe only
+   * where that renders an empty list. Use readSessionProfiles where it leads
+   * to a write.
+   */
+  public static async getSessionProfiles(): Promise<ProfileProps[]> {
+    const read = await KeyStoreWrapper.readSessionProfiles()
+    return read.status === "found" ? read.profiles : []
   }
 
   public static async removeSessionProfiles(): Promise<boolean> {
@@ -300,6 +349,10 @@ export default class KeyStoreWrapper {
    * "nothing stored" and "the keystore is unhappy" arrive the same way and only
    * the error code tells them apart. Callers that would destroy or overwrite a
    * credential based on an empty read must use this instead of getActiveToken.
+   *
+   * The code only tells them apart on Android — see the note above
+   * KEY_NOT_FOUND_CODE. On iOS every failed read reports absent, so the failed
+   * branch its callers take is unreachable there.
    */
   public static async readActiveToken(): Promise<ActiveTokenRead> {
     try {
@@ -376,8 +429,16 @@ export default class KeyStoreWrapper {
   }
 
   public static async removeSessionProfileByToken(token: string): Promise<boolean> {
-    const profiles = await KeyStoreWrapper.getSessionProfiles()
-    const remaining = profiles.filter((profile) => profile.token !== token)
+    const read = await KeyStoreWrapper.readSessionProfiles()
+    // Rewriting the list from a failed read would sign every other saved
+    // account out; leaving this one entry behind is the lesser harm. The
+    // logout caller ignores the result either way, so false is a report, not
+    // a branch.
+    if (read.status === "failed") return false
+    // Nothing stored means nothing to remove — and no reason to write "[]".
+    if (read.status === "absent") return true
+
+    const remaining = read.profiles.filter((profile) => profile.token !== token)
     return KeyStoreWrapper.saveSessionProfiles(remaining)
   }
 


### PR DESCRIPTION
Fixes [blinkbitcoin/blink-wip#1164](https://github.com/blinkbitcoin/blink-wip/issues/1164) (close manually on merge — cross-repo `Fixes` doesn't auto-close).

## Problem

`KeyStoreWrapper.getSessionProfiles` collapses two different answers into the same `[]`: "no profiles are stored" and "the read failed". The native modules reject a missing key rather than resolving empty, so both arrive through the same `catch`, and only the error code separates them — which the getter discards.

Four call sites then act on that empty list. Three read it, modify it and write it back, so a transient keystore failure does not degrade, it **deletes**: session profiles carry their sessions' tokens, and the rewrite drops every account the read could not see.

- `useSaveSessionProfile.saveProfile` writes `[newProfile]` over the intact list — every other account signed out on login.
- `useSaveSessionProfile.updateCurrentProfile` writes `[].map(...)`, which is `[]` — every profile gone.
- `KeyStoreWrapper.removeSessionProfileByToken` writes the filtered empty list, so a keystore hiccup during logout signs the user out of every other account too.

The fourth is different and worse. `useSwitchToNextProfile` does not write; it returns "no next profile", and its two callers answer that with an untokened `logout()`, which calls `removeSessionProfiles()` and erases the whole store.

The same distinction already exists one method away: `readActiveToken` was built in [#4160](https://github.com/blinkbitcoin/blink-mobile/pull/4160) precisely so a failed token read is never scored as "no token". Session profiles never got it.

## What changed

**`readSessionProfiles`** ([`secureStorage.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/65cedeb9f/app/utils/storage/secureStorage.ts)) — a sibling of `readActiveToken` returning the same three-way union, `found` / `absent` / `failed`. `getSessionProfiles` stays as the collapsing wrapper for the read-only display callers (`use-account-registry`, `use-switch-to-next-profile`'s neighbours, `multi-account/utils`, `use-resolve-transaction-account`), where an empty list merely renders an empty list.

**The three write paths abort on `failed`** rather than writing. In `saveProfile` the guard sits immediately before the write, after `resetUpgradeModal()` and `updateDeviceSessionCount()`, so the login's own side effects still run — only the list is left alone. `updateCurrentProfile` only rewrites entries that already exist, so anything but a list in hand is a no-op. `removeSessionProfileByToken` returns `false` without writing.

**`SwitchProfileOutcome`** ([`use-switch-to-next-profile.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/65cedeb9f/app/hooks/use-switch-to-next-profile.ts)) — the hook now answers `Switched`, `NoOtherProfile` or `ProfilesUnreadable` instead of `ProfileProps | undefined`, so an unreadable store can no longer reach a caller as "there is nothing left". The dead session is still deactivated either way, scoped to its own token.

**`preserveStoredCredentials`** ([`use-logout.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/65cedeb9f/app/hooks/use-logout.ts)) — signs out of the active session and leaves what the device stored alone: the profiles, the PIN, the biometrics flag and the schema marker. The group cannot be split; see the decisions below. Both callers of the switch hook pass it on `ProfilesUnreadable`, and `network-error-component` also passes it on its two blind paths: a 401 arriving with no active token (a stale one landing mid-switch) and the `catch`, which by definition knows least of all.

## Decisions and rejected alternatives

1. **A sibling reader, not a changed signature.** `getSessionProfiles` keeps its shape, so the ~26 specs that mock the module wholesale stay untouched and the read-only callers keep the convenient form.

2. **An unparseable payload is `absent`, not `failed`.** Refusing to overwrite it would protect no session — it holds nothing recoverable — while permanently disabling multi-account, since nothing but a full sign-out ever clears that key. Reporting it absent lets the next login heal the slot.

3. **`preserveStoredCredentials` covers the whole group.** Keeping the profiles while removing the PIN would leave live bearer tokens on the device with the lock that guarded them gone. Dropping `SCHEMA_VERSION_KEY` alone would be worse still: the next boot reads as a fresh install and its reinstall sweep erases the profiles anyway, undoing the preservation one launch later.

4. **A stale entry is the accepted cost.** On an unreadable store, `removeSessionProfileByToken` no-ops, so a signed-out profile can survive and be offered again, and a deleted account can 401 once. Both are cheaper than erasing sessions that were only invisible.

5. **A skipped write is not retried.** A login whose read failed leaves the account authenticated but out of the switcher until the next login. Rejected the alternative — write anyway — because that is the bug.

6. **Android only, by construction.** iOS's `RNSecureKeyStore.m` discards the `OSStatus` from `SecItemCopyMatching` (`searchKeychainCopyMatching` returns nil for any failure) and `get` rejects nil with `"404"`, so `failed` is unreachable there and every caller degrades to today's behaviour. Android reserves `"404"` for `FileNotFoundException` and routes everything else through `EUNSPECIFIED`, so the split is real. The caveat is documented at the one place that makes the classification, and it closes when the slots move to `react-native-keychain` in [blinkbitcoin/blink-wip#1161](https://github.com/blinkbitcoin/blink-wip/issues/1161).

## Verification

- 518 tests across 32 suites: the four touched specs plus every transitive consumer (`use-logout`, `use-account-registry`, `use-resolve-transaction-account`, `multi-account`, `persistent-state`, the authentication screens, `app-state`).
- 100% statements, branches, functions and lines on `use-logout.ts`, `use-save-session-profile.ts`, `use-switch-to-next-profile.ts` and `delete.tsx`. The two remaining files keep only pre-existing gaps: `secureStorage.ts:274` belongs to the PIN lockout that [#4199](https://github.com/blinkbitcoin/blink-mobile/pull/4199) reverts, and `network-error-component.tsx`'s are toast branches and the re-entrancy guard, none of them on this diff.
- Every new guard is mutation-verified: restoring the collapsing read at each call site turns exactly one test red, six for six.
- `tsc -p .`, ESLint and Prettier clean on all twelve files.

## Device test

Android emulator, staging, two custodial accounts saved.

| Step | Result |
|---|---|
| Cold start with a saved session | Home renders on the active account, balances intact |
| Open the account switcher | Both accounts listed, the active one checked |
| Switch to the second account | Switched, and the first survives |
| Reopen the switcher | Both still there, the check moved |
| Switch back, force-stop, relaunch | Both survive the restart, the active account is correct |
| Account settings on the active account | Renders in full, level and ways-to-get-paid intact |

`logcat` clean throughout: no errors, no exceptions.
