### PR TITLE
feat(display-currency): default a self-custodial account to its device region

### DIFF
--- a/__tests__/self-custodial/components/display-currency-from-region-mount.spec.tsx
+++ b/__tests__/self-custodial/components/display-currency-from-region-mount.spec.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+// React 19 react-test-renderer calls window.dispatchEvent for error
+// reporting which doesn't exist in React Native jest environment.
+if (typeof window !== "undefined" && !window.dispatchEvent) {
+  window.dispatchEvent = jest.fn()
+}
+
+import { DisplayCurrencyFromRegionMount } from "@app/self-custodial/components/display-currency-from-region-mount"
+
+const mockDisplayCurrencyFromRegion = jest.fn()
+jest.mock("@app/self-custodial/hooks/use-display-currency-from-region", () => ({
+  useDisplayCurrencyFromRegion: () => mockDisplayCurrencyFromRegion(),
+}))
+
+describe("DisplayCurrencyFromRegionMount", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("mounts the region default hook exactly once per render", () => {
+    render(<DisplayCurrencyFromRegionMount />)
+
+    expect(mockDisplayCurrencyFromRegion).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders null so it contributes no UI to the tree", () => {
+    const { toJSON } = render(<DisplayCurrencyFromRegionMount />)
+
+    expect(toJSON()).toBeNull()
+  })
+})

--- a/__tests__/self-custodial/hooks/use-display-currency-from-region.spec.ts
+++ b/__tests__/self-custodial/hooks/use-display-currency-from-region.spec.ts
@@ -1,0 +1,174 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+
+import { useDisplayCurrencyFromRegion } from "@app/self-custodial/hooks/use-display-currency-from-region"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import { DefaultAccountId } from "@app/types/wallet"
+
+const mockGetCurrencies = jest.fn<string[], []>()
+jest.mock("react-native-localize", () => ({
+  getCurrencies: () => mockGetCurrencies(),
+  getLocales: () => [],
+}))
+
+type CurrencyListResult = { data?: { currencyList: { id: string }[] } }
+const mockUseCurrencyListQuery = jest.fn<CurrencyListResult, [unknown]>()
+jest.mock("@app/graphql/generated", () => ({
+  useCurrencyListQuery: (options: unknown) => mockUseCurrencyListQuery(options),
+}))
+
+const SELF_CUSTODIAL_ID = "self-custodial-1"
+
+let mockPersistentState: PersistentState
+const mockUpdateState = jest.fn()
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: mockPersistentState,
+    updateState: mockUpdateState,
+  }),
+}))
+
+/** What the hook actually stored, read back through the updater it handed to the context. */
+const storedCurrency = (): string | undefined => {
+  const update = mockUpdateState.mock.calls[0][0]
+  const next: PersistentState = update(mockPersistentState)
+  return next.selfCustodialDisplayCurrencyByAccountId?.[SELF_CUSTODIAL_ID]
+}
+
+describe("useDisplayCurrencyFromRegion", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPersistentState = {
+      schemaVersion: 20,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "",
+      activeAccountId: SELF_CUSTODIAL_ID,
+    }
+    mockGetCurrencies.mockReturnValue(["CRC", "USD"])
+    mockUseCurrencyListQuery.mockReturnValue({
+      data: { currencyList: [{ id: "USD" }, { id: "EUR" }, { id: "CRC" }] },
+    })
+  })
+
+  it("gives an account with no preference the currency of its region", async () => {
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+    expect(storedCurrency()).toBe("CRC")
+  })
+
+  it("leaves a stored preference alone", async () => {
+    mockPersistentState = {
+      ...mockPersistentState,
+      selfCustodialDisplayCurrencyByAccountId: { [SELF_CUSTODIAL_ID]: "USD" },
+    }
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("does not ask for the currency list once a preference is stored", () => {
+    mockPersistentState = {
+      ...mockPersistentState,
+      selfCustodialDisplayCurrencyByAccountId: { [SELF_CUSTODIAL_ID]: "EUR" },
+    }
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    expect(mockUseCurrencyListQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: true }),
+    )
+  })
+
+  it("asks for the currency list only while the preference is unanswered", () => {
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    expect(mockUseCurrencyListQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: false }),
+    )
+  })
+
+  it("writes nothing for a custodial account", async () => {
+    mockPersistentState = {
+      ...mockPersistentState,
+      activeAccountId: DefaultAccountId.Custodial,
+    }
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("writes nothing when no account is active", async () => {
+    mockPersistentState = { ...mockPersistentState, activeAccountId: undefined }
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("waits for the currency list instead of guessing", async () => {
+    mockUseCurrencyListQuery.mockReturnValue({ data: undefined })
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("waits rather than write from an empty currency list", async () => {
+    mockUseCurrencyListQuery.mockReturnValue({ data: { currencyList: [] } })
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("leaves the fallback in place when the region's currency cannot be priced", async () => {
+    mockGetCurrencies.mockReturnValue(["XBT"])
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUseCurrencyListQuery).toHaveBeenCalled())
+    expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  it("writes under the active account without disturbing the other accounts", async () => {
+    mockPersistentState = {
+      ...mockPersistentState,
+      selfCustodialDisplayCurrencyByAccountId: { "self-custodial-2": "GBP" },
+    }
+
+    renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+    const update = mockUpdateState.mock.calls[0][0]
+    expect(update(mockPersistentState).selfCustodialDisplayCurrencyByAccountId).toEqual({
+      "self-custodial-1": "CRC",
+      "self-custodial-2": "GBP",
+    })
+  })
+
+  it("writes once and stops once the account holds a currency", async () => {
+    const { rerender } = renderHook(() => useDisplayCurrencyFromRegion())
+
+    await waitFor(() => expect(mockUpdateState).toHaveBeenCalledTimes(1))
+
+    mockPersistentState = {
+      ...mockPersistentState,
+      selfCustodialDisplayCurrencyByAccountId: { [SELF_CUSTODIAL_ID]: "CRC" },
+    }
+    rerender(undefined)
+
+    await waitFor(() =>
+      expect(mockUseCurrencyListQuery).toHaveBeenLastCalledWith(
+        expect.objectContaining({ skip: true }),
+      ),
+    )
+    expect(mockUpdateState).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/store/persistent-state/migrated-account-settings.spec.ts
+++ b/__tests__/store/persistent-state/migrated-account-settings.spec.ts
@@ -80,7 +80,7 @@ describe("seedMigratedAccountSettings", () => {
     expect(next).toBe(baseState)
 
     const activated: PersistentState = { ...next, activeAccountId: migratedId }
-    expect(getSelfCustodialDisplayCurrency(activated)).toBe("USD")
+    expect(getSelfCustodialDisplayCurrency(activated)).toBeUndefined()
     expect(getSelfCustodialLanguage(activated)).toBe("DEFAULT")
     expect(getThemePreference(activated)).toBe("system")
   })

--- a/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
@@ -13,8 +13,8 @@ const baseState: PersistentState = {
 }
 
 describe("getSelfCustodialDisplayCurrency", () => {
-  it("returns USD as the ultimate default", () => {
-    expect(getSelfCustodialDisplayCurrency(baseState)).toBe("USD")
+  it("returns undefined when nothing has been stored", () => {
+    expect(getSelfCustodialDisplayCurrency(baseState)).toBeUndefined()
   })
 
   it("returns the per-account map value when set for the active id", () => {
@@ -50,33 +50,43 @@ describe("getSelfCustodialDisplayCurrency", () => {
     ).toBe("GBP")
   })
 
-  it("falls back to USD when map is absent for the active id", () => {
+  it("returns undefined when the map holds nothing for the active id", () => {
     const state: PersistentState = {
       ...baseState,
       activeAccountId: "self-custodial-new",
       selfCustodialDisplayCurrencyByAccountId: { "self-custodial-other": "EUR" },
     }
 
+    expect(getSelfCustodialDisplayCurrency(state)).toBeUndefined()
+  })
+
+  it("tells a deliberate USD apart from an unanswered preference", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      selfCustodialDisplayCurrencyByAccountId: { "self-custodial-1": "USD" },
+    }
+
     expect(getSelfCustodialDisplayCurrency(state)).toBe("USD")
   })
 
-  it("returns USD when active is custodial", () => {
+  it("returns undefined when active is custodial", () => {
     const state: PersistentState = {
       ...baseState,
       activeAccountId: DefaultAccountId.Custodial,
       selfCustodialDisplayCurrencyByAccountId: { "self-custodial-1": "EUR" },
     }
 
-    expect(getSelfCustodialDisplayCurrency(state)).toBe("USD")
+    expect(getSelfCustodialDisplayCurrency(state)).toBeUndefined()
   })
 
-  it("returns USD when there is no active account", () => {
+  it("returns undefined when there is no active account", () => {
     const state: PersistentState = {
       ...baseState,
       selfCustodialDisplayCurrencyByAccountId: { "self-custodial-1": "EUR" },
     }
 
-    expect(getSelfCustodialDisplayCurrency(state)).toBe("USD")
+    expect(getSelfCustodialDisplayCurrency(state)).toBeUndefined()
   })
 })
 

--- a/__tests__/utils/locale-detector.test.ts
+++ b/__tests__/utils/locale-detector.test.ts
@@ -1,12 +1,23 @@
 import {
   detectDefaultCurrency,
+  detectDefaultLocale,
+  getLanguageFromString,
+  getLocaleFromLanguage,
   matchOsLocaleToSupportedLocale,
 } from "../../app/utils/locale-detector"
 
+type OsLocale = {
+  countryCode: string
+  languageTag: string
+  languageCode: string
+  isRTL: boolean
+}
+
 const mockGetCurrencies = jest.fn<string[], []>()
+const mockGetLocales = jest.fn<OsLocale[], []>()
 jest.mock("react-native-localize", () => ({
   getCurrencies: () => mockGetCurrencies(),
-  getLocales: () => [],
+  getLocales: () => mockGetLocales(),
 }))
 
 describe("matchOsLocaleToSupportedLocale", () => {
@@ -70,5 +81,53 @@ describe("detectDefaultCurrency", () => {
     mockGetCurrencies.mockReturnValue(["CRC"])
 
     expect(detectDefaultCurrency([])).toBeUndefined()
+  })
+})
+
+describe("detectDefaultLocale", () => {
+  it("reads the locale the OS reports", () => {
+    mockGetLocales.mockReturnValue([
+      { countryCode: "CA", languageTag: "fr-CA", languageCode: "fr", isRTL: false },
+    ])
+
+    expect(detectDefaultLocale()).toBe("fr")
+  })
+
+  it("falls back to english when the OS reports nothing", () => {
+    mockGetLocales.mockReturnValue([])
+
+    expect(detectDefaultLocale()).toBe("en")
+  })
+})
+
+describe("getLanguageFromString", () => {
+  it("treats a missing language as the OS default", () => {
+    expect(getLanguageFromString()).toBe("DEFAULT")
+  })
+
+  it("keeps a language the app supports", () => {
+    expect(getLanguageFromString("es")).toBe("es")
+  })
+
+  it("accepts the region-tagged values written server side before", () => {
+    expect(getLanguageFromString("pt-BR")).toBe("pt")
+  })
+
+  it("treats an unsupported language as the OS default", () => {
+    expect(getLanguageFromString("na-XY")).toBe("DEFAULT")
+  })
+})
+
+describe("getLocaleFromLanguage", () => {
+  it("resolves DEFAULT against the OS", () => {
+    mockGetLocales.mockReturnValue([
+      { countryCode: "SV", languageTag: "es-SV", languageCode: "es", isRTL: false },
+    ])
+
+    expect(getLocaleFromLanguage("DEFAULT")).toBe("es")
+  })
+
+  it("returns a chosen language untouched", () => {
+    expect(getLocaleFromLanguage("fr")).toBe("fr")
   })
 })

--- a/__tests__/utils/locale-detector.test.ts
+++ b/__tests__/utils/locale-detector.test.ts
@@ -1,4 +1,13 @@
-import { matchOsLocaleToSupportedLocale } from "../../app/utils/locale-detector"
+import {
+  detectDefaultCurrency,
+  matchOsLocaleToSupportedLocale,
+} from "../../app/utils/locale-detector"
+
+const mockGetCurrencies = jest.fn<string[], []>()
+jest.mock("react-native-localize", () => ({
+  getCurrencies: () => mockGetCurrencies(),
+  getLocales: () => [],
+}))
 
 describe("matchOsLocaleToSupportedLocale", () => {
   it("exactly matches a supported locale", () => {
@@ -23,5 +32,43 @@ describe("matchOsLocaleToSupportedLocale", () => {
     ]
     const locale = matchOsLocaleToSupportedLocale(unsupportedCountryAndLang)
     expect(locale).toEqual("en")
+  })
+})
+
+describe("detectDefaultCurrency", () => {
+  const supportedCurrencyIds = ["USD", "EUR", "GBP", "CRC"]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns the currency the device prefers", () => {
+    mockGetCurrencies.mockReturnValue(["CRC", "USD"])
+
+    expect(detectDefaultCurrency(supportedCurrencyIds)).toBe("CRC")
+  })
+
+  it("takes the next device currency when the preferred one cannot be priced", () => {
+    mockGetCurrencies.mockReturnValue(["XBT", "GBP"])
+
+    expect(detectDefaultCurrency(supportedCurrencyIds)).toBe("GBP")
+  })
+
+  it("returns undefined when no device currency can be priced", () => {
+    mockGetCurrencies.mockReturnValue(["XBT", "XAU"])
+
+    expect(detectDefaultCurrency(supportedCurrencyIds)).toBeUndefined()
+  })
+
+  it("returns undefined when the device names no currency", () => {
+    mockGetCurrencies.mockReturnValue([])
+
+    expect(detectDefaultCurrency(supportedCurrencyIds)).toBeUndefined()
+  })
+
+  it("returns undefined when nothing is known to be priceable yet", () => {
+    mockGetCurrencies.mockReturnValue(["CRC"])
+
+    expect(detectDefaultCurrency([])).toBeUndefined()
   })
 })

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -26,6 +26,7 @@ import { CustodialWalletProvider } from "./custodial/providers/wallet"
 import {
   AccountModeSyncMount,
   AutoConvertListenerMount,
+  DisplayCurrencyFromRegionMount,
 } from "./self-custodial/components"
 import { AutoConvertStatusProvider } from "./self-custodial/providers/auto-convert-status"
 import { BackupStateProvider } from "./self-custodial/providers/backup-state"
@@ -86,6 +87,7 @@ export const App = () => (
                                         <PushNotificationComponent />
                                         <AutoConvertListenerMount />
                                         <AccountModeSyncMount />
+                                        <DisplayCurrencyFromRegionMount />
                                         <RootStack />
                                         <NetworkErrorComponent />
                                         <ActionModals />

--- a/app/hooks/use-effective-display-currency.ts
+++ b/app/hooks/use-effective-display-currency.ts
@@ -15,6 +15,10 @@ import { AccountType } from "@app/types/wallet"
 
 import { useAccountRegistry } from "./use-account-registry"
 
+/** Held until a preference is known: the account's own, or the one the device's region
+ *  implies once {@link useDisplayCurrencyFromRegion} has been able to read it. */
+export const DEFAULT_DISPLAY_CURRENCY = "USD"
+
 type EffectiveDisplayCurrencyReturn = {
   displayCurrency: string
   setDisplayCurrency: (currency: string) => Promise<void>
@@ -54,14 +58,16 @@ export const useEffectiveDisplayCurrency = (): EffectiveDisplayCurrencyReturn =>
 
   if (isSelfCustodial) {
     return {
-      displayCurrency: getSelfCustodialDisplayCurrency(persistentState),
+      displayCurrency:
+        getSelfCustodialDisplayCurrency(persistentState) ?? DEFAULT_DISPLAY_CURRENCY,
       setDisplayCurrency: setDisplayCurrencySelfCustodial,
       loading: false,
     }
   }
 
   return {
-    displayCurrency: data?.me?.defaultAccount?.displayCurrency ?? "USD",
+    displayCurrency:
+      data?.me?.defaultAccount?.displayCurrency ?? DEFAULT_DISPLAY_CURRENCY,
     setDisplayCurrency: setDisplayCurrencyCustodial,
     loading: queryLoading || mutationLoading,
   }

--- a/app/self-custodial/components/display-currency-from-region-mount.tsx
+++ b/app/self-custodial/components/display-currency-from-region-mount.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+import { useDisplayCurrencyFromRegion } from "../hooks/use-display-currency-from-region"
+
+/**
+ * Root-level host: the account that needs a default is the one that has just been restored
+ * or created, and the currency list it is matched against may only arrive later, which no
+ * single screen stays mounted for.
+ */
+export const DisplayCurrencyFromRegionMount: React.FC = () => {
+  useDisplayCurrencyFromRegion()
+  return null
+}

--- a/app/self-custodial/components/index.ts
+++ b/app/self-custodial/components/index.ts
@@ -1,4 +1,5 @@
 export { AccountModeSyncMount } from "./account-mode-sync-mount"
 export { AutoConvertListenerMount } from "./auto-convert-listener-mount"
+export { DisplayCurrencyFromRegionMount } from "./display-currency-from-region-mount"
 export { OfflineGate } from "./offline-gate"
 export { PaymentOfflineNotice } from "./payment-offline-notice"

--- a/app/self-custodial/hooks/use-display-currency-from-region.ts
+++ b/app/self-custodial/hooks/use-display-currency-from-region.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react"
+
+import { useCurrencyListQuery } from "@app/graphql/generated"
+import { usePersistentStateContext } from "@app/store/persistent-state"
+import { resolveActiveSelfCustodialId } from "@app/store/persistent-state/active-self-custodial-account"
+import {
+  getSelfCustodialDisplayCurrency,
+  withSelfCustodialDisplayCurrency,
+} from "@app/store/persistent-state/self-custodial-display-currency"
+import { detectDefaultCurrency } from "@app/utils/locale-detector"
+
+/**
+ * Gives an account that has never named a display currency the one its device's region
+ * implies, so a restored wallet stops landing on dollars in a country that does not use
+ * them. A custodial account is not covered: its preference lives on the server and always
+ * holds a value, so it has no unanswered case to fill.
+ *
+ * The choice is written once rather than re-derived on every read. An unwritten default
+ * would resolve again on each launch, so a cold currency list would show dollars and then
+ * switch mid-session, and the settings row would read as already selected while refusing
+ * the tap that would confirm it.
+ *
+ * The device's currency is honoured only when the backend can price it: an unsupported
+ * code leaves the realtime price with no denominator, which is worse than dollars.
+ *
+ * A launch that never reaches the currency list writes nothing and leaves the account on
+ * dollars until the next one, since the client's retry link gives up in seconds and no
+ * refetch follows. Restoring a wallet needs the network anyway, so the list is there on
+ * the launch that matters; waiting a session beats freezing a guess.
+ */
+export const useDisplayCurrencyFromRegion = (): void => {
+  const { persistentState, updateState } = usePersistentStateContext()
+
+  const activeAccountId = resolveActiveSelfCustodialId(persistentState)
+  const isDisplayCurrencyUnanswered =
+    Boolean(activeAccountId) && !getSelfCustodialDisplayCurrency(persistentState)
+
+  const { data } = useCurrencyListQuery({
+    skip: !isDisplayCurrencyUnanswered,
+    fetchPolicy: "cache-first",
+  })
+  const currencyList = data?.currencyList
+
+  useEffect(() => {
+    if (!isDisplayCurrencyUnanswered || !currencyList?.length) return
+
+    const currencyFromRegion = detectDefaultCurrency(
+      currencyList.map((currency) => currency.id),
+    )
+    if (!currencyFromRegion) return
+
+    updateState(
+      (prev) => prev && withSelfCustodialDisplayCurrency(prev, currencyFromRegion),
+    )
+  }, [isDisplayCurrencyUnanswered, currencyList, updateState])
+}

--- a/app/store/persistent-state/self-custodial-display-currency.ts
+++ b/app/store/persistent-state/self-custodial-display-currency.ts
@@ -3,10 +3,14 @@ import { DefaultAccountId } from "@app/types/wallet"
 import { resolveActiveSelfCustodialId } from "./active-self-custodial-account"
 import { PersistentState } from "./state-migrations"
 
-export const getSelfCustodialDisplayCurrency = (state: PersistentState): string => {
+/** Undefined when the account has never stored one, so a caller can tell an unanswered
+ *  preference from a deliberate "USD" and infer a default only in the first case. */
+export const getSelfCustodialDisplayCurrency = (
+  state: PersistentState,
+): string | undefined => {
   const id = resolveActiveSelfCustodialId(state)
-  if (!id) return "USD"
-  return state.selfCustodialDisplayCurrencyByAccountId?.[id] ?? "USD"
+  if (!id) return undefined
+  return state.selfCustodialDisplayCurrencyByAccountId?.[id]
 }
 
 export const withSelfCustodialDisplayCurrency = (

--- a/app/utils/locale-detector.ts
+++ b/app/utils/locale-detector.ts
@@ -24,6 +24,18 @@ export const detectDefaultLocale = (): Locales => {
   return matchOsLocaleToSupportedLocale(localesFromOs)
 }
 
+/**
+ * The device's preferred currency, taken from the OS region and locale settings, so it
+ * costs no permission and no network call. Undefined when the device names no currency the
+ * backend can price, which leaves the caller on its own fallback.
+ */
+export const detectDefaultCurrency = (
+  supportedCurrencyIds: readonly string[],
+): string | undefined => {
+  const currenciesFromOs = RNLocalize.getCurrencies()
+  return currenciesFromOs.find((currencyId) => supportedCurrencyIds.includes(currencyId))
+}
+
 export const Languages = ["DEFAULT", ...locales] as const
 
 export type Language = (typeof Languages)[number]


### PR DESCRIPTION
Fixes [blinkbitcoin/blink-wip#1167](https://github.com/blinkbitcoin/blink-wip/issues/1167) (close manually on merge — cross-repo `Fixes` doesn't auto-close).

## Problem

Restore a wallet in Costa Rica, Japan or anywhere else and the app shows dollars. The user has to go and set their own currency by hand, every time, on every device.

The cause is that the display currency is stored and never derived. A custodial account keeps it on the server, so it survives. A self-custodial account keeps it in `persistentState` under its account id, and a device that has never seen that account has no entry — so the read falls through to a hardcoded `"USD"`:

```ts
// app/store/persistent-state/self-custodial-display-currency.ts, before
export const getSelfCustodialDisplayCurrency = (state: PersistentState): string => {
  const id = resolveActiveSelfCustodialId(state)
  if (!id) return "USD"
  return state.selfCustodialDisplayCurrencyByAccountId?.[id] ?? "USD"
}
```

That fallback also hides the distinction the fix needs: an account that deliberately chose dollars and an account that was never asked read back identically.

## What this does

A self-custodial account that has never named a display currency is given the one its device's region implies. Anything already stored wins, dollars included.

- `getSelfCustodialDisplayCurrency` now returns `string | undefined`. `undefined` means unanswered; `"USD"` now only ever means someone chose it. `useEffectiveDisplayCurrency` owns the `DEFAULT_DISPLAY_CURRENCY` fallback for both account types.
- `detectDefaultCurrency` in `app/utils/locale-detector.ts` reads the device's currencies and returns the first one the backend can price.
- `useDisplayCurrencyFromRegion` writes that value once, mounted at the root next to `AccountModeSyncMount`.

Custodial accounts are not touched. Their preference lives on the server and always holds a value, so they have no unanswered case to fill.

## Why the device and not the IP

The app already resolves a country from the request IP through `regionCheck`, and it is the wrong source here. It is scoped to custodial rules, it needs the query to have answered, and Anon mode deliberately does not read an IP at all.

`RNLocalize.getCurrencies()` reads the OS region and locale settings instead: no permission prompt, no network call, no new dependency — the library is already used by `detectDefaultLocale` in the same file.

## Why it is written once instead of resolved on every read

Resolving at read time is the smaller diff and it is wrong in two ways I verified rather than assumed.

The currency list arrives over the network, so a launch that has not received it yet resolves to dollars and switches afterwards. `usePriceConversion` guards on the price denominator matching the display currency, and `convertWithRounding` sets the amount to `NaN` and files a `recordAppError` when a display amount is converted after the currency moves under it. Deriving on every read reopens that window on every launch.

It also cannot be confirmed by the user. The settings row would already render as selected, and `MenuSelect`'s item returns early on a tap on the selected row:

```ts
// app/components/menu-select/item.tsx
const onPress = async () => {
  if (selected || loading) return
```

So the currency shown could never be turned into a stored preference, and a later change of device region would silently re-denominate the whole app.

Writing once settles both: the value becomes an ordinary preference, identical to one picked in settings.

## Why the currency is matched against `currencyList`

`realtimePriceUnauthed` takes the display currency as its denominator. A code the backend cannot price leaves it with no price at all, which is worse than dollars, so a device currency is only honoured when it appears in the list. When it does not, the account stays on the `USD` fallback.

One consequence worth knowing: a launch that never reaches the list writes nothing and leaves the account on dollars until the next one, since the client's retry link gives up in seconds and no refetch follows. Restoring a wallet needs the network anyway, so the list is there on the launch that matters.

## Screenshots

| A wallet that never chose a currency, device region CR | The same wallet after the device region becomes JP |
| --- | --- |
| <img width="300" alt="01-region-cr-shows-crc" src="https://github.com/user-attachments/assets/4d9d99ec-b696-42b3-87d2-ae230b2d8f94" /> | <img width="300" alt="02-region-jp-keeps-crc" src="https://github.com/user-attachments/assets/28859d2b-2511-4511-8f3f-0ae7cd16b0b3" /> |

| Settings reflects it as an ordinary preference | A currency picked by hand survives a region change |
| --- | --- |
| <img width="300" alt="04-settings-shows-crc" src="https://github.com/user-attachments/assets/1e0af36d-dea9-40e7-92c0-aa69a3deaf5c" /> | <img width="300" alt="05-user-choice-eur-survives-jp" src="https://github.com/user-attachments/assets/2d4c9309-80e0-4481-a730-a919981d2712" /> |

## Tests

`app/utils/locale-detector.ts`, `app/store/persistent-state/self-custodial-display-currency.ts`, `app/hooks/use-effective-display-currency.ts`, `app/self-custodial/hooks/use-display-currency-from-region.ts` and `app/self-custodial/components/display-currency-from-region-mount.tsx` are at 100% statements, branches, functions and lines.

The second commit is separate on purpose: it covers `detectDefaultLocale`, `getLanguageFromString` and `getLocaleFromLanguage`, which were already in `locale-detector.ts` untested and are not part of this change.
