### PR TITLE
feat(security): add a keychain adapter and read-through migration helper

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -124,6 +124,17 @@
     "no-plusplus": "error",
     "no-promise-executor-return": "error",
     "no-proto": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "react-native-secure-key-store",
+            "message": "Import the legacy key store only from app/utils/storage/legacy-key-store.ts, which re-arms the uninstall guard before every call. See blinkbitcoin/blink-wip#1160."
+          }
+        ]
+      }
+    ],
     "no-return-assign": "error",
     "no-return-await": "error",
     "no-script-url": "error",
@@ -164,6 +175,17 @@
     "jest/no-async-promise-executor": "off"
 
   },
+  "overrides": [
+    {
+      "files": [
+        "app/utils/storage/legacy-key-store.ts",
+        "app/utils/storage/secureStorage.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    }
+  ],
   "settings": {
     "react": {
       "version": "detect"

--- a/__mocks__/react-native-keychain.js
+++ b/__mocks__/react-native-keychain.js
@@ -4,6 +4,7 @@ const resetGenericPassword = jest.fn(() => Promise.resolve(true))
 
 const setInternetCredentials = jest.fn(() => Promise.resolve({ service: "mock-service" }))
 const getInternetCredentials = jest.fn(() => Promise.resolve(false))
+const hasInternetCredentials = jest.fn(() => Promise.resolve(false))
 const resetInternetCredentials = jest.fn(() => Promise.resolve(undefined))
 
 const ACCESSIBLE = {
@@ -21,6 +22,7 @@ export {
   resetGenericPassword,
   setInternetCredentials,
   getInternetCredentials,
+  hasInternetCredentials,
   resetInternetCredentials,
   ACCESSIBLE,
 }
@@ -31,6 +33,7 @@ export default {
   resetGenericPassword,
   setInternetCredentials,
   getInternetCredentials,
+  hasInternetCredentials,
   resetInternetCredentials,
   ACCESSIBLE,
 }

--- a/__mocks__/react-native-secure-key-store.js
+++ b/__mocks__/react-native-secure-key-store.js
@@ -1,0 +1,38 @@
+// Root manual mock, applied automatically to every spec.
+//
+// Without it the legacy library loads for real, `NativeModules.RNSecureKeyStore`
+// is undefined, and every legacy read throws a TypeError. That reads as "the
+// keystore failed", not as "nothing is stored" — so the read-through helper
+// would report `failed` in the default world of every consumer spec instead of
+// `absent`. Rejecting with the missing-key code keeps the default state
+// "absent everywhere", which is what those specs assume.
+//
+// Both native modules reject a missing key with code "404"
+// (ios/RNSecureKeyStore.m `get`, RNSecureKeyStoreModule#get). React Native turns
+// a native rejection into an Error carrying that code, so the mock does too.
+const keyNotFoundError = () =>
+  Object.assign(new Error("key does not present"), { code: "404" })
+
+const get = jest.fn(() => Promise.reject(keyNotFoundError()))
+const set = jest.fn(() => Promise.resolve("key stored successfully"))
+const remove = jest.fn(() => Promise.resolve("cleared alias"))
+const setResetOnAppUninstallTo = jest.fn(() => true)
+
+const ACCESSIBLE = {
+  WHEN_UNLOCKED: "AccessibleWhenUnlocked",
+  AFTER_FIRST_UNLOCK: "AccessibleAfterFirstUnlock",
+  ALWAYS: "AccessibleAlways",
+  WHEN_PASSCODE_SET_THIS_DEVICE_ONLY: "AccessibleWhenPasscodeSetThisDeviceOnly",
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: "AccessibleWhenUnlockedThisDeviceOnly",
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: "AccessibleAfterFirstUnlockThisDeviceOnly",
+  ALWAYS_THIS_DEVICE_ONLY: "AccessibleAlwaysThisDeviceOnly",
+}
+
+export { ACCESSIBLE }
+
+export default {
+  get,
+  set,
+  remove,
+  setResetOnAppUninstallTo,
+}

--- a/__tests__/utils/key-store-api-stability.spec.ts
+++ b/__tests__/utils/key-store-api-stability.spec.ts
@@ -42,6 +42,7 @@ const PINNED_SURFACE = [
   "prototype",
   "read",
   "readActiveToken",
+  "readSessionProfiles",
   "readWithStatus",
   "removeActiveToken",
   "removeIsBiometricsEnabled",

--- a/__tests__/utils/key-store-api-stability.spec.ts
+++ b/__tests__/utils/key-store-api-stability.spec.ts
@@ -1,0 +1,90 @@
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+
+/**
+ * 23 files under `app/` call `KeyStoreWrapper`, and ~26 specs mock it as a
+ * partial object literal holding only the methods their subject calls. None of
+ * them name the underlying library. So as long as this surface only ever grows,
+ * swapping the storage backend under it (blinkbitcoin/blink-wip#1143) touches
+ * one file and no consumer at all.
+ *
+ * This spec is what makes that a checked property rather than an intention: a
+ * rename, a removal or a signature move shows up here first, in a failure whose
+ * message names the member. Adding a method is expected and safe, and updating
+ * the list below is the deliberate act that records it.
+ */
+const PINNED_SURFACE = [
+  "ACTIVE_TOKEN",
+  "IS_BIOMETRICS_ENABLED",
+  "LEGACY_PIN_ATTEMPTS",
+  "MNEMONIC",
+  "MNEMONIC_NETWORK",
+  "PIN",
+  "PIN_FAILURE_STATE",
+  "SESSION_PROFILES",
+  "clearPinFailureState",
+  "clearUninstallSurvivingCredentials",
+  "deleteMnemonicForAccount",
+  "erase",
+  "getActiveToken",
+  "getIsBiometricsEnabled",
+  "getIsPinEnabled",
+  "getMnemonicForAccount",
+  "getMnemonicNetworkForAccount",
+  "getPin",
+  "getPinFailureState",
+  "getSessionProfiles",
+  "has",
+  "length",
+  "mnemonicKeyFor",
+  "mnemonicNetworkKeyFor",
+  "name",
+  "parsePinFailureState",
+  "prototype",
+  "read",
+  "readActiveToken",
+  "readWithStatus",
+  "removeActiveToken",
+  "removeIsBiometricsEnabled",
+  "removePin",
+  "removeSessionProfileByToken",
+  "removeSessionProfiles",
+  "saveSessionProfiles",
+  "setActiveToken",
+  "setIsBiometricsEnabled",
+  "setMnemonicForAccount",
+  "setMnemonicNetworkForAccount",
+  "setPin",
+  "setPinFailureState",
+  "write",
+]
+
+/** Everything on the class that is a method rather than a constant. */
+const CALLABLE_MEMBERS = PINNED_SURFACE.filter((member) => {
+  const isClassInternal = ["length", "name", "prototype"].includes(member)
+  const isSlotNameConstant = member === member.toUpperCase()
+  return !isClassInternal && !isSlotNameConstant
+})
+
+/** Private statics are part of the surface but absent from the public type. */
+const surfaceOf = (target: typeof KeyStoreWrapper): Record<string, unknown> =>
+  target as unknown as Record<string, unknown>
+
+describe("KeyStoreWrapper API stability", () => {
+  it("still exposes every pinned member, so no consumer mock has gone stale", () => {
+    const surface = Object.getOwnPropertyNames(KeyStoreWrapper)
+
+    expect(surface).toEqual(expect.arrayContaining(PINNED_SURFACE))
+  })
+
+  it("exposes exactly the pinned surface, so a new member is a deliberate act", () => {
+    expect(Object.getOwnPropertyNames(KeyStoreWrapper).sort()).toEqual(PINNED_SURFACE)
+  })
+
+  it("keeps every pinned method callable, not merely present", () => {
+    const surface = surfaceOf(KeyStoreWrapper)
+
+    CALLABLE_MEMBERS.forEach((method) => {
+      expect(typeof surface[method]).toBe("function")
+    })
+  })
+})

--- a/__tests__/utils/legacy-key-store.spec.ts
+++ b/__tests__/utils/legacy-key-store.spec.ts
@@ -1,0 +1,164 @@
+import { Platform } from "react-native"
+
+import { legacyErase, legacyRead } from "@app/utils/storage/legacy-key-store"
+
+const mockGet = jest.fn()
+const mockRemove = jest.fn()
+const mockSetResetOnAppUninstallTo = jest.fn()
+
+jest.mock("react-native-secure-key-store", () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    remove: (...args: unknown[]) => mockRemove(...args),
+    setResetOnAppUninstallTo: (...args: unknown[]) =>
+      mockSetResetOnAppUninstallTo(...args),
+  },
+}))
+
+const setPlatform = (os: typeof Platform.OS) => {
+  Object.defineProperty(Platform, "OS", { configurable: true, value: os })
+}
+
+/** Both native modules reject a missing key with this code. */
+const keyNotFound = () =>
+  Object.assign(new Error("key does not present"), { code: "404" })
+
+describe("legacy-key-store", () => {
+  const originalPlatform = Platform.OS
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setPlatform("ios")
+  })
+
+  afterAll(() => {
+    setPlatform(originalPlatform)
+  })
+
+  describe("the uninstall guard", () => {
+    it("disarms the reinstall wipe before reading, not after", async () => {
+      const calls: string[] = []
+      mockSetResetOnAppUninstallTo.mockImplementation(() => calls.push("guard"))
+      mockGet.mockImplementation(() => {
+        calls.push("get")
+        return Promise.resolve("value")
+      })
+
+      await legacyRead("PIN")
+
+      expect(calls).toEqual(["guard", "get"])
+      expect(mockSetResetOnAppUninstallTo).toHaveBeenCalledWith(false)
+    })
+
+    it("is left off the erase, the one entry point the wipe never reaches", async () => {
+      mockRemove.mockResolvedValue("cleared alias")
+
+      await legacyErase("PIN")
+
+      expect(mockSetResetOnAppUninstallTo).not.toHaveBeenCalled()
+    })
+
+    it("re-arms per call, since a skipped wipe leaves the trigger armed", async () => {
+      mockGet.mockResolvedValue("value")
+
+      await legacyRead("PIN")
+      await legacyRead("PIN")
+
+      expect(mockSetResetOnAppUninstallTo).toHaveBeenCalledTimes(2)
+    })
+
+    it("skips the guard on Android, whose module has no such method", async () => {
+      setPlatform("android")
+      mockGet.mockResolvedValue("value")
+
+      const read = await legacyRead("PIN")
+
+      expect(mockSetResetOnAppUninstallTo).not.toHaveBeenCalled()
+      expect(read).toEqual({ status: "found", value: "value" })
+    })
+
+    it("still performs the read when the guard itself throws", async () => {
+      mockSetResetOnAppUninstallTo.mockImplementation(() => {
+        throw new Error("bridge method missing")
+      })
+      mockGet.mockResolvedValue("value")
+
+      expect(await legacyRead("PIN")).toEqual({ status: "found", value: "value" })
+    })
+  })
+
+  describe("legacyRead", () => {
+    it("reads the key it is given and reports the value as found", async () => {
+      mockGet.mockResolvedValue("1234")
+
+      expect(await legacyRead("PIN")).toEqual({ status: "found", value: "1234" })
+      expect(mockGet).toHaveBeenCalledWith("PIN")
+    })
+
+    it("reports an empty stored value as absent", async () => {
+      mockGet.mockResolvedValue("")
+
+      expect(await legacyRead("PIN")).toEqual({ status: "absent" })
+    })
+
+    it("reports a non-string resolution as absent", async () => {
+      mockGet.mockResolvedValue(null)
+
+      expect(await legacyRead("PIN")).toEqual({ status: "absent" })
+    })
+
+    it("reports the missing-key code as absent", async () => {
+      mockGet.mockRejectedValue(keyNotFound())
+
+      expect(await legacyRead("PIN")).toEqual({ status: "absent" })
+    })
+
+    it("reports the missing-key code as absent when it arrives as a number", async () => {
+      mockGet.mockRejectedValue({ code: 404 })
+
+      expect(await legacyRead("PIN")).toEqual({ status: "absent" })
+    })
+
+    it("reports any other code as failed, never as absent", async () => {
+      const err = Object.assign(new Error("decrypt failed"), { code: "1" })
+      mockGet.mockRejectedValue(err)
+
+      expect(await legacyRead("PIN")).toEqual({ status: "failed", err })
+    })
+
+    it("reports an error carrying no code as failed", async () => {
+      const err = new Error("bridge unavailable")
+      mockGet.mockRejectedValue(err)
+
+      expect(await legacyRead("PIN")).toEqual({ status: "failed", err })
+    })
+
+    it("reports a non-object rejection as failed", async () => {
+      mockGet.mockRejectedValue("404")
+
+      expect(await legacyRead("PIN")).toEqual({ status: "failed", err: "404" })
+    })
+
+    it("reports a null rejection as failed", async () => {
+      mockGet.mockRejectedValue(null)
+
+      expect(await legacyRead("PIN")).toEqual({ status: "failed", err: null })
+    })
+  })
+
+  describe("legacyErase", () => {
+    it("removes the key it is given", async () => {
+      mockRemove.mockResolvedValue("cleared alias")
+
+      expect(await legacyErase("PIN")).toBe(true)
+      expect(mockRemove).toHaveBeenCalledWith("PIN")
+    })
+
+    it("returns false on a rejection instead of throwing at the caller", async () => {
+      mockRemove.mockRejectedValue(new Error("keystore unavailable"))
+
+      expect(await legacyErase("PIN")).toBe(false)
+    })
+  })
+})

--- a/__tests__/utils/secure-store-migration.spec.ts
+++ b/__tests__/utils/secure-store-migration.spec.ts
@@ -509,6 +509,63 @@ describe("per-slot serialization", () => {
     expect(await queued).toEqual({ status: "absent" })
   })
 
+  it("drops the migrating write of an abandoned read that lands after a remove", async () => {
+    jest.useFakeTimers()
+    let releaseAbandonedRead: () => void = () => {}
+    mockedSecureRead.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseAbandonedRead = () => resolve({ status: "absent" })
+        }),
+    )
+    mockedLegacyRead.mockResolvedValue({ status: "found", value: "stale-token" })
+    mockedLegacyErase.mockResolvedValue(true)
+    mockedSecureRemove.mockResolvedValue(true)
+
+    const abandoned = readThrough(ARGS)
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(await abandoned).toEqual({
+      status: "failed",
+      err: expect.objectContaining({
+        message: "secure store sessionProfiles timed out after 30000ms",
+      }),
+    })
+
+    expect(await removeThrough(REMOVE_ARGS)).toBe(true)
+    mockedSecureWrite.mockClear()
+
+    // The hung native call finally answers. Its continuation is the danger: it
+    // still holds the legacy value it was migrating, and the slot it was
+    // migrating into has since been emptied by the remove above.
+    releaseAbandonedRead()
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(mockedSecureWrite).not.toHaveBeenCalled()
+  })
+
+  it("drops the new-store delete of an abandoned remove that lands late", async () => {
+    jest.useFakeTimers()
+    let releaseAbandonedErase: () => void = () => {}
+    mockedLegacyErase.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseAbandonedErase = () => resolve(true)
+        }),
+    )
+    mockedSecureRemove.mockResolvedValue(true)
+
+    const abandoned = removeThrough(REMOVE_ARGS)
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(await abandoned).toBe(false)
+
+    // The slot is free now, so whatever a caller writes next is what lives
+    // there. The abandoned remove must not reach in and empty it.
+    releaseAbandonedErase()
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(mockedSecureRemove).not.toHaveBeenCalled()
+  })
+
   it("keeps an account id out of the timeout message", async () => {
     jest.useFakeTimers()
     mockedSecureRead.mockImplementation(() => new Promise<never>(() => {}))

--- a/__tests__/utils/secure-store-migration.spec.ts
+++ b/__tests__/utils/secure-store-migration.spec.ts
@@ -1,0 +1,628 @@
+/* eslint-disable camelcase */
+import { ACCESSIBLE } from "react-native-keychain"
+
+import { legacyErase, legacyRead } from "@app/utils/storage/legacy-key-store"
+import {
+  existsThrough,
+  readThrough,
+  removeThrough,
+} from "@app/utils/storage/secure-store-migration"
+import {
+  secureExists,
+  secureRead,
+  secureRemove,
+  secureWrite,
+} from "@app/utils/storage/secure-store"
+
+const mockLogEvent = jest.fn()
+
+jest.mock("@react-native-firebase/analytics", () => () => ({
+  logEvent: (...args: unknown[]) => mockLogEvent(...args),
+}))
+
+const mockRecordAppError = jest.fn()
+
+jest.mock("@app/utils/error-reporting", () => ({
+  ...jest.requireActual("@app/utils/error-reporting"),
+  recordAppError: (...args: unknown[]) => mockRecordAppError(...args),
+}))
+
+jest.mock("@app/utils/storage/secure-store", () => ({
+  ...jest.requireActual("@app/utils/storage/secure-store"),
+  secureRead: jest.fn(),
+  secureWrite: jest.fn(),
+  secureRemove: jest.fn(),
+  secureExists: jest.fn(),
+}))
+
+jest.mock("@app/utils/storage/legacy-key-store", () => ({
+  ...jest.requireActual("@app/utils/storage/legacy-key-store"),
+  legacyRead: jest.fn(),
+  legacyErase: jest.fn(),
+}))
+
+const mockedSecureRead = jest.mocked(secureRead)
+const mockedSecureWrite = jest.mocked(secureWrite)
+const mockedSecureRemove = jest.mocked(secureRemove)
+const mockedSecureExists = jest.mocked(secureExists)
+const mockedLegacyRead = jest.mocked(legacyRead)
+const mockedLegacyErase = jest.mocked(legacyErase)
+
+const ARGS = {
+  slot: "sessionProfiles",
+  legacyKey: "sessionProfiles",
+  accessible: ACCESSIBLE.AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+  deleteLegacyOnMigrate: true,
+}
+
+const REMOVE_ARGS = { slot: ARGS.slot, legacyKey: ARGS.legacyKey }
+
+// A test that fails before restoring them would otherwise leak fake timers into
+// every test after it.
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe("readThrough", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // The real logEvent returns a promise; a bare jest.fn() would not, and the
+    // counter's rejection handling would never be exercised.
+    mockLogEvent.mockResolvedValue(undefined)
+    mockedSecureWrite.mockResolvedValue(true)
+    mockedLegacyErase.mockResolvedValue(true)
+  })
+
+  describe("the new store answers", () => {
+    it("returns its value and never touches the legacy library", async () => {
+      mockedSecureRead.mockResolvedValue({ status: "found", value: "new-value" })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "new-value" })
+      expect(mockedLegacyRead).not.toHaveBeenCalled()
+      expect(mockedSecureWrite).not.toHaveBeenCalled()
+      expect(mockedSecureRead).toHaveBeenCalledWith(ARGS.slot)
+    })
+
+    it("wins over a legacy copy holding a different value, without comparing", async () => {
+      mockedSecureRead.mockResolvedValue({ status: "found", value: "new-value" })
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "stale-value" })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "new-value" })
+      expect(mockedLegacyRead).not.toHaveBeenCalled()
+    })
+
+    it("reports its failure as failed and does not fall back to legacy", async () => {
+      const err = new Error("E_CRYPTO_FAILED")
+      mockedSecureRead.mockResolvedValue({ status: "failed", err })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "failed", err })
+      expect(mockedLegacyRead).not.toHaveBeenCalled()
+      expect(mockedSecureWrite).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("the legacy store answers", () => {
+    beforeEach(() => {
+      mockedSecureRead.mockResolvedValue({ status: "absent" })
+    })
+
+    it("returns the legacy value and migrates it to the new store", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockedLegacyRead).toHaveBeenCalledWith(ARGS.legacyKey)
+      expect(mockedSecureWrite).toHaveBeenCalledWith(
+        ARGS.slot,
+        "legacy-value",
+        ARGS.accessible,
+      )
+    })
+
+    it("writes the new copy before erasing the legacy one", async () => {
+      const calls: string[] = []
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      mockedSecureWrite.mockImplementation(async () => {
+        calls.push("write")
+        return true
+      })
+      mockedLegacyErase.mockImplementation(async () => {
+        calls.push("erase")
+        return true
+      })
+
+      await readThrough(ARGS)
+
+      expect(calls).toEqual(["write", "erase"])
+      expect(mockedLegacyErase).toHaveBeenCalledWith(ARGS.legacyKey)
+    })
+
+    it("keeps the legacy copy when the migrating write fails", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      mockedSecureWrite.mockResolvedValue(false)
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockedLegacyErase).not.toHaveBeenCalled()
+    })
+
+    it("keeps the legacy copy when the caller opts out of deleting it", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      const read = await readThrough({ ...ARGS, deleteLegacyOnMigrate: false })
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockedSecureWrite).toHaveBeenCalled()
+      expect(mockedLegacyErase).not.toHaveBeenCalled()
+    })
+
+    it("still returns the value when erasing the legacy copy fails", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      mockedLegacyErase.mockResolvedValue(false)
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockRecordAppError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Legacy key store erase failed: sessionProfiles",
+        }),
+        { dedupKey: "storage-legacy-erase-failed-sessionProfiles" },
+      )
+    })
+
+    it("reports nothing when the erase failed on a key that was already gone", async () => {
+      mockedLegacyRead
+        .mockResolvedValueOnce({ status: "found", value: "legacy-value" })
+        .mockResolvedValueOnce({ status: "absent" })
+      mockedLegacyErase.mockResolvedValue(false)
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockRecordAppError).not.toHaveBeenCalled()
+    })
+
+    it("reports nothing when the legacy copy is erased cleanly", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      await readThrough(ARGS)
+
+      expect(mockRecordAppError).not.toHaveBeenCalled()
+    })
+
+    it("serves two concurrent reads the same value, migrating once", async () => {
+      let stored: string | null = null
+      mockedSecureRead.mockImplementation(async () => {
+        if (stored === null) return { status: "absent" }
+        return { status: "found", value: stored }
+      })
+      mockedSecureWrite.mockImplementation(async (_slot, value) => {
+        stored = value
+        return true
+      })
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      const [first, second] = await Promise.all([readThrough(ARGS), readThrough(ARGS)])
+
+      expect(first).toEqual({ status: "found", value: "legacy-value" })
+      expect(second).toEqual(first)
+      expect(mockedSecureWrite).toHaveBeenCalledTimes(1)
+      expect(mockedSecureWrite).toHaveBeenCalledWith(
+        ARGS.slot,
+        "legacy-value",
+        ARGS.accessible,
+      )
+    })
+  })
+
+  describe("neither store answers", () => {
+    beforeEach(() => {
+      mockedSecureRead.mockResolvedValue({ status: "absent" })
+    })
+
+    it("reports absent, the only path that produces it", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "absent" })
+      expect(mockedSecureWrite).not.toHaveBeenCalled()
+      expect(mockedLegacyErase).not.toHaveBeenCalled()
+    })
+
+    it("reports a failed legacy read as failed, never as absent", async () => {
+      const err = new Error("keystore unavailable")
+      mockedLegacyRead.mockResolvedValue({ status: "failed", err })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "failed", err })
+      expect(mockedSecureWrite).not.toHaveBeenCalled()
+      expect(mockedLegacyErase).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("the legacy-hit counter", () => {
+    beforeEach(() => {
+      mockedSecureRead.mockResolvedValue({ status: "absent" })
+    })
+
+    it("counts a legacy hit, tagged by key class", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      await readThrough(ARGS)
+
+      expect(mockLogEvent).toHaveBeenCalledWith("legacy_key_store_hit", {
+        key_class: "sessionProfiles",
+      })
+    })
+
+    it("drops the account id from a per-account key", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+      await readThrough({ ...ARGS, legacyKey: "mnemonic:account-abc123" })
+
+      expect(mockLogEvent).toHaveBeenCalledWith("legacy_key_store_hit", {
+        key_class: "mnemonic",
+      })
+    })
+
+    it("does not count a read the new store answered", async () => {
+      mockedSecureRead.mockResolvedValue({ status: "found", value: "new-value" })
+
+      await readThrough(ARGS)
+
+      expect(mockLogEvent).not.toHaveBeenCalled()
+    })
+
+    it("does not count a miss in both stores", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+      await readThrough(ARGS)
+
+      expect(mockLogEvent).not.toHaveBeenCalled()
+    })
+
+    it("still returns the value when the counter itself throws", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      mockLogEvent.mockImplementation(() => {
+        throw new Error("analytics not initialised")
+      })
+
+      const read = await readThrough(ARGS)
+
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+      expect(mockedSecureWrite).toHaveBeenCalled()
+    })
+
+    it("handles the rejection of the promise the counter returns", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      const catchHandler = jest.fn().mockReturnValue(Promise.resolve())
+      mockLogEvent.mockReturnValue({ catch: catchHandler })
+
+      const read = await readThrough(ARGS)
+
+      expect(catchHandler).toHaveBeenCalled()
+      expect(read).toEqual({ status: "found", value: "legacy-value" })
+    })
+
+    it("swallows a rejected counter without failing the read", async () => {
+      mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+      mockLogEvent.mockRejectedValue(new Error("analytics transport down"))
+
+      expect(await readThrough(ARGS)).toEqual({ status: "found", value: "legacy-value" })
+    })
+  })
+})
+
+describe("removeThrough", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogEvent.mockResolvedValue(undefined)
+    mockedSecureRemove.mockResolvedValue(true)
+    mockedLegacyErase.mockResolvedValue(true)
+  })
+
+  it("erases the legacy copy before removing the new slot", async () => {
+    const calls: string[] = []
+    mockedLegacyErase.mockImplementation(async () => {
+      calls.push("legacy")
+      return true
+    })
+    mockedSecureRemove.mockImplementation(async () => {
+      calls.push("new")
+      return true
+    })
+
+    expect(await removeThrough(REMOVE_ARGS)).toBe(true)
+    expect(calls).toEqual(["legacy", "new"])
+    expect(mockedLegacyErase).toHaveBeenCalledWith(REMOVE_ARGS.legacyKey)
+    expect(mockedSecureRemove).toHaveBeenCalledWith(REMOVE_ARGS.slot)
+  })
+
+  it("reports false when the new-store removal fails", async () => {
+    mockedSecureRemove.mockResolvedValue(false)
+
+    expect(await removeThrough(REMOVE_ARGS)).toBe(false)
+  })
+
+  it("leaves the new slot alone when the legacy copy is still readable", async () => {
+    mockedLegacyErase.mockResolvedValue(false)
+    mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+    expect(await removeThrough(REMOVE_ARGS)).toBe(false)
+    // Emptying the new store here is what would make the stale copy the answer
+    // to the next read.
+    expect(mockedSecureRemove).not.toHaveBeenCalled()
+    expect(mockRecordAppError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Legacy key store erase failed: sessionProfiles",
+      }),
+      { dedupKey: "storage-legacy-erase-failed-sessionProfiles" },
+    )
+  })
+
+  it("leaves the new slot alone when the legacy store cannot say what is left", async () => {
+    mockedLegacyErase.mockResolvedValue(false)
+    mockedLegacyRead.mockResolvedValue({
+      status: "failed",
+      err: new Error("keystore unavailable"),
+    })
+
+    // Emptying the new store here would turn "two copies, one deleted" into
+    // "one copy, and it is the stale one" the moment the legacy store recovers.
+    expect(await removeThrough(REMOVE_ARGS)).toBe(false)
+    expect(mockedSecureRemove).not.toHaveBeenCalled()
+  })
+
+  it("reports false when the operation times out", async () => {
+    jest.useFakeTimers()
+    mockedLegacyErase.mockImplementation(() => new Promise<never>(() => {}))
+
+    const remove = removeThrough(REMOVE_ARGS)
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(await remove).toBe(false)
+  })
+
+  it("succeeds when the erase failed on a key that was never there", async () => {
+    mockedLegacyErase.mockResolvedValue(false)
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    expect(await removeThrough(REMOVE_ARGS)).toBe(true)
+    expect(mockRecordAppError).not.toHaveBeenCalled()
+  })
+})
+
+describe("per-slot serialization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogEvent.mockResolvedValue(undefined)
+    mockedSecureWrite.mockResolvedValue(true)
+    mockedSecureRemove.mockResolvedValue(true)
+    mockedLegacyErase.mockResolvedValue(true)
+  })
+
+  it("holds a remove behind a read already in flight on the same slot", async () => {
+    const calls: string[] = []
+    mockedSecureRead.mockImplementation(async () => {
+      calls.push("read:new")
+      return { status: "absent" }
+    })
+    mockedLegacyRead.mockImplementation(async () => {
+      calls.push("read:legacy")
+      return { status: "found", value: "legacy-value" }
+    })
+    mockedSecureWrite.mockImplementation(async () => {
+      calls.push("read:write")
+      return true
+    })
+    mockedLegacyErase.mockImplementation(async () => {
+      calls.push("legacy:erase")
+      return true
+    })
+    mockedSecureRemove.mockImplementation(async () => {
+      calls.push("remove:new")
+      return true
+    })
+
+    const read = readThrough(ARGS)
+    const remove = removeThrough(REMOVE_ARGS)
+
+    expect(await read).toEqual({ status: "found", value: "legacy-value" })
+    expect(await remove).toBe(true)
+    // The read runs to completion first: its migrating write, then its erase of
+    // the migrated copy, and only then the remove. Interleaved, the read writes
+    // the legacy value back after the remove has already cleared the slot, and
+    // the deleted credential is readable again.
+    expect(calls).toEqual([
+      "read:new",
+      "read:legacy",
+      "read:write",
+      "legacy:erase",
+      "legacy:erase",
+      "remove:new",
+    ])
+  })
+
+  it("does not make one slot wait on another", async () => {
+    let releaseStuckSlot = () => {}
+    mockedSecureRead.mockImplementation(async (slot) => {
+      if (slot !== "stuck-slot") return { status: "absent" }
+      return new Promise((resolve) => {
+        releaseStuckSlot = () => resolve({ status: "absent" })
+      })
+    })
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    const stuck = readThrough({ ...ARGS, slot: "stuck-slot", legacyKey: "stuck-slot" })
+
+    expect(await readThrough(ARGS)).toEqual({ status: "absent" })
+
+    releaseStuckSlot()
+    expect(await stuck).toEqual({ status: "absent" })
+  })
+
+  it("runs work queued behind a failed predecessor", async () => {
+    mockedSecureRead
+      .mockRejectedValueOnce(new Error("adapter blew up"))
+      .mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    const first = readThrough(ARGS)
+    const second = readThrough(ARGS)
+
+    // The public helpers never reject: a thrown adapter is reported as failed.
+    expect(await first).toEqual({
+      status: "failed",
+      err: expect.objectContaining({ message: "adapter blew up" }),
+    })
+    expect(await second).toEqual({ status: "absent" })
+  })
+
+  it("frees a slot whose operation never settles, instead of deadlocking it", async () => {
+    jest.useFakeTimers()
+    mockedSecureRead.mockImplementationOnce(() => new Promise<never>(() => {}))
+    mockedSecureRead.mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    const stuck = readThrough(ARGS)
+    const queued = readThrough(ARGS)
+
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(await stuck).toEqual({
+      status: "failed",
+      err: expect.objectContaining({
+        message: "secure store sessionProfiles timed out after 30000ms",
+      }),
+    })
+    expect(await queued).toEqual({ status: "absent" })
+  })
+
+  it("keeps an account id out of the timeout message", async () => {
+    jest.useFakeTimers()
+    mockedSecureRead.mockImplementation(() => new Promise<never>(() => {}))
+
+    const stuck = readThrough({
+      ...ARGS,
+      slot: "mnemonic:account-abc123",
+      legacyKey: "mnemonic:account-abc123",
+    })
+
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(await stuck).toEqual({
+      status: "failed",
+      err: expect.objectContaining({
+        message: "secure store mnemonic timed out after 30000ms",
+      }),
+    })
+  })
+})
+
+describe("existsThrough", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLogEvent.mockResolvedValue(undefined)
+    mockedSecureWrite.mockResolvedValue(true)
+    mockedLegacyErase.mockResolvedValue(true)
+  })
+
+  it("answers from the probe without decrypting or touching legacy", async () => {
+    mockedSecureExists.mockResolvedValue({ status: "yes" })
+
+    expect(await existsThrough(ARGS)).toEqual({ status: "yes" })
+    expect(mockedSecureRead).not.toHaveBeenCalled()
+    expect(mockedLegacyRead).not.toHaveBeenCalled()
+  })
+
+  it("reports a failed probe as failed, never as no", async () => {
+    const err = new Error("E_CRYPTO_FAILED")
+    mockedSecureExists.mockResolvedValue({ status: "failed", err })
+
+    expect(await existsThrough(ARGS)).toEqual({ status: "failed", err })
+    expect(mockedLegacyRead).not.toHaveBeenCalled()
+  })
+
+  it("answers yes for a slot that has yet to migrate, and migrates it", async () => {
+    mockedSecureExists.mockResolvedValue({ status: "no" })
+    mockedSecureRead.mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "found", value: "legacy-value" })
+
+    expect(await existsThrough(ARGS)).toEqual({ status: "yes" })
+    expect(mockedSecureWrite).toHaveBeenCalledWith(
+      ARGS.slot,
+      "legacy-value",
+      ARGS.accessible,
+    )
+  })
+
+  it("answers no only when neither store has the slot", async () => {
+    mockedSecureExists.mockResolvedValue({ status: "no" })
+    mockedSecureRead.mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    expect(await existsThrough(ARGS)).toEqual({ status: "no" })
+  })
+
+  it("waits for a remove in flight on the same slot before answering", async () => {
+    const calls: string[] = []
+    mockedLegacyErase.mockImplementation(async () => {
+      calls.push("remove:legacy")
+      return true
+    })
+    mockedSecureRemove.mockImplementation(async () => {
+      calls.push("remove:new")
+      return true
+    })
+    mockedSecureExists.mockImplementation(async () => {
+      calls.push("exists:probe")
+      return { status: "no" }
+    })
+    mockedSecureRead.mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "absent" })
+
+    const remove = removeThrough(REMOVE_ARGS)
+    const exists = existsThrough(ARGS)
+
+    expect(await remove).toBe(true)
+    expect(await exists).toEqual({ status: "no" })
+    // Probing outside the queue would let this answer yes for a slot the remove
+    // is in the middle of deleting.
+    expect(calls).toEqual(["remove:legacy", "remove:new", "exists:probe"])
+  })
+
+  it("reports failed when the operation times out", async () => {
+    jest.useFakeTimers()
+    mockedSecureExists.mockImplementation(() => new Promise<never>(() => {}))
+
+    const exists = existsThrough(ARGS)
+    await jest.advanceTimersByTimeAsync(30_000)
+
+    expect(await exists).toEqual({
+      status: "failed",
+      err: expect.objectContaining({
+        message: "secure store sessionProfiles timed out after 30000ms",
+      }),
+    })
+  })
+
+  it("reports a failed fallback read as failed, never as no", async () => {
+    const err = new Error("keystore unavailable")
+    mockedSecureExists.mockResolvedValue({ status: "no" })
+    mockedSecureRead.mockResolvedValue({ status: "absent" })
+    mockedLegacyRead.mockResolvedValue({ status: "failed", err })
+
+    expect(await existsThrough(ARGS)).toEqual({ status: "failed", err })
+  })
+})

--- a/__tests__/utils/secure-store.spec.ts
+++ b/__tests__/utils/secure-store.spec.ts
@@ -1,0 +1,197 @@
+import { BLINK_DOMAIN } from "@app/config/appinfo"
+import {
+  secureExists,
+  secureRead,
+  secureRemove,
+  secureWrite,
+  serverFor,
+} from "@app/utils/storage/secure-store"
+
+const mockGetInternetCredentials = jest.fn()
+const mockHasInternetCredentials = jest.fn()
+const mockSetInternetCredentials = jest.fn()
+const mockResetInternetCredentials = jest.fn()
+
+jest.mock("react-native-keychain", () => ({
+  getInternetCredentials: (...args: unknown[]) => mockGetInternetCredentials(...args),
+  hasInternetCredentials: (...args: unknown[]) => mockHasInternetCredentials(...args),
+  setInternetCredentials: (...args: unknown[]) => mockSetInternetCredentials(...args),
+  resetInternetCredentials: (...args: unknown[]) => mockResetInternetCredentials(...args),
+  ACCESSIBLE: {
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: "AccessibleAfterFirstUnlockThisDeviceOnly",
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "AccessibleWhenUnlockedThisDeviceOnly",
+  },
+}))
+
+const SLOT = "pinFailureState"
+const SLOT_SERVER = "secure-store.blink.local/pinFailureState"
+const ACCESSIBLE_AFTER_FIRST_UNLOCK =
+  "AccessibleAfterFirstUnlockThisDeviceOnly" as Parameters<typeof secureWrite>[2]
+
+/** Shape of a resolved `getInternetCredentials`, minus the fields we ignore. */
+const credentials = (password: string) => ({
+  server: SLOT_SERVER,
+  username: SLOT,
+  password,
+  storage: "KeystoreAESGCM_NoAuth",
+})
+
+describe("secure-store", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("serverFor", () => {
+    it("namespaces the slot name", () => {
+      expect(serverFor(SLOT)).toBe(SLOT_SERVER)
+    })
+
+    it("gives every slot its own server", () => {
+      expect(serverFor("PIN")).not.toBe(serverFor("pinAttempts"))
+    })
+
+    it("never collides with BLINK_DOMAIN, whose items a slot delete would erase", () => {
+      const slots = ["PIN", "galoyAuthToken", "sessionProfiles", BLINK_DOMAIN]
+
+      slots.forEach((slot) => {
+        expect(serverFor(slot)).not.toBe(BLINK_DOMAIN)
+      })
+    })
+  })
+
+  describe("secureRead", () => {
+    it("reports a stored value as found, queried by the slot's server", async () => {
+      mockGetInternetCredentials.mockResolvedValue(credentials("stored-secret"))
+
+      const read = await secureRead(SLOT)
+
+      expect(read).toEqual({ status: "found", value: "stored-secret" })
+      expect(mockGetInternetCredentials).toHaveBeenCalledWith(SLOT_SERVER)
+    })
+
+    it("reports false as absent, the only shape a missing item resolves to", async () => {
+      mockGetInternetCredentials.mockResolvedValue(false)
+
+      expect(await secureRead(SLOT)).toEqual({ status: "absent" })
+    })
+
+    it("reports an empty password as absent, not as an empty found value", async () => {
+      mockGetInternetCredentials.mockResolvedValue(credentials(""))
+
+      expect(await secureRead(SLOT)).toEqual({ status: "absent" })
+    })
+
+    it("reports a rejection as failed, never as absent", async () => {
+      const err = new Error("E_KEYSTORE_ACCESS_ERROR")
+      mockGetInternetCredentials.mockRejectedValue(err)
+
+      expect(await secureRead(SLOT)).toEqual({ status: "failed", err })
+    })
+  })
+
+  describe("secureExists", () => {
+    it("probes by server without decrypting", async () => {
+      mockHasInternetCredentials.mockResolvedValue(true)
+
+      expect(await secureExists(SLOT)).toEqual({ status: "yes" })
+      expect(mockHasInternetCredentials).toHaveBeenCalledWith({ server: SLOT_SERVER })
+      expect(mockGetInternetCredentials).not.toHaveBeenCalled()
+    })
+
+    it("reports a missing item as no", async () => {
+      mockHasInternetCredentials.mockResolvedValue(false)
+
+      expect(await secureExists(SLOT)).toEqual({ status: "no" })
+    })
+
+    it("reports a rejection as failed, never as no", async () => {
+      const err = new Error("E_CRYPTO_FAILED")
+      mockHasInternetCredentials.mockRejectedValue(err)
+
+      expect(await secureExists(SLOT)).toEqual({ status: "failed", err })
+    })
+  })
+
+  describe("secureWrite", () => {
+    it("puts the secret in password and the slot name in username", async () => {
+      mockSetInternetCredentials.mockResolvedValue({ service: SLOT_SERVER })
+
+      const written = await secureWrite(SLOT, "a-secret", ACCESSIBLE_AFTER_FIRST_UNLOCK)
+
+      expect(written).toBe(true)
+      expect(mockSetInternetCredentials).toHaveBeenCalledWith(
+        SLOT_SERVER,
+        SLOT,
+        "a-secret",
+        { accessible: ACCESSIBLE_AFTER_FIRST_UNLOCK },
+      )
+    })
+
+    it("passes the caller's accessibility class through unchanged", async () => {
+      mockSetInternetCredentials.mockResolvedValue({ service: SLOT_SERVER })
+      const whenUnlocked = "AccessibleWhenUnlockedThisDeviceOnly" as Parameters<
+        typeof secureWrite
+      >[2]
+
+      await secureWrite(SLOT, "a-secret", whenUnlocked)
+
+      const [, , , options] = mockSetInternetCredentials.mock.calls[0]
+      expect(options.accessible).toBe(whenUnlocked)
+    })
+
+    it("passes no accessControl: any biometry value flips the Android cipher", async () => {
+      mockSetInternetCredentials.mockResolvedValue({ service: SLOT_SERVER })
+
+      await secureWrite(SLOT, "a-secret", ACCESSIBLE_AFTER_FIRST_UNLOCK)
+
+      const [, , , options] = mockSetInternetCredentials.mock.calls[0]
+      expect(Object.keys(options)).toEqual(["accessible"])
+      expect(options).not.toHaveProperty("accessControl")
+    })
+
+    it("passes no cloudSync: these secrets must not reach the iCloud Keychain", async () => {
+      mockSetInternetCredentials.mockResolvedValue({ service: SLOT_SERVER })
+
+      await secureWrite(SLOT, "a-secret", ACCESSIBLE_AFTER_FIRST_UNLOCK)
+
+      const [, , , options] = mockSetInternetCredentials.mock.calls[0]
+      expect(options).not.toHaveProperty("cloudSync")
+    })
+
+    it("refuses an empty value, which would read back as an unset slot", async () => {
+      expect(await secureWrite(SLOT, "", ACCESSIBLE_AFTER_FIRST_UNLOCK)).toBe(false)
+      expect(mockSetInternetCredentials).not.toHaveBeenCalled()
+    })
+
+    it("returns false when the library reports the write did not land", async () => {
+      mockSetInternetCredentials.mockResolvedValue(false)
+
+      expect(await secureWrite(SLOT, "a-secret", ACCESSIBLE_AFTER_FIRST_UNLOCK)).toBe(
+        false,
+      )
+    })
+
+    it("returns false on a rejection instead of throwing at the caller", async () => {
+      mockSetInternetCredentials.mockRejectedValue(new Error("keystore write-locked"))
+
+      expect(await secureWrite(SLOT, "a-secret", ACCESSIBLE_AFTER_FIRST_UNLOCK)).toBe(
+        false,
+      )
+    })
+  })
+
+  describe("secureRemove", () => {
+    it("deletes by the slot's server", async () => {
+      mockResetInternetCredentials.mockResolvedValue(undefined)
+
+      expect(await secureRemove(SLOT)).toBe(true)
+      expect(mockResetInternetCredentials).toHaveBeenCalledWith({ server: SLOT_SERVER })
+    })
+
+    it("returns false on a rejection instead of throwing at the caller", async () => {
+      mockResetInternetCredentials.mockRejectedValue(new Error("keystore unavailable"))
+
+      expect(await secureRemove(SLOT)).toBe(false)
+    })
+  })
+})

--- a/app/utils/storage/legacy-key-store.ts
+++ b/app/utils/storage/legacy-key-store.ts
@@ -1,0 +1,103 @@
+import { Platform } from "react-native"
+import RNSecureKeyStore from "react-native-secure-key-store"
+
+import type { SecureRead } from "./secure-store"
+
+/**
+ * The module that owns the uninstall guard below, so that a legacy touch cannot
+ * bypass it by forgetting to re-arm it. The `no-restricted-imports` rule in
+ * `.eslintrc.json` is what keeps new call paths from reaching the library
+ * directly.
+ *
+ * The invariant is not complete yet, and this file is not what completes it:
+ * `secureStorage.ts` holds the one other exception in that config and still
+ * calls the library unguarded, so on iOS the reinstall sweep is armed on its
+ * first boot-path read exactly as it is today. That closes when its slots move
+ * behind the read-through helper in blinkbitcoin/blink-wip#1161 and the
+ * exception goes away.
+ *
+ * This module is the read-and-erase half of the migration off that library
+ * (blinkbitcoin/blink-wip#1143); it deliberately has no write primitive.
+ * Migrated values are only ever written to the new store.
+ */
+
+/**
+ * Both native modules reject a missing key with code "404"
+ * (ios/RNSecureKeyStore.m `get`, RNSecureKeyStoreModule#get). Every other code
+ * means the read itself went wrong.
+ */
+const KEY_NOT_FOUND_CODE = "404"
+
+const isKeyNotFound = (err: unknown): boolean =>
+  typeof err === "object" &&
+  err !== null &&
+  "code" in err &&
+  String((err as { code: unknown }).code) === KEY_NOT_FOUND_CODE
+
+/**
+ * Re-arms the uninstall guard immediately before every legacy touch.
+ *
+ * `resetOnAppUninstall` is instance state set to `YES` in the module's `init`,
+ * so it has to be re-established per process. Worse, the wipe is only ever
+ * skipped, never disarmed: `handleAppUninstallation` sets its
+ * `RnSksIsAppInstalled` NSUserDefaults flag *inside* the branch it guards, so a
+ * skipped wipe leaves the trigger armed for the next call — and `get:` and
+ * `set:` both reach it. Setting it per call rather than once at module load is
+ * what makes the guard hold regardless of a bridge reload.
+ *
+ * It is native-module state, not per-caller state, so once any call here has
+ * run the sweep is disarmed for every caller in the process, `secureStorage.ts`
+ * included. That is a side effect, not a design: which of them runs first is
+ * boot-path ordering nobody controls, so it is not something to rely on.
+ *
+ * Defense in depth only. The load-bearing defense is that this app's own items
+ * are internet credentials, which `clearSecureKeyStore` cannot reach — see
+ * `secure-store.ts`. This guard additionally covers `kSecClassKey` items and
+ * any future dependency that stores generic passwords.
+ *
+ * iOS-only: the Android module exports `get` / `set` / `remove` and nothing
+ * else, and has no such wipe to disarm.
+ */
+const disableUninstallReset = (): void => {
+  if (Platform.OS !== "ios") return
+  try {
+    RNSecureKeyStore.setResetOnAppUninstallTo(false)
+  } catch {
+    // A fire-and-forget void bridge method. A failure here must not stop the
+    // operation it precedes.
+  }
+}
+
+/**
+ * An empty stored value reads as absent, matching the new store so that a slot
+ * cannot change meaning by migrating.
+ */
+export const legacyRead = async (key: string): Promise<SecureRead> => {
+  disableUninstallReset()
+  try {
+    const value: unknown = await RNSecureKeyStore.get(key)
+    const hasValue = typeof value === "string" && value.length > 0
+    if (!hasValue) return { status: "absent" }
+    return { status: "found", value }
+  } catch (err) {
+    if (isKeyNotFound(err)) return { status: "absent" }
+    return { status: "failed", err }
+  }
+}
+
+/**
+ * False covers both a failed erase and a key that was never there: iOS `remove:`
+ * rejects with code "6" when `deleteKeychainValue` gets `errSecItemNotFound`.
+ *
+ * Not guarded, unlike the read: `remove:` is the one entry point that never
+ * reaches `handleAppUninstallation`, so the guard would be a bridge call that
+ * provably does nothing.
+ */
+export const legacyErase = async (key: string): Promise<boolean> => {
+  try {
+    await RNSecureKeyStore.remove(key)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/app/utils/storage/secure-store-migration.ts
+++ b/app/utils/storage/secure-store-migration.ts
@@ -89,14 +89,44 @@ const SLOT_OPERATION_TIMEOUT_MS = 30_000
  */
 const pendingBySlot = new Map<string, Promise<void>>()
 
-const onSlot = <T>(slot: string, task: () => Promise<T>): Promise<T> => {
+/**
+ * Passed to every queued task so it can ask whether it still holds the slot.
+ *
+ * The timeout cannot cancel a hung native call — `withTimeout` only races it —
+ * so an abandoned task keeps running and its continuation still fires. Freeing
+ * the queue while that task is alive is what makes the two overlap: the task
+ * has to stop mutating on its own, and this is how it is told to.
+ *
+ * Every side effect that follows an `await` inside a task is guarded by it.
+ * Unguarded, a read that hangs past the timeout and resolves after a logout has
+ * emptied the slot writes the legacy value it was mid-migration back into the
+ * new store, restoring the credential the logout just removed.
+ */
+type IsCurrent = () => boolean
+
+const onSlot = <T>(
+  slot: string,
+  task: (isCurrent: IsCurrent) => Promise<T>,
+): Promise<T> => {
   const previous = pendingBySlot.get(slot) ?? Promise.resolve()
-  // The timeout cannot cancel a hung native call, but it does let the queue
-  // move on, and it lands the caller on the `failed` path the rest of this
-  // design is built to handle safely.
-  const result = previous.then(() =>
-    withTimeout(task(), SLOT_OPERATION_TIMEOUT_MS, `secure store ${keyClassOf(slot)}`),
-  )
+  const result = previous.then(() => {
+    // Scoped to this operation, so it is collected with the closure rather than
+    // living in a map that has to be pruned. Pruning is the hazard here: a
+    // reset counter would hand a still-running abandoned task its slot back.
+    let isAbandoned = false
+    const running = task(() => !isAbandoned)
+
+    return withTimeout(
+      running,
+      SLOT_OPERATION_TIMEOUT_MS,
+      `secure store ${keyClassOf(slot)}`,
+    ).catch((err) => {
+      // Reached on timeout, where the task is still running and must stop, and
+      // on a task that rejected, where the flag is set on work already over.
+      isAbandoned = true
+      throw err
+    })
+  })
 
   // What gets queued is the settled promise, not the result: it absorbs the
   // rejection so that one failed operation cannot cancel the work behind it,
@@ -156,7 +186,22 @@ export type RemoveThroughArgs = {
   readonly legacyKey: string
 }
 
-const runRead = async (args: ReadThroughArgs): Promise<SecureRead> => {
+/**
+ * The answer an abandoned task gives instead of its real one. It is not
+ * normally observed — the caller was handed a timeout the moment the slot was
+ * taken away — but `failed` is the only honest value left: the slot moved on,
+ * so whatever this task read no longer describes it. Reporting the value it was
+ * holding would be reporting a credential that may since have been deleted.
+ */
+const abandoned = (slot: string): { status: "failed"; err: unknown } => ({
+  status: "failed",
+  err: new Error(`secure store ${keyClassOf(slot)} operation was abandoned`),
+})
+
+const runRead = async (
+  args: ReadThroughArgs,
+  isCurrent: IsCurrent,
+): Promise<SecureRead> => {
   const current = await secureRead(args.slot)
 
   // The steady state after migration: the legacy library is never touched
@@ -178,19 +223,30 @@ const runRead = async (args: ReadThroughArgs): Promise<SecureRead> => {
   // scoring the first as absent is what deletes credentials downstream.
   if (legacy.status === "failed") return legacy
 
+  // Both stores have answered, so the slot may have changed hands while they
+  // did. Everything above this line only reads; everything below it writes.
+  if (!isCurrent()) return abandoned(args.slot)
+
   logLegacyHit(args.legacyKey)
 
   // A failed write leaves the legacy copy intact and retries on the next read:
   // migration bookkeeping must never cost availability, so the erase outcome is
   // reported inside `eraseLegacyCopy` and never changes what the caller gets.
   const written = await secureWrite(args.slot, legacy.value, args.accessible)
-  const shouldEraseLegacy = written && args.deleteLegacyOnMigrate
+  // Re-checked because the write is itself an await: a slot handed over while
+  // it was in flight leaves this erase as the one side effect still ahead. An
+  // unerased legacy copy is the harmless outcome — the new store answers first,
+  // so it stays unreachable, and the next `removeThrough` clears it.
+  const shouldEraseLegacy = written && args.deleteLegacyOnMigrate && isCurrent()
   if (shouldEraseLegacy) await eraseLegacyCopy(args.legacyKey)
 
   return legacy
 }
 
-const runRemove = async (args: RemoveThroughArgs): Promise<boolean> => {
+const runRemove = async (
+  args: RemoveThroughArgs,
+  isCurrent: IsCurrent,
+): Promise<boolean> => {
   // The legacy copy goes first, and a copy that is not provably gone stops the
   // removal there. While the new store still holds the value it answers first,
   // so the survivor stays unreachable; emptying the new store anyway would turn
@@ -205,15 +261,23 @@ const runRemove = async (args: RemoveThroughArgs): Promise<boolean> => {
   const legacyGone = await eraseLegacyCopy(args.legacyKey)
   if (!legacyGone) return false
 
+  // The mirror of the read guard: emptying the new store after the slot has
+  // moved on deletes whatever took this value's place. `false` is already the
+  // contract for "not provably gone", so the caller keeps treating it as set.
+  if (!isCurrent()) return false
+
   return secureRemove(args.slot)
 }
 
-const runExists = async (args: ReadThroughArgs): Promise<SecureExists> => {
+const runExists = async (
+  args: ReadThroughArgs,
+  isCurrent: IsCurrent,
+): Promise<SecureExists> => {
   const current = await secureExists(args.slot)
   if (current.status === "yes") return current
   if (current.status === "failed") return current
 
-  const read = await runRead(args)
+  const read = await runRead(args, isCurrent)
   if (read.status === "found") return { status: "yes" }
   if (read.status === "absent") return { status: "no" }
   return { status: "failed", err: read.err }
@@ -232,7 +296,7 @@ const runExists = async (args: ReadThroughArgs): Promise<SecureExists> => {
  */
 export const readThrough = async (args: ReadThroughArgs): Promise<SecureRead> => {
   try {
-    return await onSlot(args.slot, () => runRead(args))
+    return await onSlot(args.slot, (isCurrent) => runRead(args, isCurrent))
   } catch (err) {
     return { status: "failed", err }
   }
@@ -252,7 +316,7 @@ export const readThrough = async (args: ReadThroughArgs): Promise<SecureRead> =>
  */
 export const removeThrough = async (args: RemoveThroughArgs): Promise<boolean> => {
   try {
-    return await onSlot(args.slot, () => runRemove(args))
+    return await onSlot(args.slot, (isCurrent) => runRemove(args, isCurrent))
   } catch {
     return false
   }
@@ -272,7 +336,7 @@ export const removeThrough = async (args: RemoveThroughArgs): Promise<boolean> =
  */
 export const existsThrough = async (args: ReadThroughArgs): Promise<SecureExists> => {
   try {
-    return await onSlot(args.slot, () => runExists(args))
+    return await onSlot(args.slot, (isCurrent) => runExists(args, isCurrent))
   } catch (err) {
     return { status: "failed", err }
   }

--- a/app/utils/storage/secure-store-migration.ts
+++ b/app/utils/storage/secure-store-migration.ts
@@ -1,0 +1,279 @@
+/* eslint-disable camelcase */
+import analytics from "@react-native-firebase/analytics"
+import type { ACCESSIBLE } from "react-native-keychain"
+
+import { recordAppError } from "@app/utils/error-reporting"
+import { withTimeout } from "@app/utils/with-timeout"
+
+import { legacyErase, legacyRead } from "./legacy-key-store"
+import {
+  type SecureExists,
+  type SecureRead,
+  secureExists,
+  secureRead,
+  secureRemove,
+  secureWrite,
+} from "./secure-store"
+
+/**
+ * Lazy, per-slot read-through migration off `react-native-secure-key-store`
+ * (blinkbitcoin/blink-wip#1143). No boot-time sweep: a slot moves the first
+ * time it is read, and only then.
+ *
+ * Writes never read through. `set*` writes the new store only.
+ *
+ * Nothing here ever rejects. Every failure arrives as `failed` or `false`, so a
+ * consumer that today swallows a keystore error into `null` keeps working
+ * unchanged when it moves over in blinkbitcoin/blink-wip#1161.
+ */
+
+const KEY_CLASS_SEPARATOR = ":"
+
+/**
+ * `mnemonic:<accountId>` becomes `mnemonic`. Cutting at the first separator is
+ * what structurally keeps an account id out of telemetry, out of Crashlytics
+ * and out of error messages, rather than trusting each call site to pass a safe
+ * label.
+ */
+const keyClassOf = (key: string): string => key.split(KEY_CLASS_SEPARATOR)[0]
+
+/**
+ * The legacy-hit counter. Dropping the legacy dependency
+ * (blinkbitcoin/blink-wip#1163) is gated on this going quiet, so it has to
+ * exist from the first migrating build or that decision has no evidence behind
+ * it. Tagged by key class only, never by value or account id.
+ *
+ * Deliberately not deduplicated per process: once a slot has migrated the new
+ * store answers first and this never fires again, so a repeat is real signal
+ * that the migrating write keeps failing.
+ *
+ * It lives here rather than in `app/utils/analytics.ts` because the storage
+ * layer must not take on that module's import graph — `secureStorage.ts` starts
+ * depending on this helper in blinkbitcoin/blink-wip#1161, and it is imported
+ * from screens.
+ */
+const logLegacyHit = (legacyKey: string): void => {
+  try {
+    // Both halves are isolated: the synchronous call by the catch, the promise
+    // it returns by its own handler. Migration bookkeeping never costs
+    // availability, telemetry included.
+    analytics()
+      .logEvent("legacy_key_store_hit", { key_class: keyClassOf(legacyKey) })
+      .catch(() => {})
+  } catch {
+    // Firebase not initialised.
+  }
+}
+
+/**
+ * Far beyond any real keychain operation. It is not a latency budget; it exists
+ * so that one native call that never settles cannot hold a slot's queue open
+ * for the rest of the process.
+ */
+const SLOT_OPERATION_TIMEOUT_MS = 30_000
+
+/**
+ * Per-slot serialization of everything that can move a value between the two
+ * stores.
+ *
+ * A read racing a remove on one slot is not hypothetical: a logout removes the
+ * auth token while other callers are still reading it. Unserialized, the read
+ * can resolve its legacy value before the remove runs and write it back after,
+ * so a logout that reported success leaves the credential readable again. It
+ * also collapses two concurrent first reads into a single migration instead of
+ * two writes and two erases.
+ *
+ * Keyed by slot, so unrelated slots never wait on each other, and the entry is
+ * dropped once nothing follows it — the map stays bounded by the slots in
+ * flight, not by every slot ever touched.
+ */
+const pendingBySlot = new Map<string, Promise<void>>()
+
+const onSlot = <T>(slot: string, task: () => Promise<T>): Promise<T> => {
+  const previous = pendingBySlot.get(slot) ?? Promise.resolve()
+  // The timeout cannot cancel a hung native call, but it does let the queue
+  // move on, and it lands the caller on the `failed` path the rest of this
+  // design is built to handle safely.
+  const result = previous.then(() =>
+    withTimeout(task(), SLOT_OPERATION_TIMEOUT_MS, `secure store ${keyClassOf(slot)}`),
+  )
+
+  // What gets queued is the settled promise, not the result: it absorbs the
+  // rejection so that one failed operation cannot cancel the work behind it,
+  // while the rejection still reaches its own caller through `result`.
+  const settled = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  pendingBySlot.set(slot, settled)
+  settled.then(() => {
+    const isLastInLine = pendingBySlot.get(slot) === settled
+    if (isLastInLine) pendingBySlot.delete(slot)
+  })
+
+  return result
+}
+
+/**
+ * Erases the legacy copy and reports whether it is provably gone.
+ *
+ * The legacy `remove` rejects with code "6" for a key that was never there
+ * (ios/RNSecureKeyStore.m `remove:`, whose `deleteKeychainValue` returns NO on
+ * `errSecItemNotFound`), so a failed erase is not evidence of anything on its
+ * own. Asking what is still readable is what tells a genuine failure apart from
+ * a key another read already migrated away.
+ *
+ * A read that cannot answer counts as not gone. It is the conservative half of
+ * a real trade-off, recorded at `runRemove`.
+ */
+const eraseLegacyCopy = async (legacyKey: string): Promise<boolean> => {
+  const erased = await legacyErase(legacyKey)
+  if (erased) return true
+
+  const remaining = await legacyRead(legacyKey)
+  if (remaining.status === "absent") return true
+
+  const keyClass = keyClassOf(legacyKey)
+  recordAppError(new Error(`Legacy key store erase failed: ${keyClass}`), {
+    dedupKey: `storage-legacy-erase-failed-${keyClass}`,
+  })
+  return false
+}
+
+export type ReadThroughArgs = {
+  /** Slot name in the new store. */
+  readonly slot: string
+  /** The key this value currently lives under in the legacy store. */
+  readonly legacyKey: string
+  /** Protection class for the migrating write. */
+  readonly accessible: ACCESSIBLE
+  /** Whether a successful migration should erase the legacy copy. */
+  readonly deleteLegacyOnMigrate: boolean
+}
+
+export type RemoveThroughArgs = {
+  readonly slot: string
+  readonly legacyKey: string
+}
+
+const runRead = async (args: ReadThroughArgs): Promise<SecureRead> => {
+  const current = await secureRead(args.slot)
+
+  // The steady state after migration: the legacy library is never touched
+  // again, which is what keeps its unscoped reinstall wipe from ever firing.
+  if (current.status === "found") return current
+
+  // A transient new-store failure must not fall back. The legacy copy may be
+  // stale, and falling back would re-enter the legacy library on exactly the
+  // path where its wipe is most likely to still be armed.
+  if (current.status === "failed") return current
+
+  const legacy = await legacyRead(args.legacyKey)
+
+  // The only path that produces `absent`, which is what keeps a genuine fresh
+  // install honest.
+  if (legacy.status === "absent") return legacy
+
+  // "Flaky keystore" and "nothing there" are indistinguishable here, and
+  // scoring the first as absent is what deletes credentials downstream.
+  if (legacy.status === "failed") return legacy
+
+  logLegacyHit(args.legacyKey)
+
+  // A failed write leaves the legacy copy intact and retries on the next read:
+  // migration bookkeeping must never cost availability, so the erase outcome is
+  // reported inside `eraseLegacyCopy` and never changes what the caller gets.
+  const written = await secureWrite(args.slot, legacy.value, args.accessible)
+  const shouldEraseLegacy = written && args.deleteLegacyOnMigrate
+  if (shouldEraseLegacy) await eraseLegacyCopy(args.legacyKey)
+
+  return legacy
+}
+
+const runRemove = async (args: RemoveThroughArgs): Promise<boolean> => {
+  // The legacy copy goes first, and a copy that is not provably gone stops the
+  // removal there. While the new store still holds the value it answers first,
+  // so the survivor stays unreachable; emptying the new store anyway would turn
+  // "two copies, one deleted" into "one copy, and it is the stale one".
+  //
+  // Rejected alternative: carry on when the legacy store cannot say what is
+  // left, on the grounds that a copy nobody can read is a copy nobody can
+  // resurrect. It buys a completed delete on a permanently broken legacy store,
+  // at the price of a silently restored credential the moment that store
+  // recovers. Leaving a failed operation with everything where it was is the
+  // safer half, and the caller is told so.
+  const legacyGone = await eraseLegacyCopy(args.legacyKey)
+  if (!legacyGone) return false
+
+  return secureRemove(args.slot)
+}
+
+const runExists = async (args: ReadThroughArgs): Promise<SecureExists> => {
+  const current = await secureExists(args.slot)
+  if (current.status === "yes") return current
+  if (current.status === "failed") return current
+
+  const read = await runRead(args)
+  if (read.status === "found") return { status: "yes" }
+  if (read.status === "absent") return { status: "no" }
+  return { status: "failed", err: read.err }
+}
+
+/**
+ * Reads a slot, migrating it from the legacy store on the way if that is where
+ * it still lives.
+ *
+ * When both stores hold a value the new store wins, unconditionally and without
+ * comparing: neither store carries a timestamp, so any other rule is a guess.
+ * Returning on the first hit enforces that for free, and it is also what makes
+ * an orphaned legacy copy from a failed erase unreachable and harmless — for as
+ * long as the new store holds the value, which is what `removeThrough` and the
+ * per-slot queue exist to keep true.
+ */
+export const readThrough = async (args: ReadThroughArgs): Promise<SecureRead> => {
+  try {
+    return await onSlot(args.slot, () => runRead(args))
+  } catch (err) {
+    return { status: "failed", err }
+  }
+}
+
+/**
+ * Deletes a slot from both stores.
+ *
+ * A delete that only reached the new store is not a delete: the next
+ * `readThrough` would miss, fall through to the legacy copy and write the old
+ * value straight back. That resurrection is why a read-through store cannot
+ * have a new-store-only remove.
+ *
+ * False means the value is not provably gone and the caller must treat the slot
+ * as still set — the same contract as the erase primitives it replaces, and a
+ * state a retry can act on.
+ */
+export const removeThrough = async (args: RemoveThroughArgs): Promise<boolean> => {
+  try {
+    return await onSlot(args.slot, () => runRemove(args))
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Asks whether a slot is set, without deciding it is not just because the value
+ * has yet to migrate.
+ *
+ * `secureExists` alone answers `no` for every unmigrated slot, which is how a
+ * consumer like `getIsPinEnabled` would skip the lock screen for every
+ * upgrading user. The probe is still tried first, since it is the only one that
+ * answers before first unlock; only when it comes back `no` does this fall
+ * through to a full read, which migrates the value as a side effect. By then
+ * the slot is unmigrated by definition, so its legacy copy is still readable
+ * under the protection class it has today.
+ */
+export const existsThrough = async (args: ReadThroughArgs): Promise<SecureExists> => {
+  try {
+    return await onSlot(args.slot, () => runExists(args))
+  } catch (err) {
+    return { status: "failed", err }
+  }
+}

--- a/app/utils/storage/secure-store.ts
+++ b/app/utils/storage/secure-store.ts
@@ -1,0 +1,134 @@
+import * as Keychain from "react-native-keychain"
+
+/**
+ * The Keychain-backed secure store: one item per slot, read and written through
+ * these four primitives only.
+ *
+ * **Items are internet credentials, never generic passwords.** The legacy
+ * `react-native-secure-key-store` module runs an unscoped `SecItemDelete` over
+ * `kSecClassGenericPassword` and `kSecClassKey` (`clearSecureKeyStore`,
+ * ios/RNSecureKeyStore.m l.118), reached from the first statement of `get:` and
+ * `set:` on the first call after a reinstall. Any generic password this app
+ * owned would be deleted by that sweep, and the read-through helper is itself
+ * what triggers it. `kSecClassInternetPassword` is not in that class list,
+ * which is why the app's existing Keychain usage survives today and why this
+ * module stores its items the same way.
+ *
+ * See blinkbitcoin/blink-wip#1160.
+ */
+const SERVER_NAMESPACE = "secure-store.blink.local"
+
+/**
+ * One server per slot, and never a server another feature already owns.
+ *
+ * iOS queries internet credentials by server with `kSecMatchLimitOne` and no
+ * account predicate, so several items sharing a server collapse to one
+ * OS-picked entry (the trap documented in `use-credential-backup.ts`). One
+ * server per slot means there is only ever one item per server, and
+ * `setInternetCredentialsForServer` deletes by server before every insert, so a
+ * duplicate cannot be created even by changing the username.
+ *
+ * The same by-server delete is why the namespace must not collide with
+ * `BLINK_DOMAIN`: a slot stored there would erase the iCloud mnemonic backup.
+ */
+export const serverFor = (slot: string): string => `${SERVER_NAMESPACE}/${slot}`
+
+/**
+ * "Nothing stored" is kept distinct from "the read failed". Collapsing them is
+ * what lets a transient keystore error be scored as absent and destroy a
+ * credential downstream.
+ */
+export type SecureRead =
+  | { readonly status: "found"; readonly value: string }
+  | { readonly status: "absent" }
+  | { readonly status: "failed"; readonly err: unknown }
+
+export type SecureExists =
+  | { readonly status: "yes" }
+  | { readonly status: "no" }
+  | { readonly status: "failed"; readonly err: unknown }
+
+/**
+ * `getInternetCredentials` resolves `false` only for `errSecItemNotFound` and
+ * rejects on every other `OSStatus`; on Android it resolves `false` only when
+ * the prefs entry is missing and rejects `E_CRYPTO_FAILED` /
+ * `E_KEYSTORE_ACCESS_ERROR`. So `false` means absent and a throw means failed,
+ * on both platforms.
+ *
+ * An empty password is reported as absent, preserving the `token ? found :
+ * absent` behaviour of the slots this store is replacing.
+ */
+export const secureRead = async (slot: string): Promise<SecureRead> => {
+  try {
+    const credentials = await Keychain.getInternetCredentials(serverFor(slot))
+    if (credentials === false) return { status: "absent" }
+    if (!credentials.password) return { status: "absent" }
+    return { status: "found", value: credentials.password }
+  } catch (err) {
+    return { status: "failed", err }
+  }
+}
+
+/**
+ * Existence without decryption. `hasInternetCredentials` resolves `YES` even on
+ * `errSecInteractionNotAllowed`, so a probe answers correctly before the first
+ * unlock — which is what lets a boot-path caller ask "is this slot set?"
+ * without a protection class that can refuse the read.
+ */
+export const secureExists = async (slot: string): Promise<SecureExists> => {
+  try {
+    const exists = await Keychain.hasInternetCredentials({ server: serverFor(slot) })
+    if (exists) return { status: "yes" }
+    return { status: "no" }
+  } catch (err) {
+    return { status: "failed", err }
+  }
+}
+
+/**
+ * The secret always goes in `password`; `username` carries the slot name so
+ * items are self-describing in a Keychain dump.
+ *
+ * `accessible` is a required parameter and never defaulted: a default would let
+ * a future slot silently inherit the wrong protection class. Choosing it per
+ * slot is a real decision, not a copy: `Keychain.ACCESSIBLE` has no
+ * `ALWAYS_THIS_DEVICE_ONLY`, which is what every non-mnemonic slot uses today,
+ * so each one has to be re-argued when it moves in
+ * blinkbitcoin/blink-wip#1161.
+ *
+ * The options object holds `accessible` and nothing else, deliberately.
+ * `accessControl` with any biometry value flips the Android cipher to the
+ * authenticating one and makes every boot-path read raise a biometric prompt,
+ * and `cloudSync: true` (which the neighbouring credential backup sets on
+ * purpose) would push these secrets into the iCloud Keychain.
+ *
+ * An empty value is refused rather than stored. `secureRead` reports one as
+ * absent, so storing it would leave a slot that reads as unset and sends the
+ * read-through helper back to the legacy store, resurrecting the stale
+ * pre-migration value. Clearing a slot is `secureRemove`'s job.
+ */
+export const secureWrite = async (
+  slot: string,
+  value: string,
+  accessible: Keychain.ACCESSIBLE,
+): Promise<boolean> => {
+  if (!value) return false
+
+  try {
+    const result = await Keychain.setInternetCredentials(serverFor(slot), slot, value, {
+      accessible,
+    })
+    return result !== false
+  } catch {
+    return false
+  }
+}
+
+export const secureRemove = async (slot: string): Promise<boolean> => {
+  try {
+    await Keychain.resetInternetCredentials({ server: serverFor(slot) })
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Fixes [blinkbitcoin/blink-wip#1160](https://github.com/blinkbitcoin/blink-wip/issues/1160) (close manually on merge — cross-repo `Fixes` doesn't auto-close).

Step 1 of 4 of [blinkbitcoin/blink-wip#1143](https://github.com/blinkbitcoin/blink-wip/issues/1143), itself item 5 of the [#1092](https://github.com/blinkbitcoin/blink-wip/issues/1092) red-team report.

## Problem

`react-native-secure-key-store` (`^2.0.9`, unmaintained since ~2019) holds every credential the app owns: the PIN, its lockout state, the biometrics flag, `sessionProfiles`, `galoyAuthToken` and the per-account BIP-39 mnemonics. Nothing is broken today. The risk is the ordinary one — an unmaintained native dependency holding funds-bearing key material eventually breaks on some OS release, and it gets fixed under pressure with users locked out.

Moving those slots is a funds-at-risk data migration, so this lands the storage adapter and the read-through helper **without moving a single slot**. `secureStorage.ts` is untouched and [`__tests__/utils/secure-storage.spec.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/main/__tests__/utils/secure-storage.spec.ts) needs zero changes; that is the acceptance criterion for "no behaviour change", and both hold.

One constraint shapes everything else. `clearSecureKeyStore` (`ios/RNSecureKeyStore.m` l.118) issues an **unscoped** `SecItemDelete` over `kSecClassGenericPassword` and `kSecClassKey` — every such item the app owns, not just the library's own. It runs from `handleAppUninstallation`, the first statement of `get:` and `set:`, and fires whenever `NSUserDefaults` key `RnSksIsAppInstalled` is false, i.e. the first call after any reinstall, since `NSUserDefaults` is wiped by an uninstall and the Keychain is not.

Harmless today, because the app owns no generic passwords. **Lethal after the migration** if the new store used them: on a reinstall boot, any slot that misses in the new store falls through to the legacy library, which then deletes every migrated mnemonic. The read-through design is itself what pulls the trigger. `kSecClassInternetPassword` is not in that class list, which is why the app's existing Keychain usage is safe today ([`use-credential-backup.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/main/app/screens/self-custodial/onboarding/hooks/use-credential-backup.ts), [`use-create-device-account.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/main/app/screens/get-started-screen/use-create-device-account.ts)) and why the new store stores its items the same way.

## What changed

Three new modules under `app/utils/storage/`, plus the test scaffolding they need.

**[`secure-store.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/feat--keychain-adapter-1160/app/utils/storage/secure-store.ts)** — the Keychain adapter. `serverFor`, `secureRead`, `secureExists`, `secureWrite`, `secureRemove`, over **internet credentials with a distinct `server` per slot** under `secure-store.blink.local/<slot>`. The secret goes in `password`; `username` carries the slot name so items are self-describing in a Keychain dump. `false ⇒ absent, throw ⇒ failed` holds on both platforms: `getInternetCredentials` resolves `false` only for `errSecItemNotFound` and rejects on every other `OSStatus`, and Android resolves `false` only when the prefs entry is missing, rejecting `E_CRYPTO_FAILED` / `E_KEYSTORE_ACCESS_ERROR`. `secureExists` goes through `hasInternetCredentials`, which resolves `YES` even on `errSecInteractionNotAllowed`, so a probe answers **before first unlock**. The write options object carries `accessible` and nothing else.

**[`legacy-key-store.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/feat--keychain-adapter-1160/app/utils/storage/legacy-key-store.ts)** — the legacy read and erase primitives, owning the `404`-vs-other-code classification and the `setResetOnAppUninstallTo(false)` guard. A `no-restricted-imports` rule in `.eslintrc.json` keeps new call paths from reaching the library directly; `secureStorage.ts` holds the only other exception, and it goes away when its slots move in [#1161](https://github.com/blinkbitcoin/blink-wip/issues/1161). The module deliberately has no write primitive — migrated values are only ever written to the new store.

**[`secure-store-migration.ts`](https://github.com/blinkbitcoin/blink-mobile/blob/feat--keychain-adapter-1160/app/utils/storage/secure-store-migration.ts)** — the lazy per-slot migration.

- `readThrough` — new store first. `found` returns immediately and never touches the legacy library, which is what keeps a migrated user off it entirely. `failed` returns `failed` without falling back. Only when both stores confirm a miss does `absent` come back. A legacy hit is written to the new store, then the legacy copy is erased; a failed write leaves the legacy copy intact and retries on the next read.
- `removeThrough` — deletes from both stores, legacy copy first. A new-store-only remove is not a remove: the next read would miss, fall through and write the old value straight back.
- `existsThrough` — the probe first, since it is the only one that answers before first unlock, falling through to a full read when it comes back `no`, so an unmigrated slot is never reported as unset.
- A per-slot queue serializes everything that can move a value between the stores, and a 30s deadline keeps one hung native call from holding a slot's queue open for the rest of the process.
- A legacy-hit counter, `legacy_key_store_hit`, tagged by key class only. `mnemonic:<accountId>` is cut at the first separator, so an account id cannot reach telemetry, Crashlytics or an error message.

**Test scaffolding.** `__mocks__/react-native-keychain.js` grew `hasInternetCredentials`. A new root `__mocks__/react-native-secure-key-store.js` rejects `get` with the missing-key code: without it the legacy library loads for real in every consumer spec, `NativeModules.RNSecureKeyStore` is undefined and every legacy read throws, flipping the default world of ~26 specs from "absent" to "failed". Behavioural mocking stays inline per spec.

## Decisions and rejected alternatives

1. **Internet credentials, not generic passwords.** Rejected `setResetOnAppUninstallTo(false)` as the load-bearing defense: `resetOnAppUninstall` is instance state re-initialised to `YES` on every module construction and the setter is a fire-and-forget void bridge method, so it is defended by call ordering rather than by structure. It is called anyway as defense in depth — it also covers `kSecClassKey` items and any future dependency.

2. **The guard is re-armed before every legacy read, not once at module load.** The wipe is only ever skipped, never disarmed: `handleAppUninstallation` sets its `RnSksIsAppInstalled` flag *inside* the branch it guards, so a skipped wipe leaves the trigger armed for the next call. It is iOS-only — the Android module exports `get` / `set` / `remove` and nothing else — and it is left off the erase, the one entry point that never reaches `handleAppUninstallation`.

3. **One `server` per slot, and never one another feature owns.** iOS matches internet credentials by server with `kSecMatchLimitOne` and no account predicate, so several items sharing a server collapse to one OS-picked entry — the trap documented in `use-credential-backup.ts`. One item per server sidesteps it, and `setInternetCredentialsForServer` deletes by server before every insert, so a duplicate cannot be created even by changing the username. The same by-server delete is why a test pins the namespace apart from `BLINK_DOMAIN`, whose items are the iCloud mnemonic backup.

4. **A failed new-store read returns `failed` and does not fall back.** The legacy copy may be stale, and falling back would re-enter the legacy library on exactly the path where its wipe is most likely to be armed.

5. **A failed legacy read returns `failed`, not `absent`.** "Flaky keystore" and "nothing there" are indistinguishable, and scoring the first as absent is what deletes credentials. `absent` has exactly one producer: both stores confirming a miss, which is what keeps a genuine fresh install honest.

6. **The new store wins over legacy unconditionally, without comparing.** Neither store carries a timestamp, so any other rule is a guess. Returning on the first hit enforces it for free and makes an orphaned legacy copy unreachable.

7. **Migration bookkeeping never costs availability.** A failed migrating write still returns the value, a failed erase is reported and tolerated, and the telemetry call is isolated on both halves — the synchronous one by a `catch`, the promise it returns by its own handler.

8. **`removeThrough` stops when the legacy copy is not provably gone.** While the new store still holds the value it answers first, so the survivor stays unreachable; emptying the new store anyway would turn "two copies, one deleted" into "one copy, and it is the stale one". Rejected the alternative — carry on when the legacy store cannot say what is left, on the grounds that a copy nobody can read is a copy nobody can resurrect — because it trades a completed delete on a broken store for a silently restored credential the moment that store recovers.

9. **A per-slot queue, not a global one.** A read racing a remove on one slot is not hypothetical: a logout removes the auth token while other callers still read it. Unserialized, the read resolves its legacy value before the remove runs and writes it back after. Unrelated slots never wait on each other, and the entry is dropped once nothing follows it.

10. **The helpers never reject.** Every failure arrives as `failed` or `false`, so a consumer that today swallows a keystore error into `null` keeps working unchanged when it moves over.

11. **The legacy-hit counter is not deduplicated per process.** Once a slot has migrated the new store answers first and it never fires again, so a repeat is real signal that the migrating write keeps failing. Removal in [#1163](https://github.com/blinkbitcoin/blink-wip/issues/1163) is gated on it going quiet, so it has to exist from the first migrating build. It lives in the migration module rather than `app/utils/analytics.ts` because that module's import graph reaches screens, and `secureStorage.ts` starts depending on this helper in #1161.

12. **`accessible` is a required parameter, never defaulted.** `Keychain.ACCESSIBLE` has no `ALWAYS_THIS_DEVICE_ONLY`, which is what every non-mnemonic slot uses today, so each slot's protection class is a decision to be made as it moves in #1161 rather than one to inherit silently here.

13. **`secureWrite` refuses an empty value.** `secureRead` reports one as absent, so storing it would leave a slot that reads as unset and sends the helper back to the legacy store. Clearing a slot is `secureRemove`'s job.

## Verification

- 146 tests across 5 suites: the four new specs plus `secure-storage.spec.ts`, which passes **unmodified** under the new root mock.
- 100% statements, branches, functions and lines on all three new modules.
- **33 mutations**, each applied alone and reverted after: every one turns the suite red. They cover all nine read-through branches (new-hit with legacy never called, new-miss + legacy-hit with write-before-erase ordering asserted through a shared call-order array, both-miss, legacy-read-fails, new-write-fails, legacy-erase-fails, both-present-and-differ, concurrent reads, the write path), the remove and exists policies, the queue, the deadline, the telemetry redaction and the four adapter guards. Three of them do not merely fail the suite — dropping the telemetry promise handler, or queueing the unsettled promise, aborts the Node process on an unhandled rejection.
- An API-stability spec pins `Object.getOwnPropertyNames(KeyStoreWrapper).sort()` to a literal list. 23 files under `app/` call `KeyStoreWrapper` and ~26 specs mock it as a partial object literal, none of them naming the underlying library, so as long as that surface only grows the blast radius of the whole backend swap is one file.
- `tsc -p .`, ESLint and Prettier clean on all ten files.
- The release JS bundle built from this branch contains **no** string from the new modules — `secure-store.blink.local`, `legacy_key_store_hit`, `storage-legacy-erase-failed` and `setResetOnAppUninstallTo` are all absent from 34.7 MB, while `galoyAuthToken`, `sessionProfiles`, `pinFailureState` and `RNSecureKeyStore` are present. Nothing imports the new modules, so Metro never pulls them in and the shipped bundle is unchanged.

## Device test

iOS simulator (iPhone 16 Pro, iOS 18.6), Metro serving this branch, self-custodial account with a saved session.

| Step | Result |
|---|---|
| Terminate the app, cold launch | Splash renders, no red screen and no Metro resolution error |
| Wait for the bundle to load | Home renders on the active account |
| Session across the kill | Restored — the keystore read that backs it still works |
| Balances and action row | Bitcoin, Dollar, Transfer / Receive / Send / Scan all intact |
| Non-custodial banner and tab bar | Unchanged |
