### PR TITLE
refactor(map): call the add-place form a panel, since that is what it is

### DIFF
--- a/__tests__/components/map-component/add-place-panel.spec.tsx
+++ b/__tests__/components/map-component/add-place-panel.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 
-import { AddPlaceSheet } from "@app/components/map-component/add-place-sheet"
+import { AddPlacePanel } from "@app/components/map-component/add-place-panel"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { ContextForScreen } from "../../screens/helper"
@@ -19,11 +19,11 @@ const LOCATION = { latitude: 13.496743, longitude: -89.439462 }
 const onSubmit = jest.fn<Promise<string | null>, [unknown]>()
 const onClose = jest.fn()
 
-type SheetProps = React.ComponentProps<typeof AddPlaceSheet>
+type SheetProps = React.ComponentProps<typeof AddPlacePanel>
 
 const sheet = (props: Partial<SheetProps> = {}) => (
   <ContextForScreen>
-    <AddPlaceSheet location={LOCATION} onSubmit={onSubmit} onClose={onClose} {...props} />
+    <AddPlacePanel location={LOCATION} onSubmit={onSubmit} onClose={onClose} {...props} />
   </ContextForScreen>
 )
 
@@ -50,7 +50,7 @@ beforeEach(() => {
   loadLocale("en")
 })
 
-describe("AddPlaceSheet", () => {
+describe("AddPlacePanel", () => {
   it("shows where the pin is pointing", async () => {
     // The form is the only place the coordinates are readable, so a pin left in
     // the wrong street can still be caught before it is submitted.

--- a/__tests__/components/map-component/map-component.spec.tsx
+++ b/__tests__/components/map-component/map-component.spec.tsx
@@ -101,10 +101,10 @@ jest.mock("@app/components/map-component/category-filter-sheet", () => ({
 let capturedAddPlaceProps: Record<string, unknown> | undefined
 let addPlaceMountCount = 0
 let isAddPlaceMounted = false
-jest.mock("@app/components/map-component/add-place-sheet", () => {
+jest.mock("@app/components/map-component/add-place-panel", () => {
   const ReactActual = jest.requireActual<typeof React>("react")
   return {
-    AddPlaceSheet: (props: Record<string, unknown>) => {
+    AddPlacePanel: (props: Record<string, unknown>) => {
       capturedAddPlaceProps = props
       ReactActual.useEffect(() => {
         addPlaceMountCount += 1

--- a/app/components/map-component/add-place-panel.tsx
+++ b/app/components/map-component/add-place-panel.tsx
@@ -40,6 +40,12 @@ type Props = {
  * modal. A modal window would take every touch on the screen, and the map
  * above has to stay pannable for the whole time this is open.
  *
+ * A panel, and named for one. Every other surface over this map is a bottom
+ * sheet, and while this was called a sheet too it kept being read as one that
+ * had simply been built wrong — twice it was asked for the scrim and the
+ * drag-to-dismiss its siblings have, and both would cost the panning that is
+ * the reason it is not a sheet.
+ *
  * The name and the category are both required — see `buildPlaceSubmission` for
  * why the category is. Submit stays disabled rather than explaining itself
  * afterwards, since which of the two is missing is visible on the form.
@@ -48,7 +54,7 @@ type Props = {
  * be filled in alongside, and the pin usually wants placing before there is
  * anything to type.
  */
-export const AddPlaceSheet: React.FC<Props> = ({ location, onSubmit, onClose }) => {
+export const AddPlacePanel: React.FC<Props> = ({ location, onSubmit, onClose }) => {
   const {
     theme: { colors },
   } = useTheme()

--- a/app/components/map-component/index.tsx
+++ b/app/components/map-component/index.tsx
@@ -38,7 +38,7 @@ import { useFocusEffect } from "@react-navigation/native"
 import { isIOS } from "@rn-vui/base"
 import { Text, makeStyles, useTheme } from "@rn-vui/themed"
 
-import { AddPlaceSheet } from "./add-place-sheet"
+import { AddPlacePanel } from "./add-place-panel"
 import { CategoryFilterSheet } from "./category-filter-sheet"
 import { ClusterMarker, ClusterMarkerData } from "./cluster-marker"
 import { Viewport, placeLabels } from "./label-collision"
@@ -603,7 +603,7 @@ export default function MapComponent({
           typed — so the map gets all of itself back and a next attempt starts
           on an empty form. */}
       {isAddingPlace && (
-        <AddPlaceSheet
+        <AddPlacePanel
           location={center}
           onSubmit={handlePlaceSubmit}
           onClose={stopAddingPlace}


### PR DESCRIPTION
Addresses the naming half of https://github.com/blinkbitcoin/blink-wip/issues/1254.

Stacked on #4249, based on its head. Independent of #4251: the two touch disjoint files and merge cleanly in either order.

### The problem is the name

`add-place-sheet.tsx` is not a sheet. It has no scrim, no pull handle, no drag-to-dismiss and no modal window, and it has none of them on purpose — it sits *beside* the map rather than over it, so the map stays pannable while the pin is being aimed. A modal window would take every touch on the screen. The file has said so in its own docstring since it was written.

The name outvoted the docstring. Two tickets have now been filed against this component asking for the scrim and the drag-to-dismiss its siblings have — [#1254](https://github.com/blinkbitcoin/blink-wip/issues/1254) and [#1255](https://github.com/blinkbitcoin/blink-wip/issues/1255) — both reading the name and reasonably expecting the surface it describes. #1255 lists it as an acceptance requirement: *"Add to map opens as a bottom sheet over the map: scrim, pull handle, drag-to-dismiss."*

Granting either would cost the panning that is the reason it is built this way. So the name is what moves, not the component.

### Tradeoff

This declines an explicit acceptance requirement of #1255, and that is worth stating plainly rather than quietly not doing.

The alternative is to give the add-place form a scrim and a drag-to-dismiss like its siblings, and accept that the map goes back to being unusable while the form is open — which is the complaint #1254 opened with, in its original form ("the user has just finished aiming a pin at a specific spot and is describing *that place*", with the map hidden). The current design answers that complaint more completely than a sheet would: the map is not merely visible behind a scrim, it is still live.

A third option — putting it on the shared primitive with a no-scrim, non-capturing mode — was considered and left. It grows a second personality on the primitive to serve one caller, and what comes out is not a sheet either.

If the sheet presentation is wanted regardless, this PR is the wrong one and #1255's requirement should be implemented instead. Happy to take that direction.

### What changed

Nothing but the name.

- `app/components/map-component/add-place-sheet.tsx` → `add-place-panel.tsx`, `AddPlaceSheet` → `AddPlacePanel`
- the spec file and its mock in `map-component.spec.tsx` follow
- the docstring picks up *why the name matters*, not only why the component does, so the next reader is told what the two tickets had to work out for themselves

No testID changes, so the map-component suites that drive this flow needed no edits. Props untouched.

### On the rest of #1254

Worth recording, since the ticket reads as a longer list than what is left of it. #1254's ranked items were written against an earlier state of #4249 and its later commits have overtaken most of them:

| # | Item | State |
|---|---|---|
| 1 | `borderRadius: 20` → `16` | Constant deleted — the locator bar it belonged to no longer exists |
| 2 | `BUTTON_GAP: 4` → `5` | Deleted with it |
| 3 | `BAR_PADDING: 12` → `14` | Deleted with it |
| 4 | Split the `__DEV__` change into its own commit | Already done — `chore(map): open the add-place button in dev builds` |
| 5 | `colors.grey7` over `colors.white` for the panel | Closed: `white` is what all six map overlays use; matching them was preferred to matching the token |
| 6 | Measure `BAR_HEIGHT` via `onLayout` | Moot — `BAR_HEIGHT` and `locatorBarTop` are both gone |

`place-locator.tsx` is now 64 lines: a pin and a hint, `pointerEvents="none"`, no buttons and no bar.

The sheet-extraction half of #1254 is #4251.

## Acceptance requirements

- [x] The component's name describes what it is, so the docstring is no longer the only thing saying so
- [x] No behaviour, prop, or testID changes
- [x] No stale `AddPlaceSheet` / `add-place-sheet` references anywhere in `app/` or `__tests__/`
- [x] The docstring records why a sheet was declined, so the question is not reopened a third time
- [x] Existing map-component suites pass unedited
- [x] Merges cleanly with #4251 in either order
- [ ] #1255's "Add to map opens as a bottom sheet" — **declined**; see Tradeoff

## Testing specs

- **Regression**: all 187 tests across the 10 map-component suites pass with no assertion edits — the point of the change being name-only. `add-place-panel.spec.tsx` and the `map-component.spec.tsx` mock follow the rename and nothing else.
- **Static**: no `AddPlaceSheet` or `add-place-sheet` identifier survives in `app/` or `__tests__/`; `tsc` would catch a missed import and is clean.
- **Merge-order**: both merge orders with #4251 produce an identical tree; `tsc`, `eslint` and 197 tests green on the combined result.
- **Manual**: none needed — no rendered output changes.

Local: `tsc`, `eslint` and `prettier` clean. All 187 tests across the 10 map-component suites pass.

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
