### PR TITLE
fix(copy): Fix lightning and onchain send rate copy

### DIFF
--- a/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
@@ -51,7 +51,7 @@ describe("FeeRatesScreen", () => {
   })
 
   it("renders Send, Receive and Transfer sections with remote-config default rates", async () => {
-    const { getByText, getAllByText, queryByText, findByText } = render(
+    const { getByText, getAllByText, findByText } = render(
       <ContextForScreen>
         <FeeRatesScreen />
       </ContextForScreen>,
@@ -63,9 +63,15 @@ describe("FeeRatesScreen", () => {
 
     expect(getByText("Lightning")).toBeTruthy()
     expect(getAllByText("no fee")).toHaveLength(4)
+
+    // An onchain send is priced by the payout queue it is put on, so each of
+    // the three speeds the send screen offers is quoted at its own rate.
+    expect(getByText("Onchain Priority (~10m)")).toBeTruthy()
     expect(getByText("from ~0.9%")).toBeTruthy()
-    expect(queryByText("Onchain Standard (~4h)")).toBeNull()
-    expect(queryByText("Onchain Economy (~24h)")).toBeNull()
+    expect(getByText("Onchain Standard (~4h)")).toBeTruthy()
+    expect(getByText("from ~0.6%")).toBeTruthy()
+    expect(getByText("Onchain Economy (~24h)")).toBeTruthy()
+    expect(getByText("from ~0.4%")).toBeTruthy()
 
     expect(getByText("Transfer fee")).toBeTruthy()
     expect(getByText("0.5%")).toBeTruthy()
@@ -91,23 +97,45 @@ describe("FeeRatesScreen", () => {
     await findByText("2,500 SAT")
   })
 
-  it("shows onchain standard and economy tiers when remote config enables them", async () => {
+  it("reprices each onchain tier independently from remote config", async () => {
     mockFeeRatesConfig = {
       ...defaultFeeRatesConfig,
-      onchainStandardBps: 60,
-      onchainEconomyBps: 40,
+      onchainPriorityBps: 120,
+      onchainStandardBps: 75,
+      onchainEconomyBps: 0,
     }
 
-    const { getByText, findByText } = render(
+    const { getByText, getAllByText, queryByText, findByText } = render(
       <ContextForScreen>
         <FeeRatesScreen />
       </ContextForScreen>,
     )
 
-    expect(getByText("Onchain Standard (~4h)")).toBeTruthy()
-    expect(getByText("from ~0.6%")).toBeTruthy()
+    expect(getByText("from ~1.2%")).toBeTruthy()
+    expect(getByText("from ~0.75%")).toBeTruthy()
+    // A repriced tier must not leave its shipped fallback on screen.
+    expect(queryByText("from ~0.9%")).toBeNull()
+    expect(queryByText("from ~0.6%")).toBeNull()
+    // Zero is free, not hidden: the row stays and reads "no fee".
     expect(getByText("Onchain Economy (~24h)")).toBeTruthy()
-    expect(getByText("from ~0.4%")).toBeTruthy()
+    expect(getAllByText("no fee")).toHaveLength(5)
+
+    await findByText("2,500 SAT")
+  })
+
+  it("hides only the onchain tiers remote config sets negative", async () => {
+    mockFeeRatesConfig = { ...defaultFeeRatesConfig, onchainStandardBps: -1 }
+
+    const { getByText, queryByText, findByText } = render(
+      <ContextForScreen>
+        <FeeRatesScreen />
+      </ContextForScreen>,
+    )
+
+    expect(queryByText("Onchain Standard (~4h)")).toBeNull()
+    expect(queryByText("from ~0.6%")).toBeNull()
+    expect(getByText("Onchain Priority (~10m)")).toBeTruthy()
+    expect(getByText("Onchain Economy (~24h)")).toBeTruthy()
 
     await findByText("2,500 SAT")
   })
@@ -133,12 +161,6 @@ describe("FeeRatesScreen", () => {
   })
 
   it("renders every Send row in the order the design specifies", async () => {
-    mockFeeRatesConfig = {
-      ...defaultFeeRatesConfig,
-      onchainStandardBps: 60,
-      onchainEconomyBps: 40,
-    }
-
     const { getAllByText, findByText } = render(
       <ContextForScreen>
         <FeeRatesScreen />

--- a/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
@@ -73,20 +73,20 @@ describe("FeeRatesScreen", () => {
     await findByText("2,500 SAT")
   })
 
-  it("shows the lightning send fee once remote config sets non-zero rates", async () => {
-    mockFeeRatesConfig = {
-      ...defaultFeeRatesConfig,
-      lightningSendBps: 20,
-      lightningRoutingBps: 10,
-    }
+  it("shows the lightning send rate alone once remote config sets a non-zero rate", async () => {
+    mockFeeRatesConfig = { ...defaultFeeRatesConfig, lightningSendBps: 20 }
 
-    const { getByText, findByText } = render(
+    const { getByText, queryByText, findByText } = render(
       <ContextForScreen>
         <FeeRatesScreen />
       </ContextForScreen>,
     )
 
-    expect(getByText("0.2% + ~0.1% routing fee")).toBeTruthy()
+    expect(getByText("0.2%")).toBeTruthy()
+    // The rate is quoted on its own — no routing-fee addendum, and not the
+    // "from ~" hedge the onchain tiers carry.
+    expect(queryByText(/routing/i)).toBeNull()
+    expect(queryByText("from ~0.2%")).toBeNull()
 
     await findByText("2,500 SAT")
   })

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -67,7 +67,6 @@ type ReplaceCardDeliveryConfig = Record<string, DeliveryOptionConfig>
 
 export type FeeRatesConfig = {
   lightningSendBps: number
-  lightningRoutingBps: number
   onchainPriorityBps: number
   onchainStandardBps: number
   onchainEconomyBps: number
@@ -135,7 +134,6 @@ const defaultReplaceCardDeliveryConfig = {
 // rows can be shown/hidden and repriced remotely without an app release.
 export const defaultFeeRatesConfig: FeeRatesConfig = {
   lightningSendBps: 0,
-  lightningRoutingBps: 0,
   onchainPriorityBps: 90,
   onchainStandardBps: -1,
   onchainEconomyBps: -1,

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -132,11 +132,18 @@ const defaultReplaceCardDeliveryConfig = {
 // Fee rates page contract: a negative rate hides its row (and the section when
 // no rows remain), 0 renders as "no fee", positive values render the rate — so
 // rows can be shown/hidden and repriced remotely without an app release.
+//
+// The three onchain rates are the payout speeds a custodial send actually
+// offers, priced apart because the queue you pick changes what you pay:
+// PAYOUT_SPEED_BY_FEE_TIER maps Fast/Medium/Slow onto the ~10m/~4h/~24h queues
+// the send screen's tier selector shows. All three ship visible — quoting only
+// Priority reads as one flat onchain rate and overstates what a Standard or
+// Economy send costs.
 export const defaultFeeRatesConfig: FeeRatesConfig = {
   lightningSendBps: 0,
   onchainPriorityBps: 90,
-  onchainStandardBps: -1,
-  onchainEconomyBps: -1,
+  onchainStandardBps: 60,
+  onchainEconomyBps: 40,
   transferBps: 50,
 }
 

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2809,7 +2809,6 @@ const en: BaseTranslation = {
       "Onchain between {lower: string} and {upper: string} SAT",
     transferFee: "Transfer fee",
     noFee: "no fee",
-    lightningSendFee: "{fee: string} + ~{routingFee: string} routing fee",
     fromApprox: "from ~{fee: string}",
     satAmount: "{amount: string} SAT",
     error: "Unable to fetch fees at this time",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -8885,12 +8885,6 @@ type RootTranslation = {
 		 */
 		noFee: string
 		/**
-		 * {​f​e​e​}​ ​+​ ​~​{​r​o​u​t​i​n​g​F​e​e​}​ ​r​o​u​t​i​n​g​ ​f​e​e
-		 * @param {string} fee
-		 * @param {string} routingFee
-		 */
-		lightningSendFee: RequiredParams<'fee' | 'routingFee'>
-		/**
 		 * f​r​o​m​ ​~​{​f​e​e​}
 		 * @param {string} fee
 		 */
@@ -22477,10 +22471,6 @@ export type TranslationFunctions = {
 		 * no fee
 		 */
 		noFee: () => LocalizedString
-		/**
-		 * {fee} + ~{routingFee} routing fee
-		 */
-		lightningSendFee: (arg: { fee: string, routingFee: string }) => LocalizedString
 		/**
 		 * from ~{fee}
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2702,7 +2702,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Transfer fee",
         "noFee": "no fee",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} routing fee",
         "fromApprox": "from ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "Unable to fetch fees at this time"

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Oordragfooi",
     "noFee": "geen fooi",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} roeteringsfooi",
     "fromApprox": "vanaf ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Kan nie nou fooie verkry nie"

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "رسوم التحويل",
     "noFee": "بدون رسوم",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} رسوم توجيه",
     "fromApprox": "من ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "لم يُستطَع الحصول على الرسوم الآن"

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Comissió de transferència",
     "noFee": "sense comissió",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} de comissió d'encaminament",
     "fromApprox": "des de ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "No es poden obtenir les comissions en aquest moment"

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Poplatek za převod",
     "noFee": "bez poplatku",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} směrovací poplatek",
     "fromApprox": "od ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "V tuto chvíli nelze načíst poplatky"

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Overførselsgebyr",
     "noFee": "intet gebyr",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} routinggebyr",
     "fromApprox": "fra ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Kunne ikke hente gebyrer i øjeblikket"

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Übertragungsgebühr",
         "noFee": "keine Gebühr",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} Routing-Gebühr",
         "fromApprox": "ab ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "Gebühren können aktuell nicht abgerufen werden"

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Τέλος μεταφοράς",
     "noFee": "χωρίς τέλη",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} τέλος δρομολόγησης",
     "fromApprox": "από ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Δεν είναι δυνατή η λήψη των τελών αυτή τη στιγμή"

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Comisión por transferencia",
         "noFee": "sin comisión",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} de comisión de enrutamiento",
         "fromApprox": "desde ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "No se pueden obtener las comisiones en este momento"

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Frais de transfert",
         "noFee": "aucuns frais",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} de frais de routage",
         "fromApprox": "à partir de ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "Impossible de récupérer les frais pour le moment"

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Naknada za prijenos",
     "noFee": "bez naknade",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} naknada za usmjeravanje",
     "fromApprox": "od ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Trenutačno nije moguće dohvatiti naknade"

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Átutalási díj",
     "noFee": "díjmentes",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} útválasztási díj",
     "fromApprox": "~{fee: string}-tól",
     "satAmount": "{amount: string} SAT",
     "error": "Jelenleg nem lehet lekérdezni a díjakat"

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Փոխանցման վճար",
     "noFee": "առանց վճարի",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} երթուղավորման վճար",
     "fromApprox": "սկսած ~{fee: string}-ից",
     "satAmount": "{amount: string} SAT",
     "error": "Չհաջողվեց ստանալ վճարներն այս պահին"

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Biaya transfer",
     "noFee": "tanpa biaya",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} biaya routing",
     "fromApprox": "mulai ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Tidak dapat mengambil biaya saat ini"

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Commissione di trasferimento",
         "noFee": "nessuna commissione",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} di commissione di routing",
         "fromApprox": "da ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "Impossibile recuperare le commissioni al momento"

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "振替手数料",
         "noFee": "手数料なし",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} ルーティング手数料",
         "fromApprox": "~{fee: string} から",
         "satAmount": "{amount: string} SAT",
         "error": "現時点では手数料を取得できません"

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Ekisale ky'okuweereza",
     "noFee": "tewali kisale",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} ekisale ky'okutambuza",
     "fromApprox": "okuva ku ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Tetusobodde kufuna bisale mu kiseera kino"

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Caj pindahan",
     "noFee": "tiada caj",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} caj penghalaan",
     "fromApprox": "dari ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Tak dapat mendapatkan caj buat masa ini"

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Overschrijvingskosten",
     "noFee": "geen kosten",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} routeringskosten",
     "fromApprox": "vanaf ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Kan momenteel geen kosten ophalen"

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2689,7 +2689,6 @@
         "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Taxa de transferência",
         "noFee": "sem taxa",
-        "lightningSendFee": "{fee: string} + ~{routingFee: string} de taxa de roteamento",
         "fromApprox": "a partir de ~{fee: string}",
         "satAmount": "{amount: string} SAT",
         "error": "Incapaz de obter as taxas agora"

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Astaypa chanin",
     "noFee": "mana chaniyuq",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} purichiy chanin",
     "fromApprox": "~{fee: string}manta",
     "satAmount": "{amount: string} SAT",
     "error": "Kunanqa mana chaninkunata chaskiyta atinchikchu"

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Taxă de transfer",
     "noFee": "fără taxă",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} taxă de rutare",
     "fromApprox": "de la ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Nu se pot obține taxele în acest moment"

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Poplatok za prevod",
     "noFee": "bez poplatku",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} smerovací poplatok",
     "fromApprox": "od ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Momentálne nie je možné načítať poplatky"

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Накнада за пренос",
     "noFee": "без накнаде",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} накнада за рутирање",
     "fromApprox": "од ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Тренутно није могуће преузети накнаде"

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Ada ya uhamisho",
     "noFee": "hakuna ada",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} ada ya uelekezaji",
     "fromApprox": "kuanzia ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Hatuwezi kupata ada kwa wakati huu"

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "ค่าธรรมเนียมการโอน",
     "noFee": "ไม่มีค่าธรรมเนียม",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} ค่าธรรมเนียมการกำหนดเส้นทาง",
     "fromApprox": "เริ่มต้น ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "ไม่สามารถเรียกค่าธรรมเนียมได้ในขณะนี้"

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Transfer ücreti",
     "noFee": "ücretsiz",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} yönlendirme ücreti",
     "fromApprox": "en az ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Şu an için ücretlere ulaşamıyoruz"

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Phí chuyển khoản",
     "noFee": "miễn phí",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} phí định tuyến",
     "fromApprox": "từ ~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Không thể lấy thông tin phí tại thời điểm này"

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2689,7 +2689,6 @@
     "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Umrhumo wokudlulisela",
     "noFee": "akukho mrhumo",
-    "lightningSendFee": "{fee: string} + ~{routingFee: string} umrhumo wokuthumela",
     "fromApprox": "ukusuka ku-~{fee: string}",
     "satAmount": "{amount: string} SAT",
     "error": "Ayikwazanga kufumana imirhumo ngeli xesha"

--- a/app/screens/settings-screen/fee-rates-screen.tsx
+++ b/app/screens/settings-screen/fee-rates-screen.tsx
@@ -138,20 +138,13 @@ export const FeeRatesScreen: React.FC = () => {
     const items: React.FC[] = []
     if (isRowVisible(feeRatesConfig.lightningSendBps)) {
       items.push(function LightningSendRow() {
-        const isFree =
-          feeRatesConfig.lightningSendBps === 0 && feeRatesConfig.lightningRoutingBps <= 0
         return (
           <FeeRateRow
             label={LL.FeeRatesScreen.lightning()}
             value={
-              isFree
+              feeRatesConfig.lightningSendBps === 0
                 ? LL.FeeRatesScreen.noFee()
-                : LL.FeeRatesScreen.lightningSendFee({
-                    fee: formatBps(feeRatesConfig.lightningSendBps),
-                    routingFee: formatBps(
-                      Math.max(feeRatesConfig.lightningRoutingBps, 0),
-                    ),
-                  })
+                : formatBps(feeRatesConfig.lightningSendBps)
             }
           />
         )


### PR DESCRIPTION
The Send section rendered the lightning rate as "0.2% + ~0% routing fee",
pairing a rate the account is actually charged with an estimate of a
network cost that Blink does not bill. The design quotes the rate alone,
so the row now reads "0.2%".

Drop lightningRoutingBps from FeeRatesConfig
--------------------------------------------
It was read in exactly one place — the string this commit deletes — so
with the routing fee off the screen it became a config key nothing
consumes, which invites someone to set it in Firebase and wonder why the
UI never moves.

fix(fee-rates): quote all three onchain payout speeds, not just Priority
----------------------------------------------------------------------------------------------------

The Send section listed a single "Onchain Priority (~10m)" row, so the
screen read as though onchain had one flat rate. It does not: a custodial
onchain send is priced by the payout queue it is put on, and the send
screen's own tier selector offers three of them. Standard and Economy
sends are cheaper than the one number the fee page quoted, so the page
overstated what they cost.