### PR TITLE
security(storage): purge the legacy key store items and gate the dependency drop

### DIFF
--- a/__tests__/self-custodial/storage/account-index.spec.ts
+++ b/__tests__/self-custodial/storage/account-index.spec.ts
@@ -4,6 +4,7 @@ const mockGetMnemonicForAccount = jest.fn()
 const mockReadMnemonicWithStatus = jest.fn()
 const mockGetMnemonicNetworkForAccount = jest.fn()
 const mockRememberMnemonicAccount = jest.fn()
+const mockPurgeLegacyKeyStore = jest.fn()
 
 jest.mock("@react-native-async-storage/async-storage", () => ({
   __esModule: true,
@@ -21,6 +22,7 @@ jest.mock("@app/utils/storage/secureStorage", () => ({
     getMnemonicNetworkForAccount: (...args: unknown[]) =>
       mockGetMnemonicNetworkForAccount(...args),
     rememberMnemonicAccount: (...args: unknown[]) => mockRememberMnemonicAccount(...args),
+    purgeLegacyKeyStore: (...args: unknown[]) => mockPurgeLegacyKeyStore(...args),
   },
 }))
 
@@ -38,11 +40,15 @@ import {
   removeSelfCustodialAccountId,
   setSelfCustodialLightningAddress,
   sweepMnemonicMigration,
+  purgeLegacyKeyStoreOnce,
   type SelfCustodialAccountEntry,
 } from "@app/self-custodial/storage/account-index"
 
 const ACCOUNT_INDEX_KEY = "selfCustodialAccountIndex"
 const LEGACY_ID_LIST_KEY = "selfCustodialAccountIds"
+const LEGACY_PURGE_DONE_KEY = "legacyKeyStorePurged"
+
+const SWEEP_OK = { status: "ok", migrated: 1 } as const
 
 const setIndex = (entries: SelfCustodialAccountEntry[]) => {
   mockGetItem.mockImplementation((key: string) =>
@@ -68,6 +74,7 @@ describe("self-custodial account-index", () => {
     mockReadMnemonicWithStatus.mockResolvedValue({ status: "absent" })
     mockGetMnemonicNetworkForAccount.mockResolvedValue(null)
     mockRememberMnemonicAccount.mockResolvedValue(undefined)
+    mockPurgeLegacyKeyStore.mockResolvedValue(true)
   })
 
   describe("listSelfCustodialAccounts", () => {
@@ -474,6 +481,93 @@ describe("self-custodial account-index", () => {
       const second = await sweepMnemonicMigration()
 
       expect(second).toEqual(first)
+    })
+  })
+
+  describe("purgeLegacyKeyStoreOnce", () => {
+    /** The index is read for the account ids, and the done-flag from its own key. */
+    const setIndexAndFlag = (
+      entries: SelfCustodialAccountEntry[],
+      flag: string | null,
+    ) => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === ACCOUNT_INDEX_KEY) return Promise.resolve(JSON.stringify(entries))
+        if (key === LEGACY_PURGE_DONE_KEY) return Promise.resolve(flag)
+        return Promise.resolve(null)
+      })
+    }
+
+    it("purges every account in the index and records itself as done", async () => {
+      setIndexAndFlag([{ id: "a1", lightningAddress: null }], null)
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "done" })
+      expect(mockPurgeLegacyKeyStore).toHaveBeenCalledWith(["a1"])
+      expect(mockSetItem).toHaveBeenCalledWith(LEGACY_PURGE_DONE_KEY, "true")
+    })
+
+    it("purges the fixed keys when the index holds no accounts", async () => {
+      setIndexAndFlag([], null)
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "done" })
+      expect(mockPurgeLegacyKeyStore).toHaveBeenCalledWith([])
+    })
+
+    it("does not purge while the sweep left an account unread", async () => {
+      setIndexAndFlag([{ id: "a1", lightningAddress: null }], null)
+
+      const result = await purgeLegacyKeyStoreOnce({ status: "incomplete", failures: 1 })
+
+      expect(result).toEqual({ status: "skipped", reason: "sweep-incomplete" })
+      expect(mockPurgeLegacyKeyStore).not.toHaveBeenCalled()
+    })
+
+    it("does not purge twice on the same install", async () => {
+      setIndexAndFlag([{ id: "a1", lightningAddress: null }], "true")
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "skipped", reason: "already-done" })
+      expect(mockPurgeLegacyKeyStore).not.toHaveBeenCalled()
+    })
+
+    it("purges anyway when the done-flag cannot be read", async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === LEGACY_PURGE_DONE_KEY) {
+          return Promise.reject(new Error("AsyncStorage unavailable"))
+        }
+        return Promise.resolve(JSON.stringify([{ id: "a1", lightningAddress: null }]))
+      })
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "done" })
+      expect(mockPurgeLegacyKeyStore).toHaveBeenCalledWith(["a1"])
+    })
+
+    it("does not purge when the index cannot be read", async () => {
+      mockGetItem.mockImplementation((key: string) => {
+        if (key === LEGACY_PURGE_DONE_KEY) return Promise.resolve(null)
+        return Promise.reject(new Error("AsyncStorage unavailable"))
+      })
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "skipped", reason: "index-unreadable" })
+      expect(mockPurgeLegacyKeyStore).not.toHaveBeenCalled()
+    })
+
+    it("leaves the flag unset when a key could not be erased", async () => {
+      setIndexAndFlag([{ id: "a1", lightningAddress: null }], null)
+      mockPurgeLegacyKeyStore.mockResolvedValue(false)
+
+      const result = await purgeLegacyKeyStoreOnce(SWEEP_OK)
+
+      expect(result).toEqual({ status: "incomplete" })
+      expect(mockSetItem).not.toHaveBeenCalledWith(LEGACY_PURGE_DONE_KEY, "true")
     })
   })
 })

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -23,10 +23,12 @@ jest.mock("@app/utils/storage", () => ({
 }))
 
 const mockSweepMnemonicMigration = jest.fn()
-// Scheduled off the boot path once the state has loaded; its own spec covers
-// what it does, and here it must not add reports to the ones under assertion.
+const mockPurgeLegacyKeyStoreOnce = jest.fn()
+// Scheduled off the boot path once the state has loaded; their own specs cover
+// what they do, and here they must not add reports to the ones under assertion.
 jest.mock("@app/self-custodial/storage/account-index", () => ({
   sweepMnemonicMigration: (...args: unknown[]) => mockSweepMnemonicMigration(...args),
+  purgeLegacyKeyStoreOnce: (...args: unknown[]) => mockPurgeLegacyKeyStoreOnce(...args),
 }))
 
 const mockGetActiveToken = jest.fn()
@@ -111,6 +113,7 @@ const setupStorageMockDefaults = () => {
   jest.clearAllMocks()
   storedStrings.clear()
   mockSweepMnemonicMigration.mockResolvedValue({ status: "ok", migrated: 0 })
+  mockPurgeLegacyKeyStoreOnce.mockResolvedValue({ status: "done" })
   mockSaveJson.mockResolvedValue(undefined)
   mockSaveString.mockResolvedValue(true)
   mockLoadString.mockImplementation(async (key: string) => storedStrings.get(key) ?? null)

--- a/__tests__/utils/key-store-api-stability.spec.ts
+++ b/__tests__/utils/key-store-api-stability.spec.ts
@@ -45,6 +45,8 @@ const PINNED_SURFACE = [
   "name",
   "parsePinFailureState",
   "prototype",
+  "purgeLegacyKeyStore",
+  "purgeSlot",
   "readActiveToken",
   "readIsBiometricsEnabled",
   "readIsPinEnabled",

--- a/__tests__/utils/secure-storage.spec.ts
+++ b/__tests__/utils/secure-storage.spec.ts
@@ -1733,3 +1733,220 @@ describe("KeyStoreWrapper clearUninstallSurvivingCredentials", () => {
     ])
   })
 })
+
+describe("KeyStoreWrapper.purgeLegacyKeyStore", () => {
+  /** Every key the purge is expected to name, in the order it names them. */
+  const FIXED_KEYS = [
+    "isBiometricsEnabled",
+    "PIN",
+    "pinFailureState",
+    "pinAttempts",
+    "sessionProfiles",
+    "galoyAuthToken",
+  ]
+
+  /**
+   * Both stores, so that a purge which migrates before erasing is exercised the
+   * way it runs: the legacy value moves across and the new store then answers
+   * for it.
+   */
+  const stores = {
+    legacy: new Map<string, string>(),
+    migrated: new Map<string, string>(),
+  }
+
+  const legacyNotFound = () =>
+    Object.assign(new Error("key does not present"), { code: "404" })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stores.legacy.clear()
+    stores.migrated.clear()
+
+    mockGet.mockImplementation(async (key: string) => {
+      const value = stores.legacy.get(key)
+      if (value === undefined) throw legacyNotFound()
+      return value
+    })
+    mockRemove.mockImplementation(async (key: string) => {
+      stores.legacy.delete(key)
+    })
+    mockGetInternet.mockImplementation(async (server: string) => {
+      const slot = server.replace("secure-store.blink.local/", "")
+      const value = stores.migrated.get(slot)
+      if (value === undefined) return false
+      return { username: slot, password: value }
+    })
+    mockSetInternet.mockImplementation(
+      async (server: string, slot: string, value: string) => {
+        stores.migrated.set(slot, value)
+        return { service: server }
+      },
+    )
+    mockResetInternet.mockResolvedValue(undefined)
+  })
+
+  it("erases the six fixed keys", async () => {
+    FIXED_KEYS.forEach((key) => stores.legacy.set(key, `${key}-value`))
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore([])
+
+    expect(purged).toBe(true)
+    expect([...stores.legacy.keys()]).toEqual([])
+  })
+
+  it("erases both mnemonic keys for every account it is given", async () => {
+    stores.legacy.set("mnemonic:alice", "alpha beta")
+    stores.legacy.set("mnemonic_network:alice", "bitcoin")
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(true)
+    expect([...stores.legacy.keys()]).toEqual([])
+  })
+
+  it("moves a value to the new store before erasing it", async () => {
+    stores.legacy.set("mnemonic:alice", "alpha beta")
+
+    await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(stores.migrated.get("mnemonic:alice")).toBe("alpha beta")
+  })
+
+  it("counts a key that was never there as gone", async () => {
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore([])
+
+    expect(purged).toBe(true)
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The failure this whole ordering exists for: a read-through answers `found`
+   * from the legacy store even when the migrating write failed, so erasing on
+   * that answer would delete the only copy of someone's seed.
+   */
+  it("keeps the legacy copy when the migrating write failed", async () => {
+    stores.legacy.set("mnemonic:alice", "alpha beta")
+    mockSetInternet.mockResolvedValue(false)
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(false)
+    expect(stores.legacy.get("mnemonic:alice")).toBe("alpha beta")
+  })
+
+  it("keeps the legacy copy when the new store cannot be read back", async () => {
+    stores.legacy.set("PIN", "1234")
+    mockGetInternet.mockRejectedValue(new Error("keychain unavailable"))
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore([])
+
+    expect(purged).toBe(false)
+    expect(stores.legacy.get("PIN")).toBe("1234")
+  })
+
+  it("keeps going when the legacy store cannot say what it holds", async () => {
+    mockGet.mockRejectedValue(new Error("keychain unavailable"))
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore([])
+
+    expect(purged).toBe(false)
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+
+  /**
+   * The iOS module returns nil for any failed lookup and rejects it with the
+   * not-found code, so a read taken before first unlock reports an empty store
+   * rather than an unreadable one. Believing it would record the purge as done
+   * over a seed that never left the legacy store.
+   */
+  it("does not call a mnemonic purged on an empty legacy read alone", async () => {
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(false)
+  })
+
+  it("calls a mnemonic purged once the new store holds it", async () => {
+    stores.migrated.set("mnemonic:alice", "alpha beta")
+    stores.migrated.set("mnemonic_network:alice", "bitcoin")
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(true)
+  })
+
+  /**
+   * The marker is optional metadata, so demanding proof of it would leave the
+   * purge unable to finish for an account that never had one.
+   */
+  it("completes for an account with a seed but no network marker", async () => {
+    stores.migrated.set("mnemonic:alice", "alpha beta")
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(true)
+  })
+
+  /** A user who never set a PIN has nothing here and must not be retried forever. */
+  it("accepts an empty legacy read for the session slots", async () => {
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore([])
+
+    expect(purged).toBe(true)
+  })
+
+  it("still purges every remaining slot after one of them fails", async () => {
+    FIXED_KEYS.forEach((key) => stores.legacy.set(key, `${key}-value`))
+    stores.legacy.set("mnemonic:alice", "alpha beta")
+    mockRemove.mockImplementation(async (key: string) => {
+      if (key === "PIN") throw new Error("keychain unavailable")
+      stores.legacy.delete(key)
+    })
+
+    const purged = await KeyStoreWrapper.purgeLegacyKeyStore(["alice"])
+
+    expect(purged).toBe(false)
+    expect([...stores.legacy.keys()]).toEqual(["PIN"])
+  })
+
+  /**
+   * The timeout only races a hung native call, it cannot cancel it. So the
+   * verify can still be running when its slot is handed on, and the erase that
+   * follows would then be deleting a legacy copy on behalf of a slot that has
+   * moved on.
+   */
+  it("drops the erase of a verify that lands after its slot moved on", async () => {
+    jest.useFakeTimers()
+    stores.legacy.set("PIN", "1234")
+    stores.migrated.set("PIN", "1234")
+
+    // The verify is the SECOND read of this slot: the read-through ahead of it
+    // does the first, and only the verify may be left holding a stale slot.
+    let releaseHungVerify: () => void = () => {}
+    let pinReads = 0
+    mockGetInternet.mockImplementation(async (server: string) => {
+      const slot = server.replace("secure-store.blink.local/", "")
+      if (slot === "PIN") {
+        pinReads += 1
+        if (pinReads === 2) {
+          return new Promise((resolve) => {
+            releaseHungVerify = () => resolve({ username: "PIN", password: "1234" })
+          })
+        }
+      }
+      const value = stores.migrated.get(slot)
+      if (value === undefined) return false
+      return { username: slot, password: value }
+    })
+
+    const purged = KeyStoreWrapper.purgeLegacyKeyStore([])
+    await jest.advanceTimersByTimeAsync(30_000)
+    expect(await purged).toBe(false)
+
+    mockRemove.mockClear()
+    releaseHungVerify()
+    await jest.advanceTimersByTimeAsync(0)
+
+    expect(mockRemove).not.toHaveBeenCalled()
+    jest.useRealTimers()
+  })
+})

--- a/app/self-custodial/storage/account-index.ts
+++ b/app/self-custodial/storage/account-index.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { recordAppError } from "@app/utils/error-reporting"
+import { readString, saveString } from "@app/utils/storage"
 
 import { normalizeMnemonic } from "@app/utils/mnemonic"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
@@ -156,6 +157,13 @@ export type SweepResult =
   | { status: "ok"; migrated: number }
   | { status: "incomplete"; failures: number }
 
+export type PurgeSkippedReason = "sweep-incomplete" | "already-done" | "index-unreadable"
+
+export type PurgeResult =
+  | { status: "done" }
+  | { status: "incomplete" }
+  | { status: "skipped"; reason: PurgeSkippedReason }
+
 /**
  * Migrates the mnemonic of every account in the index, whether or not the user
  * ever opens it.
@@ -208,4 +216,49 @@ export const sweepMnemonicMigration = async (): Promise<SweepResult> => {
   }
 
   return failures > 0 ? { status: "incomplete", failures } : { status: "ok", migrated }
+}
+
+const LEGACY_PURGE_DONE_KEY = "legacyKeyStorePurged"
+
+/**
+ * Erases everything this app left in the legacy key store, once per install.
+ *
+ * Runs only after a sweep that reported every account read. The purge deletes
+ * the legacy mnemonic copies, so running it over an incomplete sweep would
+ * delete a copy whose value never reached the new store — the one failure mode
+ * in this migration that costs someone their funds rather than a re-login.
+ *
+ * The done-flag lives in AsyncStorage, which a reinstall clears. That is the
+ * right lifetime: after a reinstall the legacy store can still hold items that
+ * survived it, so the purge should run again rather than believe a flag from an
+ * install that is gone.
+ *
+ * The flag is set only on a purge that proved every key gone. A partial purge
+ * leaves it unset and simply runs again on the next boot, which is why nothing
+ * here retries or reports: there is no failure state to recover from, only a
+ * later attempt.
+ */
+export const purgeLegacyKeyStoreOnce = async (
+  sweep: SweepResult,
+): Promise<PurgeResult> => {
+  if (sweep.status !== "ok") return { status: "skipped", reason: "sweep-incomplete" }
+
+  const done = await readString(LEGACY_PURGE_DONE_KEY)
+  // A flag that cannot be read is not a flag that is unset: purging again is
+  // harmless, so the safe reading is to go ahead rather than skip.
+  if (done.status === "found") return { status: "skipped", reason: "already-done" }
+
+  const result = await readIndex()
+  // Without the index the per-account keys cannot be named, and a purge that
+  // skips them would still record itself as done.
+  if (result.status === StorageReadStatus.ReadFailed) {
+    return { status: "skipped", reason: "index-unreadable" }
+  }
+
+  const accountIds = result.entries.map((entry) => entry.id)
+  const purged = await KeyStoreWrapper.purgeLegacyKeyStore(accountIds)
+  if (!purged) return { status: "incomplete" }
+
+  await saveString(LEGACY_PURGE_DONE_KEY, "true")
+  return { status: "done" }
 }

--- a/app/store/persistent-state/index.tsx
+++ b/app/store/persistent-state/index.tsx
@@ -2,7 +2,10 @@ import { createContext, useContext, PropsWithChildren } from "react"
 import * as React from "react"
 import { InteractionManager } from "react-native"
 
-import { sweepMnemonicMigration } from "@app/self-custodial/storage/account-index"
+import {
+  purgeLegacyKeyStoreOnce,
+  sweepMnemonicMigration,
+} from "@app/self-custodial/storage/account-index"
 
 import { recordAppError } from "@app/utils/error-reporting"
 
@@ -408,10 +411,15 @@ export const PersistentStateProvider: React.FC<PropsWithChildren> = ({ children 
       // Scheduled after the interactions this boot has queued, so a slow
       // keystore cannot compete with the first frame.
       InteractionManager.runAfterInteractions(() => {
-        sweepMnemonicMigration().catch(() => {
-          // Never rejects by contract; a caught error here would still be a
-          // migration detail and must not reach a boot path.
-        })
+        // The purge is chained onto the sweep rather than scheduled beside it:
+        // it deletes the legacy mnemonic copies, so it must see whether every
+        // account's value actually reached the new store first.
+        sweepMnemonicMigration()
+          .then(purgeLegacyKeyStoreOnce)
+          .catch(() => {
+            // Neither rejects by contract; a caught error here would still be a
+            // migration detail and must not reach a boot path.
+          })
       })
     })()
   }, [])

--- a/app/utils/storage/secure-store-migration.ts
+++ b/app/utils/storage/secure-store-migration.ts
@@ -164,8 +164,12 @@ export const onSlot = <T>(
  *
  * A read that cannot answer counts as not gone. It is the conservative half of
  * a real trade-off, recorded at `runRemove`.
+ *
+ * Exported for the one-shot purge, which erases legacy copies the read path is
+ * no longer allowed to reach and needs the same proof of absence to decide
+ * whether it may record itself as done.
  */
-const eraseLegacyCopy = async (legacyKey: string): Promise<boolean> => {
+export const eraseLegacyCopy = async (legacyKey: string): Promise<boolean> => {
   const erased = await legacyErase(legacyKey)
   if (erased) return true
 

--- a/app/utils/storage/secureStorage.ts
+++ b/app/utils/storage/secureStorage.ts
@@ -1,8 +1,9 @@
 import { ACCESSIBLE } from "react-native-keychain"
 
-import { eraseEntireLegacyStore } from "./legacy-key-store"
+import { eraseEntireLegacyStore, legacyRead } from "./legacy-key-store"
 import { type SecureExists, secureRead, secureRemove, secureWrite } from "./secure-store"
 import {
+  eraseLegacyCopy,
   type ReadThroughArgs,
   existsThrough,
   onSlot,
@@ -743,5 +744,133 @@ export default class KeyStoreWrapper {
       value: network,
       accessible: ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
     })
+  }
+
+  /**
+   * Finishes a slot's migration and then erases its legacy copy, in that order.
+   *
+   * Erasing first is what the obvious implementation does and it is wrong. A
+   * read-through reports `found` for a value it read out of the legacy store
+   * even when the migrating write failed, so "this slot has been read" is not
+   * evidence the new store holds anything. Erasing on that evidence deletes the
+   * only copy — a re-login for a session slot, and someone's seed for a
+   * mnemonic.
+   *
+   * So the new store has to say `found` itself before anything is deleted, and
+   * every step runs inside the slot queue: a read-through migrating this same
+   * slot concurrently sits between its own miss and its legacy read, and an
+   * unqueued erase in that window takes the value out from under it.
+   *
+   * False whenever the copy is not provably safe to remove, which simply leaves
+   * it for the next boot. Never rejects, like every other operation on this
+   * queue: a slot that timed out must cost its own key and not the ones behind
+   * it, which a rejection propagating out of the loop would.
+   */
+  private static async purgeSlot(
+    args: ReadThroughArgs,
+    requireMigrated: boolean,
+  ): Promise<boolean> {
+    // Migrates as its side effect, and takes its own turn in the queue. A slot
+    // nothing has read yet is unmigrated by definition, and this is the last
+    // chance it gets before its legacy copy is gone.
+    await readThrough(args)
+
+    try {
+      return await onSlot(args.slot, async (isCurrent) => {
+        const migratedFirst = await secureRead(args.slot)
+
+        const legacy = await legacyRead(args.legacyKey)
+        if (legacy.status === "failed") return false
+
+        // `absent` is not the proof it looks like on iOS: the native module
+        // discards the OSStatus and rejects every failed lookup with the
+        // not-found code, so a read taken before first unlock reports an empty
+        // store rather than an unreadable one. Believing it is what would let a
+        // silent-push launch record the purge as done over a mnemonic that
+        // never left the legacy store.
+        //
+        // Where getting it wrong costs a re-login, absence is accepted: a user
+        // who never set a PIN has nothing here and must not be retried forever.
+        // Where it costs a seed, the new store has to hold the value first.
+        if (legacy.status === "absent") {
+          return requireMigrated ? migratedFirst.status === "found" : true
+        }
+
+        // The only status that proves the value survived the move. `absent`
+        // means the migrating write failed, `failed` means the store could not
+        // say. Re-read, because the read-through above may have migrated it
+        // since.
+        const migrated = await secureRead(args.slot)
+        if (migrated.status !== "found") return false
+
+        if (!isCurrent()) return false
+
+        return eraseLegacyCopy(args.legacyKey)
+      })
+    } catch {
+      return false
+    }
+  }
+
+  /**
+   * Erases every item this app ever wrote to the legacy key store, by name.
+   *
+   * The migration moves a slot the first time something reads it, so a value
+   * nothing reads is still sitting in the legacy store; and the mnemonic slots
+   * keep their legacy copy deliberately, so those are there even after they
+   * migrate (see mnemonicSlotFor). This is what finally removes both, and it is
+   * the only thing that does: dropping the dependency deletes no data, it just
+   * removes the code that could have.
+   *
+   * By name rather than by service, unlike eraseEntireLegacyStore: a named
+   * delete is the half that also works on Android, where the legacy store is a
+   * shared-preferences file rather than a Keychain service.
+   *
+   * `accountIds` comes from the caller because the account index lives in
+   * AsyncStorage, outside this file. An id missing from that list leaves its
+   * mnemonic behind, which is the conservative direction: the key stays until a
+   * boot that can name it.
+   *
+   * True only when every key is provably gone, so that a caller recording this
+   * as done cannot record it over a store that still holds something.
+   */
+  public static async purgeLegacyKeyStore(accountIds: string[]): Promise<boolean> {
+    // What an empty legacy read is allowed to mean, carried per slot rather than
+    // derived from the key name: only the seed is held to the strict rule.
+    // Session slots may legitimately have never existed, and the network marker
+    // is optional metadata, so demanding proof of either would leave the purge
+    // unable to finish and retrying every boot forever.
+    const sessionSlots = [
+      KeyStoreWrapper.IS_BIOMETRICS_ENABLED,
+      KeyStoreWrapper.PIN,
+      KeyStoreWrapper.PIN_FAILURE_STATE,
+      KeyStoreWrapper.LEGACY_PIN_ATTEMPTS,
+      KeyStoreWrapper.SESSION_PROFILES,
+      KeyStoreWrapper.ACTIVE_TOKEN,
+    ].map((key) => ({ args: KeyStoreWrapper.slotFor(key), requireMigrated: false }))
+
+    const mnemonicSlots = accountIds.flatMap((accountId) => [
+      {
+        args: KeyStoreWrapper.mnemonicSlotFor(KeyStoreWrapper.mnemonicKeyFor(accountId)),
+        requireMigrated: true,
+      },
+      {
+        args: KeyStoreWrapper.mnemonicSlotFor(
+          KeyStoreWrapper.mnemonicNetworkKeyFor(accountId),
+        ),
+        requireMigrated: false,
+      },
+    ])
+
+    let allGone = true
+    for (const slot of [...sessionSlots, ...mnemonicSlots]) {
+      // Sequential, and never short-circuited: one slot that cannot be purged
+      // must not leave the rest behind for a purge that may not run again for
+      // months.
+      const gone = await KeyStoreWrapper.purgeSlot(slot.args, slot.requireMigrated)
+      if (!gone) allGone = false
+    }
+
+    return allGone
   }
 }


### PR DESCRIPTION
Closes blinkbitcoin/blink-wip#1163 (the purge half). Stacked on #4224, which has to merge first.

Step 4 of the migration off `react-native-secure-key-store` moves in two releases, and this is the first one. The library stays installed, because it is the only thing that can read and delete what it wrote. Dropping the dependency is the release after, and it deletes nothing on its own.

## What it does

On boot, after the mnemonic migration sweep, the app erases what it still owns in the legacy store: the six session keys, plus `mnemonic:<id>` and `mnemonic_network:<id>` for every account in the index. Once per install, behind an AsyncStorage flag that a reinstall clears, since a reinstall can leave items behind for the purge to reach again.

## Migrate, then verify, then erase

The ordering is the whole point, and the obvious implementation gets it wrong.

A read-through reports `found` for a value it read out of the legacy store even when the migrating write failed, so "this slot has been read" is not evidence the new store holds anything. Erasing on that evidence deletes the only copy: a re-login for a session slot, a seed for a mnemonic. So the new store has to answer `found` itself before anything is deleted, and every step runs inside the per-slot queue, because a read-through migrating the same slot sits between its own miss and its legacy read.

An empty legacy read is not the proof it looks like either. On iOS the native module discards the OSStatus and rejects every failed lookup with the not-found code, so a read taken before first unlock reports an empty store rather than an unreadable one. Where getting that wrong costs a re-login it is accepted, since a user who never set a PIN must not be retried forever. Where it costs a seed, the new store has to hold the value first.

The flag is set only when every key is provably gone. A partial purge leaves it unset and runs again on the next boot, so there is no failure state to recover from.

## Testing

Covered at 100%, and tested on the emulator with a self-custodial account. The purge runs, completes and records itself, and the account survives it.

## Not in this release

The legacy read-through fallback for the six session slots stays. The issue puts its removal here, but dropping it in the same release as the purge is strictly worse for someone upgrading from an older build: the PIN is read at boot, before the purge runs, so with the fallback in place that user migrates cleanly and the purge then finds the copy already gone. Without it they lose the lock and the session for nothing, since the purge deletes the data either way. It belongs with the dependency removal.

## Two things for #4224

Both are in the parent branch, and this change makes the first one matter more.

`rememberMnemonicAccount` discards its write result, so a failed tracking write is invisible. The sweep still reports `ok`, this purge erases the legacy copy, and the seed ends up in the new store un-named by the account list, where a later reinstall neither wipes it nor catches it.

`sweepMnemonicMigration` scores `absent` as a success and only `failed` as a failure, so its `ok` does not mean what its docstring says. The purge no longer depends on that, since it verifies each slot itself, but the contract and the code still disagree.
