### PR TITLE
fix(android): keep content clear of the system bars under Android 15 edge to edge

### DIFF
--- a/__tests__/navigation/header-less-screen-insets.spec.ts
+++ b/__tests__/navigation/header-less-screen-insets.spec.ts
@@ -16,6 +16,8 @@ const NAVIGATION_DIR = path.join(APP_DIR, "navigation")
 
 type Route = { name: string; component: string; file: string }
 
+type HeaderLessScreen = { label: string; component: string }
+
 const readSource = (file: string): string => fs.readFileSync(file, "utf8")
 
 const navigationSources = (): string[] =>
@@ -43,6 +45,16 @@ const headerLessRoutes = (): Route[] => {
   return routes
 }
 
+const BAILOUT_RENDER = /return\s*\(?\s*<([A-Z]\w*)(?![\w.])[^<>]*\/>/g
+
+/**
+ * A component the file hands the whole screen over to before any header is in play: the
+ * navigator bails out to it instead of mounting its tree, or a header-less route
+ * delegates to it. It draws with no toolbar above it, so the same rule reaches it.
+ */
+const bailoutRenders = (source: string): string[] =>
+  [...source.matchAll(BAILOUT_RENDER)].map((match) => match[1])
+
 const sourceFiles = (dir: string): string[] =>
   fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = path.join(dir, entry.name)
@@ -51,14 +63,60 @@ const sourceFiles = (dir: string): string[] =>
     return isSource ? [full] : []
   })
 
+let appSources: string[] | null = null
+
 const componentFile = (component: string): string | null => {
   const declaration = new RegExp(
     `export (?:const|function) ${component}\\b|const ${component}: React\\.FC`,
   )
-  for (const file of sourceFiles(APP_DIR)) {
+  appSources = appSources ?? sourceFiles(APP_DIR)
+  for (const file of appSources) {
     if (declaration.test(readSource(file))) return file
   }
   return null
+}
+
+/**
+ * Every screen that renders without a header: the header-less routes, the components a
+ * navigator bails out to, and whatever those in turn delegate to.
+ */
+const headerLessScreens = (): HeaderLessScreen[] => {
+  const screens: HeaderLessScreen[] = []
+  const queued = new Set<string>()
+  const pending: HeaderLessScreen[] = []
+
+  const enqueue = (screen: HeaderLessScreen) => {
+    if (queued.has(screen.component)) return
+    queued.add(screen.component)
+    pending.push(screen)
+  }
+
+  for (const route of headerLessRoutes()) {
+    enqueue({ label: route.name, component: route.component })
+  }
+  for (const file of navigationSources()) {
+    for (const component of bailoutRenders(readSource(file))) {
+      enqueue({ label: `${path.basename(file)} bail-out`, component })
+    }
+  }
+
+  const enqueueDelegates = (screen: HeaderLessScreen) => {
+    /** An accepted exception already answers for everything it draws, delegates included. */
+    if (HANDLES_ITS_OWN_INSETS.has(screen.component)) return
+    const file = componentFile(screen.component)
+    if (!file) return
+    for (const component of bailoutRenders(readSource(file))) {
+      enqueue({ label: `${screen.component} bail-out`, component })
+    }
+  }
+
+  while (pending.length > 0) {
+    const screen = pending.shift() as HeaderLessScreen
+    screens.push(screen)
+    enqueueDelegates(screen)
+  }
+
+  return screens
 }
 
 /**
@@ -109,25 +167,25 @@ const declaresTopInset = (source: string): boolean => {
 }
 
 describe("header-less routes and the top inset", () => {
-  const routes = headerLessRoutes()
+  const screens = headerLessScreens()
 
-  it("finds the header-less routes to check", () => {
-    expect(routes.length).toBeGreaterThan(0)
+  it("finds the header-less screens to check", () => {
+    expect(screens.length).toBeGreaterThan(0)
   })
 
   it("keeps no stale entries in the exception list", () => {
-    const headerLess = new Set(routes.map((route) => route.component))
+    const headerLess = new Set(screens.map((screen) => screen.component))
     const stale = [...HANDLES_ITS_OWN_INSETS].filter(
       (component) => !headerLess.has(component),
     )
     expect(stale).toEqual([])
   })
 
-  routes
-    .filter((route) => !HANDLES_ITS_OWN_INSETS.has(route.component))
-    .forEach((route) => {
-      it(`${route.name} (${route.component}) asks Screen for the top inset`, () => {
-        const file = componentFile(route.component)
+  screens
+    .filter((screen) => !HANDLES_ITS_OWN_INSETS.has(screen.component))
+    .forEach((screen) => {
+      it(`${screen.label} (${screen.component}) asks Screen for the top inset`, () => {
+        const file = componentFile(screen.component)
         expect(file).not.toBeNull()
         expect(declaresTopInset(readSource(file as string))).toBe(true)
       })

--- a/__tests__/navigation/header-less-screen-insets.spec.ts
+++ b/__tests__/navigation/header-less-screen-insets.spec.ts
@@ -156,8 +156,56 @@ const declaresHeaderHidden = (tag: string): boolean => {
   return headerShown[1].trim() !== "true"
 }
 
+/**
+ * The opening tag of every `<Name ...>` in the file, ending at the `>` that closes it
+ * rather than at one nested inside a prop like `header={<Close />}` or an arrow.
+ */
+const openingTags = (source: string, name: string): string[] => {
+  const tags: string[] = []
+  for (const match of source.matchAll(new RegExp(`<${name}\\b`, "g"))) {
+    const start = match.index as number
+    let depth = 0
+    for (let i = start; i < source.length; i += 1) {
+      if (source[i] === "<") depth += 1
+      if (source[i] === ">" && source[i - 1] !== "=") depth -= 1
+      if (depth === 0) {
+        tags.push(source.slice(start, i + 1))
+        break
+      }
+    }
+  }
+  return tags
+}
+
+const HEADER_PASSTHROUGH = /<Screen\b[^>]*headerShown=\{headerShown\}/
+const LAYOUT_EXPORT = /export const (\w+): React\.FC/g
+
+/**
+ * A layout that takes a `headerShown` prop and hands it straight to `Screen`. A screen
+ * built on one never writes `<Screen>` itself, so the rule has to reach through it. A
+ * screen that passes some other flag, like `getStarted`, is answering for itself.
+ *
+ * Every component the file exports counts, not just the first: naming the wrong one would
+ * take the layout out of the rule without failing anything.
+ */
+let insetLayouts: string[] | null = null
+
+const layoutComponents = (): string[] => {
+  appSources = appSources ?? sourceFiles(APP_DIR)
+  insetLayouts =
+    insetLayouts ??
+    appSources.flatMap((file) => {
+      const source = readSource(file)
+      if (!HEADER_PASSTHROUGH.test(source)) return []
+      return [...source.matchAll(LAYOUT_EXPORT)].map((exported) => exported[1])
+    })
+  return insetLayouts
+}
+
 const declaresTopInset = (source: string): boolean => {
-  const screenTags = source.match(/<Screen\b[^>]*>/g) ?? []
+  const screenTags = ["Screen", ...layoutComponents()].flatMap((name) =>
+    openingTags(source, name),
+  )
   if (screenTags.length === 0) return true
   return screenTags.every((tag) => {
     const optsOut = /\bunsafe\b/.test(tag)
@@ -171,6 +219,12 @@ describe("header-less routes and the top inset", () => {
 
   it("finds the header-less screens to check", () => {
     expect(screens.length).toBeGreaterThan(0)
+  })
+
+  /** Screens built on a layout carry no `<Screen>` of their own, so losing the layouts
+   *  would wave them through on nothing rather than fail. */
+  it("finds the layouts that forward headerShown", () => {
+    expect(layoutComponents().length).toBeGreaterThan(0)
   })
 
   it("keeps no stale entries in the exception list", () => {

--- a/__tests__/navigation/header-less-screen-insets.spec.ts
+++ b/__tests__/navigation/header-less-screen-insets.spec.ts
@@ -1,0 +1,124 @@
+import fs from "fs"
+import path from "path"
+
+const APP_DIR = path.resolve(__dirname, "..", "..", "app")
+const NAVIGATION_DIR = path.join(APP_DIR, "navigation")
+
+/**
+ * A route that hides the navigation header has no toolbar reserving the status bar, so
+ * its screen has to ask for the top inset itself. `Screen` only adds that edge when it
+ * is told the header is hidden, and from Android 15 the window runs edge to edge, so a
+ * screen that stays silent draws its first row underneath the status bar.
+ *
+ * This walks the navigators rather than a hand-kept list, so a new header-less route
+ * cannot be added without either handling its insets or being recorded below.
+ */
+
+type Route = { name: string; component: string; file: string }
+
+const readSource = (file: string): string => fs.readFileSync(file, "utf8")
+
+const navigationSources = (): string[] =>
+  fs
+    .readdirSync(NAVIGATION_DIR)
+    .filter((name) => name.endsWith(".tsx"))
+    .map((name) => path.join(NAVIGATION_DIR, name))
+
+const SCREEN_ENTRY = /<\w+\.Screen\b([\s\S]*?)(?:\/>|<\/\w+\.Screen>)/g
+
+const headerLessRoutes = (): Route[] => {
+  const routes: Route[] = []
+  for (const file of navigationSources()) {
+    const source = readSource(file)
+    for (const match of source.matchAll(SCREEN_ENTRY)) {
+      const entry = match[1]
+      const name = entry.match(/name="([^"]+)"/)
+      const component = entry.match(/component=\{(\w+)\}/)
+      const isHeaderLess = entry.includes("headerShown: false")
+      if (name && component && isHeaderLess) {
+        routes.push({ name: name[1], component: component[1], file })
+      }
+    }
+  }
+  return routes
+}
+
+const sourceFiles = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) return sourceFiles(full)
+    const isSource = entry.name.endsWith(".tsx") || entry.name.endsWith(".ts")
+    return isSource ? [full] : []
+  })
+
+const componentFile = (component: string): string | null => {
+  const declaration = new RegExp(
+    `export (?:const|function) ${component}\\b|const ${component}: React\\.FC`,
+  )
+  for (const file of sourceFiles(APP_DIR)) {
+    if (declaration.test(readSource(file))) return file
+  }
+  return null
+}
+
+/**
+ * Screens that opt out of `Screen`'s safe area on purpose and pay the insets from their
+ * own layout, or that render no chrome at all. Each is a deliberate exception, so the
+ * list may shrink but should not grow without a reason recorded here.
+ */
+const HANDLES_ITS_OWN_INSETS = new Set([
+  // Full-bleed camera preview; the controls read useSafeAreaInsets directly.
+  "ScanningQRCodeGated",
+  // Full-bleed detail sheet; reads useSafeAreaInsets directly.
+  "TransactionDetailScreen",
+  // Redirect-only, renders no UI of its own.
+  "MigrationEntryScreen",
+  // Full-bleed map; MapComponent offsets its own controls by insets.top.
+  "MapScreen",
+  // Decorative full-bleed maps and quiz backdrops, unchanged by this rule.
+  "EarnMapScreen",
+  "EarnQuiz",
+  "SectionCompleted",
+  // Nested navigators: their own routes carry the options.
+  "PrimaryNavigator",
+  "ContactNavigator",
+  "OnboardingNavigator",
+  "PhoneLoginNavigator",
+])
+
+const declaresTopInset = (source: string): boolean => {
+  const screenTags = source.match(/<Screen\b[^>]*>/g) ?? []
+  if (screenTags.length === 0) return true
+  return screenTags.every((tag) => {
+    const passesHeaderShown = tag.includes("headerShown=")
+    const optsOut = /\bunsafe\b/.test(tag)
+    const overridesEdges = /edges=\{\[[^\]]*"top"/.test(tag)
+    return passesHeaderShown || optsOut || overridesEdges
+  })
+}
+
+describe("header-less routes and the top inset", () => {
+  const routes = headerLessRoutes()
+
+  it("finds the header-less routes to check", () => {
+    expect(routes.length).toBeGreaterThan(0)
+  })
+
+  it("keeps no stale entries in the exception list", () => {
+    const headerLess = new Set(routes.map((route) => route.component))
+    const stale = [...HANDLES_ITS_OWN_INSETS].filter(
+      (component) => !headerLess.has(component),
+    )
+    expect(stale).toEqual([])
+  })
+
+  routes
+    .filter((route) => !HANDLES_ITS_OWN_INSETS.has(route.component))
+    .forEach((route) => {
+      it(`${route.name} (${route.component}) asks Screen for the top inset`, () => {
+        const file = componentFile(route.component)
+        expect(file).not.toBeNull()
+        expect(declaresTopInset(readSource(file as string))).toBe(true)
+      })
+    })
+})

--- a/__tests__/navigation/header-less-screen-insets.spec.ts
+++ b/__tests__/navigation/header-less-screen-insets.spec.ts
@@ -86,14 +86,25 @@ const HANDLES_ITS_OWN_INSETS = new Set([
   "PhoneLoginNavigator",
 ])
 
+/**
+ * `Screen` only adds the top edge when it is told the header is hidden, so a hard
+ * `headerShown={true}` leaves the status bar uncovered. A screen may still pass an
+ * expression: `getStarted` shows its header only when there is somewhere to go back to,
+ * and hands `Screen` the very flag it toggles the header with.
+ */
+const declaresHeaderHidden = (tag: string): boolean => {
+  const headerShown = tag.match(/headerShown=\{([^}]*)\}/)
+  if (!headerShown) return false
+  return headerShown[1].trim() !== "true"
+}
+
 const declaresTopInset = (source: string): boolean => {
   const screenTags = source.match(/<Screen\b[^>]*>/g) ?? []
   if (screenTags.length === 0) return true
   return screenTags.every((tag) => {
-    const passesHeaderShown = tag.includes("headerShown=")
     const optsOut = /\bunsafe\b/.test(tag)
     const overridesEdges = /edges=\{\[[^\]]*"top"/.test(tag)
-    return passesHeaderShown || optsOut || overridesEdges
+    return declaresHeaderHidden(tag) || optsOut || overridesEdges
   })
 }
 

--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { Alert } from "react-native"
+import type { ReactTestInstance } from "react-test-renderer"
 import { Network as mockSparkNetwork } from "@breeztech/breez-sdk-spark-react-native"
 import {
   act,
@@ -99,6 +100,11 @@ jest.mock("react-native-image-picker", () => ({
 }))
 
 const mockToastShow = jest.fn()
+jest.mock("react-native-safe-area-context", () => ({
+  ...jest.requireActual("react-native-safe-area-context"),
+  useSafeAreaInsets: () => ({ top: 24, bottom: 48, left: 0, right: 0 }),
+}))
+
 jest.mock("@app/utils/toast", () => ({
   ...jest.requireActual("@app/utils/toast"),
   toastShow: (...args: unknown[]) => mockToastShow(...args),
@@ -389,6 +395,44 @@ describe("ScanningQRCodeScreen", () => {
     await fireScan("lnbc1second")
 
     expect(mockResolveDestination).toHaveBeenCalledTimes(2)
+  })
+
+  /**
+   * The controls used to sit at fixed offsets from the window edge. From Android 15 the
+   * window runs under the system bars, so those offsets put the gallery and clipboard
+   * buttons behind the navigation bar and the close button behind the status bar.
+   */
+  describe("clearing the system bars", () => {
+    const flattenedStyle = (node: { props: { style?: unknown } }) =>
+      Object.assign({}, ...[node.props.style].flat(Infinity).filter(Boolean)) as Record<
+        string,
+        number | undefined
+      >
+
+    const styleOfAncestorWith = (node: ReactTestInstance | null, key: string) => {
+      let current = node
+      while (current) {
+        const style = flattenedStyle(current)
+        if (style[key] !== undefined) return style
+        current = current.parent
+      }
+      throw new Error(`no ancestor carries a ${key} style`)
+    }
+
+    it("offsets the bottom controls by the bottom inset", async () => {
+      const screen = await renderScreen()
+      const gallery = screen.getByTestId("open-gallery")
+
+      expect(styleOfAncestorWith(gallery, "bottom").bottom).toBe(48 + 24)
+    })
+
+    it("offsets the close button by the top inset", async () => {
+      const screen = await renderScreen()
+      const closeIcon = screen.UNSAFE_getAllByProps({ name: "close" })[0]
+      const closeContainer = closeIcon.parent?.parent
+
+      expect(flattenedStyle(closeContainer as never).marginTop).toBe(24 + 16)
+    })
   })
 
   describe("picking a QR from the gallery", () => {

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -10,6 +10,7 @@ import ErrorBoundary from "react-native-error-boundary"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
 import "react-native-reanimated"
 import { RootSiblingParent } from "react-native-root-siblings"
+import { SafeAreaProvider, initialWindowMetrics } from "react-native-safe-area-context"
 // for URL; need a polyfill on react native
 import "react-native-url-polyfill/auto"
 
@@ -59,47 +60,53 @@ if (__DEV__) console.log(`Loaded default locale: ${defaultLocale}`)
 export const App = () => (
   /* eslint-disable-next-line react-native/no-inline-styles */
   <GestureHandlerRootView style={{ flex: 1 }}>
-    <PersistentStateProvider>
-      <TypesafeI18n locale={detectDefaultLocale()}>
-        <GaloyClient>
-          <GaloyThemeProvider>
-            <FeatureFlagContextProvider>
-              <CustodialWalletProvider>
-                <SelfCustodialWalletProvider>
-                  <BackupStateProvider>
-                    <AutoConvertStatusProvider>
-                      <ActionsProvider>
-                        <MigrationBlockerProvider>
-                          <NavigationContainerWrapper>
-                            <ErrorBoundary FallbackComponent={ErrorScreen}>
-                              <RootSiblingParent>
-                                <EnhancedModePromptProvider>
-                                  <RestrictedRegionProvider>
-                                    <NotificationsProvider>
-                                      <AppStateWrapper />
-                                      <PushNotificationComponent />
-                                      <AutoConvertListenerMount />
-                                      <AccountModeSyncMount />
-                                      <RootStack />
-                                      <NetworkErrorComponent />
-                                      <ActionModals />
-                                    </NotificationsProvider>
-                                  </RestrictedRegionProvider>
-                                </EnhancedModePromptProvider>
-                                <GaloyToast />
-                              </RootSiblingParent>
-                            </ErrorBoundary>
-                          </NavigationContainerWrapper>
-                        </MigrationBlockerProvider>
-                      </ActionsProvider>
-                    </AutoConvertStatusProvider>
-                  </BackupStateProvider>
-                </SelfCustodialWalletProvider>
-              </CustodialWalletProvider>
-            </FeatureFlagContextProvider>
-          </GaloyThemeProvider>
-        </GaloyClient>
-      </TypesafeI18n>
-    </PersistentStateProvider>
+    {/* Every screen reads its window insets from here. React Navigation supplies a
+        provider of its own inside each navigator, but only there and only after the
+        first frame, so anything rendered outside or before it measured zero insets
+        and drew under the system bars. */}
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <PersistentStateProvider>
+        <TypesafeI18n locale={detectDefaultLocale()}>
+          <GaloyClient>
+            <GaloyThemeProvider>
+              <FeatureFlagContextProvider>
+                <CustodialWalletProvider>
+                  <SelfCustodialWalletProvider>
+                    <BackupStateProvider>
+                      <AutoConvertStatusProvider>
+                        <ActionsProvider>
+                          <MigrationBlockerProvider>
+                            <NavigationContainerWrapper>
+                              <ErrorBoundary FallbackComponent={ErrorScreen}>
+                                <RootSiblingParent>
+                                  <EnhancedModePromptProvider>
+                                    <RestrictedRegionProvider>
+                                      <NotificationsProvider>
+                                        <AppStateWrapper />
+                                        <PushNotificationComponent />
+                                        <AutoConvertListenerMount />
+                                        <AccountModeSyncMount />
+                                        <RootStack />
+                                        <NetworkErrorComponent />
+                                        <ActionModals />
+                                      </NotificationsProvider>
+                                    </RestrictedRegionProvider>
+                                  </EnhancedModePromptProvider>
+                                  <GaloyToast />
+                                </RootSiblingParent>
+                              </ErrorBoundary>
+                            </NavigationContainerWrapper>
+                          </MigrationBlockerProvider>
+                        </ActionsProvider>
+                      </AutoConvertStatusProvider>
+                    </BackupStateProvider>
+                  </SelfCustodialWalletProvider>
+                </CustodialWalletProvider>
+              </FeatureFlagContextProvider>
+            </GaloyThemeProvider>
+          </GaloyClient>
+        </TypesafeI18n>
+      </PersistentStateProvider>
+    </SafeAreaProvider>
   </GestureHandlerRootView>
 )

--- a/app/screens/account-migration/to-non-custodial/migration-gate.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-gate.tsx
@@ -260,7 +260,7 @@ export const MigrationGate: React.FC = () => {
 
   if (hasGateDataError) {
     return (
-      <Screen preset="fixed">
+      <Screen preset="fixed" headerShown={false}>
         <View style={styles.messageContainer}>
           <GaloyIcon name="warning" size={64} color={colors.warning} />
           <Text type="p1" style={styles.messageText}>
@@ -283,7 +283,7 @@ export const MigrationGate: React.FC = () => {
    *  migration would flash the intro it is about to navigate away from. */
   if (isGateDataLoading || shouldResumeLockedMigration) {
     return (
-      <Screen preset="fixed">
+      <Screen preset="fixed" headerShown={false}>
         <View style={styles.loadingContainer}>
           <ActivityIndicator
             size="large"

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -272,7 +272,7 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   const screenFooter = isRecoverable ? recoverableFooter : waitingFooter
 
   return (
-    <Screen preset="fixed">
+    <Screen preset="fixed" headerShown={false}>
       <StatusScreenLayout
         icon="clock"
         iconColor={colors.warning}

--- a/app/screens/conversion-flow/conversion-success-screen.tsx
+++ b/app/screens/conversion-flow/conversion-success-screen.tsx
@@ -70,7 +70,7 @@ export const ConversionSuccessScreen = () => {
   }, [navigation, returnTo])
 
   return (
-    <Screen preset="scroll" style={styles.screen}>
+    <Screen preset="scroll" style={styles.screen} headerShown={false}>
       <View style={styles.container}>
         <SuccessIconAnimation>
           <GaloyIcon name={"payment-success"} size={128} />

--- a/app/screens/feature-unavailable/temporarily-unavailable-screen.tsx
+++ b/app/screens/feature-unavailable/temporarily-unavailable-screen.tsx
@@ -16,7 +16,7 @@ export const TemporarilyUnavailableScreen: React.FC = () => {
   const { LL } = useI18nContext()
 
   return (
-    <Screen preset="fixed">
+    <Screen preset="fixed" headerShown={false}>
       <View style={styles.container} {...testProps("temporarily-unavailable-screen")}>
         <GaloyIcon name="warning" size={64} color={colors.warning} />
         <Text type="h1" style={styles.title}>

--- a/app/screens/self-custodial/mode-switch-success-screen.tsx
+++ b/app/screens/self-custodial/mode-switch-success-screen.tsx
@@ -38,7 +38,7 @@ export const ModeSwitchSuccessScreen = () => {
   }, [navigation])
 
   return (
-    <Screen preset="scroll" style={styles.screen}>
+    <Screen preset="scroll" style={styles.screen} headerShown={false}>
       <View style={styles.container}>
         <SuccessIconAnimation>
           <GaloyIcon name={"payment-success"} size={128} />

--- a/app/screens/self-custodial/onboarding/backup-success-screen.tsx
+++ b/app/screens/self-custodial/onboarding/backup-success-screen.tsx
@@ -45,7 +45,7 @@ export const BackupSuccessScreen: React.FC = () => {
   const message = customMessage ?? fallbackMessage
 
   return (
-    <Screen preset="fixed">
+    <Screen preset="fixed" headerShown={false}>
       <SuccessScreenLayout onAnimationComplete={handleAnimationComplete}>
         <Text style={styles.message}>{message}</Text>
       </SuccessScreenLayout>

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -13,6 +13,7 @@ import Svg, { Circle } from "react-native-svg"
 import { Camera, CameraType } from "react-native-camera-kit"
 import { check, request, PERMISSIONS, RESULTS } from "react-native-permissions"
 import RNQRGenerator from "rn-qr-generator"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import { gql } from "@apollo/client"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
@@ -47,7 +48,13 @@ import { testProps } from "@app/utils/testProps"
 import { resolveDestination } from "./payment-destination/resolve-destination"
 
 const { width: screenWidth } = Dimensions.get("window")
-const { height: screenHeight } = Dimensions.get("window")
+
+/** Gaps kept between the scanner's own controls and whatever the system draws over the
+ *  window. From Android 15 the window runs edge to edge, so the status bar and the
+ *  navigation or gesture bar sit on top of the camera preview rather than beside it, and
+ *  a control placed at a fixed offset from the window edge lands underneath them. */
+const CLOSE_BUTTON_GAP = 16
+const BOTTOM_CONTROLS_GAP = 24
 
 /**
  * Longest side the picker is allowed to hand back. The QR decoder holds the decoded
@@ -108,6 +115,7 @@ export const ScanningQRCodeScreen: React.FC = () => {
   })
 
   const { LL } = useI18nContext()
+  const insets = useSafeAreaInsets()
   const { displayCurrency } = useDisplayCurrency()
   const { sdk } = useSelfCustodialWallet()
   const sparkNetwork = useSparkNetwork()
@@ -424,6 +432,8 @@ export const ScanningQRCodeScreen: React.FC = () => {
    *  so opening it would read as a dead button. Dimming says the same thing the guard
    *  does, before the user spends a trip through the gallery on it. */
   const galleryIconStyle = pending ? styles.iconGaleryPending : styles.iconGalery
+  const closeInsetStyle = { marginTop: insets.top + CLOSE_BUTTON_GAP }
+  const bottomControlsInsetStyle = { bottom: insets.bottom + BOTTOM_CONTROLS_GAP }
 
   return (
     <Screen unsafe>
@@ -443,14 +453,14 @@ export const ScanningQRCodeScreen: React.FC = () => {
           <View style={styles.rectangle} />
         </View>
         <Pressable onPress={navigation.goBack}>
-          <View style={styles.close}>
+          <View style={[styles.close, closeInsetStyle]}>
             <Svg viewBox="0 0 100 100">
               <Circle cx={50} cy={50} r={50} fill={colors._white} opacity={0.5} />
             </Svg>
             <GaloyIcon name="close" size={64} style={styles.iconClose} />
           </View>
         </Pressable>
-        <View style={styles.openGallery}>
+        <View style={[styles.openGallery, bottomControlsInsetStyle]}>
           <Pressable
             {...testProps("open-gallery")}
             disabled={pending}
@@ -483,15 +493,13 @@ const useStyles = makeStyles(({ colors }) => ({
     alignSelf: "flex-end",
     height: 64,
     marginRight: 16,
-    marginTop: 40,
     width: 64,
   },
 
   openGallery: {
-    height: 128,
+    height: 64,
     left: 32,
     position: "absolute",
-    top: screenHeight - 96,
     width: screenWidth,
   },
 


### PR DESCRIPTION
Closes blinkbitcoin/blink-wip#887

## What the audit found

From Android 15 a target of 35 or above draws edge to edge, and this app targets 36, so production is already edge to edge. Only three screens call `useSafeAreaInsets`, which reads as thin coverage, but it is not where the work happens: [`app/components/screen/screen.tsx`](https://github.com/blinkbitcoin/blink-mobile/blob/main/app/components/screen/screen.tsx) wraps every screen in a `SafeAreaView` and derives its edges from whether a navigation header is shown, and the bottom tab bar adds `insets.bottom` to its own height. Most screens are covered by that alone.

Two classes are not, and I walked all 21 header-less routes to find them.

**Screens that opt out with `unsafe` and then place controls at a fixed offset from the window edge.** One real case: the QR scanner.

**Screens on a route the navigator marks `headerShown: false` that never pass that on to `Screen`.** `Screen` only adds the top edge when it is told the header is hidden, so these draw their first row under the status bar. Six of them.

## The scanner

`scanning-qrcode-screen.tsx` renders `<Screen unsafe>` and placed its controls with two hardcoded numbers:

```ts
close:       { marginTop: 40 }                       // stood in for the status bar
openGallery: { top: screenHeight - 96, height: 128 } // ends 32px past the window
```

`screenHeight` comes from `Dimensions.get("window")`, which under edge to edge includes the area the system bars are drawn over. The gallery and clipboard buttons ran off the bottom of the window and the navigation bar cut them in half. Both offsets now come from `useSafeAreaInsets()`.

## Screenshots

This is the change with the visible impact, so it is the one shown here. Captured on an Android 15 emulator against both navigation modes.

Three-button navigation, where the navigation bar cuts the controls:

| Before | After |
| :---: | :---: |
| <img width="300" alt="01-scanner-3button-BEFORE" src="https://github.com/user-attachments/assets/ea23b751-ebc7-4800-a216-f0abbfc7ce42" /> | <img width="300" alt="02-scanner-3button-AFTER" src="https://github.com/user-attachments/assets/aa907267-8f55-4038-a34c-a42fcfb2e130" /> |

Gesture navigation:

| Before | After |
| :---: | :---: |
| <img width="300" alt="03-scanner-gesture-BEFORE" src="https://github.com/user-attachments/assets/8630bd98-aebc-44bd-9649-bba3855662c3" /> | <img width="300" alt="04-scanner-gesture-AFTER" src="https://github.com/user-attachments/assets/c543c44f-4946-476e-b364-c19da03eb4a9" /> |

The six header-less screens are centered layouts, so their fix moves content by the height of the status bar without a difference a screenshot can show. They are covered by tests instead, below.

## The six header-less screens

`conversionSuccess`, `selfCustodialBackupSuccess`, `selfCustodialModeSwitchSuccess`, `accountMigrationStart`, `accountMigrationTransferringFunds` and `temporarilyUnavailable` now pass `headerShown={false}`, which is what `sendBitcoinCompleted`, `contactDetail` and `peopleHome` were already doing correctly.

## Edge-to-edge setup, as the ticket asks it be documented

`app.tsx` had no `SafeAreaProvider`. React Navigation ships `SafeAreaProviderCompat` inside each navigator, which is why insets worked at all, but only inside a navigator and only from the first measured frame. The tree is now wrapped in `SafeAreaProvider` with `initialWindowMetrics`, so insets are correct on the first frame and available to anything rendered outside a navigator. React Navigation's compat degrades to a plain `View` when it finds insets already in context, so values inside navigators are unchanged.

**On `BootTheme`:** `styles.xml` comments that `BootTheme` should inherit from `Theme.BootSplash` or `Theme.BootSplash.EdgeToEdge`. I tried the `EdgeToEdge` parent and backed it out. `BootTheme` is `MainActivity`'s manifest theme, so that parent makes the whole activity window edge to edge on every release from Android 8, not only on 15, and `postBootSplashTheme` does not reset those window attributes afterwards. The window is already edge to edge on 15 through the target SDK, so it buys nothing there and puts the older releases at risk. `styles.xml` is untouched.

## Tests

14 new tests.

- `__tests__/navigation/header-less-screen-insets.spec.ts` walks the navigators and asserts that every route declaring `headerShown: false` passes it on to `Screen`. It derives the route list from the source rather than a hand-kept list, so a new header-less screen cannot be added without either handling its insets or being recorded in the exception set, and a second test fails if an exception entry goes stale.
- The scanner spec mocks `useSafeAreaInsets` and asserts the bottom controls are offset by `insets.bottom` and the close button by `insets.top`.

519 tests across 39 suites pass. `tsc` and `eslint --max-warnings 0` are clean.

## Verification

Android 15 (API 35) emulator in both gesture and three-button navigation, switching modes live with `cmd overlay enable`, and an Android 14 (API 34) emulator for the no-regression check.

## Not folded in

blink-wip#888 (deprecated `setStatusBarColor` / `setNavigationBarColor`) and blink-wip#889 (portrait lock) are their own tickets and stay out of this one.


