### PR TITLE
fix(android): remove the portrait-only restriction for large-screen support

### DIFF
--- a/__tests__/components/qr-carousel.spec.tsx
+++ b/__tests__/components/qr-carousel.spec.tsx
@@ -4,6 +4,17 @@ import { render } from "@testing-library/react-native"
 
 import { QRCarousel } from "@app/components/qr-carousel"
 
+/** Mocked at the module the index re-exports: spreading `react-native` itself pulls in the
+ *  whole index eagerly and the dev-menu TurboModule throws under jest. */
+const mockWindow = { width: 360, height: 800, scale: 2, fontScale: 1 }
+jest.mock("react-native/Libraries/Utilities/useWindowDimensions", () => ({
+  __esModule: true,
+  default: () => mockWindow,
+}))
+
+/** What the carousel was asked to be, so a test can read the size back. */
+const mockCarouselProps: { width?: number; height?: number } = {}
+
 jest.mock("@rn-vui/themed", () => ({
   makeStyles: () => () => ({
     page: {},
@@ -33,15 +44,19 @@ jest.mock("react-native-reanimated-carousel", () => {
     height: number
   }
 
-  const Carousel = React.forwardRef((props: CarouselProps, _ref: React.Ref<never>) => (
-    <RNView testID="carousel">
-      {props.data.map((_, index: number) => (
-        <RNView key={index} testID={`carousel-item-${index}`}>
-          {props.renderItem({ index, animationValue: { value: 0 } })}
-        </RNView>
-      ))}
-    </RNView>
-  ))
+  const Carousel = React.forwardRef((props: CarouselProps, _ref: React.Ref<never>) => {
+    mockCarouselProps.width = props.width
+    mockCarouselProps.height = props.height
+    return (
+      <RNView testID="carousel">
+        {props.data.map((_, index: number) => (
+          <RNView key={index} testID={`carousel-item-${index}`}>
+            {props.renderItem({ index, animationValue: { value: 0 } })}
+          </RNView>
+        ))}
+      </RNView>
+    )
+  })
   Carousel.displayName = "MockCarousel"
 
   return {
@@ -67,6 +82,41 @@ describe("QRCarousel", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockWindow.width = 360
+    mockWindow.height = 800
+  })
+
+  /** The page holding the code is square, so the window's shorter edge bounds it. Taking
+   *  the width instead overflowed the viewport once the screen could rotate. */
+  describe("sizing against the window", () => {
+    const renderedHeight = (): number | undefined => {
+      render(<QRCarousel page0={page0} page1={page1} onSnap={mockOnSnap} />)
+      return mockCarouselProps.height
+    }
+
+    it("keeps the portrait height in landscape rather than following the long edge", () => {
+      const portrait = renderedHeight()
+
+      mockWindow.width = 800
+      mockWindow.height = 360
+
+      expect(renderedHeight()).toBe(portrait)
+    })
+
+    it("stays within the shorter edge in landscape", () => {
+      mockWindow.width = 800
+      mockWindow.height = 360
+
+      expect(renderedHeight()).toBeLessThanOrEqual(360)
+    })
+
+    it("still spans the full width for paging", () => {
+      mockWindow.width = 800
+      mockWindow.height = 360
+      render(<QRCarousel page0={page0} page1={page1} onSnap={mockOnSnap} />)
+
+      expect(mockCarouselProps.width).toBe(800)
+    })
   })
 
   it("renders without crashing", () => {

--- a/__tests__/receive-bitcoin/components/qr-view.spec.tsx
+++ b/__tests__/receive-bitcoin/components/qr-view.spec.tsx
@@ -4,6 +4,15 @@ import { render } from "@testing-library/react-native"
 import { QRView } from "@app/screens/receive-bitcoin-screen/qr-view"
 import { Invoice } from "@app/screens/receive-bitcoin-screen/payment/index.types"
 
+/** Mocked at the module the index re-exports, rather than by spreading `react-native`
+ *  itself: that spread pulls in the whole index eagerly and the dev-menu TurboModule
+ *  throws under jest. */
+const mockWindow = { width: 360, height: 800, scale: 2, fontScale: 1 }
+jest.mock("react-native/Libraries/Utilities/useWindowDimensions", () => ({
+  __esModule: true,
+  default: () => mockWindow,
+}))
+
 jest.mock("@rn-vui/themed", () => ({
   makeStyles: () => () => ({
     container: {},
@@ -99,6 +108,55 @@ const defaultProps = {
 describe("QRView", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockWindow.width = 360
+    mockWindow.height = 800
+    mockWindow.scale = 2
+  })
+
+  /** The code is square, so the window's shorter edge is what it has to fit inside. Taking
+   *  the width instead clipped it in landscape, and a clipped QR cannot be scanned. */
+  describe("sizing against the window", () => {
+    type RenderedNode = {
+      type?: string
+      props?: { size?: number }
+      children?: RenderedNode[] | null
+    }
+
+    const findQrSize = (
+      node: RenderedNode | RenderedNode[] | null,
+    ): number | undefined => {
+      if (!node) return undefined
+      if (Array.isArray(node)) {
+        return node.map(findQrSize).find((size) => size !== undefined)
+      }
+      if (node.type === "QRCode") return node.props?.size
+      return findQrSize(node.children ?? null)
+    }
+
+    const renderedQrSize = (): number | undefined => {
+      const { toJSON } = render(<QRView {...defaultProps} />)
+      return findQrSize(toJSON() as RenderedNode | RenderedNode[] | null)
+    }
+
+    it("fills the width in portrait", () => {
+      expect(renderedQrSize()).toBe(194)
+    })
+
+    it("keeps the portrait size in landscape rather than following the long edge", () => {
+      const portrait = renderedQrSize()
+
+      mockWindow.width = 800
+      mockWindow.height = 360
+
+      expect(renderedQrSize()).toBe(portrait)
+    })
+
+    it("never asks for more than the shorter edge leaves", () => {
+      mockWindow.width = 800
+      mockWindow.height = 360
+
+      expect(renderedQrSize()).toBeLessThanOrEqual(360)
+    })
   })
 
   it("renders QR code when ready with getFullUri", () => {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,7 +50,6 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
         android:launchMode="singleTask"
-        android:screenOrientation="portrait"
         android:windowSoftInputMode="adjustResize"
         android:exported="true"
         android:theme="@style/BootTheme"> <!-- Apply @style/BootTheme on .MainActivity -->

--- a/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
+++ b/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react"
-import { ActivityIndicator, Dimensions, View, I18nManager } from "react-native"
+import { ActivityIndicator, I18nManager, useWindowDimensions, View } from "react-native"
 import { Gesture, GestureDetector } from "react-native-gesture-handler"
 import Animated, {
   Extrapolate,
@@ -18,8 +18,11 @@ import { Text, makeStyles, useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon } from "../galoy-icon"
 
-const BUTTON_WIDTH = Dimensions.get("screen").width - 40
-const SWIPE_RANGE = BUTTON_WIDTH - 50
+/** The track spans the screen less the padding its callers put either side. */
+const TRACK_INSET = 40
+/** How far short of the track's end the travel stops. Not the handle's width, which is
+ *  60: this is the pre-existing figure, kept so the commit threshold does not move. */
+const TRAVEL_INSET = 50
 const isRTL = I18nManager.isRTL
 
 type SwipeButtonPropsType = {
@@ -40,7 +43,10 @@ const GaloySliderButton = ({
   const {
     theme: { colors },
   } = useTheme()
-  const styles = useStyles()
+  const { width: screenWidth } = useWindowDimensions()
+  const buttonWidth = screenWidth - TRACK_INSET
+  const swipeRange = buttonWidth - TRAVEL_INSET
+  const styles = useStyles({ buttonWidth })
 
   const X = useSharedValue(0)
 
@@ -56,12 +62,12 @@ const GaloySliderButton = ({
     .onUpdate((e) => {
       const newValue = Math.abs(e.translationX)
 
-      if (newValue >= 0 && newValue <= SWIPE_RANGE) {
+      if (newValue >= 0 && newValue <= swipeRange) {
         X.value = newValue
       }
     })
     .onEnd(() => {
-      if (X.value < SWIPE_RANGE * 0.6) {
+      if (X.value < swipeRange * 0.6) {
         X.value = withSpring(0)
       } else {
         runOnJS(onSwipe)()
@@ -72,8 +78,8 @@ const GaloySliderButton = ({
     swipeButton: useAnimatedStyle(() => {
       const translateX = interpolate(
         X.value,
-        [20, BUTTON_WIDTH],
-        [0, BUTTON_WIDTH],
+        [20, buttonWidth],
+        [0, buttonWidth],
         Extrapolation.CLAMP,
       )
 
@@ -84,23 +90,23 @@ const GaloySliderButton = ({
           },
         ],
       }
-    }, [X, isRTL]),
+    }, [X, isRTL, buttonWidth]),
     swipeText: useAnimatedStyle(() => {
       const translateX = interpolate(
         X.value,
-        [20, SWIPE_RANGE],
-        [0, BUTTON_WIDTH / 3],
+        [20, swipeRange],
+        [0, buttonWidth / 3],
         Extrapolate.CLAMP,
       )
       return {
-        opacity: interpolate(X.value, [0, BUTTON_WIDTH / 4], [1, 0], Extrapolate.CLAMP),
+        opacity: interpolate(X.value, [0, buttonWidth / 4], [1, 0], Extrapolate.CLAMP),
         transform: [
           {
             translateX: isRTL ? -translateX : translateX,
           },
         ],
       }
-    }, [X, isRTL]),
+    }, [X, isRTL, buttonWidth, swipeRange]),
   }
 
   return (
@@ -139,7 +145,7 @@ const GaloySliderButton = ({
   )
 }
 
-const useStyles = makeStyles(({ colors }) => ({
+const useStyles = makeStyles(({ colors }, { buttonWidth }: { buttonWidth: number }) => ({
   swipeButtonContainer: {
     height: 60,
     backgroundColor: colors.grey5,
@@ -149,7 +155,7 @@ const useStyles = makeStyles(({ colors }) => ({
     justifyContent: "center",
     alignItems: "center",
     flexDirection: "row",
-    width: BUTTON_WIDTH,
+    width: buttonWidth,
     position: "relative",
   },
   swipeButton: {

--- a/app/components/qr-carousel/qr-carousel.tsx
+++ b/app/components/qr-carousel/qr-carousel.tsx
@@ -44,11 +44,13 @@ const CarouselItem: React.FC<{
 export const QRCarousel = forwardRef<ICarouselInstance, QRCarouselProps>(
   ({ page0, page1, onSnap }, ref) => {
     const styles = useStyles()
-    const { width: screenWidth } = useWindowDimensions()
+    const { width: screenWidth, height: screenHeight } = useWindowDimensions()
 
+    /** Square, so it is bounded by the shorter edge rather than by the width: the two are
+     *  the same in portrait, and only the width overflows once the screen can rotate. */
     const qrContainerSize = useMemo(
-      () => Math.round(QR_TO_SCREEN_RATIO * screenWidth),
-      [screenWidth],
+      () => Math.round(QR_TO_SCREEN_RATIO * Math.min(screenWidth, screenHeight)),
+      [screenWidth, screenHeight],
     )
     const parallaxOffset = useMemo(
       () => Math.round(PARALLAX_TO_SCREEN_RATIO * screenWidth),

--- a/app/screens/earns-screen/earns-section.tsx
+++ b/app/screens/earns-screen/earns-section.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useState } from "react"
-import { Dimensions, Text, View, Alert } from "react-native"
+import { Text, useWindowDimensions, View, Alert } from "react-native"
 import { TouchableOpacity } from "react-native-gesture-handler"
 import { useSharedValue } from "react-native-reanimated"
 import Carousel from "react-native-reanimated-carousel"
@@ -23,8 +23,6 @@ import {
   getCardsFromSection,
   getQuizQuestionsContent,
 } from "./helpers"
-
-const { width: screenWidth } = Dimensions.get("window")
 
 export type QuizQuestion = {
   id: string
@@ -53,9 +51,7 @@ export type QuizSectionContent = {
   content: QuizQuestionContent[]
 }
 
-const svgWidth = screenWidth
-
-const useStyles = makeStyles(({ colors }) => ({
+const useStyles = makeStyles(({ colors }, { screenWidth }: { screenWidth: number }) => ({
   container: {
     alignItems: "center",
     flex: 1,
@@ -80,7 +76,7 @@ const useStyles = makeStyles(({ colors }) => ({
   item: {
     backgroundColor: colors._lightBlue,
     borderRadius: 16,
-    width: svgWidth,
+    width: screenWidth,
   },
 
   itemTitle: {
@@ -164,7 +160,8 @@ export const EarnSection = ({ route }: Props) => {
   const {
     theme: { colors },
   } = useTheme()
-  const styles = useStyles()
+  const { width: screenWidth } = useWindowDimensions()
+  const styles = useStyles({ screenWidth })
 
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList, "earnsSection">>()
@@ -245,7 +242,7 @@ export const EarnSection = ({ route }: Props) => {
             disabled={!item.enabled}
           >
             <View style={styles.svgContainer}>
-              {SVGs({ name: item.id, width: svgWidth })}
+              {SVGs({ name: item.id, width: screenWidth })}
             </View>
           </TouchableOpacity>
           <View>

--- a/app/screens/map-screen/map-screen.tsx
+++ b/app/screens/map-screen/map-screen.tsx
@@ -1,7 +1,7 @@
 import { CountryCode } from "libphonenumber-js/mobile"
 import * as React from "react"
 // eslint-disable-next-line react-native/split-platform-components
-import { Alert, Dimensions } from "react-native"
+import { Alert, useWindowDimensions } from "react-native"
 import { Region } from "react-native-maps"
 import { check, PermissionStatus, RESULTS } from "react-native-permissions"
 
@@ -24,9 +24,13 @@ const EL_ZONTE_COORDS = {
 }
 
 // essentially calculates zoom for location being set based on country
-const { height, width } = Dimensions.get("window")
 const LATITUDE_DELTA = 15 // <-- decrease for more zoom
-const LONGITUDE_DELTA = LATITUDE_DELTA * (width / height)
+
+/** Read per render rather than once at import: the window is not a constant on a device
+ *  that rotates, and a span measured against the wrong aspect ratio zooms to the wrong
+ *  area. */
+const longitudeDeltaFor = (width: number, height: number): number =>
+  LATITUDE_DELTA * (width / height)
 
 Geolocation.setRNConfiguration({
   skipPermissionRequests: true,
@@ -44,6 +48,8 @@ export const MapScreen: React.FC = () => {
   const { countryCode, loading } = useDeviceLocation()
   const { data: lastRegion, error: lastRegionError } = useRegionQuery()
   const { LL } = useI18nContext()
+  const { width, height } = useWindowDimensions()
+  const longitudeDelta = longitudeDeltaFor(width, height)
 
   const [initialLocation, setInitialLocation] = React.useState<Region>()
   const [userCoords, setUserCoords] = React.useState<LatLng>()
@@ -110,7 +116,7 @@ export const MapScreen: React.FC = () => {
             latitude: countryCoords.lat,
             longitude: countryCoords.lng,
             latitudeDelta: LATITUDE_DELTA,
-            longitudeDelta: LONGITUDE_DELTA,
+            longitudeDelta,
           }
           setInitialLocation(region)
           // backup if country code is not recognized
@@ -119,7 +125,7 @@ export const MapScreen: React.FC = () => {
         }
       }
     }
-  }, [isInitializing, countryCode, lastRegion, loading, initialLocation])
+  }, [isInitializing, countryCode, lastRegion, loading, initialLocation, longitudeDelta])
 
   return (
     <Screen edges={["left", "right"]}>

--- a/app/screens/receive-bitcoin-screen/qr-view.tsx
+++ b/app/screens/receive-bitcoin-screen/qr-view.tsx
@@ -89,12 +89,17 @@ const QRViewBase: React.FC<Props> = ({
     (!isPayCode || isPayCodeAndCanUsePayCode)
 
   const styles = useStyles()
-  const { width, scale } = useWindowDimensions()
-  const baseSize = Math.round(QR_BASE_RATIO * width) - 2 * QR_CONTAINER_PADDING
-  const qrSize =
+  const { width, height, scale } = useWindowDimensions()
+  /** A square has to fit the window's shorter edge, which is the width in portrait and
+   *  the height in landscape. Sizing off the width alone clipped the code once the
+   *  screen could rotate, and a clipped QR cannot be scanned. */
+  const shortestEdge = Math.min(width, height)
+  const baseSize = Math.round(QR_BASE_RATIO * shortestEdge) - 2 * QR_CONTAINER_PADDING
+  const preferredSize =
     Platform.OS === "android" && scale > QR_ANDROID_HIGH_DPI_SCALE
       ? QR_ANDROID_HIGH_DPI_SIZE
       : baseSize
+  const qrSize = Math.min(preferredSize, shortestEdge - 2 * QR_CONTAINER_PADDING)
 
   const { LL } = useI18nContext()
 

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -1,11 +1,11 @@
 import * as React from "react"
 import {
   Alert,
-  Dimensions,
   Linking,
   Platform,
   Pressable,
   StyleSheet,
+  useWindowDimensions,
   View,
 } from "react-native"
 import { launchImageLibrary } from "react-native-image-picker"
@@ -46,8 +46,6 @@ import {
 import { testProps } from "@app/utils/testProps"
 
 import { resolveDestination } from "./payment-destination/resolve-destination"
-
-const { width: screenWidth } = Dimensions.get("window")
 
 /** Gaps kept between the scanner's own controls and whatever the system draws over the
  *  window. From Android 15 the window runs edge to edge, so the status bar and the
@@ -324,7 +322,11 @@ export const ScanningQRCodeScreen: React.FC = () => {
     [scannedCache, processInvoice],
   )
 
-  const styles = useStyles()
+  const { width, height } = useWindowDimensions()
+  /** The viewfinder is square, so it is bounded by the shorter edge. Sizing it off
+   *  the width put its horizontal borders off-screen once the screen could rotate. */
+  const shortestEdge = Math.min(width, height)
+  const styles = useStyles({ width, shortestEdge })
 
   const handleInvoicePaste = async () => {
     try {
@@ -488,55 +490,57 @@ export const ScanningQRCodeScreen: React.FC = () => {
   )
 }
 
-const useStyles = makeStyles(({ colors }) => ({
-  close: {
-    alignSelf: "flex-end",
-    height: 64,
-    marginRight: 16,
-    width: 64,
-  },
+const useStyles = makeStyles(
+  ({ colors }, { width, shortestEdge }: { width: number; shortestEdge: number }) => ({
+    close: {
+      alignSelf: "flex-end",
+      height: 64,
+      marginRight: 16,
+      width: 64,
+    },
 
-  openGallery: {
-    height: 64,
-    left: 32,
-    position: "absolute",
-    width: screenWidth,
-  },
+    openGallery: {
+      height: 64,
+      left: 32,
+      position: "absolute",
+      width,
+    },
 
-  rectangle: {
-    borderColor: colors.primary,
-    borderWidth: 2,
-    height: screenWidth * 0.75,
-    width: screenWidth * 0.75,
-  },
+    rectangle: {
+      borderColor: colors.primary,
+      borderWidth: 2,
+      height: shortestEdge * 0.75,
+      width: shortestEdge * 0.75,
+    },
 
-  rectangleContainer: {
-    alignItems: "center",
-    bottom: 0,
-    justifyContent: "center",
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-  },
+    rectangleContainer: {
+      alignItems: "center",
+      bottom: 0,
+      justifyContent: "center",
+      left: 0,
+      position: "absolute",
+      right: 0,
+      top: 0,
+    },
 
-  iconClose: { position: "absolute", top: -2, color: colors._black },
+    iconClose: { position: "absolute", top: -2, color: colors._black },
 
-  iconGalery: { opacity: 0.8 },
+    iconGalery: { opacity: 0.8 },
 
-  iconGaleryPending: { opacity: 0.4 },
+    iconGaleryPending: { opacity: 0.4 },
 
-  iconClipboard: { opacity: 0.8, position: "absolute", bottom: "5%", right: "15%" },
+    iconClipboard: { opacity: 0.8, position: "absolute", bottom: "5%", right: "15%" },
 
-  permissionMissing: {
-    alignItems: "center",
-    flex: 1,
-    justifyContent: "center",
-    rowGap: 32,
-  },
+    permissionMissing: {
+      alignItems: "center",
+      flex: 1,
+      justifyContent: "center",
+      rowGap: 32,
+    },
 
-  permissionMissingText: {
-    width: "80%",
-    textAlign: "center",
-  },
-}))
+    permissionMissingText: {
+      width: "80%",
+      textAlign: "center",
+    },
+  }),
+)


### PR DESCRIPTION
Fixes [blinkbitcoin/blink-wip#889](https://github.com/blinkbitcoin/blink-wip/issues/889) (close manually on merge — cross-repo `Fixes` doesn't auto-close).

**Draft.** The manifest change does not affect iOS, which stays locked to portrait, and the two shared layout commits have now been verified there — see *iOS verification*. Still draft for the open items in *What is left*.

## Problem

`MainActivity` is pinned with `android:screenOrientation="portrait"`. Play Console flags it because **from Android 16 the platform ignores resizability and orientation restrictions on large screens** — foldables, tablets, desktop windowing. The app does not opt out of rotation then; it simply gets rotated into a layout nobody ever looked at.

So this is not about adding landscape support as a feature. It is about not being forced into it broken.

## What removing the lock exposed

Dropping the attribute is one line. Doing only that ships two broken core flows, both confirmed on an emulator rather than reasoned about:

- **Receive**: the QR is sized `0.694 * windowWidth`. In a 873x393dp landscape window that is a 606dp square in a 393dp-tall viewport, so the code is clipped. A clipped QR cannot be scanned.
- **Scan**: the viewfinder is `windowWidth * 0.75` square, so its horizontal borders fall off-screen entirely and the frame renders as two vertical lines.

That is what the issue's second acceptance criterion is about — *"core mobile flows remain usable when Android ignores orientation/resizability restrictions"* — so both are fixed here rather than deferred.

## The three commits

**1. `fix(android): stop locking the app to portrait on large screens`**

Removes the attribute. `configChanges` already lists `orientation|screenLayout|screenSize|smallestScreenSize`, so the activity handles the config change itself and is not recreated.

**2. `fix(layout): read the window per render instead of freezing it at import`**

Four files read `Dimensions.get()` at module scope, which is evaluated once when the bundle loads and never again — so every value derived from it kept the launch orientation forever. They now use `useWindowDimensions()`. The two that needed the value inside `makeStyles` pass it as a style prop, which is the pattern already used by `map-component/index.tsx` and `place-search-modal.tsx`.

**3. `fix(layout): size square QR surfaces against the window's shorter edge`**

A square is bounded by the shorter edge of the window, not by its width. `Math.min(width, height)` **is** the width in portrait, so nothing about the current portrait rendering changes; only the landscape overflow goes away.

The scanner's gallery row deliberately stays on the full width — it is a row, not a square.

## Verification

Built and installed on an Android 15 emulator (the manifest is native, a bundle reload would not have covered it), then rotated on each screen.

- The window really does rotate now: captures went from 1080x2400 to 2400x1080.
- Receive and Scan re-checked after the fix.

Tests: 5 suites / 52 passing, with 6 new cases asserting that a rotated window does not push these surfaces past the shorter edge. `tsc --noEmit` and eslint clean.

## Screenshots

| Receive, before | Receive, after |
| --- | --- |
| <img width="2400" height="1080" alt="01-before-receive-qr-clipped" src="https://github.com/user-attachments/assets/6a4baf9b-4d9b-4f34-8802-8ffd51e45a90" /> | <img width="2400" height="1080" alt="02-after-receive-qr-fits" src="https://github.com/user-attachments/assets/63697354-6737-4842-bf52-a9825c862175" /> |

| Scan, before | Scan, after |
| --- | --- |
| <img width="2400" height="1080" alt="03-before-scanner-frame-offscreen" src="https://github.com/user-attachments/assets/05eca61f-32fd-4f87-9d4e-78ffc20fa59e" /> | <img width="2400" height="1080" alt="04-after-scanner-frame-visible" src="https://github.com/user-attachments/assets/6e724e57-ca03-4538-83be-12bb9d282665" /> |

| Home in landscape |
| --- |
| <img width="2400" height="1080" alt="05-home-landscape" src="https://github.com/user-attachments/assets/466f74e4-53ba-4ce0-82b8-a7b3f3f74999" /> |

## iOS verification

iOS is locked to portrait in `Info.plist`, and unlocking it is out of scope for an Android ticket raised from a Play Console recommendation. So this is a regression pass on portrait, not a landscape one.

Verified on an iPhone 16 Pro simulator, iOS 18.6, against this branch.

### The risk worth measuring

Commit 2 changed the slide-to-send track from `Dimensions.get("screen").width` to `useWindowDimensions().width`. Note that `screen` became `window`. On Android those are near-identical, which is why nothing moved there, but on iOS `screen` is the whole display and `window` is the app's window, so they can differ.

Measured rather than assumed, by rendering both values into the running app and reading them off a screenshot:

```
win 402x874 | scr 402x874 | before 362 after 362 | delta 0
```

Identical, so the track width did not move.

The other two files in commit 2 already read `Dimensions.get("window")`, so they are a straight swap with no `screen`/`window` change.

### Portrait pass

| Screen | Result |
| --- | --- |
| Receive | QR square, complete, not cropped |
| Scan | viewfinder measured 688x684px, so square, all four borders on-screen |
| Send confirmation | track as measured above |
| Earns | carousel centred, next card peeking, nothing clipped |
| Map | full-bleed, clustering and controls intact |

### Not measured: iPad

`TARGETED_DEVICE_FAMILY` is unset on the app target and there is no `UIRequiresFullScreen`, so in Split View `screen` and `window` genuinely can differ. No iPad simulator was installed to check, so this is stated as unmeasured rather than assumed.

It is also the one case where the change is an improvement rather than a risk: the old code sized the track against the whole display and would overflow the app's window.

## What is left

Kept out on purpose, so the diff stays reviewable:

- **The camera preview renders rotated 90° in landscape.** Found while testing, not in review. It is a `react-native-camera-kit` orientation concern rather than layout, and it is still there — so scanning is framed correctly now but the preview is sideways. This is the one thing that stops the scanner being genuinely usable in landscape, and it wants its own change.
- **The slide-to-send track hardcodes its callers' 40dp padding** and ignores the left/right safe area, so a side navigation bar or cutout can push the end of the travel off-screen. Fixing it properly means measuring the parent with `onLayout`.
- The Earns carousel width against `Screen`'s horizontal padding, and map clustering possibly holding a stale viewport after a resize. Both raised in review as plausible; neither was measured, so neither was touched.


