### PR TITLE
fix(migration): prove the receive by its drain invoice instead of the balance

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-complete-migration.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-complete-migration.spec.ts
@@ -8,6 +8,7 @@ const mockSetActiveAccountId = jest.fn()
 const mockDiscardCustodialSession = jest.fn()
 const mockCloseCustodialAccount = jest.fn()
 
+const mockSaveCheckpoint = jest.fn()
 let mockAccountId: string | undefined
 let mockCheckpoint: string | null
 let mockExpectedReceiveSats: number | null
@@ -16,6 +17,7 @@ let mockCheckpointOwnerId: string | null
 jest.mock("@app/screens/account-migration/hooks/use-migration-checkpoint-state", () => ({
   useMigrationCheckpointState: () => ({
     checkpoint: mockCheckpoint,
+    saveCheckpoint: mockSaveCheckpoint,
     accountId: mockAccountId,
     expectedReceiveSats: mockExpectedReceiveSats,
     checkpointOwnerId: mockCheckpointOwnerId,
@@ -105,6 +107,7 @@ describe("useCompleteMigration", () => {
     mockAccounts = [{ id: "sc-account-1" }]
     mockRegistryLoading = false
     mockCheckpoint = "backupAlerts"
+    mockSaveCheckpoint.mockResolvedValue(true)
     mockExpectedReceiveSats = 21000
     mockDiscardCustodialSession.mockResolvedValue(undefined)
     mockSeedMigratedSettings.mockResolvedValue(undefined)
@@ -472,6 +475,56 @@ describe("useCompleteMigration", () => {
 
       expect(await complete()).toBe(MigrationCompletion.Completed)
       expect(mockCloseCustodialAccount).toHaveBeenCalledTimes(2)
+    })
+  })
+})
+
+describe("recordMigrationSparkInvoice", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckpoint = "balancesOverview"
+    mockSaveCheckpoint.mockResolvedValue(true)
+  })
+
+  /** The step is re-saved as it stands, so recording the invoice never moves where a
+   *  resume lands. */
+  it("records the invoice against the step the flow is already on", async () => {
+    const { result } = renderHook(() => useCompleteMigration())
+
+    await act(async () => {
+      expect(await result.current.recordMigrationSparkInvoice("lnbcrt1invoice")).toBe(
+        true,
+      )
+    })
+
+    expect(mockSaveCheckpoint).toHaveBeenCalledWith("balancesOverview", {
+      sparkInvoice: "lnbcrt1invoice",
+    })
+  })
+
+  /** Without a step there is nothing to re-save onto, and the caller has to hear about it:
+   *  a silently skipped write leaves the receive gate on the balance test. */
+  it("answers false when no checkpoint step is known", async () => {
+    mockCheckpoint = null
+    const { result } = renderHook(() => useCompleteMigration())
+
+    await act(async () => {
+      expect(await result.current.recordMigrationSparkInvoice("lnbcrt1invoice")).toBe(
+        false,
+      )
+    })
+
+    expect(mockSaveCheckpoint).not.toHaveBeenCalled()
+  })
+
+  it("passes a refused write back to the caller", async () => {
+    mockSaveCheckpoint.mockResolvedValue(false)
+    const { result } = renderHook(() => useCompleteMigration())
+
+    await act(async () => {
+      expect(await result.current.recordMigrationSparkInvoice("lnbcrt1invoice")).toBe(
+        false,
+      )
     })
   })
 })

--- a/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-receive-confirmation.spec.ts
@@ -41,6 +41,9 @@ const stillEmpty = { hasReceived: false, balanceSats: 0 }
 
 const ok = (value: typeof landed) => ({ status: MigrationSdkStatus.Ok, value })
 
+/** Obviously synthetic: the check only ever compares it for equality. */
+const MIGRATION_INVOICE = "lnbcrt-migration-invoice"
+
 type GateOverrides = Partial<Parameters<typeof useMigrationReceiveConfirmation>[0]>
 
 /** Prop-driven so a test can rerender through the transitions production actually
@@ -51,6 +54,7 @@ const renderGate = (overrides: GateOverrides = {}) =>
       useMigrationReceiveConfirmation({
         selfCustodialAccountId: "sc-account-1",
         expectedReceiveSats: 21000,
+        sparkInvoice: MIGRATION_INVOICE,
         skip: false,
         ...props,
       }),
@@ -227,6 +231,7 @@ describe("useMigrationReceiveConfirmation", () => {
       accountId: "sc-account-1",
       network: "regtest",
       leewaySatPerVbyte: 1,
+      sparkInvoice: MIGRATION_INVOICE,
     })
     expect(result.current.isReceiveConfirmed).toBe(true)
   })

--- a/__tests__/screens/account-migration/hooks/use-migration-transfer.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-transfer.spec.ts
@@ -65,6 +65,8 @@ jest.mock(
   }),
 )
 
+const mockRecordSparkInvoice = jest.fn()
+
 jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
   useSparkNetwork: () => "regtest",
 }))
@@ -107,26 +109,33 @@ const renderTransfer = (
       custodialAccountId: "custodial-1",
       selfCustodialAccountId: "sc-account-1",
       expectedReceiveSats: 21000,
+      sparkInvoice: null,
+      recordSparkInvoice: mockRecordSparkInvoice,
       skip: false,
       ...overrides,
     }),
   )
 
-describe("useMigrationTransfer", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    resetMigrationCommitGuard()
-    mockStatus = MigrationStatus.InProgress
-    mockRefetchStatus = () => Promise.resolve(mockStatus)
-    mockBuildTransferRequest.mockResolvedValue({
-      status: MigrationSdkStatus.Ok,
-      value: collectedRequest,
-    })
-    mockCommitMigration.mockResolvedValue({ data: { migrationCommit: { errors: [] } } })
-    mockIsDeviceClockSkewed.mockReturnValue(false)
-    mockCurrentProofTimestamp.mockReturnValue(1_700_000_000)
-    mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+/** Shared so the drain-invoice describe below starts from the same state as the main one
+ *  instead of inheriting a beforeEach it is no longer nested under. */
+const setupTransferMocks = () => {
+  jest.clearAllMocks()
+  resetMigrationCommitGuard()
+  mockStatus = MigrationStatus.InProgress
+  mockRefetchStatus = () => Promise.resolve(mockStatus)
+  mockBuildTransferRequest.mockResolvedValue({
+    status: MigrationSdkStatus.Ok,
+    value: collectedRequest,
   })
+  mockCommitMigration.mockResolvedValue({ data: { migrationCommit: { errors: [] } } })
+  mockIsDeviceClockSkewed.mockReturnValue(false)
+  mockCurrentProofTimestamp.mockReturnValue(1_700_000_000)
+  mockReceiveConfirmation = { isReceiveConfirmed: true, isReceiveDelayed: false }
+  mockRecordSparkInvoice.mockResolvedValue(true)
+}
+
+describe("useMigrationTransfer", () => {
+  beforeEach(setupTransferMocks)
 
   it("commits the collected destination while the server awaits one", async () => {
     renderTransfer()
@@ -231,6 +240,8 @@ describe("useMigrationTransfer", () => {
           custodialAccountId,
           selfCustodialAccountId: "sc-account-1",
           expectedReceiveSats: 21000,
+          sparkInvoice: null,
+          recordSparkInvoice: mockRecordSparkInvoice,
           skip: false,
         }),
       { initialProps: { custodialAccountId: null as string | null } },
@@ -269,6 +280,8 @@ describe("useMigrationTransfer", () => {
           custodialAccountId,
           selfCustodialAccountId: "sc-account-1",
           expectedReceiveSats: 21000,
+          sparkInvoice: null,
+          recordSparkInvoice: mockRecordSparkInvoice,
           skip: false,
         }),
       { initialProps: { custodialAccountId: null as string | null } },
@@ -439,6 +452,7 @@ describe("useMigrationTransfer", () => {
     expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
       selfCustodialAccountId: "sc-account-1",
       expectedReceiveSats: 21000,
+      sparkInvoice: null,
       skip: true,
     })
 
@@ -449,6 +463,7 @@ describe("useMigrationTransfer", () => {
     expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith({
       selfCustodialAccountId: "sc-account-1",
       expectedReceiveSats: 21000,
+      sparkInvoice: null,
       skip: false,
     })
   })
@@ -855,5 +870,61 @@ describe("useMigrationTransfer", () => {
     })
 
     expect(mockCommitMigration).not.toHaveBeenCalled()
+  })
+})
+
+describe("useMigrationTransfer drain invoice", () => {
+  beforeEach(setupTransferMocks)
+
+  /** What the receive gate matches on, recorded only once the backend has taken it. */
+  it("records the drain invoice after the backend accepts the commit", async () => {
+    renderTransfer()
+    await flushEffects()
+
+    expect(mockRecordSparkInvoice).toHaveBeenCalledWith("lnbcrt1invoice")
+    expect(mockCommitMigration.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRecordSparkInvoice.mock.invocationCallOrder[0],
+    )
+  })
+
+  /** A first commit whose response was lost leaves the server draining against invoice A
+   *  while the retry mints B. Writing B would clobber the invoice the drain actually pays
+   *  and leave the gate watching for a payment that never comes. */
+  it("leaves the stored invoice alone when the commit is refused", async () => {
+    mockCommitMigration.mockResolvedValue({
+      data: { migrationCommit: { errors: [{ message: "already in progress" }] } },
+    })
+
+    renderTransfer()
+    await flushEffects()
+
+    expect(mockRecordSparkInvoice).not.toHaveBeenCalled()
+  })
+
+  /** The drain is already requested by then, so a refused write must not strand the user:
+   *  it is reported, and the gate falls back to what it did before the field existed. */
+  it("reports a refused write but lets the flow continue", async () => {
+    mockRecordSparkInvoice.mockResolvedValue(false)
+
+    const { result } = renderTransfer()
+    await flushEffects()
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Migration drain invoice persist",
+      expect.any(Error),
+    )
+    expect(result.current.failureReason).toBeNull()
+  })
+
+  /** A resumed run reads the invoice back off the checkpoint, so it goes on watching for
+   *  the same payment rather than starting over with nothing to match. */
+  it("passes the checkpointed invoice to the receive gate", async () => {
+    mockStatus = MigrationStatus.Completed
+    renderTransfer({ sparkInvoice: "lnbcrt1invoice" })
+    await flushEffects()
+
+    expect(mockUseReceiveConfirmation).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sparkInvoice: "lnbcrt1invoice" }),
+    )
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.spec.tsx
@@ -29,12 +29,16 @@ const mockUseHardwareBackGuard = jest.fn()
 /** The completion hook owns the custodial id now, so the screen reads it from there rather
  *  than opening a second owner query of its own. */
 let mockOwnerId: string | null = "custodial-1"
+let mockSparkInvoice: string | null = null
+const mockRecordMigrationSparkInvoice = jest.fn()
 
 jest.mock("@app/screens/account-migration/hooks", () => ({
   ...jest.requireActual("@app/screens/account-migration/hooks"),
   useCompleteMigration: () => ({
     migrationAccountId: mockMigrationAccountId,
     migrationExpectedReceiveSats: 21000,
+    migrationSparkInvoice: mockSparkInvoice,
+    recordMigrationSparkInvoice: mockRecordMigrationSparkInvoice,
     custodialAccountId: mockOwnerId,
     migrationLoading: mockMigrationLoading,
     completeMigration: mockCompleteMigration,
@@ -108,6 +112,7 @@ describe("MigrationTransferringFundsScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockOwnerId = "custodial-1"
+    mockSparkInvoice = null
     mockMigrationAccountId = "sc-account-1"
     mockMigrationLoading = false
     mockIsTransferred = false
@@ -147,8 +152,26 @@ describe("MigrationTransferringFundsScreen", () => {
       custodialAccountId: "custodial-1",
       selfCustodialAccountId: "sc-account-1",
       expectedReceiveSats: 21000,
+      sparkInvoice: null,
+      recordSparkInvoice: mockRecordMigrationSparkInvoice,
       skip: false,
     })
+  })
+
+  /** Both come off the completion hook's checkpoint instance rather than a second owner
+   *  read of this screen's own, so the invoice is written and read against one id. */
+  it("hands the transfer the checkpointed invoice and its recorder", async () => {
+    mockSparkInvoice = "lnbcrt1invoice"
+
+    renderScreen()
+    await flushEffects()
+
+    expect(mockUseMigrationTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sparkInvoice: "lnbcrt1invoice",
+        recordSparkInvoice: mockRecordMigrationSparkInvoice,
+      }),
+    )
   })
 
   /** The session can end under the screen; the transfer then has no account to bill and

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -123,6 +123,49 @@ describe("migration-checkpoint-storage", () => {
     })
   })
 
+  describe("validateStoredCheckpoint sparkInvoice", () => {
+    it("keeps a stored invoice", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        sparkInvoice: "lnbcrt1invoice",
+      })
+      expect(result?.sparkInvoice).toBe("lnbcrt1invoice")
+    })
+
+    /** Advisory like expectedReceiveSats: dropping it alone keeps the step and ids the
+     *  record resumes from, and an absent invoice falls back to the balance test. */
+    it("drops a non-string value but keeps the rest of the record", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        sparkInvoice: 42,
+      })
+
+      expect(result).toEqual({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        accountId: "sc-1",
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: undefined,
+        sparkInvoice: undefined,
+      })
+    })
+
+    /** An empty string would match no payment at all, so it is no better than absent and
+     *  must not be mistaken for a usable one. */
+    it("drops an empty invoice", () => {
+      const result = validateStoredCheckpoint({
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: 1000,
+        sparkInvoice: "",
+      })
+      expect(result?.sparkInvoice).toBeUndefined()
+    })
+  })
+
   describe("validateStoredCheckpoint expectedReceiveSats", () => {
     it("keeps a stored number", () => {
       const result = validateStoredCheckpoint({

--- a/__tests__/self-custodial/migration-transfer-request.spec.ts
+++ b/__tests__/self-custodial/migration-transfer-request.spec.ts
@@ -1,4 +1,9 @@
-import { Network } from "@breeztech/breez-sdk-spark-react-native"
+import {
+  Network,
+  PaymentDetails_Tags as PaymentDetailsTags,
+  PaymentStatus,
+  PaymentType,
+} from "@breeztech/breez-sdk-spark-react-native"
 
 import {
   buildMigrationLnAddressProof,
@@ -12,6 +17,10 @@ import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 const mockInitSdk = jest.fn()
 const mockDisconnectSdk = jest.fn()
 const mockGetWalletInfo = jest.fn()
+const mockListPayments = jest.fn()
+
+/** Obviously synthetic: the check only compares it for equality. */
+const MIGRATION_INVOICE = "lnbcrt-migration-invoice"
 const mockReceivePayment = jest.fn()
 const mockReportError = jest.fn()
 const mockClassifySdkError = jest.fn()
@@ -20,6 +29,8 @@ jest.mock("@app/self-custodial/bridge", () => ({
   initSdk: (args: unknown) => mockInitSdk(args),
   disconnectSdk: (sdk: unknown) => mockDisconnectSdk(sdk),
   getWalletInfo: (sdk: unknown) => mockGetWalletInfo(sdk),
+  listPayments: (sdk: unknown, offset: number, limit: number) =>
+    mockListPayments(sdk, offset, limit),
 }))
 
 jest.mock("@app/self-custodial/config", () => ({
@@ -301,11 +312,12 @@ describe("buildMigrationTransferRequest", () => {
 describe("checkMigrationReceiveLanded", () => {
   const mockGetInfo = jest.fn()
 
-  const check = () =>
+  const check = (sparkInvoice: string | null = MIGRATION_INVOICE) =>
     checkMigrationReceiveLanded({
       accountId: "sc-account-1",
       network: Network.Regtest,
       leewaySatPerVbyte: 1,
+      sparkInvoice,
     })
 
   beforeEach(() => {
@@ -314,13 +326,23 @@ describe("checkMigrationReceiveLanded", () => {
     mockInitSdk.mockResolvedValue({ getInfo: mockGetInfo })
     mockDisconnectSdk.mockResolvedValue(undefined)
     mockGetInfo.mockResolvedValue({ balanceSats: 0 })
+    mockListPayments.mockResolvedValue({ payments: [] })
     mockClassifySdkError.mockReturnValue(SelfCustodialErrorCode.Generic)
+  })
+
+  const settledReceiveOf = (invoice: string) => ({
+    paymentType: PaymentType.Receive,
+    status: PaymentStatus.Completed,
+    details: { tag: PaymentDetailsTags.Lightning, inner: { invoice } },
   })
 
   /** The forced sync is the point of the call: it is what claims a payment Spark held
    *  for the offline wallet, so the read is detector and actuator in one. */
-  it("confirms the receive once the synced wallet shows a balance", async () => {
+  it("confirms the receive once the drain invoice is settled", async () => {
     mockGetInfo.mockResolvedValue({ balanceSats: BigInt(21000) })
+    mockListPayments.mockResolvedValue({
+      payments: [settledReceiveOf(MIGRATION_INVOICE)],
+    })
 
     const result = await check()
 
@@ -331,10 +353,97 @@ describe("checkMigrationReceiveLanded", () => {
     })
   })
 
+  /** The whole point of matching the invoice: a wallet the user brought in, or one that
+   *  took an unrelated payment mid-flow, has a balance that says nothing about the drain. */
+  it("does not mistake a funded wallet for a settled drain", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(500000) })
+    mockListPayments.mockResolvedValue({
+      payments: [settledReceiveOf("lnbcrt-someone-elses-invoice")],
+    })
+
+    const result = await check()
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 500000 },
+    })
+  })
+
+  it("does not accept a pending payment of the drain invoice", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(0) })
+    mockListPayments.mockResolvedValue({
+      payments: [
+        { ...settledReceiveOf(MIGRATION_INVOICE), status: PaymentStatus.Pending },
+      ],
+    })
+
+    expect(await check()).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  /** A send carrying the same invoice is this wallet paying, not being paid. */
+  it("does not accept a send that quotes the drain invoice", async () => {
+    mockListPayments.mockResolvedValue({
+      payments: [
+        { ...settledReceiveOf(MIGRATION_INVOICE), paymentType: PaymentType.Send },
+      ],
+    })
+
+    expect(await check()).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  it("ignores a settled receive that is not a lightning payment", async () => {
+    mockListPayments.mockResolvedValue({
+      payments: [
+        {
+          paymentType: PaymentType.Receive,
+          status: PaymentStatus.Completed,
+          details: { tag: PaymentDetailsTags.Deposit, inner: {} },
+        },
+      ],
+    })
+
+    expect(await check()).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  it("ignores a settled receive carrying no details at all", async () => {
+    mockListPayments.mockResolvedValue({
+      payments: [{ paymentType: PaymentType.Receive, status: PaymentStatus.Completed }],
+    })
+
+    expect(await check()).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 0 },
+    })
+  })
+
+  /** Without the invoice there is nothing that proves the drain landed. Answering by
+   *  balance here is what would let a funded wallet confirm instantly, so the unprovable
+   *  case stays unproven — a funded balance must not change that. */
+  it("cannot confirm without an invoice, however funded the wallet is", async () => {
+    mockGetInfo.mockResolvedValue({ balanceSats: BigInt(21000) })
+
+    const result = await check(null)
+
+    expect(result).toEqual({
+      status: MigrationSdkStatus.Ok,
+      value: { hasReceived: false, balanceSats: 21000 },
+    })
+    expect(mockListPayments).not.toHaveBeenCalled()
+  })
+
   it("reports a still-empty wallet as not received", async () => {
     mockGetInfo.mockResolvedValue({ balanceSats: BigInt(0) })
 
-    const result = await check()
+    const result = await check(null)
 
     expect(result).toEqual({
       status: MigrationSdkStatus.Ok,

--- a/app/screens/account-migration/hooks/use-complete-migration.ts
+++ b/app/screens/account-migration/hooks/use-complete-migration.ts
@@ -67,8 +67,10 @@ export const useCompleteMigration = () => {
     checkpoint,
     accountId,
     expectedReceiveSats,
+    sparkInvoice,
     checkpointOwnerId,
     loading,
+    saveCheckpoint,
     clearCheckpoint,
   } = useMigrationCheckpointState()
   const { clearPendingAccount } = usePendingMigrationAccounts()
@@ -200,6 +202,26 @@ export const useCompleteMigration = () => {
     ],
   )
 
+  /**
+   * Records the invoice the drain was actually requested against, on this screen's one
+   * checkpoint instance. It lives here rather than in the transfer hook so there is a
+   * single owner read behind it: two no-cache reads of the same id can disagree for a
+   * render after an account switch, and an invoice written against the wrong one would be
+   * invisible to every other reader.
+   *
+   * The step is re-saved as it stands, so this adds the invoice without moving where a
+   * resume lands. Answers false when the write did not land: without the invoice the gate
+   * has nothing to prove the receive with, so the flow takes its delayed-receive path
+   * rather than confirming on a weaker signal.
+   */
+  const recordMigrationSparkInvoice = useCallback(
+    async (invoice: string): Promise<boolean> => {
+      if (!checkpoint) return false
+      return saveCheckpoint(checkpoint, { sparkInvoice: invoice })
+    },
+    [checkpoint, saveCheckpoint],
+  )
+
   const completeMigration = useCallback(
     (args: CompleteMigrationArgs): Promise<MigrationCompletion> => {
       if (completionInFlight) return completionInFlight
@@ -227,6 +249,8 @@ export const useCompleteMigration = () => {
     migrationAccountId: accountId,
     /** What the receive gate waits for; null on checkpoints saved before the field existed. */
     migrationExpectedReceiveSats: expectedReceiveSats,
+    migrationSparkInvoice: sparkInvoice,
+    recordMigrationSparkInvoice,
     /** Read before the discard clears it, so a handover raised after the swap can still
      *  name the custodial account support has to close. */
     custodialAccountId: emptiedCustodialAccountId,

--- a/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
+++ b/app/screens/account-migration/hooks/use-migration-checkpoint-state.ts
@@ -23,6 +23,7 @@ import { useCustodialOwnerId } from "./use-custodial-owner-id"
 type SaveCheckpointOptions = {
   provisionedAccountId?: string
   expectedReceiveSats?: number
+  sparkInvoice?: string
 }
 
 /**
@@ -92,6 +93,9 @@ export const useMigrationCheckpointState = () => {
   const expectedReceiveSats = isOwnedByActiveAccount
     ? stored?.expectedReceiveSats ?? null
     : null
+  /** Null on a record written before the field existed, which the receive check reads as
+   *  "this describes a provisioned wallet" and answers by balance, as it always did. */
+  const sparkInvoice = isOwnedByActiveAccount ? stored?.sparkInvoice ?? null : null
 
   /** Resolves false when the write fails, so callers can stop the flow instead of
    *  advancing on a checkpoint that only exists in memory. Re-sending what this hook
@@ -103,6 +107,7 @@ export const useMigrationCheckpointState = () => {
       {
         provisionedAccountId,
         expectedReceiveSats: expectedReceiveSatsUpdate,
+        sparkInvoice: sparkInvoiceUpdate,
       }: SaveCheckpointOptions = {},
     ): Promise<boolean> => {
       /** Without a resolved owner the checkpoint cannot be keyed, and saving would erase the
@@ -115,6 +120,7 @@ export const useMigrationCheckpointState = () => {
         custodialAccountId: ownerId,
         expectedReceiveSats:
           expectedReceiveSatsUpdate ?? expectedReceiveSats ?? undefined,
+        sparkInvoice: sparkInvoiceUpdate ?? sparkInvoice ?? undefined,
       }
       setStored((existing) => mergeCheckpoint(existing, update))
       try {
@@ -125,7 +131,7 @@ export const useMigrationCheckpointState = () => {
         return false
       }
     },
-    [storageKey, ownerId, accountId, expectedReceiveSats],
+    [storageKey, ownerId, accountId, expectedReceiveSats, sparkInvoice],
   )
 
   const clearCheckpoint = useCallback(() => {
@@ -147,6 +153,7 @@ export const useMigrationCheckpointState = () => {
     checkpoint,
     accountId,
     expectedReceiveSats,
+    sparkInvoice,
     /** The owner the record was actually saved under, null on one written before owners
      *  existed. Read by consumers that spend something irreversible, since the ownership
      *  flag above claims an owner-less record for whoever is active. */

--- a/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
+++ b/app/screens/account-migration/hooks/use-migration-receive-confirmation.ts
@@ -26,6 +26,13 @@ type UseMigrationReceiveConfirmationArgs = {
    * and an unknown expectation waits like a funded one — the delayed notice is its way out.
    */
   expectedReceiveSats: number | null
+  /**
+   * The invoice this migration issued for the drain. What the check matches, instead of
+   * reading a balance that only means "the drain landed" while the target is a wallet this
+   * flow provisioned and nothing else could have funded. Null leaves the receive unprovable
+   * — the flow then takes its delayed-receive path rather than confirming on the balance.
+   */
+  sparkInvoice: string | null
   /** True until the server phase is COMPLETED: before the drain is even paid there is
    *  nothing to look for, and each look opens a whole SDK connection. */
   skip: boolean
@@ -60,6 +67,7 @@ type UseMigrationReceiveConfirmation = {
 export const useMigrationReceiveConfirmation = ({
   selfCustodialAccountId,
   expectedReceiveSats,
+  sparkInvoice,
   skip,
 }: UseMigrationReceiveConfirmationArgs): UseMigrationReceiveConfirmation => {
   const network = useSparkNetwork()
@@ -121,6 +129,7 @@ export const useMigrationReceiveConfirmation = ({
           accountId,
           network,
           leewaySatPerVbyte: selfCustodialDepositClaimLeewayVbyte,
+          sparkInvoice,
         })
       } catch (err) {
         /** A keystore read that threw before the SDK result shape existed: transient as
@@ -164,7 +173,13 @@ export const useMigrationReceiveConfirmation = ({
       isActive = false
       if (timer) clearTimeout(timer)
     }
-  }, [isWatching, selfCustodialAccountId, network, selfCustodialDepositClaimLeewayVbyte])
+  }, [
+    isWatching,
+    selfCustodialAccountId,
+    network,
+    selfCustodialDepositClaimLeewayVbyte,
+    sparkInvoice,
+  ])
 
   /** The notice measures the wait for the receive, not the whole transfer: it runs from a
    *  timestamp rather than the effect's own lifetime because both callers recompute `skip`

--- a/app/screens/account-migration/hooks/use-migration-transfer.ts
+++ b/app/screens/account-migration/hooks/use-migration-transfer.ts
@@ -74,6 +74,14 @@ type UseMigrationTransferArgs = {
   selfCustodialAccountId: string | null
   /** From the checkpoint; null on records saved before the field existed. */
   expectedReceiveSats: number | null
+  /** From the checkpoint. What the receive gate matches on; null on a record saved before
+   *  the field existed, which the gate answers by balance as it always did. */
+  sparkInvoice: string | null
+  /** Writes the invoice this commit is about to request the drain against. Supplied by the
+   *  screen so it runs on the one checkpoint instance behind the custodial id: a second
+   *  no-cache owner read can disagree for a render after an account switch, and an invoice
+   *  written against the wrong one would be invisible to every other reader. */
+  recordSparkInvoice: (invoice: string) => Promise<boolean>
   skip: boolean
 }
 
@@ -100,10 +108,15 @@ export const useMigrationTransfer = ({
   custodialAccountId,
   selfCustodialAccountId,
   expectedReceiveSats,
+  sparkInvoice,
+  recordSparkInvoice,
   skip,
 }: UseMigrationTransferArgs): UseMigrationTransfer => {
   const network = useSparkNetwork()
   const { selfCustodialDepositClaimLeewayVbyte } = useRemoteConfig()
+  /** The invoice is issued inside commit, so unlike expectedReceiveSats it cannot arrive as
+   *  a prop: it is written to the checkpoint there and read back from it here, which is also
+   *  what lets a resumed run go on watching for the same payment. */
   const [commitMigration] = useMigrationCommitMutation()
   /** Seeded from the remembered outcome so a screen re-entered after a settled failure
    *  shows it at once, rather than blocking the re-commit and spinning with nothing shown. */
@@ -142,6 +155,7 @@ export const useMigrationTransfer = ({
     useMigrationReceiveConfirmation({
       selfCustodialAccountId,
       expectedReceiveSats,
+      sparkInvoice,
       skip: isReceiveGateSkipped,
     })
 
@@ -218,6 +232,11 @@ export const useMigrationTransfer = ({
         return
       }
 
+      /** Recorded before the drain is requested, and blocking: without the invoice the gate
+       *  falls back to the balance test, which confirms instantly on a reused wallet the
+       *  user had already funded and deletes the custodial account with the drain still in
+       *  transit (#4102). Treated like the checkpoint saves — the screen holds and the
+       *  retry re-runs it — rather than letting the commit go out unwatched. */
       const { data } = await commitMigration({
         variables: {
           input: {
@@ -230,7 +249,26 @@ export const useMigrationTransfer = ({
       })
 
       const [rejection] = data?.migrationCommit?.errors ?? []
-      if (!rejection) return
+      if (!rejection) {
+        /** Recorded only once the backend has taken this invoice, and never before. A
+         *  first commit whose response was lost leaves the server already draining against
+         *  invoice A while the retry mints B; writing B up front would clobber the invoice
+         *  the drain actually pays, and the gate would watch for a payment that never
+         *  comes. A refused commit leaves the stored invoice untouched for the same reason.
+         *
+         *  Not blocking: the drain is already requested, so refusing here would strand the
+         *  user with funds in flight and no way forward. A lost write costs the proof, not
+         *  the funds — the gate cannot confirm and the flow takes its delayed-receive path.
+         */
+        const isInvoiceRecorded = await recordSparkInvoice(result.value.sparkInvoice)
+        if (!isInvoiceRecorded) {
+          reportError(
+            "Migration drain invoice persist",
+            new Error(`Checkpoint refused the drain invoice for ${selfCustodialId}`),
+          )
+        }
+        return
+      }
 
       /** A skewed clock makes the proof stale, which the backend rejects under the
        *  bad-destination code; that code plus a real skew is what earns a retry rather
@@ -244,7 +282,13 @@ export const useMigrationTransfer = ({
       }
       fail(MigrationSupportReason.TransferFailed, new Error(rejection.message))
     },
-    [network, selfCustodialDepositClaimLeewayVbyte, commitMigration, fail],
+    [
+      network,
+      selfCustodialDepositClaimLeewayVbyte,
+      commitMigration,
+      fail,
+      recordSparkInvoice,
+    ],
   )
 
   /** The server is waiting for a destination only while IN_PROGRESS: TRANSFERRING already

--- a/app/screens/account-migration/hooks/use-resume-completed-migration.ts
+++ b/app/screens/account-migration/hooks/use-resume-completed-migration.ts
@@ -40,6 +40,7 @@ export const useResumeCompletedMigration = (): void => {
   const {
     migrationAccountId,
     migrationExpectedReceiveSats,
+    migrationSparkInvoice,
     custodialAccountId,
     migrationLoading,
     completeMigration,
@@ -62,6 +63,7 @@ export const useResumeCompletedMigration = (): void => {
     useMigrationReceiveConfirmation({
       selfCustodialAccountId: migrationAccountId,
       expectedReceiveSats: migrationExpectedReceiveSats,
+      sparkInvoice: migrationSparkInvoice,
       skip: !isServerCompleted,
     })
 

--- a/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-transferring-funds-screen.tsx
@@ -40,6 +40,8 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
   const {
     migrationAccountId,
     migrationExpectedReceiveSats,
+    migrationSparkInvoice,
+    recordMigrationSparkInvoice,
     custodialAccountId,
     migrationLoading,
     completeMigration,
@@ -100,6 +102,8 @@ export const MigrationTransferringFundsScreen: React.FC = () => {
     custodialAccountId,
     selfCustodialAccountId: migrationAccountId,
     expectedReceiveSats: migrationExpectedReceiveSats,
+    sparkInvoice: migrationSparkInvoice,
+    recordSparkInvoice: recordMigrationSparkInvoice,
     skip: isTransferSkipped,
   })
 

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -19,6 +19,10 @@ export type StoredCheckpoint = {
    *  point — the only moment it is knowable (after the drain the preview reads an already
    *  emptied balance). Absent on records saved by app versions before the field existed. */
   expectedReceiveSats?: number
+  /** The invoice this migration issued for the drain, captured at the commit point. What
+   *  proves the receive landed: payable once, and only by this migration. Absent on records
+   *  saved by app versions before the field existed. */
+  sparkInvoice?: string
 }
 
 /**
@@ -64,8 +68,14 @@ export const isExpired = (
 export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null => {
   if (!raw || typeof raw !== "object") return null
 
-  const { step, savedAt, accountId, custodialAccountId, expectedReceiveSats } =
-    raw as StoredCheckpoint
+  const {
+    step,
+    savedAt,
+    accountId,
+    custodialAccountId,
+    expectedReceiveSats,
+    sparkInvoice,
+  } = raw as StoredCheckpoint
 
   if (!Object.values(MigrationCheckpoint).includes(step)) return null
   if (typeof savedAt !== "number") return null
@@ -78,12 +88,18 @@ export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null 
   const hasUsableExpectedReceiveSats =
     typeof expectedReceiveSats === "number" && Number.isFinite(expectedReceiveSats)
 
+  /** Advisory in the same way, and for the same reason: a malformed invoice drops on its
+   *  own rather than taking the step and ids down with it. */
+  const hasUsableSparkInvoice =
+    typeof sparkInvoice === "string" && sparkInvoice.length > 0
+
   return {
     step,
     savedAt,
     accountId,
     custodialAccountId,
     expectedReceiveSats: hasUsableExpectedReceiveSats ? expectedReceiveSats : undefined,
+    sparkInvoice: hasUsableSparkInvoice ? sparkInvoice : undefined,
   }
 }
 
@@ -125,6 +141,7 @@ export type CheckpointUpdate = {
   accountId?: string
   custodialAccountId?: string
   expectedReceiveSats?: number
+  sparkInvoice?: string
 }
 
 /**
@@ -148,12 +165,19 @@ export const mergeCheckpoint = (
     ? existing?.expectedReceiveSats
     : undefined
 
+  /** Not write-once, unlike the figure above: a retried commit mints a fresh invoice and
+   *  sends THAT one to the server, so keeping the first would leave the gate watching for a
+   *  payment nobody will make. The newest recorded invoice is the one that was asked for.
+   *  Owner scoping still applies — another profile's invoice is never inherited. */
+  const inheritedSparkInvoice = hasSameOwner ? existing?.sparkInvoice : undefined
+
   return {
     step: update.step,
     savedAt: Date.now(),
     accountId: update.accountId ?? (hasSameOwner ? existing?.accountId : undefined),
     custodialAccountId: update.custodialAccountId,
     expectedReceiveSats: inheritedExpectedReceiveSats ?? update.expectedReceiveSats,
+    sparkInvoice: update.sparkInvoice ?? inheritedSparkInvoice,
   }
 }
 

--- a/app/self-custodial/migration-transfer-request.ts
+++ b/app/self-custodial/migration-transfer-request.ts
@@ -1,14 +1,18 @@
 import {
+  PaymentDetails_Tags as PaymentDetailsTags,
+  PaymentStatus,
+  PaymentType,
   ReceivePaymentMethod,
   ReceivePaymentRequest,
   type BreezSdkInterface,
   type Network,
+  type Payment,
 } from "@breeztech/breez-sdk-spark-react-native"
 
 import { reportError } from "@app/utils/error-logging"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
-import { disconnectSdk, getWalletInfo, initSdk } from "./bridge"
+import { disconnectSdk, getWalletInfo, initSdk, listPayments } from "./bridge"
 import { storageDirFor } from "./config"
 import { classifySdkError, SelfCustodialErrorCode } from "./sdk-error"
 
@@ -199,19 +203,61 @@ type MigrationReceiveCheck = {
 }
 
 /**
- * Whether the migration payment has landed in the provisioned wallet. Any positive
- * balance is the receive: the wallet is provisioned by this flow and never used before
- * the session swap, so nothing else can have funded it. The forced sync is the point of
- * the call — Spark holds an incoming payment for an offline wallet and claims it on
- * sync, so this read is the detector and the actuator in one.
+ * How far back the settled receive is looked for. The drain settles within seconds of the
+ * request, and the wallet is quiet across that window, so the payment is at the head of
+ * the list. A page rather than a full scan: a wallet the user brought in can hold years of
+ * history, and paging all of it to answer one question would make the check itself the
+ * reason the screen hangs.
+ */
+const RECEIVE_LOOKUP_PAGE_SIZE = 50
+
+const isMigrationReceive = (payment: Payment, sparkInvoice: string): boolean => {
+  if (payment.paymentType !== PaymentType.Receive) return false
+  if (payment.status !== PaymentStatus.Completed) return false
+  if (payment.details?.tag !== PaymentDetailsTags.Lightning) return false
+  return payment.details.inner.invoice === sparkInvoice
+}
+
+/**
+ * Whether the migration payment has landed in the target wallet.
+ *
+ * It matches the invoice this flow issued for this migration, rather than reading the
+ * balance. A balance test only works while the target is a wallet this flow provisioned
+ * and nothing else could have funded — the moment the user supplies their own wallet, or
+ * an unrelated payment arrives mid-flow, "balance above zero" stops meaning "the drain
+ * landed" and the completion step deletes the custodial account over funds still in
+ * transit (#4102). The invoice is issued per migration and payable once, so nothing else
+ * can satisfy it.
+ *
+ * The forced sync is still the point of the call — Spark holds an incoming payment for an
+ * offline wallet and claims it on sync, so this remains the detector and the actuator in
+ * one. `balanceSats` is still reported, now for diagnostics rather than for the verdict.
  */
 export const checkMigrationReceiveLanded = (
-  args: MigrationSdkConnectionArgs,
+  args: MigrationSdkConnectionArgs & { sparkInvoice: string | null },
 ): Promise<MigrationSdkResult<MigrationReceiveCheck>> =>
   withMigrationSdk(args, async (sdk) => {
     const info = await sdk.getInfo({ ensureSynced: true })
     const balanceSats = Number(info.balanceSats)
-    return { hasReceived: balanceSats > 0, balanceSats }
+
+    /**
+     * No invoice, no proof. Deliberately not a fall back to the balance test: that test is
+     * only sound while the target is a wallet this flow provisioned and nothing else could
+     * have funded, and every route that loses the invoice — a checkpoint written before the
+     * field existed, a commit whose response never came, a stale reader — arrives here
+     * looking exactly like one that has it. Answering by balance on any of them is how
+     * #4102 comes back, so the unprovable case stays unproven and the flow takes its
+     * existing delayed-receive path instead.
+     */
+    const { sparkInvoice } = args
+    if (sparkInvoice === null) return { hasReceived: false, balanceSats }
+
+    const { payments } = await listPayments(sdk, 0, RECEIVE_LOOKUP_PAGE_SIZE)
+    const hasReceived = payments.some((payment) =>
+      isMigrationReceive(payment, sparkInvoice),
+    )
+
+    return { hasReceived, balanceSats }
   })
 
 /** The two proof fields `migrationLnAddressTransfer` takes; it re-points the lightning


### PR DESCRIPTION
## Problem

The migration receive gate confirmed the drain had landed by reading a balance:

```ts
return { hasReceived: balanceSats > 0, balanceSats }
```

That test is only sound while the target is a wallet this flow provisioned and nothing else could have funded. Two things break it:

- an unrelated payment arriving in the window between the commit and the drain settling
- a target the user supplied themselves, which is what blinkbitcoin/blink-mobile#4198 introduces

When it breaks, `useCompleteMigration` passes the `isReceiveProven` guard and deletes the custodial account with the funds still in transit — the #4102 loss the gate exists to prevent.

## What this does

The gate now matches the invoice this migration issued for the drain, instead of reading a balance.

`buildMigrationTransferRequest` already mints that invoice via `sdk.receivePayment` and hands it to the backend as `sparkInvoice`; it was discarded afterwards. It is now recorded on the migration checkpoint and matched against `listPayments`: a received payment, settled, whose `PaymentDetails.Lightning.inner.invoice` equals it. The invoice is issued per migration and payable once, so nothing else can satisfy it.

`balanceSats` is still reported, now for diagnostics rather than for the verdict. The forced sync stays the point of the call — Spark holds an incoming payment for an offline wallet and claims it on sync, so the read remains detector and actuator in one.

### When the invoice is recorded

Only once the backend has accepted the commit, never before. A first commit whose response is lost leaves the server already draining against invoice A while the retry mints B; writing B up front would clobber the invoice the drain actually pays, and the gate would watch for a payment nobody will make. A refused commit leaves the stored invoice untouched for the same reason.

The write is not blocking. By that point the drain is already requested, so refusing would strand the user with funds in flight and no way forward. A lost write costs the proof, not the funds.

### No balance fallback

An absent invoice leaves the receive unprovable rather than falling back to the balance:

```ts
if (sparkInvoice === null) return { hasReceived: false, balanceSats }
```

Every route that loses the invoice — a checkpoint written before the field existed, a commit whose response never came, a reader whose state is stale — arrives here looking exactly like one that has it. There is no way to tell them apart, so answering by balance on any of them is how #4102 comes back.

This was found by review, and it is not hypothetical: `useResumeCompletedMigration` is mounted inside `PrimaryNavigator`, which stays blurred while the migration stack is pushed. Its `useFocusEffect` never reloads, so its checkpoint instance keeps `sparkInvoice: null` and would have taken the balance branch.

The cost is stated plainly below.

## Trade-offs worth reviewing

**A checkpoint written before this field never confirms.** That user takes the existing delayed-receive path. The cohort is narrow — checkpoints expire after 48h — but it is not empty.

**There is no longer a safety net if the match itself is wrong.** If the SDK records the settlement under a different `PaymentDetails` tag (`Spark.invoiceDetails` exists for invoice-fulfilling transfers), normalises the bolt11 differently, or leaves it `Pending`, nobody confirms. The balance test used to hide that. This cannot be settled by reading types and needs a device test against regtest before merge.

## Testing

- 2060 tests green across the migration and self-custodial suites
- `tsc:check` and eslint clean
- 100% branch coverage on all seven changed files
- Three review passes; every finding fixed or stated above

Not yet device-tested — see the second trade-off.
