### PR TITLE
fix(test): use defaultPersistentState instead of a hardcoded schemaVersion

### DIFF
--- a/__tests__/self-custodial/hooks/use-display-currency-from-region.spec.ts
+++ b/__tests__/self-custodial/hooks/use-display-currency-from-region.spec.ts
@@ -1,7 +1,10 @@
 import { renderHook, waitFor } from "@testing-library/react-native"
 
 import { useDisplayCurrencyFromRegion } from "@app/self-custodial/hooks/use-display-currency-from-region"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  defaultPersistentState,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const mockGetCurrencies = jest.fn<string[], []>()
@@ -38,9 +41,7 @@ describe("useDisplayCurrencyFromRegion", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPersistentState = {
-      schemaVersion: 20,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
+      ...defaultPersistentState,
       activeAccountId: SELF_CUSTODIAL_ID,
     }
     mockGetCurrencies.mockReturnValue(["CRC", "USD"])


### PR DESCRIPTION
## Summary
- `use-display-currency-from-region.spec.ts` (added in #4216) built its mock `PersistentState` with a bare `schemaVersion: 20` literal.
- The schema was bumped to 21 by #4068, which landed on `main` before #4216 merged, so the literal went stale and now fails `tsc` (`Type '20' is not assignable to type '21'`) for the merge ref of every open PR that pulls in current `main`.
- Fixed by spreading `defaultPersistentState` (the pattern already used elsewhere in the test suite) instead of hardcoding the version, so this can't drift again.

## Test plan
- [x] `yarn tsc:check` passes
- [x] `yarn jest __tests__/self-custodial/hooks/use-display-currency-from-region.spec.ts` — 11/11 pass
- [x] `prettier --check` clean