### PR TITLE
fix(settings): say "Create Lightning address" on the row with no address yet

### DIFF
--- a/__tests__/i18n/create-lightning-address-label.spec.ts
+++ b/__tests__/i18n/create-lightning-address-label.spec.ts
@@ -1,0 +1,55 @@
+import fs from "fs"
+import path from "path"
+
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+
+const TRANSLATIONS_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "app",
+  "i18n",
+  "raw-i18n",
+  "translations",
+)
+
+const ENGLISH = "Create Lightning address"
+
+const locales = fs
+  .readdirSync(TRANSLATIONS_DIR)
+  .filter((file) => file.endsWith(".json"))
+  .map((file) => file.replace(/\.json$/, ""))
+
+const createAddressFor = (locale: string): unknown => {
+  const raw = JSON.parse(
+    fs.readFileSync(path.join(TRANSLATIONS_DIR, `${locale}.json`), "utf8"),
+  )
+  return raw.SettingsScreen?.createAddress
+}
+
+describe("SettingsScreen.createAddress", () => {
+  it("reads 'Create Lightning address' in English", () => {
+    loadLocale("en")
+
+    expect(i18nObject("en").SettingsScreen.createAddress()).toBe(ENGLISH)
+  })
+
+  it("reads 'Crear dirección Lightning' in Spanish", () => {
+    loadLocale("es")
+
+    expect(i18nObject("es").SettingsScreen.createAddress()).toBe(
+      "Crear dirección Lightning",
+    )
+  })
+
+  locales.forEach((locale) => {
+    it(`is translated and names Lightning in ${locale}`, () => {
+      const value = createAddressFor(locale)
+
+      expect(typeof value).toBe("string")
+      expect(value).not.toBe(ENGLISH)
+      expect(value).toContain("Lightning")
+    })
+  })
+})

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -73,7 +73,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({
     LL: {
       SettingsScreen: {
-        createAddress: () => "Create address",
+        createAddress: () => "Set receive address",
         addressDisabled: () => "(disabled)",
       },
       GaloyAddressScreen: { copiedLightningAddressToClipboard: () => "Copied" },
@@ -105,7 +105,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Create address")
+    expect(lastRowProps().title).toBe("Set receive address")
     expect(lastRowProps().rightIcon).toBeUndefined()
     expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 
@@ -147,7 +147,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Create address")
+    expect(lastRowProps().title).toBe("Set receive address")
   })
 
   /** Registering an address is the very thing Incognito withholds: publishing one would
@@ -186,7 +186,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Create address")
+    expect(lastRowProps().title).toBe("Set receive address")
     expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 
     act(() => (lastRowProps().action as () => void)())
@@ -269,7 +269,7 @@ describe("AccountLNAddress (custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Create address")
+    expect(lastRowProps().title).toBe("Set receive address")
     expect(lastRowProps().rightIcon).toBeUndefined()
     expect(mockCustodialModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -73,7 +73,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({
     LL: {
       SettingsScreen: {
-        createAddress: () => "Set receive address",
+        createAddress: () => "Create Lightning address",
         addressDisabled: () => "(disabled)",
       },
       GaloyAddressScreen: { copiedLightningAddressToClipboard: () => "Copied" },
@@ -105,7 +105,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Set receive address")
+    expect(lastRowProps().title).toBe("Create Lightning address")
     expect(lastRowProps().rightIcon).toBeUndefined()
     expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 
@@ -147,7 +147,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Set receive address")
+    expect(lastRowProps().title).toBe("Create Lightning address")
   })
 
   /** Registering an address is the very thing Incognito withholds: publishing one would
@@ -186,7 +186,7 @@ describe("AccountLNAddress (self-custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Set receive address")
+    expect(lastRowProps().title).toBe("Create Lightning address")
     expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 
     act(() => (lastRowProps().action as () => void)())
@@ -269,7 +269,7 @@ describe("AccountLNAddress (custodial)", () => {
 
     render(<AccountLNAddress />)
 
-    expect(lastRowProps().title).toBe("Set receive address")
+    expect(lastRowProps().title).toBe("Create Lightning address")
     expect(lastRowProps().rightIcon).toBeUndefined()
     expect(mockCustodialModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
 

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -49,7 +49,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
       },
       SettingsScreen: {
         setByOs: () => "Default",
-        createAddress: () => "Create address",
+        createAddress: () => "Set receive address",
         pos: () => "POS",
         staticQr: () => "Static QR",
         donationButton: () => "Donate Button",

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -49,7 +49,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
       },
       SettingsScreen: {
         setByOs: () => "Default",
-        createAddress: () => "Set receive address",
+        createAddress: () => "Create Lightning address",
         pos: () => "POS",
         staticQr: () => "Static QR",
         donationButton: () => "Donate Button",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2510,7 +2510,7 @@ const en: BaseTranslation = {
     mode: "Mode",
     pos: "Point of Sale",
     posCopied: "Your point of sale link has been copied",
-    createAddress: "Create address",
+    createAddress: "Set receive address",
     addressDisabled: "(disabled)",
     donationButton: "Donate Button",
     btcpayServer: "BTCPay Server",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2510,7 +2510,7 @@ const en: BaseTranslation = {
     mode: "Mode",
     pos: "Point of Sale",
     posCopied: "Your point of sale link has been copied",
-    createAddress: "Set receive address",
+    createAddress: "Create Lightning address",
     addressDisabled: "(disabled)",
     donationButton: "Donate Button",
     btcpayServer: "BTCPay Server",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -7936,7 +7936,7 @@ type RootTranslation = {
 		 */
 		posCopied: string
 		/**
-		 * C​r​e​a​t​e​ ​a​d​d​r​e​s​s
+		 * S​e​t​ ​r​e​c​e​i​v​e​ ​a​d​d​r​e​s​s
 		 */
 		createAddress: string
 		/**
@@ -21502,7 +21502,7 @@ export type TranslationFunctions = {
 		 */
 		posCopied: () => LocalizedString
 		/**
-		 * Create address
+		 * Set receive address
 		 */
 		createAddress: () => LocalizedString
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -7936,7 +7936,7 @@ type RootTranslation = {
 		 */
 		posCopied: string
 		/**
-		 * S​e​t​ ​r​e​c​e​i​v​e​ ​a​d​d​r​e​s​s
+		 * C​r​e​a​t​e​ ​L​i​g​h​t​n​i​n​g​ ​a​d​d​r​e​s​s
 		 */
 		createAddress: string
 		/**
@@ -21502,7 +21502,7 @@ export type TranslationFunctions = {
 		 */
 		posCopied: () => LocalizedString
 		/**
-		 * Set receive address
+		 * Create Lightning address
 		 */
 		createAddress: () => LocalizedString
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2431,7 +2431,7 @@
         "mode": "Mode",
         "pos": "Point of Sale",
         "posCopied": "Your point of sale link has been copied",
-        "createAddress": "Create address",
+        "createAddress": "Set receive address",
         "addressDisabled": "(disabled)",
         "donationButton": "Donate Button",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2431,7 +2431,7 @@
         "mode": "Mode",
         "pos": "Point of Sale",
         "posCopied": "Your point of sale link has been copied",
-        "createAddress": "Set receive address",
+        "createAddress": "Create Lightning address",
         "addressDisabled": "(disabled)",
         "donationButton": "Donate Button",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan nie fooie skat nie. Probeer asseblief 'n ander bedrag."
   },
   "SettingsScreen": {
-    "createAddress": "Skep adres",
+    "createAddress": "Stel ontvangadres in",
     "addressDisabled": "(gedeaktiveer)",
     "donationButton": "Skenk-knoppie",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan nie fooie skat nie. Probeer asseblief 'n ander bedrag."
   },
   "SettingsScreen": {
-    "createAddress": "Stel ontvangadres in",
+    "createAddress": "Skep Lightning-adres",
     "addressDisabled": "(gedeaktiveer)",
     "donationButton": "Skenk-knoppie",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "تعذّر تقدير الرسوم. يرجى تجربة مبلغ مختلف."
   },
   "SettingsScreen": {
-    "createAddress": "إنشاء عنوان",
+    "createAddress": "تعيين عنوان الاستلام",
     "addressDisabled": "(معطّل)",
     "donationButton": "زر التبرع",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "تعذّر تقدير الرسوم. يرجى تجربة مبلغ مختلف."
   },
   "SettingsScreen": {
-    "createAddress": "تعيين عنوان الاستلام",
+    "createAddress": "إنشاء عنوان Lightning",
     "addressDisabled": "(معطّل)",
     "donationButton": "زر التبرع",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "No s'han pogut estimar les comissions. Proveu un import diferent."
   },
   "SettingsScreen": {
-    "createAddress": "Crea una adreça",
+    "createAddress": "Posa adreça per rebre",
     "addressDisabled": "(desactivat)",
     "donationButton": "Botó Donar",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "No s'han pogut estimar les comissions. Proveu un import diferent."
   },
   "SettingsScreen": {
-    "createAddress": "Posa adreça per rebre",
+    "createAddress": "Crea una adreça Lightning",
     "addressDisabled": "(desactivat)",
     "donationButton": "Botó Donar",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nelze odhadnout poplatky. Zkuste jiný částku."
   },
   "SettingsScreen": {
-    "createAddress": "Vytvořit adresu",
+    "createAddress": "Nastavit adresu příjmu",
     "addressDisabled": "(zakázáno)",
     "donationButton": "Darovací tlačítko",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nelze odhadnout poplatky. Zkuste jiný částku."
   },
   "SettingsScreen": {
-    "createAddress": "Nastavit adresu příjmu",
+    "createAddress": "Vytvořit Lightning adresu",
     "addressDisabled": "(zakázáno)",
     "donationButton": "Darovací tlačítko",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan ikke estimere gebyrer. Prøv venligst et andet beløb."
   },
   "SettingsScreen": {
-    "createAddress": "Opret adresse",
+    "createAddress": "Angiv modtageradresse",
     "addressDisabled": "(deaktiveret)",
     "donationButton": "Donér-knap",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan ikke estimere gebyrer. Prøv venligst et andet beløb."
   },
   "SettingsScreen": {
-    "createAddress": "Angiv modtageradresse",
+    "createAddress": "Opret Lightning-adresse",
     "addressDisabled": "(deaktiveret)",
     "donationButton": "Donér-knap",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Gebühren können nicht geschätzt werden. Bitte versuchen Sie einen anderen Betrag."
     },
     "SettingsScreen": {
-        "createAddress": "Adresse erstellen",
+        "createAddress": "Empfangsadresse setzen",
         "addressDisabled": "(deaktiviert)",
         "donationButton": "Spenden-Button",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Gebühren können nicht geschätzt werden. Bitte versuchen Sie einen anderen Betrag."
     },
     "SettingsScreen": {
-        "createAddress": "Empfangsadresse setzen",
+        "createAddress": "Lightning-Adresse erstellen",
         "addressDisabled": "(deaktiviert)",
         "donationButton": "Spenden-Button",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Αδυναμία εκτίμησης τελών. Δοκιμάστε διαφορετικό ποσό."
   },
   "SettingsScreen": {
-    "createAddress": "Δημιουργία διεύθυνσης",
+    "createAddress": "Ορισμός διεύθυνσης λήψης",
     "addressDisabled": "(απενεργοποιημένο)",
     "donationButton": "Κουμπί δωρεάς",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Αδυναμία εκτίμησης τελών. Δοκιμάστε διαφορετικό ποσό."
   },
   "SettingsScreen": {
-    "createAddress": "Ορισμός διεύθυνσης λήψης",
+    "createAddress": "Δημιουργία διεύθυνσης Lightning",
     "addressDisabled": "(απενεργοποιημένο)",
     "donationButton": "Κουμπί δωρεάς",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "No se pueden estimar las comisiones. Intenta con un monto diferente."
     },
     "SettingsScreen": {
-        "createAddress": "Crear dirección",
+        "createAddress": "Dirección para recibir",
         "addressDisabled": "(desactivada)",
         "donationButton": "Botón Donar",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "No se pueden estimar las comisiones. Intenta con un monto diferente."
     },
     "SettingsScreen": {
-        "createAddress": "Dirección para recibir",
+        "createAddress": "Crear dirección Lightning",
         "addressDisabled": "(desactivada)",
         "donationButton": "Botón Donar",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Impossible d'estimer les frais. Essayez un montant différent."
     },
     "SettingsScreen": {
-        "createAddress": "Créer une adresse",
+        "createAddress": "Adresse de réception",
         "addressDisabled": "(désactivée)",
         "donationButton": "Bouton de don",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Impossible d'estimer les frais. Essayez un montant différent."
     },
     "SettingsScreen": {
-        "createAddress": "Adresse de réception",
+        "createAddress": "Créer une adresse Lightning",
         "addressDisabled": "(désactivée)",
         "donationButton": "Bouton de don",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nije moguće procijeniti naknade. Pokušajte s drugim iznosom."
   },
   "SettingsScreen": {
-    "createAddress": "Stvori adresu",
+    "createAddress": "Postavi adresu primanja",
     "addressDisabled": "(onemogućeno)",
     "donationButton": "Gumb za doniranje",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nije moguće procijeniti naknade. Pokušajte s drugim iznosom."
   },
   "SettingsScreen": {
-    "createAddress": "Postavi adresu primanja",
+    "createAddress": "Stvori Lightning adresu",
     "addressDisabled": "(onemogućeno)",
     "donationButton": "Gumb za doniranje",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nem sikerült megbecsülni a díjakat. Próbáljon másik összeget."
   },
   "SettingsScreen": {
-    "createAddress": "Cím létrehozása",
+    "createAddress": "Fogadási cím beállítása",
     "addressDisabled": "(letiltva)",
     "donationButton": "Adományozás gomb",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nem sikerült megbecsülni a díjakat. Próbáljon másik összeget."
   },
   "SettingsScreen": {
-    "createAddress": "Fogadási cím beállítása",
+    "createAddress": "Lightning cím létrehozása",
     "addressDisabled": "(letiltva)",
     "donationButton": "Adományozás gomb",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Հնարավոր չէ հաշվարկել վճարները։ Խնդրում ենք փորձել այլ գումար։"
   },
   "SettingsScreen": {
-    "createAddress": "Ստեղծել հասցե",
+    "createAddress": "Սահմանել ստացման հասցեն",
     "addressDisabled": "(անջատված)",
     "donationButton": "Նվիրատվության կոճակ",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Հնարավոր չէ հաշվարկել վճարները։ Խնդրում ենք փորձել այլ գումար։"
   },
   "SettingsScreen": {
-    "createAddress": "Սահմանել ստացման հասցեն",
+    "createAddress": "Ստեղծել Lightning հասցե",
     "addressDisabled": "(անջատված)",
     "donationButton": "Նվիրատվության կոճակ",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tidak dapat memperkirakan biaya. Coba jumlah yang berbeda."
   },
   "SettingsScreen": {
-    "createAddress": "Buat alamat",
+    "createAddress": "Atur alamat penerimaan",
     "addressDisabled": "(nonaktif)",
     "donationButton": "Tombol donasi",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tidak dapat memperkirakan biaya. Coba jumlah yang berbeda."
   },
   "SettingsScreen": {
-    "createAddress": "Atur alamat penerimaan",
+    "createAddress": "Buat alamat Lightning",
     "addressDisabled": "(nonaktif)",
     "donationButton": "Tombol donasi",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Impossibile stimare le commissioni. Prova con un importo diverso."
     },
     "SettingsScreen": {
-        "createAddress": "Crea indirizzo",
+        "createAddress": "Indirizzo di ricezione",
         "addressDisabled": "(disattivato)",
         "donationButton": "Pulsante Dona",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Impossibile stimare le commissioni. Prova con un importo diverso."
     },
     "SettingsScreen": {
-        "createAddress": "Indirizzo di ricezione",
+        "createAddress": "Crea indirizzo Lightning",
         "addressDisabled": "(disattivato)",
         "donationButton": "Pulsante Dona",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "手数料を見積もれません。別の金額をお試しください。"
     },
     "SettingsScreen": {
-        "createAddress": "アドレスを作成",
+        "createAddress": "受取アドレスを設定",
         "addressDisabled": "(無効)",
         "donationButton": "寄付ボタン",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "手数料を見積もれません。別の金額をお試しください。"
     },
     "SettingsScreen": {
-        "createAddress": "受取アドレスを設定",
+        "createAddress": "Lightningアドレスを作成",
         "addressDisabled": "(無効)",
         "donationButton": "寄付ボタン",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tesobola kusoma ssente z'obukozi. Gezaako omuwendo omulala."
   },
   "SettingsScreen": {
-    "createAddress": "Kola endagiriro",
+    "createAddress": "Endagiriro y'okufuna",
     "addressDisabled": "(tekikola)",
     "donationButton": "Bbatani y'okuwaayo",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tesobola kusoma ssente z'obukozi. Gezaako omuwendo omulala."
   },
   "SettingsScreen": {
-    "createAddress": "Endagiriro y'okufuna",
+    "createAddress": "Kola endagiriro ya Lightning",
     "addressDisabled": "(tekikola)",
     "donationButton": "Bbatani y'okuwaayo",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tidak dapat menganggarkan yuran. Sila cuba jumlah yang berbeza."
   },
   "SettingsScreen": {
-    "createAddress": "Cipta alamat",
+    "createAddress": "Tetapkan alamat terima",
     "addressDisabled": "(dilumpuhkan)",
     "donationButton": "Butang derma",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Tidak dapat menganggarkan yuran. Sila cuba jumlah yang berbeza."
   },
   "SettingsScreen": {
-    "createAddress": "Tetapkan alamat terima",
+    "createAddress": "Cipta alamat Lightning",
     "addressDisabled": "(dilumpuhkan)",
     "donationButton": "Butang derma",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan kosten niet schatten. Probeer een ander bedrag."
   },
   "SettingsScreen": {
-    "createAddress": "Adres aanmaken",
+    "createAddress": "Ontvangstadres instellen",
     "addressDisabled": "(uitgeschakeld)",
     "donationButton": "Doneerknop",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Kan kosten niet schatten. Probeer een ander bedrag."
   },
   "SettingsScreen": {
-    "createAddress": "Ontvangstadres instellen",
+    "createAddress": "Lightning-adres aanmaken",
     "addressDisabled": "(uitgeschakeld)",
     "donationButton": "Doneerknop",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Não foi possível estimar as taxas. Tente um valor diferente."
     },
     "SettingsScreen": {
-        "createAddress": "Criar endereço",
+        "createAddress": "Endereço de recebimento",
         "addressDisabled": "(desativado)",
         "donationButton": "Botão Doar",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2422,7 +2422,7 @@
         "sdkGenericError": "Não foi possível estimar as taxas. Tente um valor diferente."
     },
     "SettingsScreen": {
-        "createAddress": "Endereço de recebimento",
+        "createAddress": "Criar endereço Lightning",
         "addressDisabled": "(desativado)",
         "donationButton": "Botão Doar",
         "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Mana chaninchayta atinichu. Huk yupaywan watiqmanta ruway."
   },
   "SettingsScreen": {
-    "createAddress": "Tinkunata ruray",
+    "createAddress": "Chaskina direccion",
     "addressDisabled": "(mana atikuq)",
     "donationButton": "Qaray ñit'ana",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Mana chaninchayta atinichu. Huk yupaywan watiqmanta ruway."
   },
   "SettingsScreen": {
-    "createAddress": "Chaskina direccion",
+    "createAddress": "Lightning tinkunata ruray",
     "addressDisabled": "(mana atikuq)",
     "donationButton": "Qaray ñit'ana",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nu se pot estima comisioanele. Încercați o sumă diferită."
   },
   "SettingsScreen": {
-    "createAddress": "Creează adresă",
+    "createAddress": "Setează adresa de primire",
     "addressDisabled": "(dezactivat)",
     "donationButton": "Buton de donare",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nu se pot estima comisioanele. Încercați o sumă diferită."
   },
   "SettingsScreen": {
-    "createAddress": "Setează adresa de primire",
+    "createAddress": "Creează adresă Lightning",
     "addressDisabled": "(dezactivat)",
     "donationButton": "Buton de donare",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nie je možné odhadnúť poplatky. Skúste inú sumu."
   },
   "SettingsScreen": {
-    "createAddress": "Vytvoriť adresu",
+    "createAddress": "Nastaviť adresu príjmu",
     "addressDisabled": "(zakázané)",
     "donationButton": "Darovacie tlačidlo",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nie je možné odhadnúť poplatky. Skúste inú sumu."
   },
   "SettingsScreen": {
-    "createAddress": "Nastaviť adresu príjmu",
+    "createAddress": "Vytvoriť Lightning adresu",
     "addressDisabled": "(zakázané)",
     "donationButton": "Darovacie tlačidlo",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nije moguće proceniti naknade. Pokušajte sa drugim iznosom."
   },
   "SettingsScreen": {
-    "createAddress": "Направи адресу",
+    "createAddress": "Постави адресу за пријем",
     "addressDisabled": "(онемогућено)",
     "donationButton": "Дугме за донирање",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Nije moguće proceniti naknade. Pokušajte sa drugim iznosom."
   },
   "SettingsScreen": {
-    "createAddress": "Постави адресу за пријем",
+    "createAddress": "Направи Lightning адресу",
     "addressDisabled": "(онемогућено)",
     "donationButton": "Дугме за донирање",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Haiwezekani kukadiri ada. Tafadhali jaribu kiasi tofauti."
   },
   "SettingsScreen": {
-    "createAddress": "Unda anwani",
+    "createAddress": "Weka anwani ya kupokea",
     "addressDisabled": "(imezimwa)",
     "donationButton": "Kitufe cha kuchangia",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Haiwezekani kukadiri ada. Tafadhali jaribu kiasi tofauti."
   },
   "SettingsScreen": {
-    "createAddress": "Weka anwani ya kupokea",
+    "createAddress": "Unda anwani ya Lightning",
     "addressDisabled": "(imezimwa)",
     "donationButton": "Kitufe cha kuchangia",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "ไม่สามารถประมาณค่าธรรมเนียมได้ กรุณาลองจำนวนอื่น"
   },
   "SettingsScreen": {
-    "createAddress": "สร้างแอดเดรส",
+    "createAddress": "ตั้งค่าที่อยู่รับเงิน",
     "addressDisabled": "(ปิดใช้งาน)",
     "donationButton": "ปุ่มบริจาค",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "ไม่สามารถประมาณค่าธรรมเนียมได้ กรุณาลองจำนวนอื่น"
   },
   "SettingsScreen": {
-    "createAddress": "ตั้งค่าที่อยู่รับเงิน",
+    "createAddress": "สร้างแอดเดรส Lightning",
     "addressDisabled": "(ปิดใช้งาน)",
     "donationButton": "ปุ่มบริจาค",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Ücretler tahmin edilemiyor. Lütfen farklı bir tutar deneyin."
   },
   "SettingsScreen": {
-    "createAddress": "Adres oluştur",
+    "createAddress": "Alım adresi belirle",
     "addressDisabled": "(devre dışı)",
     "donationButton": "Bağış düğmesi",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Ücretler tahmin edilemiyor. Lütfen farklı bir tutar deneyin."
   },
   "SettingsScreen": {
-    "createAddress": "Alım adresi belirle",
+    "createAddress": "Lightning adresi oluştur",
     "addressDisabled": "(devre dışı)",
     "donationButton": "Bağış düğmesi",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Không thể ước tính phí. Vui lòng thử số tiền khác."
   },
   "SettingsScreen": {
-    "createAddress": "Tạo địa chỉ",
+    "createAddress": "Đặt địa chỉ nhận",
     "addressDisabled": "(đã tắt)",
     "donationButton": "Nút quyên góp",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Không thể ước tính phí. Vui lòng thử số tiền khác."
   },
   "SettingsScreen": {
-    "createAddress": "Đặt địa chỉ nhận",
+    "createAddress": "Tạo địa chỉ Lightning",
     "addressDisabled": "(đã tắt)",
     "donationButton": "Nút quyên góp",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Ayikwazi ukuqikelela iintlawulo. Nceda uzame imali eyahlukileyo."
   },
   "SettingsScreen": {
-    "createAddress": "Yenza idilesi",
+    "createAddress": "Misela idilesi yokwamkela",
     "addressDisabled": "(icimile)",
     "donationButton": "Iqhosha lomnikelo",
     "btcpayServer": "BTCPay Server",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2422,7 +2422,7 @@
     "sdkGenericError": "Ayikwazi ukuqikelela iintlawulo. Nceda uzame imali eyahlukileyo."
   },
   "SettingsScreen": {
-    "createAddress": "Misela idilesi yokwamkela",
+    "createAddress": "Yenza idilesi ye-Lightning",
     "addressDisabled": "(icimile)",
     "donationButton": "Iqhosha lomnikelo",
     "btcpayServer": "BTCPay Server",


### PR DESCRIPTION
## Problem

In **Settings**, an account without a Lightning address shows a row titled **"Create address"**. The label doesn't say what kind of address it is, and every other place in the app calls this a **Lightning address**.

## Fix

`SettingsScreen.createAddress` now reads **"Create Lightning address"**.

This follows the review decision on the first version of this PR ("Set receive address"). "Receive address" was a new name that no other screen uses. The row opens `SetAddressModal` ("Choose Lightning Address"), and once the address is set, Account Information labels it "Lightning address". The row now uses that same name.

The key keeps its name because `createAddress` still describes the value. `app/i18n/i18n-types.ts` and `app/i18n/raw-i18n/source/en.json` are regenerated by `yarn update-translations`.

## Translations

All **28 locale files** in `app/i18n/raw-i18n/translations/` are updated in this PR. These are hand-written, not Crowdin output, so reviewers who speak these languages should check them.

Each value combines two strings that locale already has: its earlier "Create address" verb, and the wording it already uses for "Lightning address" in `SetAddressModal` / `AccountInformation`. No new terms were introduced. Every locale keeps the verb, so the row reads as an action and not as a value. `qu` is now `Lightning tinkunata ruray`, built from that file's own `tinkunata`, which also removes the unaccented "direccion".

| loc | value | chars |
|---|---|---:|
| **en** | **Create Lightning address** | 24 |
| `el` | Δημιουργία διεύθυνσης Lightning | 31 |
| `lg` | Kola endagiriro ya Lightning | 28 |
| `de` | Lightning-Adresse erstellen | 27 |
| `fr` | Créer une adresse Lightning | 27 |
| `xh` | Yenza idilesi ye-Lightning | 26 |
| `ca` | Crea una adreça Lightning | 25 |
| `cs` | Vytvořit Lightning adresu | 25 |
| `es` | Crear dirección Lightning | 25 |
| `hu` | Lightning cím létrehozása | 25 |
| `qu` | Lightning tinkunata ruray | 25 |
| `sk` | Vytvoriť Lightning adresu | 25 |
| `it` | Crea indirizzo Lightning | 24 |
| `nl` | Lightning-adres aanmaken | 24 |
| `pt` | Criar endereço Lightning | 24 |
| `ro` | Creează adresă Lightning | 24 |
| `sr` | Направи Lightning адресу | 24 |
| `sw` | Unda anwani ya Lightning | 24 |
| `tr` | Lightning adresi oluştur | 24 |
| `da` | Opret Lightning-adresse | 23 |
| `hr` | Stvori Lightning adresu | 23 |
| `hy` | Ստեղծել Lightning հասցե | 23 |
| `ms` | Cipta alamat Lightning | 22 |
| `th` | สร้างแอดเดรส Lightning | 22 |
| `ar` | إنشاء عنوان Lightning | 21 |
| `id` | Buat alamat Lightning | 21 |
| `vi` | Tạo địa chỉ Lightning | 21 |
| `af` | Skep Lightning-adres | 20 |
| `ja` | Lightningアドレスを作成 | 16 |

**Truncation is not verified on device.** The title is `numberOfLines={1}` with tail ellipsis and scales with the OS font size. Character count is not rendered width, so the longest values (`el` 31, `lg` 28, `de`/`fr` 27) still need a look on a 360dp screen at the largest font scale.

## Acceptance requirements

- [x] Settings row displays "Create Lightning address" for accounts without a Lightning address
- [x] The row uses the same name for the address as `SetAddressModal` and Account Information
- [x] All 28 locale files updated in the same PR, each keeping the verb and the locale's existing "Lightning address" wording
- [x] `yarn update-translations` run; generated files committed
- [x] Copy pinned by a test that reads the real locale files, not the i18n mock
- [ ] Longest locales (`el`, `lg`, `de`, `fr`) checked for truncation at max font scale on a 360dp screen

## Testing specs

- [x] `yarn jest __tests__/i18n` passes (9 suites, 185 tests)
- [x] `yarn jest __tests__/screens/settings-screen` passes (33 suites, 282 tests)
- [x] **Revert check:** with `en/index.ts` set back to the old string, `__tests__/i18n/create-lightning-address-label.spec.ts` fails
- [x] `yarn tsc:check` is clean
- [x] `yarn check:translations` exits 0 with the regenerated files committed
- [x] `npx eslint` on touched specs is clean; `npx prettier --check` on touched `.ts`/`.json` is clean
- [x] Each locale diff is one line; all files re-parse as valid JSON

`__tests__/i18n/create-lightning-address-label.spec.ts` loads the real `en` and `es` locales and checks that every locale file translates the value (it must differ from English) and keeps the word "Lightning". The component spec still tests how the row is wired, with its mock updated to the new copy.

## Screenshots

Closes https://github.com/blinkbitcoin/blink-wip/issues/1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
