### PR TITLE
fix(send): let a self-custodial sender pay a Blink pay code over lightning

### DIFF
--- a/__tests__/hooks/use-scan-context.spec.ts
+++ b/__tests__/hooks/use-scan-context.spec.ts
@@ -40,6 +40,7 @@ jest.mock("@app/graphql/generated", () => {
 })
 
 jest.mock("@app/self-custodial/config", () => ({
+  ...jest.requireActual("@app/self-custodial/config"),
   networkLabelFor: (network: number) =>
     network === mockSparkNetwork.Mainnet ? "mainnet" : "regtest",
 }))
@@ -142,7 +143,7 @@ describe("useScanContext", () => {
       expect(result.current.bitcoinNetwork).toBe("regtest")
     })
 
-    it("exposes lnurlDomains as [] (intraledger lookup disabled)", () => {
+    it("exposes the network's own domains, address domain first", () => {
       mockActiveWallet.mockReturnValue({
         isSelfCustodial: true,
         wallets: [
@@ -152,7 +153,10 @@ describe("useScanContext", () => {
 
       const { result } = renderHook(() => useScanContext())
 
-      expect(result.current.lnurlDomains).toEqual([])
+      expect(result.current.lnurlDomains).toEqual([
+        "staging.blink.sv",
+        "pay.staging.blink.sv",
+      ])
     })
 
     it("ignores the custodial GraphQL query when self-custodial is active", () => {

--- a/__tests__/payment-destination/merchant.spec.ts
+++ b/__tests__/payment-destination/merchant.spec.ts
@@ -209,4 +209,55 @@ describe("merchant payment destinations", () => {
     )
     expect(result).toBe(wrapped)
   })
+
+  /**
+   * A till code issued by a Blink account is served on a domain the sender declares as
+   * its own. A custodial sender pays that over the ledger; a self-custodial one has no
+   * token for it, so the account lookup must not even be attempted.
+   */
+  it("does not route a merchant on a declared domain over the ledger for a self-custodial send", async () => {
+    const merchant = {
+      id: "blink-merchant",
+      lnurl: "shop@blink.sv",
+      category: "swap" as const,
+      title: "Shop",
+      description: "A shop paid through Blink",
+      companyName: "Shop",
+      termsUrl: "https://example.com/terms",
+    }
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+    requestPayServiceParamsMock.mockResolvedValue({
+      callback: "https://example.com/callback",
+      fixed: true,
+      min: 0 as Satoshis,
+      max: 2000 as Satoshis,
+      domain: "blink.sv",
+      metadata: [["text/plain", "description"]],
+      metadataHash: "mocked_metadata_hash",
+      identifier: merchant.lnurl,
+      description: "mocked_description",
+      image: "",
+      commentAllowed: 0,
+      rawData: {},
+    })
+    mockWrapDestination.mockImplementation((destination) => destination)
+
+    const result = await resolveMerchantChoiceDestination({
+      merchant,
+      params: {
+        rawInput: merchant.lnurl,
+        myWalletIds: ["wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: ["blink.sv"],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+        displayCurrency: "USD",
+      },
+      sdk: { id: "spark-sdk" } as never,
+    })
+
+    expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+    expect(accountDefaultWalletQuery).not.toHaveBeenCalled()
+  })
 })

--- a/__tests__/payment-destination/resolve-destination.integration.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.integration.spec.ts
@@ -90,6 +90,55 @@ describe("resolveDestination (integration: real parser)", () => {
     expect(mockWrapDestination).toHaveBeenCalled()
   })
 
+  /**
+   * The domains a self-custodial sender declares are what let a Blink pay code be
+   * recognised as naming an account. They must not also route it over the ledger: the
+   * wallet has no token for that mutation, and the recipient's own address is the whole
+   * point of recognising it.
+   */
+  it("keeps a self-custodial send on LNURL even when the recipient is on a declared domain", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+
+    const result = await resolveDestination(
+      {
+        rawInput: "esaudeveloper@blink.sv",
+        myWalletIds: ["my-wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: [lnAddressHostname, "pay.blink.sv"],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+      },
+      { sdk: fakeSdk, network: mockSparkNetwork.Regtest },
+      lnAddressHostname,
+    )
+
+    expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+    expect(accountDefaultWalletQuery).not.toHaveBeenCalled()
+  })
+
+  it("still pays a custodial send to a declared domain over the ledger", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+
+    const result = await resolveDestination(
+      {
+        rawInput: "esaudeveloper@blink.sv",
+        myWalletIds: ["my-wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: [lnAddressHostname, "pay.blink.sv"],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+      },
+      { sdk: null, network: mockSparkNetwork.Regtest },
+      lnAddressHostname,
+    )
+
+    expect(result.valid && result.validDestination.paymentType).toBe(
+      PaymentType.Intraledger,
+    )
+  })
+
   it("routes a custodial send to a non-custodial Blink username through LNURL via the flag fallback", async () => {
     // No custodial wallet for the handle: the recipient is self-custodial, not custodial.
     const accountDefaultWalletQuery = jest.fn().mockResolvedValue({

--- a/__tests__/payment-destination/resolve-destination.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.spec.ts
@@ -43,6 +43,12 @@ const baseParams = {
 }
 
 const lnAddressHostname = "blink.sv"
+/** What a self-custodial sender adds: pay over lightning, never over the ledger. */
+const selfCustodialParams = {
+  ...baseParams,
+  preferLnurlForInternalHandles: true,
+  canPayIntraledger: false,
+}
 const fakeSdk = { id: "sdk" } as never
 
 describe("resolveDestination", () => {
@@ -204,7 +210,7 @@ describe("resolveDestination", () => {
         lnAddressHostname,
       )
 
-      expect(mockParseDestination).toHaveBeenCalledWith(baseParams)
+      expect(mockParseDestination).toHaveBeenCalledWith(selfCustodialParams)
       expect(mockResolveUsername).toHaveBeenCalledWith(
         parsed,
         lnAddressHostname,
@@ -233,7 +239,7 @@ describe("resolveDestination", () => {
       await resolveLnAddress("esaudeveloper@blink.sv")
 
       expect(mockParseDestination).toHaveBeenCalledWith({
-        ...baseParams,
+        ...selfCustodialParams,
         rawInput: "esaudeveloper@blink.sv",
       })
     })
@@ -258,7 +264,7 @@ describe("resolveDestination", () => {
         SparkNetwork.Regtest,
       )
       expect(mockParseDestination).toHaveBeenCalledWith({
-        ...baseParams,
+        ...selfCustodialParams,
         rawInput: "sparkrt1qabc",
       })
     })

--- a/__tests__/self-custodial/adapters/scan-context.spec.ts
+++ b/__tests__/self-custodial/adapters/scan-context.spec.ts
@@ -34,7 +34,21 @@ describe("createSelfCustodialScanContext", () => {
     expect(createSelfCustodialScanContext([], Network.Mainnet).myWalletIds).toEqual([])
   })
 
-  it("returns an empty lnurlDomains list (intraledger lookup is disabled in self-custodial)", () => {
-    expect(createSelfCustodialScanContext([], Network.Mainnet).lnurlDomains).toEqual([])
+  /**
+   * The domains are what lets a Blink pay code be recognised as naming an account
+   * instead of being fetched as an opaque lnurl. Paying one over the ledger is refused
+   * separately, by the sender, since a self-custodial wallet has no token for it.
+   */
+  it("declares the network's own domain first, so an address is spelled with it", () => {
+    const { lnurlDomains } = createSelfCustodialScanContext([], Network.Mainnet)
+
+    expect(lnurlDomains[0]).toBe("blink.sv")
+    expect(lnurlDomains).toContain("pay.blink.sv")
+  })
+
+  it("declares the regtest domains on regtest, and none of production's", () => {
+    const { lnurlDomains } = createSelfCustodialScanContext([], Network.Regtest)
+
+    expect(lnurlDomains).toEqual(["staging.blink.sv", "pay.staging.blink.sv"])
   })
 })

--- a/app/screens/send-bitcoin-screen/payment-destination/index.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.ts
@@ -34,8 +34,11 @@ export const parseDestination = async ({
   inputSource,
   displayCurrency,
   preferLnurlForInternalHandles,
+  canPayIntraledger = true,
 }: ParseDestinationParams): Promise<ParseDestinationResult> => {
   const destination = rawInput.trim()
+  /** Empty for a sender that cannot pay over the ledger, so no lnurl collapses to it. */
+  const intraledgerDomains = canPayIntraledger ? lnurlDomains : []
   const parsedDestination = parsePaymentDestination({
     destination,
     network: bitcoinNetwork as NetworkGaloyClient,
@@ -63,7 +66,7 @@ export const parseDestination = async ({
     if (merchant) {
       return resolveLnurlDestination({
         parsedLnurlDestination: merchantChoiceToLnurlDestination(merchant),
-        lnurlDomains,
+        lnurlDomains: intraledgerDomains,
         accountDefaultWalletQuery,
         myWalletIds,
       })
@@ -94,7 +97,7 @@ export const parseDestination = async ({
     case PaymentType.Lnurl: {
       return resolveLnurlDestination({
         parsedLnurlDestination: parsedDestination,
-        lnurlDomains,
+        lnurlDomains: intraledgerDomains,
         accountDefaultWalletQuery,
         myWalletIds,
       })
@@ -116,7 +119,7 @@ export const parseDestination = async ({
               lnurl,
               isMerchant: false,
             },
-            lnurlDomains,
+            lnurlDomains: intraledgerDomains,
             accountDefaultWalletQuery,
             myWalletIds,
           })

--- a/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
@@ -47,6 +47,14 @@ export type ParseDestinationParams = {
   inputSource?: InputSource
   displayCurrency?: string
   preferLnurlForInternalHandles?: boolean
+  /**
+   * `lnurlDomains` answers two questions at once: which hosts name one of our accounts,
+   * and which destinations are paid over the ledger. A self-custodial sender needs the
+   * first, so its own pay codes are recognised as naming an account, and cannot use the
+   * second, having no token for the intraledger mutation. Defaults to true, which is
+   * every caller that pays as a custodial account.
+   */
+  canPayIntraledger?: boolean
 }
 
 export const DestinationDirection = {

--- a/app/screens/send-bitcoin-screen/payment-destination/merchant.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/merchant.ts
@@ -29,9 +29,12 @@ export const resolveMerchantChoiceDestination = async ({
   params: ParseDestinationParams
   sdk: BreezSdkInterface | null
 }): Promise<ParseDestinationResult> => {
+  /** A self-custodial sender has no ledger to pay a till code over, connected sdk and all. */
+  const intraledgerDomains = sdk ? [] : params.lnurlDomains
+
   const destination = await resolveLnurlDestination({
     parsedLnurlDestination: merchantChoiceToLnurlDestination(merchant),
-    lnurlDomains: params.lnurlDomains,
+    lnurlDomains: intraledgerDomains,
     accountDefaultWalletQuery: params.accountDefaultWalletQuery,
     myWalletIds: params.myWalletIds,
   })

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
@@ -46,9 +46,21 @@ export const resolveDestination = async (
     return wrapDestination(resolveSparkDestination(sparkParsed), sdk)
   }
 
-  const parsed = await parseDestination(params)
+  /**
+   * A self-custodial wallet has no token for the intraledger mutation a Blink handle
+   * would otherwise resolve to, so its own accounts are paid over lightning like
+   * anyone else's. Its domains are declared for the same reason the flag is set: they
+   * are what lets a Blink pay code be recognised as naming an account rather than
+   * being fetched as an opaque lnurl, which is what showed the pay host on screen.
+   */
+  const selfCustodialParams = {
+    ...params,
+    preferLnurlForInternalHandles: true,
+    canPayIntraledger: false,
+  }
+  const parsed = await parseDestination(selfCustodialParams)
   const destination = await resolveUsername(parsed, lnAddressHostname, (rawInput) =>
-    parseDestination({ ...params, rawInput }),
+    parseDestination({ ...selfCustodialParams, rawInput }),
   )
   return wrapDestination(destination, sdk)
 }

--- a/app/self-custodial/adapters/scan-context.ts
+++ b/app/self-custodial/adapters/scan-context.ts
@@ -3,7 +3,7 @@ import { type Network } from "@breeztech/breez-sdk-spark-react-native"
 import { type ScanContextAdapter } from "@app/types/scan-context"
 import { type WalletState } from "@app/types/wallet"
 
-import { networkLabelFor } from "../config"
+import { lnurlDomainsFor, networkLabelFor } from "../config"
 
 export const createSelfCustodialScanContext = (
   wallets: ReadonlyArray<WalletState>,
@@ -11,5 +11,5 @@ export const createSelfCustodialScanContext = (
 ): ScanContextAdapter => ({
   myWalletIds: wallets.map((wallet) => wallet.id),
   bitcoinNetwork: networkLabelFor(network),
-  lnurlDomains: [],
+  lnurlDomains: lnurlDomainsFor(network),
 })

--- a/app/self-custodial/config.ts
+++ b/app/self-custodial/config.ts
@@ -2,6 +2,7 @@ import { Network } from "@breeztech/breez-sdk-spark-react-native"
 import Config from "react-native-config"
 import { DocumentDirectoryPath } from "react-native-fs"
 
+import { LNURL_DOMAINS } from "@app/config/appinfo"
 import { type GaloyInstanceName } from "@app/config/galoy-instances"
 
 export const SparkToken = {
@@ -38,6 +39,19 @@ const REGTEST_LNURL_DOMAIN = "staging.blink.sv"
 
 export const lnurlDomainFor = (network: Network): string =>
   network === Network.Mainnet ? MAINNET_LNURL_DOMAIN : REGTEST_LNURL_DOMAIN
+
+const REGTEST_PAY_DOMAIN = "pay.staging.blink.sv"
+
+/**
+ * Every host that serves one of our own accounts on this network, the address domain
+ * first: the point of sale answers on `pay.*` while an account is spelled without it.
+ * Kept per network because a host belongs to the deployment that serves it, and
+ * declaring another one's would name an account this network never issued.
+ */
+export const lnurlDomainsFor = (network: Network): string[] =>
+  network === Network.Mainnet
+    ? LNURL_DOMAINS
+    : [lnurlDomainFor(network), REGTEST_PAY_DOMAIN]
 
 /**
  * Base URL of the LNURL server for a self-custodial account: the same host its address is

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@apollo/client": "^3.9.11",
     "@bitcoinerlab/secp256k1": "^1.1.1",
-    "@blinkbitcoin/blink-client": "1.1.0",
+    "@blinkbitcoin/blink-client": "1.1.1",
     "@blinkbitcoin/react-native-geetest-module": "0.1.2",
     "@breeztech/breez-sdk-spark-react-native": "0.22.0",
     "@expo/react-native-action-sheet": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,10 +1832,10 @@
     "@noble/hashes" "^1.1.5"
     "@noble/secp256k1" "^1.7.1"
 
-"@blinkbitcoin/blink-client@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@blinkbitcoin/blink-client/-/blink-client-1.1.0.tgz#49a0034d798f90976698d1086cc1e2de8cf149b3"
-  integrity sha512-xcWuzOPgT+2gJrELMSTC452X4k2g120hk4YrGets5j0XbO04Vf6MMnNBkA++kHOhB/LfPT4fMH+kNdlTZ4vjbw==
+"@blinkbitcoin/blink-client@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@blinkbitcoin/blink-client/-/blink-client-1.1.1.tgz#a5f101966d1e13ac5388f74ee7ad0b1cc0d4e951"
+  integrity sha512-kKbvnxFX12ERIhOPvPGskgIngVCX5kcKWkwkh66MauBIIocaYLJM/Q7DoYloXLAuzQqsyy+FTScWYj+eXVaUSw==
 
 "@blinkbitcoin/react-native-geetest-module@0.1.2":
   version "0.1.2"


### PR DESCRIPTION
## Summary

The app-side follow-up for blinkbitcoin/blink-wip#1034, once blinkbitcoin/blink-client#51 lands: a self-custodial sender scanning a Blink pay code sees the account spelled the way its owner receives it, and pays it over lightning.

`lnurlDomains` answered two questions at once: which hosts name one of our accounts, and which destinations are paid over the ledger. A self-custodial sender needs the first — it is what lets a pay code be recognised as naming an account instead of being fetched as an opaque lnurl — and cannot use the second, having no token for the intraledger mutation. Declaring `[]` switched both off, which is why the scan context did that. The two are now separate:

- `canPayIntraledger` (default `true`) decides only the second, so the domains can be declared without a destination collapsing to a ledger payment the wallet cannot make.
- The self-custodial path sets `preferLnurlForInternalHandles: true` alongside it, and the scan context declares the domains of the network it is on, address domain first, since blink-client rebuilds the address on `lnAddressDomains[0]`.
- Domains are now per network, so regtest no longer declares production's hosts as its own.
- A merchant till code served by a declared domain takes the same route on the self-custodial path.

The parsing fix ships in blink-client#51, released as **1.1.1**; this wires the app up to it and bumps the dependency.

## Why the blink-client fix alone was not enough

In principle the bump should have been the whole change: blink-client#51 resolves the pay code to the canonical address before any network call, so nothing was expected on this side beyond depending on it.

Running it in the app said otherwise. With the fixed blink-client and this repo untouched, the parser returned the right destination and the app then undid it:

```
blink-client parser:            lnurl        ideasarelikeflames@blink.sv
this repo's parseDestination:   intraledger  handle ideasarelikeflames
```

`resolveLnurlDestination` saw the recipient's domain among `lnurlDomains` and turned the destination into an intraledger payment, which a self-custodial wallet has no token to make. That is also why the self-custodial scan context declared no domains at all: it was the only way to stop that, at the cost of blink-client never recognising a pay code.

So the bump ships together with the change that separates those two meanings. Neither half fixes #1034 on its own.

## Screenshots

Non-custodial account on the Main instance. Only the cases that change against `main` are shown; a typed `alice@blink.sv` and an external address are unaffected.

| | Before | After |
|:--|:--:|:--:|
| Pay code on `pay.blink.sv` | <img width="300" alt="sc-antes-paycode-blink" src="https://github.com/user-attachments/assets/226fdd4b-a050-411c-8784-3e3ba645896a" /> | <img width="300" alt="sc-despues-paycode-blink" src="https://github.com/user-attachments/assets/636d0aef-dd5b-4ad5-931f-13e938261350" /> |
| Pay code on `pay.bbw.sv` | <img width="300" alt="sc-antes-paycode-bbw" src="https://github.com/user-attachments/assets/8bde7c7b-a910-49f3-b1d8-90993b4caacc" /> | <img width="300" alt="sc-despues-paycode-bbw" src="https://github.com/user-attachments/assets/df42e363-1940-40f7-9b02-cb2753ff4da9" /> |





