### PR TITLE
fix(migration): let the server, not a clock, decide when a checkpoint expires

### DIFF
--- a/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
+++ b/__tests__/screens/account-migration/hooks/use-migration-next-step.spec.ts
@@ -10,6 +10,18 @@ let mockIsAtCommitPoint = false
 let mockCheckpointLoading = false
 let mockHasTransactions = false
 let mockTransactionsLoading = false
+let mockIsLocked = true
+let mockLockLoading = false
+let mockLockError = false
+
+jest.mock("@app/screens/account-migration/hooks/use-migration-lock", () => ({
+  useMigrationLock: () => ({
+    isLocked: mockIsLocked,
+    loading: mockLockLoading,
+    hasError: mockLockError,
+    refetch: jest.fn(),
+  }),
+}))
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
@@ -39,6 +51,9 @@ describe("useMigrationNextStep", () => {
     mockCheckpointLoading = false
     mockHasTransactions = false
     mockTransactionsLoading = false
+    mockIsLocked = true
+    mockLockLoading = false
+    mockLockError = false
   })
 
   it("offers the history download to a fresh migration with history", () => {
@@ -143,5 +158,70 @@ describe("useMigrationNextStep", () => {
     const { result } = renderHook(() => useMigrationNextStep())
 
     expect(result.current.loading).toBe(true)
+  })
+
+  describe("a commit point the server no longer holds open", () => {
+    /** The device left off on the commit screen, but support has since cleared the flow. */
+    const arriveWithStaleCommitPoint = (): void => {
+      mockIsAtCommitPoint = true
+      mockIsLocked = false
+    }
+
+    it("starts the flow over instead of returning to the commit screen", () => {
+      arriveWithStaleCommitPoint()
+
+      const { result } = renderHook(() => useMigrationNextStep())
+      act(() => {
+        result.current.goToNextStep()
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith("accountMigrationExplainer")
+      expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it("does the same for a skip guard, replacing rather than pushing", () => {
+      arriveWithStaleCommitPoint()
+
+      const { result } = renderHook(() => useMigrationNextStep())
+      act(() => {
+        result.current.replaceToNextStep()
+      })
+
+      expect(mockReplace).toHaveBeenCalledWith("accountMigrationExplainer")
+      expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it("offers the history download again, since this run starts from the top", () => {
+      arriveWithStaleCommitPoint()
+      mockHasTransactions = true
+
+      const { result } = renderHook(() => useMigrationNextStep())
+      act(() => {
+        result.current.goToNextStep()
+      })
+
+      expect(mockNavigate).toHaveBeenCalledWith("accountMigrationDownloadHistory")
+    })
+
+    it("never skips ahead on an unanswered server, only on a confirmed one", () => {
+      mockIsAtCommitPoint = true
+      mockLockError = true
+
+      const { result } = renderHook(() => useMigrationNextStep())
+      act(() => {
+        result.current.goToNextStep()
+      })
+
+      expect(mockNavigateToCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it("waits while the server is still being asked", () => {
+      mockIsAtCommitPoint = true
+      mockLockLoading = true
+
+      const { result } = renderHook(() => useMigrationNextStep())
+
+      expect(result.current.loading).toBe(true)
+    })
   })
 })

--- a/__tests__/screens/account-migration/to-non-custodial/migration-entry-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/migration-entry-screen.spec.tsx
@@ -34,6 +34,18 @@ let mockIsAtCommitPoint = false
 let mockHasResumableCheckpoint = false
 let mockCheckpointLoading = false
 let mockSelfCustodialDisabled = false
+let mockIsLocked = true
+let mockLockLoading = false
+let mockLockError = false
+
+jest.mock("@app/screens/account-migration/hooks/use-migration-lock", () => ({
+  useMigrationLock: () => ({
+    isLocked: mockIsLocked,
+    loading: mockLockLoading,
+    hasError: mockLockError,
+    refetch: jest.fn(),
+  }),
+}))
 
 jest.mock("@app/screens/account-migration/hooks", () => ({
   useMigrationCheckpoint: () => ({
@@ -64,6 +76,9 @@ describe("MigrationEntryScreen", () => {
     mockHasResumableCheckpoint = false
     mockCheckpointLoading = false
     mockSelfCustodialDisabled = false
+    mockIsLocked = true
+    mockLockLoading = false
+    mockLockError = false
     mockRemoteConfigReady = true
     mockRegistryLoading = false
   })
@@ -152,5 +167,52 @@ describe("MigrationEntryScreen", () => {
 
     expect(mockReplace).toHaveBeenCalledWith("Primary")
     expect(mockGoBack).not.toHaveBeenCalled()
+  })
+
+  describe("the server owns whether a migration is still open", () => {
+    /** A device that left off on the commit screen: everything local says resume. */
+    const arriveWithCommitPointCheckpoint = (): void => {
+      mockIsAtCommitPoint = true
+      mockHasResumableCheckpoint = true
+    }
+
+    it("resumes while the server still holds the flow", () => {
+      arriveWithCommitPointCheckpoint()
+
+      render(<MigrationEntryScreen />)
+
+      expect(mockReplaceToCheckpoint).toHaveBeenCalledTimes(1)
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it("starts over once support has cleared the flow, whatever the device remembers", () => {
+      arriveWithCommitPointCheckpoint()
+      mockIsLocked = false
+
+      render(<MigrationEntryScreen />)
+
+      expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
+      expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    })
+
+    it("waits for the server rather than resuming on a stale record", () => {
+      arriveWithCommitPointCheckpoint()
+      mockLockLoading = true
+
+      render(<MigrationEntryScreen />)
+
+      expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it("starts over when the server could not be asked, never resumes on a guess", () => {
+      arriveWithCommitPointCheckpoint()
+      mockLockError = true
+
+      render(<MigrationEntryScreen />)
+
+      expect(mockReplace).toHaveBeenCalledWith("accountMigrationStart")
+      expect(mockReplaceToCheckpoint).not.toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -3,7 +3,6 @@ import {
   clearCheckpointFromStorage,
   getStorageKey,
   isCommitPointCheckpoint,
-  isExpired,
   loadCheckpoint,
   resolveCheckpointRoute,
   saveCheckpointToStorage,
@@ -63,41 +62,6 @@ describe("migration-checkpoint-storage", () => {
     it("returns valid checkpoint", () => {
       const result = validateStoredCheckpoint({ step: "backupMethod", savedAt: 1000 })
       expect(result).toEqual({ step: "backupMethod", savedAt: 1000 })
-    })
-  })
-
-  describe("isExpired (48h uniform)", () => {
-    const now = 1000000000
-    const h = 60 * 60 * 1000
-
-    it("not expired at 24h", () => {
-      const cp = { step: MigrationCheckpoint.BackupMethod, savedAt: now - 24 * h }
-      expect(isExpired(cp, now)).toBe(false)
-    })
-
-    it("not expired at 47h", () => {
-      const cp = { step: MigrationCheckpoint.CloudBackup, savedAt: now - 47 * h }
-      expect(isExpired(cp, now)).toBe(false)
-    })
-
-    it("not expired at 1h", () => {
-      const cp = { step: MigrationCheckpoint.BackupAlerts, savedAt: now - Number(h) }
-      expect(isExpired(cp, now)).toBe(false)
-    })
-
-    it("expired at 49h for BackupMethod", () => {
-      const cp = { step: MigrationCheckpoint.BackupMethod, savedAt: now - 49 * h }
-      expect(isExpired(cp, now)).toBe(true)
-    })
-
-    it("expired at 49h for CloudBackup", () => {
-      const cp = { step: MigrationCheckpoint.CloudBackup, savedAt: now - 49 * h }
-      expect(isExpired(cp, now)).toBe(true)
-    })
-
-    it("expired at 49h for BackupAlerts", () => {
-      const cp = { step: MigrationCheckpoint.BackupAlerts, savedAt: now - 49 * h }
-      expect(isExpired(cp, now)).toBe(true)
     })
   })
 
@@ -249,7 +213,7 @@ describe("migration-checkpoint-storage", () => {
   })
 
   describe("loadCheckpoint", () => {
-    it("returns valid non-expired checkpoint", async () => {
+    it("returns the stored checkpoint", async () => {
       mockLoadJsonOrThrow.mockResolvedValue({
         step: "backupAlerts",
         savedAt: Date.now() - 1000,
@@ -262,15 +226,17 @@ describe("migration-checkpoint-storage", () => {
       })
     })
 
-    it("returns null and removes expired checkpoint", async () => {
+    it("keeps an old record, since only the server can retire a migration", async () => {
       mockLoadJsonOrThrow.mockResolvedValue({
-        step: "backupMethod",
-        savedAt: Date.now() - 49 * 60 * 60 * 1000,
+        step: MigrationCheckpoint.BalancesOverview,
+        savedAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
+        accountId: "sc-1",
       })
 
       const result = await loadCheckpoint("test-key")
-      expect(result).toBeNull()
-      expect(mockRemove).toHaveBeenCalledWith("test-key")
+
+      expect(result).toMatchObject({ accountId: "sc-1" })
+      expect(mockRemove).not.toHaveBeenCalled()
     })
 
     it("returns null for invalid data", async () => {
@@ -549,10 +515,10 @@ describe("migration-checkpoint-storage", () => {
       expect(mockSaveJson).not.toHaveBeenCalled()
     })
 
-    it("drops an expired prior record's account id instead of lending it to the fresh save", async () => {
+    it("lends an old record's account id to the fresh save, so the wallet is reused", async () => {
       mockLoadJsonOrThrow.mockResolvedValue({
         step: MigrationCheckpoint.BackupMethod,
-        savedAt: Date.now() - 49 * 60 * 60 * 1000,
+        savedAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
         accountId: "sc-1",
         custodialAccountId: "cust-1",
       })
@@ -565,9 +531,83 @@ describe("migration-checkpoint-storage", () => {
       expect(mockSaveJson).toHaveBeenCalledWith("test-key", {
         step: MigrationCheckpoint.BackupAlerts,
         savedAt: expect.any(Number),
-        accountId: undefined,
+        accountId: "sc-1",
         custodialAccountId: "cust-1",
       })
+    })
+  })
+
+  describe("a run that starts over", () => {
+    /** The only way back behind the commit point: the flow never walks backwards on its
+     *  own, so a step regression is a restart and its predecessor's figures are stale. */
+    const priorRun = {
+      step: MigrationCheckpoint.BalancesOverview,
+      savedAt: Date.now(),
+      accountId: "sc-1",
+      custodialAccountId: "cust-1",
+      expectedReceiveSats: 36726,
+    }
+
+    it("drops the previous run's expected receive amount", async () => {
+      mockLoadJsonOrThrow.mockResolvedValue(priorRun)
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.TermsAndConditions,
+        custodialAccountId: "cust-1",
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ expectedReceiveSats: undefined }),
+      )
+    })
+
+    it("keeps the wallet it already provisioned", async () => {
+      mockLoadJsonOrThrow.mockResolvedValue(priorRun)
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.TermsAndConditions,
+        custodialAccountId: "cust-1",
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ accountId: "sc-1" }),
+      )
+    })
+
+    it("takes the new run's own figure once it reaches the commit point again", async () => {
+      mockLoadJsonOrThrow.mockResolvedValue({
+        ...priorRun,
+        step: MigrationCheckpoint.TermsAndConditions,
+        expectedReceiveSats: undefined,
+      })
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 41000,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ expectedReceiveSats: 41000 }),
+      )
+    })
+
+    it("still holds the figure across a re-entered commit screen", async () => {
+      mockLoadJsonOrThrow.mockResolvedValue(priorRun)
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BalancesOverview,
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 0,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ expectedReceiveSats: 36726 }),
+      )
     })
   })
 

--- a/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
+++ b/__tests__/screens/account-migration/utils/migration-checkpoint-storage.spec.ts
@@ -562,6 +562,23 @@ describe("migration-checkpoint-storage", () => {
       )
     })
 
+    /** The caller re-sends the figure it already holds on every save, to heal a write that
+     *  never landed, so a restart has to refuse it from the update as well. */
+    it("drops it even when the caller echoes it back in the update", async () => {
+      mockLoadJsonOrThrow.mockResolvedValue(priorRun)
+
+      await saveCheckpointToStorage("test-key", {
+        step: MigrationCheckpoint.BackupMethod,
+        custodialAccountId: "cust-1",
+        expectedReceiveSats: 36726,
+      })
+
+      expect(mockSaveJson).toHaveBeenCalledWith(
+        "test-key",
+        expect.objectContaining({ expectedReceiveSats: undefined }),
+      )
+    })
+
     it("keeps the wallet it already provisioned", async () => {
       mockLoadJsonOrThrow.mockResolvedValue(priorRun)
 

--- a/app/screens/account-migration/hooks/use-migration-lock.ts
+++ b/app/screens/account-migration/hooks/use-migration-lock.ts
@@ -19,8 +19,8 @@ type MigrationLock = {
 /**
  * Whether the ACTIVE account is past the migration's point of no return, as the server
  * sees it. This is the whole lock: it survives a reinstall, which the local checkpoint
- * cannot (48h expiry, and AsyncStorage dies with the app), so the checkpoint is demoted
- * to remembering WHICH screen to resume on. The account type comes from the registry, as
+ * cannot (AsyncStorage dies with the app), so the checkpoint is demoted to remembering
+ * WHICH screen to resume on and this answers WHETHER there is still a flow to resume. The account type comes from the registry, as
  * in the wind-down gate, so a custodial migration never blocks a self-custodial session
  * the user switched to; and only a phase the server actually reported locks, because
  * locking every offline launch into a migration is far worse than letting a locked user

--- a/app/screens/account-migration/hooks/use-migration-next-step.ts
+++ b/app/screens/account-migration/hooks/use-migration-next-step.ts
@@ -5,8 +5,11 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 
+import { resolveCheckpointRoute } from "../utils/migration-checkpoint-storage"
+
 import { useHasTransactions } from "./use-has-transactions"
 import { useMigrationCheckpoint } from "./use-migration-checkpoint"
+import { useMigrationLock } from "./use-migration-lock"
 
 /**
  * Routes to the migration flow's next step: a migration resumed at the commit point
@@ -25,18 +28,44 @@ export const useMigrationNextStep = () => {
     isAtCommitPoint,
     loading: checkpointLoading,
   } = useMigrationCheckpoint()
+  const { isLocked, loading: lockLoading, hasError: lockError } = useMigrationLock()
+
+  /** The checkpoint says WHICH screen the device left off on; the server says WHETHER that
+   *  migration is still open, and only both together may skip the flow ahead. Without this
+   *  the entry screen's own refusal to resume is undone one tap later, landing the user
+   *  back on a commit screen for a flow support has already cleared. */
+  const isResumable = isAtCommitPoint && isLocked && !lockError
 
   /** A restarted flow is offered the download again (#4109): it replays every step, and
    *  only the commit point still skips ahead to its checkpoint. */
-  const shouldOfferHistoryDownload = hasTransactions && !isAtCommitPoint
+  const shouldOfferHistoryDownload = hasTransactions && !isResumable
+
+  /** Only a checkpoint that claims the commit point needs redirecting: everything earlier
+   *  already resolves to the same place through the route table below, and sending it the
+   *  long way round would be a second path to one destination. */
+  const isStaleCommitPoint = isAtCommitPoint && !isResumable
+  /** Where a flow the server no longer holds open starts again. Resolved through the same
+   *  route table the checkpoint uses, so the restart cannot drift from the destination a
+   *  checkpoint-less device already gets. */
+  const restartDestination = resolveCheckpointRoute(null).name
 
   const goToNextStep = useCallback(() => {
     if (shouldOfferHistoryDownload) {
       navigation.navigate("accountMigrationDownloadHistory")
       return
     }
+    if (isStaleCommitPoint) {
+      navigation.navigate(restartDestination)
+      return
+    }
     navigateToCheckpoint()
-  }, [navigation, shouldOfferHistoryDownload, navigateToCheckpoint])
+  }, [
+    navigation,
+    shouldOfferHistoryDownload,
+    isStaleCommitPoint,
+    restartDestination,
+    navigateToCheckpoint,
+  ])
 
   /** Same destination as goToNextStep, replacing the current screen: for a guard that
    *  skips its own screen, which must not leave it behind for the back gesture. */
@@ -45,12 +74,22 @@ export const useMigrationNextStep = () => {
       navigation.replace("accountMigrationDownloadHistory")
       return
     }
+    if (isStaleCommitPoint) {
+      navigation.replace(restartDestination)
+      return
+    }
     replaceToCheckpoint()
-  }, [navigation, shouldOfferHistoryDownload, replaceToCheckpoint])
+  }, [
+    navigation,
+    shouldOfferHistoryDownload,
+    isStaleCommitPoint,
+    restartDestination,
+    replaceToCheckpoint,
+  ])
 
   return {
     goToNextStep,
     replaceToNextStep,
-    loading: transactionsLoading || checkpointLoading,
+    loading: transactionsLoading || checkpointLoading || lockLoading,
   }
 }

--- a/app/screens/account-migration/to-non-custodial/migration-entry-screen.tsx
+++ b/app/screens/account-migration/to-non-custodial/migration-entry-screen.tsx
@@ -10,6 +10,7 @@ import {
   useMigrationCheckpoint,
   useSelfCustodialDisabled,
 } from "@app/screens/account-migration/hooks"
+import { useMigrationLock } from "@app/screens/account-migration/hooks/use-migration-lock"
 import { AccountType } from "@app/types/wallet"
 
 /** The single dispatcher for every migration entry: the deeplink (blink://account-migration),
@@ -20,6 +21,7 @@ export const MigrationEntryScreen: React.FC = () => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
   const { activeAccount, loading: registryLoading } = useAccountRegistry()
   const { loading, replaceToCheckpoint, isAtCommitPoint } = useMigrationCheckpoint()
+  const { isLocked, loading: lockLoading, hasError: lockError } = useMigrationLock()
   const isSelfCustodialDisabled = useSelfCustodialDisabled()
   const { remoteConfigReady } = useFeatureFlags()
 
@@ -28,14 +30,21 @@ export const MigrationEntryScreen: React.FC = () => {
   /** Only the commit point resumes (#4109): a flow left before it restarts at the gate, so
    *  reopening replays the whole thing from its first step instead of dropping the user
    *  into a backup screen they have no context for. The kill-switch outranks even that: a
-   *  disabled stack falls through to the gate, which shows the unavailable screen. */
-  const shouldResume = !isSelfCustodialDisabled && isAtCommitPoint
+   *  disabled stack falls through to the gate, which shows the unavailable screen.
+   *
+   *  And only while the server still has that flow. The checkpoint records which screen
+   *  the device left off on, never whether the migration is still open — the server owns
+   *  that, and survives the reinstall the record cannot. Once support clears a stuck flow
+   *  the account reads unlocked, and resuming would drop the user back onto a commit screen
+   *  for a migration that no longer exists instead of letting them start over. */
+  const hasLiveServerFlow = isLocked && !lockError
+  const shouldResume = !isSelfCustodialDisabled && isAtCommitPoint && hasLiveServerFlow
 
   useEffect(() => {
     /** Wait for the account list and the flag too, not just the checkpoint: an unhydrated
      *  registry reads as non-self-custodial (bouncing an SC user into the custodial gate),
      *  and an unresolved flag reads as enabled (slipping a resume past a disabled stack). */
-    if (loading || registryLoading || !remoteConfigReady) return
+    if (loading || registryLoading || lockLoading || !remoteConfigReady) return
 
     if (isSelfCustodialAccount) {
       if (navigation.canGoBack()) {
@@ -55,6 +64,7 @@ export const MigrationEntryScreen: React.FC = () => {
   }, [
     loading,
     registryLoading,
+    lockLoading,
     remoteConfigReady,
     isSelfCustodialAccount,
     shouldResume,

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -142,17 +142,24 @@ export const mergeCheckpoint = (
   const hasRestarted =
     isCommitPointCheckpoint(existing?.step ?? null) &&
     !isCommitPointCheckpoint(update.step)
-  const isFigureInheritable = hasSameOwner && !hasRestarted
-  const inheritedExpectedReceiveSats = isFigureInheritable
+  const inheritedExpectedReceiveSats = hasSameOwner
     ? existing?.expectedReceiveSats
     : undefined
+
+  /** Dropped outright on a restart, not merely left uninherited: the caller re-sends the
+   *  figure it already knows on every save (to heal a write that never landed), so a
+   *  restart has to refuse it from both directions or the previous run's amount rides back
+   *  in through the update. The next commit point supplies the new run's own. */
+  const expectedReceiveSats = hasRestarted
+    ? undefined
+    : inheritedExpectedReceiveSats ?? update.expectedReceiveSats
 
   return {
     step: update.step,
     savedAt: Date.now(),
     accountId: update.accountId ?? (hasSameOwner ? existing?.accountId : undefined),
     custodialAccountId: update.custodialAccountId,
-    expectedReceiveSats: inheritedExpectedReceiveSats ?? update.expectedReceiveSats,
+    expectedReceiveSats,
   }
 }
 

--- a/app/screens/account-migration/utils/migration-checkpoint-storage.ts
+++ b/app/screens/account-migration/utils/migration-checkpoint-storage.ts
@@ -30,8 +30,6 @@ type CheckpointDestination = {
 
 const STORAGE_KEY_PREFIX = "migrationCheckpoint"
 
-const CHECKPOINT_EXPIRATION_MS = 48 * 60 * 60 * 1000 // 48h
-
 const DEFAULT_DESTINATION: CheckpointDestination = { name: "accountMigrationExplainer" }
 
 /** Exhaustive on purpose: a step added to the enum has no entry here and fails to compile,
@@ -55,11 +53,6 @@ export const isCommitPointCheckpoint = (
 
 export const getStorageKey = (environment: string): string =>
   `${STORAGE_KEY_PREFIX}_${environment.toLowerCase()}`
-
-export const isExpired = (
-  checkpoint: StoredCheckpoint,
-  now: number = Date.now(),
-): boolean => now - checkpoint.savedAt > CHECKPOINT_EXPIRATION_MS
 
 export const validateStoredCheckpoint = (raw: unknown): StoredCheckpoint | null => {
   if (!raw || typeof raw !== "object") return null
@@ -111,17 +104,7 @@ export const resolveCheckpointRoute = (
 export const loadCheckpoint = async (
   storageKey: string,
 ): Promise<StoredCheckpoint | null> => {
-  const raw = await loadJsonOrThrow(storageKey)
-  const parsed = validateStoredCheckpoint(raw)
-
-  if (!parsed) return null
-
-  if (isExpired(parsed)) {
-    await remove(storageKey)
-    return null
-  }
-
-  return parsed
+  return validateStoredCheckpoint(await loadJsonOrThrow(storageKey))
 }
 
 export type CheckpointUpdate = {
@@ -145,10 +128,22 @@ export const mergeCheckpoint = (
     existing?.custodialAccountId === undefined ||
     existing.custodialAccountId === update.custodialAccountId
 
-  /** Write-once for one owner's flow: the figure is only knowable before the drain, so a
-   *  re-entered commit screen would carry the post-drain zero the gate reads as "nothing
-   *  will ever arrive" and swap while the funds are still in transit (#4102). */
-  const inheritedExpectedReceiveSats = hasSameOwner
+  /**
+   * Write-once for one owner's RUN of the flow: the figure is only knowable before the
+   * drain, so a re-entered commit screen would carry the post-drain zero the gate reads as
+   * "nothing will ever arrive" and swap while the funds are still in transit (#4102).
+   *
+   * A run ends when the step falls back behind the commit point, which only a restart
+   * does — the flow never walks backwards on its own. Carrying the figure across that
+   * would let a previous attempt's amount decide when the funds of a new one have landed.
+   * The clock used to sever this by expiring the record; the step does it on the evidence
+   * instead.
+   */
+  const hasRestarted =
+    isCommitPointCheckpoint(existing?.step ?? null) &&
+    !isCommitPointCheckpoint(update.step)
+  const isFigureInheritable = hasSameOwner && !hasRestarted
+  const inheritedExpectedReceiveSats = isFigureInheritable
     ? existing?.expectedReceiveSats
     : undefined
 
@@ -171,11 +166,7 @@ export const saveCheckpointToStorage = async (
   storageKey: string,
   update: CheckpointUpdate,
 ): Promise<void> => {
-  const stored = validateStoredCheckpoint(await loadJsonOrThrow(storageKey))
-  /** An expired prior record must not lend its accountId to the fresh save; treat it as
-   *  absent, matching loadCheckpoint, so the 48h expiry stays authoritative for the id. */
-  const isReusableRecord = stored !== null && !isExpired(stored)
-  const existing = isReusableRecord ? stored : null
+  const existing = validateStoredCheckpoint(await loadJsonOrThrow(storageKey))
   await saveJson(storageKey, mergeCheckpoint(existing, update))
 }
 
@@ -185,7 +176,7 @@ export const clearCheckpointFromStorage = async (storageKey: string): Promise<vo
 
 /**
  * Wallets provisioned for a migration but not yet activated, keyed by the custodial
- * account that started the flow. Unlike the checkpoint this record never expires: the
+ * account that started the flow. It never expires, and neither does the checkpoint: the
  * wallet exists (its phrase may already be written down), so a restarted flow must
  * reuse it instead of provisioning a zombie, and the account switcher must not offer it.
  */


### PR DESCRIPTION
Stacked on #4243. Closes the last cause of [blink-wip#1211](https://github.com/blinkbitcoin/blink-wip/issues/1211): the checkpoint expiring on a clock the server does not share.

## Why

The server keeps a migration locked for as long as it needs to. The device forgot it after 48 hours. Anyone stuck longer than that was guaranteed to reach `locked-without-checkpoint`, which is what the reported account did — its commit failed on Aug 31 and the record was gone by Sep 2.

Raising the number only moves the cliff. As @grimen put it on the ticket: *"a state machine (~lock) that randomly resets makes it a flawed state machine — so yes state should not randomly change/reset."* The lock is already the authority — `useMigrationLock`'s own docstring says the checkpoint is "demoted to remembering WHICH screen to resume on" — and the clock contradicted that.

## What changed

- **The expiry is gone, and no deletion replaces it.** The only paths that clear a checkpoint remain the two real ones: the migration completed, or the flow walked past it. A record the server still backs survives indefinitely; one it does not is simply never acted on.
- **Resuming requires a live server flow.** The entry dispatcher and the flow's own skip-ahead both ask before jumping to the commit point. Once support clears a stuck flow the account reads unlocked, and the user starts over instead of landing on a commit screen for a migration that no longer exists. An unanswered server never resumes either — walking the flow costs a few taps, resuming a dead one costs the funds.
- **A restart drops the previous run's expected receive figure.** The write-once rule that guards against the post-drain zero (#4102) used to be bounded by the expiry; it is now bounded by the step falling back behind the commit point, which only a restart does. The figure is refused from the update as well, since the caller re-sends what it already holds to heal a failed write.

The provisioned wallet is untouched by all of this: a restarted flow still reuses it rather than provisioning an orphan, which also means the Lightning address is already on that pubkey and comes back `ALREADY_TRANSFERRED`.

## Screenshots

| Server reset: starts over | And walks the whole flow |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/1ca45a40-55d6-4a47-b4be-52c3f18e1aee" width="260" /> | <img src="https://github.com/user-attachments/assets/1dfd5489-372a-4629-a0b4-76a8c87e6b9b" width="260" /> |

## Testing

Verified on device against the emulator's own AsyncStorage, reading the record back out of SQLite at each step:

| Scenario | Result |
| --- | --- |
| 30-day-old checkpoint, server holds the flow | Resumes — the expiry is gone |
| Same checkpoint, server reset | Does not resume: starts over |
| Continuing from there | Walks the flow, no skip back to the commit point |
| After accepting the terms | Receive figure absent, provisioned wallet kept |
| The record on disk | Survives every case |

The same checkpoint drives both of the first two rows; only the server's answer differs.

Device testing is also what found the two bugs the unit tests could not: the flow skipping back onto the commit point one tap after the entry screen refused to, and the receive figure riding back in through the caller's echo. Both now have regressions covering them.

`migration-checkpoint-storage.ts`, `use-migration-next-step.ts` and `migration-entry-screen.tsx` are at 100% across the board.
