### PR TITLE
chore(graphql): regenerate the schema types for the BTC Map place submission

### DIFF
--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -457,6 +457,28 @@ export type BlockInfo = {
   readonly blockHeight?: Maybe<Scalars['Int']['output']>;
 };
 
+export type BtcMapPlace = {
+  readonly __typename: 'BtcMapPlace';
+  readonly externalId: Scalars['String']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly origin: Scalars['String']['output'];
+};
+
+export type BtcMapPlacePayload = {
+  readonly __typename: 'BtcMapPlacePayload';
+  readonly errors: ReadonlyArray<Error>;
+  readonly place?: Maybe<BtcMapPlace>;
+};
+
+export type BtcMapPlaceSubmitInput = {
+  readonly category: Scalars['String']['input'];
+  readonly latitude: Scalars['Float']['input'];
+  readonly longitude: Scalars['Float']['input'];
+  readonly name: Scalars['String']['input'];
+  /** Client-generated UUID identifying this submission. Reuse the same value when retrying after a failed or ambiguous request so the retry does not create a duplicate place. Resubmitting with the same submissionId and different place fields updates the original submission instead. */
+  readonly submissionId: Scalars['ID']['input'];
+};
+
 export type BuildInformation = {
   readonly __typename: 'BuildInformation';
   readonly commitHash?: Maybe<Scalars['String']['output']>;
@@ -1520,6 +1542,8 @@ export type Mutation = {
   readonly apiKeyRemoveLimit: ApiKeySetLimitPayload;
   readonly apiKeyRevoke: ApiKeyRevokePayload;
   readonly apiKeySetLimit: ApiKeySetLimitPayload;
+  /** Submit a place to BTC Map. Submissions from trusted sources appear on BTC Map right away; BTC Map editors process them later for eventual inclusion in OpenStreetMap. */
+  readonly btcMapPlaceSubmit: BtcMapPlacePayload;
   readonly callbackEndpointAdd: CallbackEndpointAddPayload;
   readonly callbackEndpointDelete: SuccessPayload;
   readonly captchaCreateChallenge: CaptchaCreateChallengePayload;
@@ -1707,6 +1731,11 @@ export type MutationApiKeyRevokeArgs = {
 
 export type MutationApiKeySetLimitArgs = {
   input: ApiKeySetLimitInput;
+};
+
+
+export type MutationBtcMapPlaceSubmitArgs = {
+  input: BtcMapPlaceSubmitInput;
 };
 
 
@@ -10567,6 +10596,10 @@ export type ResolversTypes = {
   Authorization: ResolverTypeWrapper<Authorization>;
   BTCWallet: ResolverTypeWrapper<BtcWallet>;
   BlockInfo: ResolverTypeWrapper<BlockInfo>;
+  BtcMapPlace: ResolverTypeWrapper<BtcMapPlace>;
+  BtcMapPlacePayload: ResolverTypeWrapper<BtcMapPlacePayload>;
+  BtcMapPlaceSubmitInput: BtcMapPlaceSubmitInput;
+  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   BuildInformation: ResolverTypeWrapper<BuildInformation>;
   CallbackEndpoint: ResolverTypeWrapper<CallbackEndpoint>;
   CallbackEndpointAddInput: CallbackEndpointAddInput;
@@ -10586,7 +10619,6 @@ export type ResolversTypes = {
   CardCreateInput: CardCreateInput;
   CardHolder: ResolverTypeWrapper<CardHolder>;
   CardMerchant: ResolverTypeWrapper<CardMerchant>;
-  Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   CardPinUpdateInput: CardPinUpdateInput;
   CardReplaceInput: CardReplaceInput;
   CardSecretsEncrypted: ResolverTypeWrapper<CardSecretsEncrypted>;
@@ -10877,6 +10909,10 @@ export type ResolversParentTypes = {
   Authorization: Authorization;
   BTCWallet: BtcWallet;
   BlockInfo: BlockInfo;
+  BtcMapPlace: BtcMapPlace;
+  BtcMapPlacePayload: BtcMapPlacePayload;
+  BtcMapPlaceSubmitInput: BtcMapPlaceSubmitInput;
+  Float: Scalars['Float']['output'];
   BuildInformation: BuildInformation;
   CallbackEndpoint: CallbackEndpoint;
   CallbackEndpointAddInput: CallbackEndpointAddInput;
@@ -10896,7 +10932,6 @@ export type ResolversParentTypes = {
   CardCreateInput: CardCreateInput;
   CardHolder: CardHolder;
   CardMerchant: CardMerchant;
-  Float: Scalars['Float']['output'];
   CardPinUpdateInput: CardPinUpdateInput;
   CardReplaceInput: CardReplaceInput;
   CardSecretsEncrypted: CardSecretsEncrypted;
@@ -11300,6 +11335,19 @@ export type BtcWalletResolvers<ContextType = any, ParentType extends ResolversPa
 export type BlockInfoResolvers<ContextType = any, ParentType extends ResolversParentTypes['BlockInfo'] = ResolversParentTypes['BlockInfo']> = {
   blockHash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   blockHeight?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type BtcMapPlaceResolvers<ContextType = any, ParentType extends ResolversParentTypes['BtcMapPlace'] = ResolversParentTypes['BtcMapPlace']> = {
+  externalId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  origin?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type BtcMapPlacePayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['BtcMapPlacePayload'] = ResolversParentTypes['BtcMapPlacePayload']> = {
+  errors?: Resolver<ReadonlyArray<ResolversTypes['Error']>, ParentType, ContextType>;
+  place?: Resolver<Maybe<ResolversTypes['BtcMapPlace']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -11888,6 +11936,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   apiKeyRemoveLimit?: Resolver<ResolversTypes['ApiKeySetLimitPayload'], ParentType, ContextType, RequireFields<MutationApiKeyRemoveLimitArgs, 'input'>>;
   apiKeyRevoke?: Resolver<ResolversTypes['ApiKeyRevokePayload'], ParentType, ContextType, RequireFields<MutationApiKeyRevokeArgs, 'input'>>;
   apiKeySetLimit?: Resolver<ResolversTypes['ApiKeySetLimitPayload'], ParentType, ContextType, RequireFields<MutationApiKeySetLimitArgs, 'input'>>;
+  btcMapPlaceSubmit?: Resolver<ResolversTypes['BtcMapPlacePayload'], ParentType, ContextType, RequireFields<MutationBtcMapPlaceSubmitArgs, 'input'>>;
   callbackEndpointAdd?: Resolver<ResolversTypes['CallbackEndpointAddPayload'], ParentType, ContextType, RequireFields<MutationCallbackEndpointAddArgs, 'input'>>;
   callbackEndpointDelete?: Resolver<ResolversTypes['SuccessPayload'], ParentType, ContextType, RequireFields<MutationCallbackEndpointDeleteArgs, 'input'>>;
   captchaCreateChallenge?: Resolver<ResolversTypes['CaptchaCreateChallengePayload'], ParentType, ContextType>;
@@ -12622,6 +12671,8 @@ export type Resolvers<ContextType = any> = {
   Authorization?: AuthorizationResolvers<ContextType>;
   BTCWallet?: BtcWalletResolvers<ContextType>;
   BlockInfo?: BlockInfoResolvers<ContextType>;
+  BtcMapPlace?: BtcMapPlaceResolvers<ContextType>;
+  BtcMapPlacePayload?: BtcMapPlacePayloadResolvers<ContextType>;
   BuildInformation?: BuildInformationResolvers<ContextType>;
   CallbackEndpoint?: CallbackEndpointResolvers<ContextType>;
   CallbackEndpointAddPayload?: CallbackEndpointAddPayloadResolvers<ContextType>;


### PR DESCRIPTION
## Summary

`app/graphql/generated.ts` had drifted from the schema, so `yarn check:codegen` was failing on `main`. This is the regeneration, nothing hand-written.

What comes in is the BTC Map place submission mutation:

- `btcMapPlaceSubmit`, returning `BtcMapPlacePayload` (`errors`, `place`).
- `BtcMapPlaceSubmitInput`: `name`, `category`, `latitude`, `longitude`, and a client-generated `submissionId`. Reusing the same `submissionId` on a retry avoids creating a duplicate place, and resubmitting it with different fields updates the original submission.
- `BtcMapPlace`: `id`, `externalId`, `origin`.

The rest of the diff is the matching resolver-map entries plus a `Float` key that codegen moves a few lines up. No app code uses the mutation yet.

`yarn tsc:check` passes.
