### PR TITLE
fix(onboarding): stop the level 2 upgrade screen starting KYC without user input

### DIFF
--- a/__tests__/hooks/use-kyc-flow.spec.ts
+++ b/__tests__/hooks/use-kyc-flow.spec.ts
@@ -25,8 +25,8 @@ const mockKycFlowStart = jest.fn()
 jest.mock("@app/graphql/generated", () => ({
   useKycFlowStartMutation: () => [mockKycFlowStart],
   KycFlowType: {
-    Full: "FULL",
-    Basic: "BASIC",
+    Card: "CARD",
+    UpgradeLevelTwo: "UPGRADE_LEVEL_TWO",
   },
 }))
 

--- a/__tests__/hooks/use-kyc-flow.spec.ts
+++ b/__tests__/hooks/use-kyc-flow.spec.ts
@@ -119,6 +119,81 @@ describe("useKycFlow", () => {
     })
   })
 
+  it("trims leading and trailing whitespace from firstName and lastName", async () => {
+    mockKycFlowStart.mockResolvedValue({
+      data: {
+        kycFlowStart: {
+          tokenWeb: "t",
+          workflowRunId: "w",
+        },
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useKycFlow({ firstName: "  John ", lastName: "\tDoe\n" }),
+    )
+
+    await act(async () => {
+      await result.current.startKyc()
+    })
+
+    expect(mockKycFlowStart).toHaveBeenCalledWith({
+      variables: {
+        input: { firstName: "John", lastName: "Doe", type: undefined },
+      },
+    })
+  })
+
+  it("preserves internal whitespace in names", async () => {
+    mockKycFlowStart.mockResolvedValue({
+      data: {
+        kycFlowStart: {
+          tokenWeb: "t",
+          workflowRunId: "w",
+        },
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useKycFlow({ firstName: "Mary Jane", lastName: "van der Berg" }),
+    )
+
+    await act(async () => {
+      await result.current.startKyc()
+    })
+
+    expect(mockKycFlowStart).toHaveBeenCalledWith({
+      variables: {
+        input: { firstName: "Mary Jane", lastName: "van der Berg", type: undefined },
+      },
+    })
+  })
+
+  it("sends empty string for whitespace-only names", async () => {
+    mockKycFlowStart.mockResolvedValue({
+      data: {
+        kycFlowStart: {
+          tokenWeb: "t",
+          workflowRunId: "w",
+        },
+      },
+    })
+
+    const { result } = renderHook(() =>
+      useKycFlow({ firstName: "   ", lastName: " " }),
+    )
+
+    await act(async () => {
+      await result.current.startKyc()
+    })
+
+    expect(mockKycFlowStart).toHaveBeenCalledWith({
+      variables: {
+        input: { firstName: "", lastName: "", type: undefined },
+      },
+    })
+  })
+
   it("builds URL with locale and theme mode", async () => {
     mockKycFlowStart.mockResolvedValue({
       data: {

--- a/__tests__/hooks/use-kyc-flow.spec.ts
+++ b/__tests__/hooks/use-kyc-flow.spec.ts
@@ -179,9 +179,7 @@ describe("useKycFlow", () => {
       },
     })
 
-    const { result } = renderHook(() =>
-      useKycFlow({ firstName: "   ", lastName: " " }),
-    )
+    const { result } = renderHook(() => useKycFlow({ firstName: "   ", lastName: " " }))
 
     await act(async () => {
       await result.current.startKyc()

--- a/__tests__/screens/full-onboarding-flow-screen.spec.tsx
+++ b/__tests__/screens/full-onboarding-flow-screen.spec.tsx
@@ -1,7 +1,8 @@
 import React from "react"
+import { Alert } from "react-native"
 import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
-import { render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 
 import { FullOnboardingFlowScreen } from "@app/screens/full-onboarding-flow/full-onboarding-flow"
 import {
@@ -78,8 +79,8 @@ const generateFullOnboardingMock = ({
         query: KycFlowStartDocument,
         variables: {
           input: {
-            firstName: "",
-            lastName: "",
+            firstName: "John",
+            lastName: "Doe",
           },
         },
       },
@@ -89,6 +90,30 @@ const generateFullOnboardingMock = ({
             __typename: "KycFlowStartPayload",
             workflowRunId: "workflow-123",
             tokenWeb: "test-token-web-123",
+          },
+        },
+      },
+    },
+    // Trap: the screen must never start a KYC flow with the empty names it
+    // mounts with. Without this mock an unrequested start would miss the mock
+    // link entirely, get swallowed by the hook's catch, and never navigate --
+    // so the "does not start on its own" test would pass for the wrong reason.
+    {
+      request: {
+        query: KycFlowStartDocument,
+        variables: {
+          input: {
+            firstName: "",
+            lastName: "",
+          },
+        },
+      },
+      result: {
+        data: {
+          kycFlowStart: {
+            __typename: "KycFlowStartPayload",
+            workflowRunId: "workflow-trap",
+            tokenWeb: "test-token-web-trap",
           },
         },
       },
@@ -104,16 +129,57 @@ describe("FullOnboardingFlowScreen", () => {
   })
 
   describe("WebView navigation for KYC flow", () => {
-    it("should navigate to WebView with correct params when onboardingStatus is AWAITING_INPUT", async () => {
-      currentMocks = generateFullOnboardingMock({
-        onboardingStatus: OnboardingStatus.AwaitingInput,
-      })
-
-      render(
+    const renderScreen = async () => {
+      const screen = render(
         <ContextForScreen>
           <FullOnboardingFlowScreen />
         </ContextForScreen>,
       )
+
+      // The form only paints once the status query has resolved, so waiting on
+      // it is what makes a later "did not navigate" assertion meaningful.
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("First name")).toBeTruthy()
+      })
+
+      return screen
+    }
+
+    // Next only opens the confirmation alert; startKyc runs from its Yes handler.
+    const submitNames = async (screen: Awaited<ReturnType<typeof renderScreen>>) => {
+      const alertSpy = jest.spyOn(Alert, "alert")
+
+      fireEvent.changeText(screen.getByPlaceholderText("First name"), "John")
+      fireEvent.changeText(screen.getByPlaceholderText("Last name"), "Doe")
+      fireEvent.press(screen.getByTestId("Next"))
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalled()
+      })
+
+      const confirmButton = alertSpy.mock.calls[0][2]?.[1]
+      await act(async () => {
+        confirmButton?.onPress?.()
+      })
+    }
+
+    it("should not start the KYC flow on its own when onboardingStatus is AWAITING_INPUT", async () => {
+      currentMocks = generateFullOnboardingMock({
+        onboardingStatus: OnboardingStatus.AwaitingInput,
+      })
+
+      await renderScreen()
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("should navigate to WebView with correct params when the user submits their name", async () => {
+      currentMocks = generateFullOnboardingMock({
+        onboardingStatus: OnboardingStatus.AwaitingInput,
+      })
+
+      const screen = await renderScreen()
+      await submitNames(screen)
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(
@@ -127,18 +193,16 @@ describe("FullOnboardingFlowScreen", () => {
 
       const navigationCall = mockNavigate.mock.calls[0]
       expect(navigationCall[1].url).toContain("token=test-token-web-123")
+      expect(navigationCall[1].url).toContain("workflow_run_id=workflow-123")
     })
 
     it("should include theme parameter in KYC URL", async () => {
       currentMocks = generateFullOnboardingMock({
-        onboardingStatus: OnboardingStatus.AwaitingInput,
+        onboardingStatus: OnboardingStatus.NotStarted,
       })
 
-      render(
-        <ContextForScreen>
-          <FullOnboardingFlowScreen />
-        </ContextForScreen>,
-      )
+      const screen = await renderScreen()
+      await submitNames(screen)
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalled()

--- a/__tests__/screens/full-onboarding-flow-screen.spec.tsx
+++ b/__tests__/screens/full-onboarding-flow-screen.spec.tsx
@@ -163,14 +163,27 @@ describe("FullOnboardingFlowScreen", () => {
       })
     }
 
+    // navigate() is only half the assertion. A start whose payload no longer
+    // matches the trap mock above fails inside the hook's catch, which never
+    // reaches navigate() either -- so an unrequested start would look exactly
+    // like a screen that correctly stayed put. Alert and goBack are that
+    // catch's own visible effects, so they keep this honest whatever shape the
+    // mutation's input drifts into.
     it("should not start the KYC flow on its own when onboardingStatus is AWAITING_INPUT", async () => {
       currentMocks = generateFullOnboardingMock({
         onboardingStatus: OnboardingStatus.AwaitingInput,
       })
+      const alertSpy = jest.spyOn(Alert, "alert")
 
       await renderScreen()
+      // Let anything the mount kicked off actually settle. Without this the
+      // assertions can run before an unrequested mutation has resolved, and
+      // the test would report "stayed put" for a screen that did start one.
+      await act(async () => {})
 
       expect(mockNavigate).not.toHaveBeenCalled()
+      expect(alertSpy).not.toHaveBeenCalled()
+      expect(mockGoBack).not.toHaveBeenCalled()
     })
 
     it("should navigate to WebView with correct params when the user submits their name", async () => {

--- a/app/hooks/use-kyc-flow.ts
+++ b/app/hooks/use-kyc-flow.ts
@@ -52,7 +52,9 @@ export const useKycFlow = ({
 
     try {
       const res = await kycFlowStart({
-        variables: { input: { firstName, lastName, type } },
+        variables: {
+          input: { firstName: firstName?.trim(), lastName: lastName?.trim(), type },
+        },
       })
 
       const token = res.data?.kycFlowStart?.tokenWeb ?? ""

--- a/app/screens/full-onboarding-flow/full-onboarding-flow.tsx
+++ b/app/screens/full-onboarding-flow/full-onboarding-flow.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { ActivityIndicator, Alert, View } from "react-native"
 import { Input, Text, makeStyles, useTheme } from "@rn-vui/themed"
 import { gql } from "@apollo/client"
@@ -54,12 +54,6 @@ export const FullOnboardingFlowScreen: React.FC = () => {
       ],
     )
   }
-
-  useEffect(() => {
-    if (onboardingStatus === OnboardingStatus.AwaitingInput) {
-      startKyc()
-    }
-  }, [onboardingStatus, startKyc])
 
   if (loading) {
     return (
@@ -127,7 +121,7 @@ export const FullOnboardingFlowScreen: React.FC = () => {
           <GaloyPrimaryButton
             onPress={confirmNames}
             title={LL.common.next()}
-            disabled={!firstName || !lastName}
+            disabled={!firstName.trim() || !lastName.trim()}
             loading={loadingKyc}
           />
         </View>


### PR DESCRIPTION
The name/surname step of the level 2 upgrade would skip itself: the form painted, then the screen jumped straight into the KYC webflow without waiting for any input, often ending on an "internal server error" dialog. It looked intermittent because it never happened on a brand new account.

Mechanism
---------
FullOnboardingFlowScreen ran an effect that called startKyc() whenever the onboardingStatus query came back AWAITING_INPUT, bypassing both the name fields and the "Is the spelling of your name correct?" confirmation. It was the only unattended caller of startKyc in the app.

It fired in two distinct ways, and both had to go:

1. After the query resolved. On mount `loading` is true and onboardingStatus is undefined, so the guard is false; the effect fires on the first render *after* the network-only query resolves. By then the name form has already painted -- hence "the screen appears, then leaves on its own". Because the component state is still empty at that point, the mutation went out as { firstName: "", lastName: "" }. Nothing in the Apollo link chain touches variables, so the empty strings reached the server verbatim.

2. On every keystroke. AWAITING_INPUT is not in the terminal-status early return, so the form stayed live underneath. startKyc is a useCallback whose deps include firstName/lastName, and the effect depended on startKyc, so a single character typed into the form fired a second mutation and navigated again -- this time with a partial name such as { firstName: "K", lastName: "" }. A fired-once ref, or dropping startKyc from the dep array, would have left this half of the bug alive.

Why it seemed to work the first time: a fresh account is NOT_STARTED, so the effect no-ops and the form behaves correctly. Completing that first start moves the account to AWAITING_INPUT, and from then on every entry to the screen auto-fires. The error dialog's Ok handler calls goBack(), popping the screen, and all three entry points re-push a fresh instance whose network-only query returns AWAITING_INPUT again -- so the user could never get back to the form by re-entering.

The effect is not a regression from a recent change. git blame puts it in the screen's first commit, 25eecfc18 (Oct 2023), alongside the name inputs and a mutation that already took { firstName, lastName }; the two have contradicted each other from the start. There was one window where it was harmless -- 1744025d5 (#3553) deleted the name fields and made kycFlowStart argument-less, so auto-fire and button-press were the same call -- and b7cd3cd73 (#3572) restored the names 23 days later without revisiting the effect.

Fix
---
Delete the effect. AWAITING_INPUT already falls through both early returns to the name form, so it now behaves like NOT_STARTED: the form waits, and Next is disabled until both fields are filled, which makes an empty-name start structurally impossible rather than merely guarded. This also breaks the re-entry trap, since every entry now reaches the form.

The Next button's disabled check now uses .trim(), so a whitespace-only name can no longer reach the provider.

Tests
-----
The spec had pinned the bug in place: it mocked kycFlowStart with exactly { firstName: "", lastName: "" } and asserted the auto-navigation.

It now mocks the payload the real user path produces and adds a deliberate *trap* mock for the empty-name payload, returning a distinguishable token. The trap is load-bearing. Without it, an unrequested start misses the mock link, gets swallowed by the hook's catch, and never navigates -- so the "does not start on its own" test passes against the unfixed screen. Verified by mutation test: re-inserting the effect turns both new tests red, with token=test-token-web-trap in the assertion diff.

The negative assertion also avoids the `waitFor(() => expect(x).not.toHave BeenCalled(), { timeout: 500 })` idiom used elsewhere in the file, which resolves on its first non-throwing evaluation -- before the query has even resolved -- and so passes against code that definitely navigates. It anchors on the form rendering, then asserts synchronously.

Also in this change:
- assert workflow_run_id in the navigation URL; it has been unasserted since f1e68d95e (#3573) added it for Onfido support.
- move the theme-parameter test to NOT_STARTED. The theme param is orthogonal to the status, and on AWAITING_INPUT that test could not detect the bug.
- correct the stale KycFlowType mock in the useKycFlow spec, which declared { Full, Basic }. Neither member exists in the real enum, so KycFlowType.Card evaluated to undefined on both sides of its assertion and the test proved nothing about `type`.

Deliberately out of scope
-------------------------
- type: KycFlowType.UpgradeLevelTwo. This screen is the app's only kycFlowStart caller that sends no discriminator, and the enum member is used nowhere in the codebase, so the server has some default for the absent case. It is the one available change that could introduce a *new* server-side failure; it should ship alone, once backend confirms the default, so any regression stays attributable.
- An explicit "Continue KYC verification" resume branch. Better product behaviour for a returning user, but it would send {"input":{}} -- a wire shape no path in this app has ever sent -- and a nameless resume gives the affected users no way to correct an applicant that was created with blank names by this very bug.
- useKycFlow's error dialog (inverted title/body, raw err.message leaked into user-facing text, goBack() on Ok) and the retry amplification (kycFlowStart is absent from noRetryOperations and has no idempotency key, so RetryLink replays it up to 5x on a 5xx; there is also no in-flight latch, and the card flow never passes `loading` to its button). All real, all in code shared with the card flow, all tracked separately.

Note that this only removes one of three candidate causes for the reported internal-server-error. Two staging calls settle which it is: kycFlowStart with empty names and no type, and a second kycFlowStart against an account already in AWAITING_INPUT. If it is the latter, the error will still appear -- but only once, and only because the user asked for it.

To reproduce against this fix you need an account already in AWAITING_INPUT; a fresh one is NOT_STARTED and never showed the bug.


---

Here's a video of the behaviour with the fix.

https://github.com/user-attachments/assets/d825e344-20a2-4e41-9e19-8a072d7bea42

