### PR TITLE
refactor(bottom-sheet): give the map's two sheets one sheet to share

### DIFF
--- a/__tests__/components/bottom-sheet/bottom-sheet.spec.tsx
+++ b/__tests__/components/bottom-sheet/bottom-sheet.spec.tsx
@@ -1,0 +1,182 @@
+import React from "react"
+import { StyleSheet, Text, View } from "react-native"
+import type { ReactTestInstance } from "react-test-renderer"
+import { getAnimatedStyle } from "react-native-reanimated"
+import {
+  fireGestureHandler,
+  getByGestureTestId,
+} from "react-native-gesture-handler/jest-utils"
+import type { PanGesture } from "react-native-gesture-handler"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
+
+import { BOTTOM_OVERHANG, BottomSheet, PAN_TEST_ID } from "@app/components/bottom-sheet"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+
+import { ContextForScreen } from "../../screens/helper"
+
+jest.mock("react-native-safe-area-context", () => ({
+  ...jest.requireActual("react-native-safe-area-context"),
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}))
+
+const SHEET_TEST_ID = "sheet"
+
+/** The height the sheet's offsets are expressed in, not the one it is drawn at. */
+const animatedHeightOf = (sheet: ReactTestInstance) =>
+  (StyleSheet.flatten(sheet.props.style).height as number) - BOTTOM_OVERHANG
+
+const renderSheet = (props: Partial<React.ComponentProps<typeof BottomSheet>> = {}) =>
+  render(
+    <ContextForScreen>
+      <BottomSheet
+        testID={SHEET_TEST_ID}
+        isVisible
+        onClose={jest.fn()}
+        heightRatio={0.6}
+        {...props}
+      >
+        <Text>content</Text>
+      </BottomSheet>
+    </ContextForScreen>,
+  )
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  loadLocale("en")
+})
+
+describe("BottomSheet", () => {
+  it("draws what it was given", async () => {
+    const { getByText } = renderSheet()
+
+    await waitFor(() => expect(getByText("content")).toBeTruthy())
+  })
+
+  it("holds the header above the scroll, so it stays put as the content moves", async () => {
+    const { getByTestId, getByText } = renderSheet({
+      header: <Text>title</Text>,
+      headerTestID: "sheet-header",
+    })
+
+    await waitFor(() => expect(getByText("title")).toBeTruthy())
+    // Inside the header region rather than loose among the children.
+    expect(getByTestId("sheet-header")).toBeTruthy()
+  })
+
+  it("renders nothing where the header would be when it has none", async () => {
+    const { queryByTestId, getByText } = renderSheet({ headerTestID: "sheet-header" })
+
+    await waitFor(() => expect(getByText("content")).toBeTruthy())
+    expect(queryByTestId("sheet-header")).toBeNull()
+  })
+
+  it("closes when the scrim behind it is pressed", async () => {
+    const onClose = jest.fn()
+    const { getByLabelText } = renderSheet({ onClose })
+
+    await waitFor(() => expect(getByLabelText("Close")).toBeTruthy())
+    fireEvent.press(getByLabelText("Close"))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("closes when it is dragged down past the dismiss distance", async () => {
+    const onClose = jest.fn()
+    const { getByTestId } = renderSheet({ onClose })
+
+    const sheet = await waitFor(() => getByTestId(SHEET_TEST_ID))
+
+    // Far enough down to be a dismissal rather than a resize, and released
+    // without any throw of its own so only the distance decides.
+    await act(async () => {
+      fireGestureHandler<PanGesture>(getByGestureTestId(PAN_TEST_ID), [
+        { translationY: 0, velocityY: 0 },
+        { translationY: 200, velocityY: 0 },
+        { state: 5, translationY: 200, velocityY: 0 },
+      ])
+    })
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    // And it left by sliding out rather than vanishing.
+    expect(getAnimatedStyle(sheet)).toMatchObject({
+      transform: [{ translateY: animatedHeightOf(sheet) }],
+    })
+  })
+
+  it("stays open when the drag is too short to be a dismissal", async () => {
+    const onClose = jest.fn()
+    renderSheet({ onClose })
+
+    await act(async () => {
+      fireGestureHandler<PanGesture>(getByGestureTestId(PAN_TEST_ID), [
+        { translationY: 0, velocityY: 0 },
+        { translationY: 20, velocityY: 0 },
+        { state: 5, translationY: 20, velocityY: 0 },
+      ])
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("rests at the header's bottom edge when it is asked to, not fully open", async () => {
+    const { getByTestId } = renderSheet({
+      restsOnHeader: true,
+      header: <Text>title</Text>,
+      headerTestID: "sheet-header",
+    })
+
+    const sheet = await waitFor(() => getByTestId(SHEET_TEST_ID))
+    const sheetHeight = animatedHeightOf(sheet)
+
+    // Until the header has been measured it stays off-screen rather than
+    // guessing where it should stop.
+    expect(getAnimatedStyle(sheet)).toMatchObject({
+      transform: [{ translateY: sheetHeight }],
+    })
+
+    await act(async () => {
+      fireEvent(getByTestId("sheet-header"), "layout", {
+        nativeEvent: { layout: { x: 0, y: 24, width: 300, height: 120 } },
+      })
+    })
+
+    // y + height, since the handle above the header is inside the window too.
+    await waitFor(() =>
+      expect(getAnimatedStyle(sheet)).toMatchObject({
+        transform: [{ translateY: sheetHeight - (24 + 120) }],
+      }),
+    )
+  })
+
+  it("opens fully when it has no header to rest on", async () => {
+    const { getByTestId } = renderSheet()
+
+    const sheet = await waitFor(() => getByTestId(SHEET_TEST_ID))
+    await waitFor(() =>
+      expect(getAnimatedStyle(sheet)).toMatchObject({ transform: [{ translateY: 0 }] }),
+    )
+  })
+
+  it("takes itself off the screen once it is no longer visible", async () => {
+    const { queryByText, getByText, rerender } = renderSheet()
+    await waitFor(() => expect(getByText("content")).toBeTruthy())
+
+    rerender(
+      <ContextForScreen>
+        <BottomSheet
+          testID={SHEET_TEST_ID}
+          isVisible={false}
+          onClose={jest.fn()}
+          heightRatio={0.6}
+        >
+          <View />
+        </BottomSheet>
+      </ContextForScreen>,
+    )
+
+    // The modal window closes with it, so the slide-out plays against a hidden
+    // window rather than on screen. That is how it behaved before the sheet was
+    // shared and is left alone here; see the PR notes.
+    await waitFor(() => expect(queryByText("content")).toBeNull())
+  })
+})

--- a/__tests__/components/bottom-sheet/bottom-sheet.spec.tsx
+++ b/__tests__/components/bottom-sheet/bottom-sheet.spec.tsx
@@ -7,7 +7,7 @@ import {
   getByGestureTestId,
 } from "react-native-gesture-handler/jest-utils"
 import type { PanGesture } from "react-native-gesture-handler"
-import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor, within } from "@testing-library/react-native"
 
 import { BOTTOM_OVERHANG, BottomSheet, PAN_TEST_ID } from "@app/components/bottom-sheet"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
@@ -178,5 +178,60 @@ describe("BottomSheet", () => {
     // window rather than on screen. That is how it behaved before the sheet was
     // shared and is left alone here; see the PR notes.
     await waitFor(() => expect(queryByText("content")).toBeNull())
+  })
+  it("holds a footer below the scroll, so a call to action stays on the sheet", async () => {
+    const { getByText, getByTestId } = renderSheet({
+      footer: <Text>Submit</Text>,
+      scrollTestID: "sheet-scroll",
+    })
+
+    await waitFor(() => expect(getByText("Submit")).toBeTruthy())
+    // Outside the scroll rather than at the end of it, so the content cannot
+    // push it off the sheet.
+    expect(within(getByTestId("sheet-scroll")).queryByText("Submit")).toBeNull()
+  })
+
+  describe("inline", () => {
+    it("puts up no scrim, so what it sits beside keeps its own touches", async () => {
+      const { getByText, queryByLabelText } = renderSheet({ presentation: "inline" })
+
+      await waitFor(() => expect(getByText("content")).toBeTruthy())
+      // The scrim is the only thing that presses to close, and it is what would
+      // be swallowing the panning of the map this sits beside.
+      expect(queryByLabelText("Close")).toBeNull()
+    })
+
+    it("is still dragged away the same way the modal one is", async () => {
+      const onClose = jest.fn()
+      renderSheet({ presentation: "inline", onClose })
+
+      await act(async () => {
+        fireGestureHandler<PanGesture>(getByGestureTestId(PAN_TEST_ID), [
+          { translationY: 0, velocityY: 0 },
+          { translationY: 200, velocityY: 0 },
+          { state: 5, translationY: 200, velocityY: 0 },
+        ])
+      })
+
+      await waitFor(() => expect(onClose).toHaveBeenCalled())
+    })
+
+    it("takes no height of its own, so its parent decides the split", async () => {
+      const { getByTestId } = renderSheet({ presentation: "inline" })
+
+      const sheet = await waitFor(() => getByTestId(SHEET_TEST_ID))
+      const style = StyleSheet.flatten(sheet.props.style)
+
+      // A `flex` share rather than a measured height: the map above it shrinks
+      // by exactly this, instead of being covered by it.
+      expect(style.height).toBeUndefined()
+      expect(style.flex).toBe(1)
+    })
+
+    it("draws nothing at all when it is not visible", async () => {
+      const { queryByText } = renderSheet({ presentation: "inline", isVisible: false })
+
+      await waitFor(() => expect(queryByText("content")).toBeNull())
+    })
   })
 })

--- a/__tests__/components/map-component/category-filter-sheet.spec.tsx
+++ b/__tests__/components/map-component/category-filter-sheet.spec.tsx
@@ -1,23 +1,28 @@
 import React from "react"
-import { View } from "react-native"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import {
+  fireGestureHandler,
+  getByGestureTestId,
+} from "react-native-gesture-handler/jest-utils"
+import type { PanGesture } from "react-native-gesture-handler"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 
 import { PLACE_CATEGORIES, PlaceCategory } from "@app/btcmap"
+import { PAN_TEST_ID } from "@app/components/bottom-sheet"
 import { CategoryFilterSheet } from "@app/components/map-component/category-filter-sheet"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { ContextForScreen } from "../../screens/helper"
 
 // The rows are `Switch`, whose animated style predates the explicit-dependency
-// convention and throws without the Babel plugin. Same stand-in as switch.spec.
-jest.mock("react-native-reanimated", () => ({
-  __esModule: true,
-  default: { View },
-  useSharedValue: (initial: number) => ({ value: initial }),
-  useAnimatedStyle: () => ({}),
-  withTiming: (value: number) => value,
-  interpolateColor: () => "transparent",
-}))
+// convention and throws without the Babel plugin. Only that one hook is stubbed
+// now: the sheet around them is `BottomSheet`, which reaches gesture-handler
+// through the rest of the real module, and replacing the whole of it wholesale
+// — as this did while the sheet was hand-rolled here — leaves gesture-handler
+// unable to build its animated wrapper.
+jest.mock("react-native-reanimated", () => {
+  const actual = jest.requireActual("react-native-reanimated")
+  return { __esModule: true, ...actual, useAnimatedStyle: () => ({}) }
+})
 
 jest.mock("react-native-safe-area-context", () => ({
   ...jest.requireActual("react-native-safe-area-context"),
@@ -100,5 +105,24 @@ describe("CategoryFilterSheet", () => {
     // Empty is "show everything", so this is the same map — arrived at without
     // fifteen presses.
     expect(onChange).toHaveBeenCalledWith(new Set())
+  })
+  it("can be thrown away, the same as the sheet a merchant opens", async () => {
+    // It could not before it shared their sheet: the filter was a partial copy
+    // that had left the gesture behind, so the only way out of it was the
+    // scrim.
+    const onClose = jest.fn()
+    const { getByTestId } = renderSheet({ onClose })
+
+    await waitFor(() => expect(getByTestId("category-restaurants")).toBeTruthy())
+
+    await act(async () => {
+      fireGestureHandler<PanGesture>(getByGestureTestId(PAN_TEST_ID), [
+        { translationY: 0, velocityY: 0 },
+        { translationY: 200, velocityY: 0 },
+        { state: 5, translationY: 200, velocityY: 0 },
+      ])
+    })
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
   })
 })

--- a/app/components/bottom-sheet/index.tsx
+++ b/app/components/bottom-sheet/index.tsx
@@ -64,7 +64,21 @@ type Props = {
    * the window. Short of the whole thing on every current caller: what the
    * sheet is about stays partly visible behind it.
    */
-  heightRatio: number
+  heightRatio?: number
+  /**
+   * How the sheet is put on the screen.
+   *
+   * `"modal"` is a sheet in the usual sense: its own window, a scrim, and every
+   * touch on the screen belonging to it until it is dismissed.
+   *
+   * `"inline"` draws the same sheet in the layout it is placed in, with no
+   * window and no scrim, so what it sits beside keeps its own touches. It fills
+   * the slot its parent gives it — a `flex` share rather than `heightRatio` —
+   * which is what lets the surface above it shrink by exactly the sheet's
+   * height instead of being covered by it. Everything else is unchanged, the
+   * spring and the dismiss distance included, so the two read as one component.
+   */
+  presentation?: "modal" | "inline"
   /**
    * Held above the scroll and below the handle, so it stays put while the
    * content moves under it.
@@ -81,6 +95,12 @@ type Props = {
   restsOnHeader?: boolean
   headerStyle?: StyleProp<ViewStyle>
   headerTestID?: string
+  /**
+   * Held below the scroll, so a call to action stays on the sheet rather than
+   * under whatever the content has pushed off it.
+   */
+  footer?: React.ReactNode
+  footerStyle?: StyleProp<ViewStyle>
   children: React.ReactNode
   contentContainerStyle?: StyleProp<ViewStyle>
   scrollTestID?: string
@@ -100,20 +120,24 @@ type Props = {
  * That component reaches for React Native's `Modal` for the same reason and
  * gives up drag-to-dismiss to do it; this is what it would use instead.
  *
- * Not for anything that has to leave what is behind it usable. A sheet is a
- * modal window and takes every touch on the screen, so a form that has to be
- * filled in while what is behind it is still being manipulated — the map's
- * add-place form, which is aimed and described at the same time — belongs
- * beside that surface rather than on one of these.
+ * A form that has to be filled in while what is behind it is still being
+ * worked — the map's add-place form, whose pin is aimed by panning the map
+ * above it as the fields are typed — wants `presentation="inline"`. It gets
+ * the same entry, the same drag-to-dismiss and the same spring, and gives up
+ * only the window and the scrim, which are the two things that would take the
+ * panning away.
  */
 export const BottomSheet: React.FC<Props> = ({
   isVisible,
   onClose,
   heightRatio,
+  presentation = "modal",
   header,
   restsOnHeader = false,
   headerStyle,
   headerTestID,
+  footer,
+  footerStyle,
   children,
   contentContainerStyle,
   scrollTestID,
@@ -123,7 +147,16 @@ export const BottomSheet: React.FC<Props> = ({
   const styles = useStyles()
   const { height: windowHeight } = useWindowDimensions()
 
-  const sheetHeight = Math.round(windowHeight * heightRatio)
+  const isInline = presentation === "inline"
+
+  // Inline the sheet is given its height by the layout rather than taking a
+  // share of the window, so it has to be measured. Until that lands the window
+  // stands in for it, which only ever makes the entry start further below the
+  // screen than it needs to — never on screen, which is what would be visible.
+  const [measuredHeight, setMeasuredHeight] = React.useState(0)
+  const sheetHeight = isInline
+    ? measuredHeight || windowHeight
+    : Math.round(windowHeight * (heightRatio ?? 1))
 
   // Offset from the sheet's own top: 0 is fully open, `sheetHeight` is off the
   // bottom of the screen.
@@ -252,6 +285,61 @@ export const BottomSheet: React.FC<Props> = ({
     [offset, restOffset, sheetHeight],
   )
 
+  const sheet = (
+    <GestureDetector gesture={pan}>
+      <Animated.View
+        style={[
+          styles.sheet,
+          isInline
+            ? styles.sheetInline
+            : { height: sheetHeight + BOTTOM_OVERHANG, marginBottom: -BOTTOM_OVERHANG },
+          sheetStyle,
+        ]}
+        onLayout={
+          isInline
+            ? (event) => setMeasuredHeight(event.nativeEvent.layout.height)
+            : undefined
+        }
+        testID={testID}
+      >
+        <View style={styles.handle} />
+
+        {header !== undefined && (
+          <View
+            testID={headerTestID}
+            style={headerStyle}
+            onLayout={(event) => {
+              if (!restsOnHeader) return
+              const { y, height } = event.nativeEvent.layout
+              setHeaderBottom(y + height)
+            }}
+          >
+            {header}
+          </View>
+        )}
+
+        <Animated.ScrollView
+          testID={scrollTestID}
+          ref={scrollRef}
+          style={styles.scroll}
+          contentContainerStyle={contentContainerStyle}
+          showsVerticalScrollIndicator={false}
+          // Below full height the sheet itself takes the drag; a list that
+          // cannot be seen has nothing to scroll.
+          scrollEnabled={restsOnHeader ? isExpanded : true}
+        >
+          {children}
+        </Animated.ScrollView>
+
+        {footer !== undefined && <View style={footerStyle}>{footer}</View>}
+      </Animated.View>
+    </GestureDetector>
+  )
+
+  // Inline there is no window to open and no scrim to press: the sheet is drawn
+  // where it was placed, and everything around it keeps its own touches.
+  if (isInline) return isVisible ? sheet : null
+
   return (
     <Modal visible={isVisible} transparent animationType="none" onRequestClose={onClose}>
       {/* Gestures inside a Modal need their own root on Android — the one in
@@ -266,41 +354,7 @@ export const BottomSheet: React.FC<Props> = ({
           />
         </Animated.View>
 
-        <GestureDetector gesture={pan}>
-          <Animated.View
-            style={[styles.sheet, { height: sheetHeight + BOTTOM_OVERHANG }, sheetStyle]}
-            testID={testID}
-          >
-            <View style={styles.handle} />
-
-            {header !== undefined && (
-              <View
-                testID={headerTestID}
-                style={headerStyle}
-                onLayout={(event) => {
-                  if (!restsOnHeader) return
-                  const { y, height } = event.nativeEvent.layout
-                  setHeaderBottom(y + height)
-                }}
-              >
-                {header}
-              </View>
-            )}
-
-            <Animated.ScrollView
-              testID={scrollTestID}
-              ref={scrollRef}
-              style={styles.scroll}
-              contentContainerStyle={contentContainerStyle}
-              showsVerticalScrollIndicator={false}
-              // Below full height the sheet itself takes the drag; a list that
-              // cannot be seen has nothing to scroll.
-              scrollEnabled={restsOnHeader ? isExpanded : true}
-            >
-              {children}
-            </Animated.ScrollView>
-          </Animated.View>
-        </GestureDetector>
+        {sheet}
       </GestureHandlerRootView>
     </Modal>
   )
@@ -330,8 +384,11 @@ const useStyles = makeStyles(({ colors }) => ({
     borderBottomWidth: 0,
     borderColor: colors.grey4,
     paddingTop: 8,
-    // Cancels the extra height above, so only the seam moves off-screen.
-    marginBottom: -BOTTOM_OVERHANG,
+  },
+  // Fills the slot the layout gives it, so the surface above shrinks by exactly
+  // this sheet's height rather than being covered by it.
+  sheetInline: {
+    flex: 1,
   },
   handle: {
     alignSelf: "center",

--- a/app/components/bottom-sheet/index.tsx
+++ b/app/components/bottom-sheet/index.tsx
@@ -1,0 +1,347 @@
+import React from "react"
+import {
+  Modal,
+  Pressable,
+  StyleProp,
+  View,
+  ViewStyle,
+  useWindowDimensions,
+} from "react-native"
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from "react-native-gesture-handler"
+import Animated, {
+  Extrapolation,
+  interpolate,
+  runOnJS,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useScrollViewOffset,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated"
+
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { makeStyles } from "@rn-vui/themed"
+
+// A scrim has to darken in both themes; the theme's backdrop tokens invert and
+// would brighten whatever is behind the sheet in dark mode. This is the one
+// definition of it — see `category-filter-sheet` and `place-sheet`, which each
+// used to declare their own copy.
+const SCRIM_COLOR = "rgba(0, 0, 0, 0.4)"
+
+// Dragged this much further down than the snap point it started from, the sheet
+// is being dismissed rather than resized.
+const DISMISS_DISTANCE = 80
+
+// Where a flick would end up, so a fast short drag still snaps the way it was
+// thrown rather than the way it happens to have stopped.
+const VELOCITY_PROJECTION = 0.15
+
+const SPRING = { damping: 20, stiffness: 220, mass: 0.6 }
+const CLOSE_DURATION_MS = 200
+
+// The sheet's outer shape is a rounded path, so Android antialiases every edge
+// of it — including the straight bottom one. The top and sides hide that under
+// their 1px border; the bottom has no border to hide it under, and the half-lit
+// pixel that is left reads as a hairline of scrim between the sheet and the
+// screen. The sheet has no bottom edge worth showing anyway — it rests on the
+// screen's — so it is drawn this much taller and pulled down by the same
+// amount, which puts the seam off-screen without moving anything that is on it.
+export const BOTTOM_OVERHANG = 1
+
+/** @see `bottom-sheet.spec` — the drag is only reachable from a test by name. */
+export const PAN_TEST_ID = "bottom-sheet-pan"
+
+type Props = {
+  isVisible: boolean
+  onClose: () => void
+  /**
+   * How much of the screen the sheet covers once fully open, as a fraction of
+   * the window. Short of the whole thing on every current caller: what the
+   * sheet is about stays partly visible behind it.
+   */
+  heightRatio: number
+  /**
+   * Held above the scroll and below the handle, so it stays put while the
+   * content moves under it.
+   */
+  header?: React.ReactNode
+  /**
+   * Rest at the header's measured bottom edge rather than fully open, so
+   * whatever the header turns out to be is exactly what shows when the sheet
+   * arrives. Dragging up rests it at full height.
+   *
+   * Without it the sheet has one resting position, fully open, and the header
+   * is simply a region that does not scroll.
+   */
+  restsOnHeader?: boolean
+  headerStyle?: StyleProp<ViewStyle>
+  headerTestID?: string
+  children: React.ReactNode
+  contentContainerStyle?: StyleProp<ViewStyle>
+  scrollTestID?: string
+  testID?: string
+}
+
+/**
+ * A sheet that rises from the bottom of the screen over what it is about.
+ *
+ * It owns the parts every bottom sheet in the app needs and none of them should
+ * be spelling out for itself: the modal window and the gesture root Android
+ * needs inside one, the scrim and its press-to-close, the pull handle, the
+ * drag-to-dismiss, and the surface tokens.
+ *
+ * Built here rather than taken from `@gorhom/bottom-sheet`, which is broken on
+ * this stack — see the note in `amount-input-modal.tsx` for the issue links.
+ * That component reaches for React Native's `Modal` for the same reason and
+ * gives up drag-to-dismiss to do it; this is what it would use instead.
+ *
+ * Not for anything that has to leave what is behind it usable. A sheet is a
+ * modal window and takes every touch on the screen, so a form that has to be
+ * filled in while what is behind it is still being manipulated — the map's
+ * add-place form, which is aimed and described at the same time — belongs
+ * beside that surface rather than on one of these.
+ */
+export const BottomSheet: React.FC<Props> = ({
+  isVisible,
+  onClose,
+  heightRatio,
+  header,
+  restsOnHeader = false,
+  headerStyle,
+  headerTestID,
+  children,
+  contentContainerStyle,
+  scrollTestID,
+  testID,
+}) => {
+  const { LL } = useI18nContext()
+  const styles = useStyles()
+  const { height: windowHeight } = useWindowDimensions()
+
+  const sheetHeight = Math.round(windowHeight * heightRatio)
+
+  // Offset from the sheet's own top: 0 is fully open, `sheetHeight` is off the
+  // bottom of the screen.
+  const offset = useSharedValue(sheetHeight)
+  const dragStart = useSharedValue(0)
+  // The resting offset, once it has been measured. Until then the sheet stays
+  // off-screen rather than guessing.
+  const restOffset = useSharedValue(restsOnHeader ? sheetHeight : 0)
+  // The header's bottom edge within the sheet (y + height), not its bare
+  // height: the border, padding, and handle above it sit inside the visible
+  // window too, and counting only the height clips their worth off the last row
+  // the header shows.
+  const [headerBottom, setHeaderBottom] = React.useState(0)
+  const [isExpanded, setExpanded] = React.useState(false)
+
+  const scrollRef = useAnimatedRef<Animated.ScrollView>()
+  // Read straight off the scroll view, so the pan can tell a drag on a list
+  // that is already at its top from one that is scrolling it back up.
+  const scrollOffset = useScrollViewOffset(scrollRef)
+
+  // Exactly the measured bottom edge. A caller clears the home indicator with
+  // padding inside its header instead, so the strip above it belongs to the
+  // header: resting any higher than this uncovers the top of the row behind it,
+  // and a row sliced through its glyphs reads as a rendering fault.
+  const restingOffset = restsOnHeader
+    ? headerBottom
+      ? Math.max(0, sheetHeight - headerBottom)
+      : sheetHeight
+    : 0
+
+  React.useEffect(() => {
+    restOffset.value = restingOffset
+  }, [restingOffset, restOffset])
+
+  // Reopening always starts low again, however it was left last time.
+  React.useEffect(() => {
+    if (isVisible) setExpanded(false)
+  }, [isVisible])
+
+  React.useEffect(() => {
+    if (!isVisible) {
+      offset.value = withTiming(sheetHeight, { duration: CLOSE_DURATION_MS })
+      return
+    }
+    // Follow the measurement only while resting low. A header can grow after
+    // the sheet has arrived — details landing on it — and a sheet the user has
+    // already pulled up must not drop back down under them when that happens.
+    if (!restsOnHeader || (headerBottom && !isExpanded)) {
+      offset.value = withSpring(restingOffset, SPRING)
+    }
+  }, [
+    isVisible,
+    headerBottom,
+    restingOffset,
+    sheetHeight,
+    isExpanded,
+    offset,
+    restsOnHeader,
+  ])
+
+  const pan = React.useMemo(
+    () =>
+      Gesture.Pan()
+        // Named so the drag can be driven from a test — there is no other way
+        // to reach a gesture handler from one.
+        .withTestId(PAN_TEST_ID)
+        // Small movements belong to whatever is underneath — a tap on a link
+        // should not have to be perfectly still.
+        .activeOffsetY([-12, 12])
+        // So a downward drag at the top of the list can collapse the sheet
+        // instead of the scroll view swallowing it. The cast is a types-only
+        // gap: gesture-handler declares a ref to a component *type* here, and
+        // reads the instance the animated ref actually holds.
+        .simultaneousWithExternalGesture(
+          scrollRef as unknown as React.RefObject<React.ComponentType>,
+        )
+        .onBegin(() => {
+          dragStart.value = offset.value
+        })
+        .onUpdate((event) => {
+          // Fully open with the list scrolled down, a downward drag is the list
+          // being scrolled back up, not the sheet being pulled shut.
+          if (dragStart.value === 0 && scrollOffset.value > 0 && event.translationY > 0) {
+            return
+          }
+          offset.value = Math.max(0, dragStart.value + event.translationY)
+        })
+        .onEnd((event) => {
+          const projected = offset.value + event.velocityY * VELOCITY_PROJECTION
+
+          if (projected > restOffset.value + DISMISS_DISTANCE) {
+            offset.value = withTiming(
+              sheetHeight,
+              { duration: CLOSE_DURATION_MS },
+              (finished) => {
+                if (finished) runOnJS(onClose)()
+              },
+            )
+            return
+          }
+
+          const toFull = projected < restOffset.value / 2
+          offset.value = withSpring(toFull ? 0 : restOffset.value, SPRING)
+          runOnJS(setExpanded)(toFull)
+        }),
+    [dragStart, offset, restOffset, scrollOffset, scrollRef, sheetHeight, onClose],
+  )
+
+  // Dependency arrays are passed explicitly rather than left to the Babel
+  // plugin to infer, so these still work where it is not applied — the test
+  // environment among them.
+  const sheetStyle = useAnimatedStyle(
+    () => ({ transform: [{ translateY: offset.value }] }),
+    [offset],
+  )
+
+  const backdropStyle = useAnimatedStyle(
+    () => ({
+      opacity: interpolate(
+        offset.value,
+        [sheetHeight, restOffset.value],
+        [0, 1],
+        Extrapolation.CLAMP,
+      ),
+    }),
+    [offset, restOffset, sheetHeight],
+  )
+
+  return (
+    <Modal visible={isVisible} transparent animationType="none" onRequestClose={onClose}>
+      {/* Gestures inside a Modal need their own root on Android — the one in
+          app.tsx does not reach into a separate window. */}
+      <GestureHandlerRootView style={styles.root}>
+        <Animated.View style={[styles.backdrop, backdropStyle]}>
+          <Pressable
+            style={styles.backdropPress}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel={LL.common.close()}
+          />
+        </Animated.View>
+
+        <GestureDetector gesture={pan}>
+          <Animated.View
+            style={[styles.sheet, { height: sheetHeight + BOTTOM_OVERHANG }, sheetStyle]}
+            testID={testID}
+          >
+            <View style={styles.handle} />
+
+            {header !== undefined && (
+              <View
+                testID={headerTestID}
+                style={headerStyle}
+                onLayout={(event) => {
+                  if (!restsOnHeader) return
+                  const { y, height } = event.nativeEvent.layout
+                  setHeaderBottom(y + height)
+                }}
+              >
+                {header}
+              </View>
+            )}
+
+            <Animated.ScrollView
+              testID={scrollTestID}
+              ref={scrollRef}
+              style={styles.scroll}
+              contentContainerStyle={contentContainerStyle}
+              showsVerticalScrollIndicator={false}
+              // Below full height the sheet itself takes the drag; a list that
+              // cannot be seen has nothing to scroll.
+              scrollEnabled={restsOnHeader ? isExpanded : true}
+            >
+              {children}
+            </Animated.ScrollView>
+          </Animated.View>
+        </GestureDetector>
+      </GestureHandlerRootView>
+    </Modal>
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  root: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: SCRIM_COLOR,
+  },
+  backdropPress: {
+    flex: 1,
+  },
+  sheet: {
+    backgroundColor: colors.white,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    borderColor: colors.grey4,
+    paddingTop: 8,
+    // Cancels the extra height above, so only the seam moves off-screen.
+    marginBottom: -BOTTOM_OVERHANG,
+  },
+  handle: {
+    alignSelf: "center",
+    width: 26,
+    height: 3,
+    borderRadius: 999,
+    backgroundColor: colors.grey3,
+    marginBottom: 8,
+  },
+  scroll: {
+    flex: 1,
+  },
+}))

--- a/app/components/map-component/category-filter-sheet.tsx
+++ b/app/components/map-component/category-filter-sheet.tsx
@@ -1,19 +1,12 @@
 import React from "react"
-import { Modal, Pressable, ScrollView, View, useWindowDimensions } from "react-native"
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from "react-native-reanimated"
+import { Pressable, View } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import { PLACE_CATEGORIES, PlaceCategory } from "@app/btcmap"
 import { Switch } from "@app/components/atomic/switch"
+import { BottomSheet } from "@app/components/bottom-sheet"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { Text, makeStyles } from "@rn-vui/themed"
-
-const SCRIM_COLOR = "rgba(0, 0, 0, 0.4)"
-const SLIDE_DURATION_MS = 220
 
 // Tall enough that the list reads as a list, short enough that the map it is
 // filtering stays visible behind it.
@@ -33,6 +26,9 @@ type Props = {
  * `placesInCategories`. That is what makes "clear all" a way back to the whole
  * map instead of a way to empty it, and it is why the sheet opens with every
  * toggle off rather than every toggle on.
+ *
+ * One resting position: the list is the whole point of it, so there is nothing
+ * a peek would usefully show short of it.
  */
 export const CategoryFilterSheet: React.FC<Props> = ({
   isVisible,
@@ -42,25 +38,7 @@ export const CategoryFilterSheet: React.FC<Props> = ({
 }) => {
   const { LL } = useI18nContext()
   const insets = useSafeAreaInsets()
-  const { height: windowHeight } = useWindowDimensions()
   const styles = useStyles({ bottomInset: insets.bottom })
-
-  const sheetHeight = Math.round(windowHeight * SHEET_RATIO)
-  const offset = useSharedValue(sheetHeight)
-
-  React.useEffect(() => {
-    offset.value = withTiming(isVisible ? 0 : sheetHeight, {
-      duration: SLIDE_DURATION_MS,
-    })
-  }, [isVisible, sheetHeight, offset])
-
-  // The dependency array is passed explicitly rather than left to the Babel
-  // plugin to infer, so this still works where it is not applied — the test
-  // environment among them.
-  const sheetStyle = useAnimatedStyle(
-    () => ({ transform: [{ translateY: offset.value }] }),
-    [offset],
-  )
 
   const toggle = (category: PlaceCategory) => {
     const next = new Set(selected)
@@ -71,89 +49,47 @@ export const CategoryFilterSheet: React.FC<Props> = ({
   const areAllSelected = selected.size === PLACE_CATEGORIES.length
 
   return (
-    <Modal visible={isVisible} transparent animationType="fade" onRequestClose={onClose}>
-      <View style={styles.root}>
-        <Pressable
-          style={styles.backdrop}
-          onPress={onClose}
-          accessibilityRole="button"
-          accessibilityLabel={LL.common.close()}
-        />
-
-        <Animated.View
-          testID="category-filter-sheet"
-          style={[styles.sheet, { height: sheetHeight }, sheetStyle]}
-        >
-          <View style={styles.handle} />
-
-          <View style={styles.header}>
-            <Text style={styles.title}>{LL.MapScreen.categories()}</Text>
-            <Pressable
-              testID="toggle-all-categories"
-              onPress={() =>
-                onChange(areAllSelected ? new Set() : new Set(PLACE_CATEGORIES))
-              }
-              accessibilityRole="button"
-              hitSlop={8}
-            >
-              <Text style={styles.action}>
-                {areAllSelected ? LL.MapScreen.clearAll() : LL.MapScreen.selectAll()}
-              </Text>
-            </Pressable>
-          </View>
-
-          <ScrollView
-            style={styles.list}
-            contentContainerStyle={styles.listContent}
-            showsVerticalScrollIndicator={false}
+    <BottomSheet
+      testID="category-filter-sheet"
+      isVisible={isVisible}
+      onClose={onClose}
+      heightRatio={SHEET_RATIO}
+      headerStyle={styles.header}
+      contentContainerStyle={styles.listContent}
+      header={
+        <>
+          <Text style={styles.title}>{LL.MapScreen.categories()}</Text>
+          <Pressable
+            testID="toggle-all-categories"
+            onPress={() =>
+              onChange(areAllSelected ? new Set() : new Set(PLACE_CATEGORIES))
+            }
+            accessibilityRole="button"
+            hitSlop={8}
           >
-            {PLACE_CATEGORIES.map((category) => (
-              <View key={category} style={styles.row}>
-                <Text style={styles.rowLabel}>{LL.MapScreen.category[category]()}</Text>
-                <Switch
-                  testID={`category-${category}`}
-                  accessibilityLabel={LL.MapScreen.category[category]()}
-                  value={selected.has(category)}
-                  onValueChange={() => toggle(category)}
-                />
-              </View>
-            ))}
-          </ScrollView>
-        </Animated.View>
-      </View>
-    </Modal>
+            <Text style={styles.action}>
+              {areAllSelected ? LL.MapScreen.clearAll() : LL.MapScreen.selectAll()}
+            </Text>
+          </Pressable>
+        </>
+      }
+    >
+      {PLACE_CATEGORIES.map((category) => (
+        <View key={category} style={styles.row}>
+          <Text style={styles.rowLabel}>{LL.MapScreen.category[category]()}</Text>
+          <Switch
+            testID={`category-${category}`}
+            accessibilityLabel={LL.MapScreen.category[category]()}
+            value={selected.has(category)}
+            onValueChange={() => toggle(category)}
+          />
+        </View>
+      ))}
+    </BottomSheet>
   )
 }
 
 const useStyles = makeStyles(({ colors }, { bottomInset }: { bottomInset: number }) => ({
-  root: {
-    flex: 1,
-    justifyContent: "flex-end",
-  },
-  backdrop: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    // A scrim has to darken in both themes; the theme's backdrop tokens invert
-    // and would brighten the map behind the sheet in dark mode.
-    backgroundColor: SCRIM_COLOR,
-  },
-  sheet: {
-    backgroundColor: colors.white,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    paddingTop: 8,
-  },
-  handle: {
-    alignSelf: "center",
-    width: 40,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: colors.grey3,
-    marginBottom: 8,
-  },
   header: {
     flexDirection: "row",
     alignItems: "center",
@@ -170,9 +106,6 @@ const useStyles = makeStyles(({ colors }, { bottomInset }: { bottomInset: number
     fontSize: 15,
     fontWeight: "700",
     color: colors.primary,
-  },
-  list: {
-    flex: 1,
   },
   listContent: {
     paddingHorizontal: 20,

--- a/app/components/map-component/place-sheet.tsx
+++ b/app/components/map-component/place-sheet.tsx
@@ -1,29 +1,5 @@
 import React from "react"
-import {
-  Linking,
-  Modal,
-  Platform,
-  Pressable,
-  Share,
-  View,
-  useWindowDimensions,
-} from "react-native"
-import {
-  Gesture,
-  GestureDetector,
-  GestureHandlerRootView,
-} from "react-native-gesture-handler"
-import Animated, {
-  Extrapolation,
-  interpolate,
-  runOnJS,
-  useAnimatedRef,
-  useAnimatedStyle,
-  useScrollViewOffset,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from "react-native-reanimated"
+import { Linking, Platform, Pressable, Share, View } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 import {
@@ -52,6 +28,7 @@ import { GaloyIcon, IconNamesType } from "@app/components/atomic/galoy-icon"
 import { GaloyInfo } from "@app/components/atomic/galoy-info"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { GaloySecondaryButton } from "@app/components/atomic/galoy-secondary-button"
+import { BottomSheet } from "@app/components/bottom-sheet"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { recordAppError, toError } from "@app/utils/error-reporting"
 import { openExternalUrl } from "@app/utils/external"
@@ -59,32 +36,11 @@ import { toastShow } from "@app/utils/toast"
 import { Skeleton, Text, makeStyles, useTheme } from "@rn-vui/themed"
 
 const REFRESH_INTERVAL_MS = 60_000
-const SCRIM_COLOR = "rgba(0, 0, 0, 0.4)"
 
 // How much of the screen the sheet covers once fully open. Short of the whole
 // thing on purpose: the pin stays visible, so it is still clear which place is
 // being read about.
 const SHEET_RATIO = 0.88
-
-// Dragged this much further down than the snap point it started from, the sheet
-// is being dismissed rather than resized.
-const DISMISS_DISTANCE = 80
-
-// Where a flick would end up, so a fast short drag still snaps the way it was
-// thrown rather than the way it happens to have stopped.
-const VELOCITY_PROJECTION = 0.15
-
-const SPRING = { damping: 20, stiffness: 220, mass: 0.6 }
-const CLOSE_DURATION_MS = 200
-
-// The sheet's outer shape is a rounded path, so Android antialiases every edge
-// of it — including the straight bottom one. The top and sides hide that under
-// their 1px border; the bottom has no border to hide it under, and the half-lit
-// pixel that is left reads as a hairline of scrim between the sheet and the
-// screen. The sheet has no bottom edge worth showing anyway — it rests on the
-// screen's — so it is drawn this much taller and pulled down by the same
-// amount, which puts the seam off-screen without moving anything that is on it.
-const BOTTOM_OVERHANG = 1
 
 // Brand names, so they stay untranslated. They are also what the ODbL credit is
 // split on below, to find the two spans that should be drawn as links.
@@ -133,10 +89,6 @@ export const PlaceSheet: React.FC<Props> = ({ place, userLocation, onClose }) =>
   } = useTheme()
   const { LL, locale } = useI18nContext()
   const insets = useSafeAreaInsets()
-  const { height: windowHeight } = useWindowDimensions()
-
-  const sheetHeight = Math.round(windowHeight * SHEET_RATIO)
-
   // Hold on to what was last opened so the sheet still has something to draw
   // while it slides back out; `place` goes null the moment it is dismissed.
   const shownRef = React.useRef<BtcMapPlace | null>(null)
@@ -162,8 +114,6 @@ export const PlaceSheet: React.FC<Props> = ({ place, userLocation, onClose }) =>
   React.useEffect(() => {
     if (!place) return
     setNow(new Date())
-    // Reopening always starts low again, however it was left last time.
-    setExpanded(false)
   }, [place])
 
   // Then keep re-reading it while the sheet is open, so a place that opens or
@@ -175,113 +125,6 @@ export const PlaceSheet: React.FC<Props> = ({ place, userLocation, onClose }) =>
     const timer = setInterval(() => setNow(new Date()), REFRESH_INTERVAL_MS)
     return () => clearInterval(timer)
   }, [place, isTimeSensitive])
-
-  // Offset from the sheet's own top: 0 is fully open, `sheetHeight` is off the
-  // bottom of the screen.
-  const offset = useSharedValue(sheetHeight)
-  const dragStart = useSharedValue(0)
-  // The resting offset that leaves the header block showing, once it has been
-  // measured. Until then the sheet stays off-screen rather than guessing.
-  const peekOffset = useSharedValue(sheetHeight)
-  // The peek's bottom edge within the sheet (y + height), not its bare height:
-  // the border, padding, and handle above it sit inside the visible window too,
-  // and counting only the height clipped their worth off the peek's last row.
-  const [peekBottom, setPeekBottom] = React.useState(0)
-  const [isExpanded, setExpanded] = React.useState(false)
-
-  const scrollRef = useAnimatedRef<Animated.ScrollView>()
-  // Read straight off the scroll view, so the pan can tell a drag on a list
-  // that is already at its top from one that is scrolling it back up.
-  const scrollOffset = useScrollViewOffset(scrollRef)
-
-  // Exactly the measured bottom edge. The home indicator is cleared by padding
-  // inside the peek instead (see `peek` below), so the strip above it belongs to
-  // the peek: resting any higher than this uncovers the top of the row behind
-  // it, and a row sliced through its glyphs reads as a rendering fault.
-  const restingOffset = peekBottom ? Math.max(0, sheetHeight - peekBottom) : sheetHeight
-
-  React.useEffect(() => {
-    peekOffset.value = restingOffset
-  }, [restingOffset, peekOffset])
-
-  React.useEffect(() => {
-    if (!place) {
-      offset.value = withTiming(sheetHeight, { duration: CLOSE_DURATION_MS })
-      return
-    }
-    // Follow the measurement only while resting low. The header block grows
-    // once the details land — a place that can only be paid through another app
-    // gains a whole card — and a sheet the user has already pulled up must not
-    // drop back down under them when that happens.
-    if (peekBottom && !isExpanded) {
-      offset.value = withSpring(restingOffset, SPRING)
-    }
-  }, [place, peekBottom, restingOffset, sheetHeight, isExpanded, offset])
-
-  const pan = React.useMemo(
-    () =>
-      Gesture.Pan()
-        // Small movements belong to whatever is underneath — a tap on a link
-        // should not have to be perfectly still.
-        .activeOffsetY([-12, 12])
-        // So a downward drag at the top of the list can collapse the sheet
-        // instead of the scroll view swallowing it. The cast is a types-only
-        // gap: gesture-handler declares a ref to a component *type* here, and
-        // reads the instance the animated ref actually holds.
-        .simultaneousWithExternalGesture(
-          scrollRef as unknown as React.RefObject<React.ComponentType>,
-        )
-        .onBegin(() => {
-          dragStart.value = offset.value
-        })
-        .onUpdate((event) => {
-          // Fully open with the list scrolled down, a downward drag is the list
-          // being scrolled back up, not the sheet being pulled shut.
-          if (dragStart.value === 0 && scrollOffset.value > 0 && event.translationY > 0) {
-            return
-          }
-          offset.value = Math.max(0, dragStart.value + event.translationY)
-        })
-        .onEnd((event) => {
-          const projected = offset.value + event.velocityY * VELOCITY_PROJECTION
-
-          if (projected > peekOffset.value + DISMISS_DISTANCE) {
-            offset.value = withTiming(
-              sheetHeight,
-              { duration: CLOSE_DURATION_MS },
-              (finished) => {
-                if (finished) runOnJS(onClose)()
-              },
-            )
-            return
-          }
-
-          const toFull = projected < peekOffset.value / 2
-          offset.value = withSpring(toFull ? 0 : peekOffset.value, SPRING)
-          runOnJS(setExpanded)(toFull)
-        }),
-    [dragStart, offset, peekOffset, scrollOffset, scrollRef, sheetHeight, onClose],
-  )
-
-  // Dependency arrays are passed explicitly rather than left to the Babel
-  // plugin to infer, so these still work where it is not applied — the test
-  // environment among them.
-  const sheetStyle = useAnimatedStyle(
-    () => ({ transform: [{ translateY: offset.value }] }),
-    [offset],
-  )
-
-  const backdropStyle = useAnimatedStyle(
-    () => ({
-      opacity: interpolate(
-        offset.value,
-        [sheetHeight, peekOffset.value],
-        [0, 1],
-        Extrapolation.CLAMP,
-      ),
-    }),
-    [offset, peekOffset, sheetHeight],
-  )
 
   const boosted = isBoosted(details?.boostedUntil ?? shown?.boostedUntil, now)
   const styles = useStyles({ bottomInset: insets.bottom })
@@ -366,280 +209,206 @@ export const PlaceSheet: React.FC<Props> = ({ place, userLocation, onClose }) =>
   }[verification]()
 
   return (
-    <Modal
-      visible={Boolean(place)}
-      transparent
-      animationType="none"
-      onRequestClose={onClose}
-    >
-      {/* Gestures inside a Modal need their own root on Android — the one in
-          app.tsx does not reach into a separate window. */}
-      <GestureHandlerRootView style={styles.root}>
-        <Animated.View style={[styles.backdrop, backdropStyle]}>
-          <Pressable
-            style={styles.backdropPress}
-            onPress={onClose}
-            accessibilityRole="button"
-            accessibilityLabel={LL.common.close()}
-          />
-        </Animated.View>
+    <BottomSheet
+      testID="place-sheet"
+      headerTestID="place-sheet-peek"
+      scrollTestID="place-sheet-scroll"
+      isVisible={Boolean(place)}
+      onClose={onClose}
+      heightRatio={SHEET_RATIO}
+      restsOnHeader
+      headerStyle={styles.peek}
+      contentContainerStyle={styles.scrollContent}
+      /* What the lower resting position shows. Its measured bottom edge sets
+         the snap point, so this block decides where the sheet stops. */
+      header={
+        <>
+          <View style={styles.header}>
+            {isLoading && !details ? (
+              <Skeleton animation="pulse" style={styles.nameSkeleton} />
+            ) : (
+              <Text style={styles.name} numberOfLines={2}>
+                {name || LL.MapScreen.unnamedPlace()}
+              </Text>
+            )}
 
-        <GestureDetector gesture={pan}>
-          <Animated.View
-            style={[styles.sheet, { height: sheetHeight + BOTTOM_OVERHANG }, sheetStyle]}
-            testID="place-sheet"
-          >
-            <View style={styles.handle} />
-
-            {/* What the lower resting position shows. Its measured bottom edge
-                sets the snap point, so this block decides where the sheet
-                stops. */}
-            <View
-              testID="place-sheet-peek"
-              style={styles.peek}
-              onLayout={(event) =>
-                setPeekBottom(
-                  event.nativeEvent.layout.y + event.nativeEvent.layout.height,
-                )
-              }
+            <Pressable
+              testID="share-place"
+              onPress={share}
+              accessibilityRole="button"
+              accessibilityLabel={LL.common.share()}
+              hitSlop={12}
             >
-              <View style={styles.header}>
-                {isLoading && !details ? (
-                  <Skeleton animation="pulse" style={styles.nameSkeleton} />
-                ) : (
-                  <Text style={styles.name} numberOfLines={2}>
-                    {name || LL.MapScreen.unnamedPlace()}
-                  </Text>
-                )}
+              <GaloyIcon name="share" size={22} color={colors.primary} />
+            </Pressable>
+          </View>
 
-                <Pressable
-                  testID="share-place"
-                  onPress={share}
-                  accessibilityRole="button"
-                  accessibilityLabel={LL.common.share()}
-                  hitSlop={12}
-                >
-                  <GaloyIcon name="share" size={22} color={colors.primary} />
-                </Pressable>
-              </View>
+          <GaloyPrimaryButton title={LL.MapScreen.navigate()} onPress={navigate} />
 
-              <GaloyPrimaryButton title={LL.MapScreen.navigate()} onPress={navigate} />
-
-              {/* Sits with the header rather than down among the contact rows:
+          {/* Sits with the header rather than down among the contact rows:
                   "you cannot pay here with this wallet" is worth knowing before
                   setting off, so it has to be visible without expanding. */}
-              {Boolean(appUrl) && (
-                <View testID="requires-app-card">
-                  <GaloyInfo>
-                    {LL.MapScreen.requiresApp()}
-                    {"\n"}
-                    {/* The scheme is noise here — what is worth reading is
+          {Boolean(appUrl) && (
+            <View testID="requires-app-card">
+              <GaloyInfo>
+                {LL.MapScreen.requiresApp()}
+                {"\n"}
+                {/* The scheme is noise here — what is worth reading is
                         where it goes, path and all. */}
-                    <Text
-                      type="p3"
-                      style={styles.requiresAppLink}
-                      onPress={() => openUrl(appUrl ?? "")}
-                      accessibilityRole="link"
-                    >
-                      {(appUrl ?? "").replace(/^https?:\/\//i, "")}
-                    </Text>
-                  </GaloyInfo>
-                </View>
-              )}
+                <Text
+                  type="p3"
+                  style={styles.requiresAppLink}
+                  onPress={() => openUrl(appUrl ?? "")}
+                  accessibilityRole="link"
+                >
+                  {(appUrl ?? "").replace(/^https?:\/\//i, "")}
+                </Text>
+              </GaloyInfo>
+            </View>
+          )}
 
-              <View style={styles.status}>
-                {openingState !== OpeningState.Unknown && (
-                  <View style={styles.badge}>
-                    <Text
-                      style={
-                        openingState === OpeningState.Open
-                          ? styles.badgeOpen
-                          : styles.badgeClosed
-                      }
-                    >
-                      {openingState === OpeningState.Open
-                        ? LL.MapScreen.openNow()
-                        : LL.MapScreen.closedNow()}
-                    </Text>
-                  </View>
-                )}
-                {boosted && (
-                  <View style={styles.badge}>
-                    <Text style={styles.badgeBoosted}>{LL.MapScreen.boosted()}</Text>
-                  </View>
-                )}
-                {Boolean(details) && (
-                  <View style={styles.verification}>
-                    <GaloyIcon
-                      name={
-                        verification === VerificationState.Verified
-                          ? "check-circle"
-                          : "warning"
-                      }
-                      size={14}
-                      color={
-                        verification === VerificationState.Verified
-                          ? colors._green
-                          : colors.grey2
-                      }
-                    />
-                    <Text style={styles.verificationText}>{verificationLabel}</Text>
-                  </View>
-                )}
+          <View style={styles.status}>
+            {openingState !== OpeningState.Unknown && (
+              <View style={styles.badge}>
+                <Text
+                  style={
+                    openingState === OpeningState.Open
+                      ? styles.badgeOpen
+                      : styles.badgeClosed
+                  }
+                >
+                  {openingState === OpeningState.Open
+                    ? LL.MapScreen.openNow()
+                    : LL.MapScreen.closedNow()}
+                </Text>
               </View>
+            )}
+            {boosted && (
+              <View style={styles.badge}>
+                <Text style={styles.badgeBoosted}>{LL.MapScreen.boosted()}</Text>
+              </View>
+            )}
+            {Boolean(details) && (
+              <View style={styles.verification}>
+                <GaloyIcon
+                  name={
+                    verification === VerificationState.Verified
+                      ? "check-circle"
+                      : "warning"
+                  }
+                  size={14}
+                  color={
+                    verification === VerificationState.Verified
+                      ? colors._green
+                      : colors.grey2
+                  }
+                />
+                <Text style={styles.verificationText}>{verificationLabel}</Text>
+              </View>
+            )}
+          </View>
 
-              {/* Where the place is and when it is open, under the status row as
+          {/* Where the place is and when it is open, under the status row as
                   the design has them: both are read on the way to deciding
                   whether to set off, so neither is worth a drag to reach. */}
-              {Boolean(details?.address) && (
-                <Text style={styles.peekFact}>{details?.address}</Text>
-              )}
-              {Boolean(details?.openingHours) && (
-                <Text style={styles.peekFact}>{details?.openingHours}</Text>
-              )}
-            </View>
+          {Boolean(details?.address) && (
+            <Text style={styles.peekFact}>{details?.address}</Text>
+          )}
+          {Boolean(details?.openingHours) && (
+            <Text style={styles.peekFact}>{details?.openingHours}</Text>
+          )}
+        </>
+      }
+    >
+      {hasError && (
+        <Pressable style={styles.errorRow} onPress={retry}>
+          <GaloyIcon name="warning" size={16} color={colors.error} />
+          <Text style={styles.errorText}>{LL.MapScreen.detailsError()}</Text>
+          <Text style={styles.retryText}>{LL.common.tryAgain()}</Text>
+        </Pressable>
+      )}
 
-            <Animated.ScrollView
-              testID="place-sheet-scroll"
-              ref={scrollRef}
-              style={styles.scroll}
-              contentContainerStyle={styles.scrollContent}
-              showsVerticalScrollIndicator={false}
-              // Below full height the sheet itself takes the drag; a list that
-              // cannot be seen has nothing to scroll.
-              scrollEnabled={isExpanded}
-            >
-              {hasError && (
-                <Pressable style={styles.errorRow} onPress={retry}>
-                  <GaloyIcon name="warning" size={16} color={colors.error} />
-                  <Text style={styles.errorText}>{LL.MapScreen.detailsError()}</Text>
-                  <Text style={styles.retryText}>{LL.common.tryAgain()}</Text>
-                </Pressable>
-              )}
+      {isLoading && !details && (
+        <View style={styles.skeletonBlock}>
+          <Skeleton animation="pulse" style={styles.skeletonRow} />
+          <Skeleton animation="pulse" style={styles.skeletonRow} />
+          <Skeleton animation="pulse" style={styles.skeletonRow} />
+        </View>
+      )}
 
-              {isLoading && !details && (
-                <View style={styles.skeletonBlock}>
-                  <Skeleton animation="pulse" style={styles.skeletonRow} />
-                  <Skeleton animation="pulse" style={styles.skeletonRow} />
-                  <Skeleton animation="pulse" style={styles.skeletonRow} />
-                </View>
-              )}
-
-              <View style={styles.rows}>
-                {/* The number and address are worth reading even when they are
+      <View style={styles.rows}>
+        {/* The number and address are worth reading even when they are
                     not in a shape we are willing to hand to the dialer or mail
                     app, so these two rows stay — they just stop being tappable. */}
-                {Boolean(details?.phone) &&
-                  renderRow(
-                    "phone",
-                    details?.phone ?? "",
-                    phoneUrl ? () => openUrl(phoneUrl) : undefined,
-                  )}
-                {Boolean(websiteUrl) &&
-                  renderRow("globe", hostOf(websiteUrl ?? ""), () =>
-                    openUrl(websiteUrl ?? ""),
-                  )}
-                {Boolean(details?.email) &&
-                  renderRow(
-                    "email-add",
-                    details?.email ?? "",
-                    emailUrl ? () => openUrl(emailUrl) : undefined,
-                  )}
-                {Boolean(details?.paymentUrl) &&
-                  renderRow("lightning", LL.MapScreen.payMerchant(), () =>
-                    openUrl(details?.paymentUrl ?? ""),
-                  )}
-                {/* No brand glyphs in the icon set, so they share one. */}
-                {socials.map(([label, url]) => (
-                  <React.Fragment key={label}>
-                    {renderRow("link", label, () => openUrl(url))}
-                  </React.Fragment>
-                ))}
-              </View>
+        {Boolean(details?.phone) &&
+          renderRow(
+            "phone",
+            details?.phone ?? "",
+            phoneUrl ? () => openUrl(phoneUrl) : undefined,
+          )}
+        {Boolean(websiteUrl) &&
+          renderRow("globe", hostOf(websiteUrl ?? ""), () => openUrl(websiteUrl ?? ""))}
+        {Boolean(details?.email) &&
+          renderRow(
+            "email-add",
+            details?.email ?? "",
+            emailUrl ? () => openUrl(emailUrl) : undefined,
+          )}
+        {Boolean(details?.paymentUrl) &&
+          renderRow("lightning", LL.MapScreen.payMerchant(), () =>
+            openUrl(details?.paymentUrl ?? ""),
+          )}
+        {/* No brand glyphs in the icon set, so they share one. */}
+        {socials.map(([label, url]) => (
+          <React.Fragment key={label}>
+            {renderRow("link", label, () => openUrl(url))}
+          </React.Fragment>
+        ))}
+      </View>
 
-              {Boolean(details?.description) && (
-                <Text style={styles.description}>{details?.description}</Text>
-              )}
+      {Boolean(details?.description) && (
+        <Text style={styles.description}>{details?.description}</Text>
+      )}
 
-              {/* Dragging the sheet down closes it, but that is a gesture you
+      {/* Dragging the sheet down closes it, but that is a gesture you
                   have to know about. This is the same thing, spelled out, and
                   it is the last thing you reach going down the detail. */}
-              <GaloySecondaryButton
-                testID="close-place-sheet"
-                title={LL.common.close()}
-                onPress={onClose}
-                containerStyle={styles.close}
-              />
+      <GaloySecondaryButton
+        testID="close-place-sheet"
+        title={LL.common.close()}
+        onPress={onClose}
+        containerStyle={styles.close}
+      />
 
-              {/* The places are OpenStreetMap data under ODbL, which asks that
+      {/* The places are OpenStreetMap data under ODbL, which asks that
                   anyone looking at it can see where it came from and reach the
                   licence. It reads as a footnote here rather than as a chip on
                   the map, where a large system font size grew it until it
                   covered the streets it was crediting. */}
-              <Text testID="place-sheet-attribution" style={styles.attribution}>
-                {attribution.map((part, index) => {
-                  const url = ATTRIBUTION_LINKS[part]
-                  return url ? (
-                    <Text
-                      key={`${part}-${index}`}
-                      style={styles.attributionLink}
-                      onPress={() => openUrl(url)}
-                      accessibilityRole="link"
-                    >
-                      {part}
-                    </Text>
-                  ) : (
-                    part
-                  )
-                })}
-              </Text>
-            </Animated.ScrollView>
-          </Animated.View>
-        </GestureDetector>
-      </GestureHandlerRootView>
-    </Modal>
+      <Text testID="place-sheet-attribution" style={styles.attribution}>
+        {attribution.map((part, index) => {
+          const url = ATTRIBUTION_LINKS[part]
+          return url ? (
+            <Text
+              key={`${part}-${index}`}
+              style={styles.attributionLink}
+              onPress={() => openUrl(url)}
+              accessibilityRole="link"
+            >
+              {part}
+            </Text>
+          ) : (
+            part
+          )
+        })}
+      </Text>
+    </BottomSheet>
   )
 }
 
 type StyleProps = { bottomInset: number }
 
 const useStyles = makeStyles(({ colors }, { bottomInset }: StyleProps) => ({
-  root: {
-    flex: 1,
-    justifyContent: "flex-end",
-  },
-  backdrop: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    // A scrim has to darken in both themes; the theme's backdrop tokens invert
-    // and would brighten the map behind the sheet in dark mode.
-    backgroundColor: SCRIM_COLOR,
-  },
-  backdropPress: {
-    flex: 1,
-  },
-  sheet: {
-    backgroundColor: colors.white,
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    borderWidth: 1,
-    borderBottomWidth: 0,
-    borderColor: colors.grey4,
-    paddingTop: 8,
-    // Cancels the extra height above, so only the seam moves off-screen.
-    marginBottom: -BOTTOM_OVERHANG,
-  },
-  handle: {
-    alignSelf: "center",
-    width: 40,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: colors.grey3,
-    marginBottom: 8,
-  },
   peek: {
     paddingHorizontal: 20,
     rowGap: 14,
@@ -713,9 +482,6 @@ const useStyles = makeStyles(({ colors }, { bottomInset }: StyleProps) => ({
   peekFact: {
     fontSize: 14,
     color: colors.grey1,
-  },
-  scroll: {
-    flex: 1,
   },
   scrollContent: {
     paddingHorizontal: 20,


### PR DESCRIPTION
Closes https://github.com/blinkbitcoin/blink-wip/issues/1255 (partly — see Scope).

Based on `main`, which now carries #4249. **#4254 now builds on this**, so this one merges first — see *Order* below.

`category-filter-sheet` was a partial copy of `place-sheet`:

- `SCRIM_COLOR = "rgba(0, 0, 0, 0.4)"` declared verbatim in both
- the `handle` style block byte-identical in both
- each re-deriving its own `offset` shared value and `useAnimatedStyle`

The copy had dropped the drag-to-dismiss on its way across, so the two sheets did not behave the same: a merchant's sheet could be flicked away, the filter could only be closed from its scrim.

`app/components/bottom-sheet/` now owns what neither caller should be spelling out for itself — the modal window and the gesture root Android needs inside one, the scrim and its press-to-close, the pull handle, the drag-to-dismiss, and the surface tokens. The filter goes from 149 lines to 119, the place sheet from 590 to 254.

### Why build one rather than install one

`@gorhom/bottom-sheet` is broken on this stack. `amount-input-modal.tsx` already carries the issue links, reaches for React Native's `Modal` for the same reason, and gives up drag-to-dismiss to do it. A stale `__mocks__/@gorhom/bottom-sheet.tsx` is still in the tree from when it was tried.

This is what `amount-input-modal` would use instead, which is why the primitive lives under `app/components/` rather than `map-component/`.

### One prop, two shapes

The place sheet rests on its header's measured bottom edge and expands from there. The filter has one position — the list is the whole point of it, and there is nothing short of it a peek would usefully show. `restsOnHeader` is the difference; everything else is the same sheet.

### Off-spec values corrected

Both files were identically wrong, so both move together and it costs nothing extra to do it here:

| | Was | Now |
|---|---|---|
| Pull handle | `40 × 4` | `26 × 3` |
| Top corners | `20` | `16` (`radius.lg`) |

Confirmed with design before changing, per the ticket.

The filter sheet also picks up the place sheet's 1px border and its bottom overhang, which is what stops Android antialiasing a hairline of scrim under the sheet.

### Behaviour changes, called out

- **The filter gains drag-to-dismiss.** Not a pure refactor — it stops being a degraded copy of its sibling. This is an acceptance requirement of #1255.
- **The filter's corners and handle change size**, as above.

### Noted, not fixed

`place-sheet` keeps a `shownRef` so it "still has something to draw while it slides back out", but the modal window closes at the same moment the slide begins, so that animation plays against a hidden window. Pre-existing, unchanged here, and left alone deliberately — it wants its own commit.

### Scope

Map only, by agreement. #1255 asks for every applicable screen; there are at least six more bottom-anchored sheets outside the map — `amount-input-modal` (radius 20), `home-screen` (12), `earns-quiz` (24), `modal-tooltip` (40), `contact-modal`, `set-lightning-address-screen` — most on `react-native-modal` rather than RN's `Modal`, so migrating them is a larger job than these two. Worth its own ticket once the primitive has proved itself here.

`add-place` **is** now a caller, through a second presentation added in the follow-up commit below — see *Inline presentation*.

### Inline presentation

Review of the running build asked for the add-place form to animate in and drag away exactly as the merchant sheet does. It cannot become a modal sheet: its pin is aimed by panning the map above it while the fields are typed, and a window and a scrim are precisely what would swallow that panning.

So `presentation` splits the two apart:

| | `"modal"` (default) | `"inline"` |
|---|---|---|
| Window | `Modal` + `GestureHandlerRootView` | none, drawn where placed |
| Scrim | animated, press to close | none |
| Height | `heightRatio` of the window | fills its layout slot (`flex`), measured |
| Entry, handle, drag, spring | shared | shared |

The behaviour is *shared rather than matched*, which is the point: the two presentations cannot drift. Inline the sheet fills the slot its parent gives it rather than taking a share of the window, so the map above shrinks by exactly the sheet's height instead of being covered by it — which is what keeps the pin's centre, the coordinate actually submitted, correct.

`footer` came with it: content that scrolls can push a call to action off the sheet, so a footer is held below the scroll rather than at the end of it. The two map sheets do not use it; the add-place form does, and it is what let its category chips come back in #4254.

`heightRatio` is now optional, since inline callers have no use for it.

### Order

These two were independent and order-free until the review; they are not any more. #4254 consumes `presentation="inline"` and `footer`, so **this PR merges first**. GitHub will not take a base branch that lives on the fork, so #4254 targets `main` and its diff shows these commits too until this one lands.

`map-component/index.tsx` is untouched: both components keep the props they had.

## Acceptance requirements

- [x] A single bottom-sheet component exists; `SCRIM_COLOR` and the handle style are each defined exactly once in the codebase
- [x] `place-sheet.tsx` and `category-filter-sheet.tsx` both consume it
- [x] The filter sheet gains drag-to-dismiss, matching the merchant sheet rather than staying a degraded copy
- [x] Handle is `26 × 3`, top corners `radius.lg` (16)
- [x] Existing map-component suites still pass, unchanged bar the filter's new case
- [x] `add-place` moved onto it, without taking the map's panning away
- [x] All applicable non-map screens refactored — **deferred**; see Scope

## Testing specs

- **Unit** (`__tests__/components/bottom-sheet/bottom-sheet.spec.tsx`, 9 new): the primitive mounts and renders its children; holds a header above the scroll and renders no header region when given none; fires `onClose` on scrim press; fires `onClose` on a pan past the dismiss distance and slides out as it goes; stays open on a drag too short to count; rests at the header's measured bottom edge when asked and stays off-screen until that measurement arrives; opens fully when it has no header; leaves the screen when no longer visible.
- **Regression**: all existing `place-sheet` and `category-filter-sheet` assertions pass unchanged against the extracted component, including the geometry ones that read `translateY` off the sheet and drive the peek's `onLayout`.
- **New regression**: the filter sheet closes on a drag past the threshold — fails against the pre-extraction copy, which had no gesture.
- **Inline presentation** (5 further tests): the footer sits outside the scroll; inline puts up no scrim, still drags away on a pan past the threshold, takes no height of its own so its parent decides the split, and draws nothing when hidden.
- **Manual, both platforms, still to do**: drag-to-dismiss mid-scroll in the merchant sheet; the filter sheet's new gesture against its list; system font size at max.

Local: `tsc`, `eslint` and `prettier` clean. 197 tests pass across 11 suites on this branch — the 187 map-component ones plus 14 on the primitive, with 1 added to the filter.

## Screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)
